### PR TITLE
Always show term to unify account behaviour

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -50,7 +50,6 @@ mmNewAcctDialog::mmNewAcctDialog( )
 mmNewAcctDialog::mmNewAcctDialog(Model_Account::Data* account, wxWindow* parent)
     : m_account(account)
     , m_currencyID(-1)
-    , m_termAccount(false)
     , m_textAccountName()
     , m_notesCtrl()
     , m_itemInitValue()
@@ -328,11 +327,6 @@ void mmNewAcctDialog::OnAttachments(wxCommandEvent& /*event*/)
 	dlg.ShowModal();
 }
 
-bool mmNewAcctDialog::termAccountActivated()
-{
-    return m_termAccount;
-}
-
 void mmNewAcctDialog::OnOk(wxCommandEvent& /*event*/)
 {
     wxString acctName = m_textAccountName->GetValue().Trim();
@@ -355,8 +349,6 @@ void mmNewAcctDialog::OnOk(wxCommandEvent& /*event*/)
 
     m_account->ACCOUNTNAME = acctName;
     m_account->ACCOUNTTYPE = Model_Account::all_type()[acctType];
-    if (acctType == Model_Account::TERM)
-        this->m_termAccount = true;
 
     wxTextCtrl* textCtrlAcctNumber = (wxTextCtrl*)FindWindow(ID_ACCTNUMBER);
     wxTextCtrl* textCtrlHeldAt = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_HELDAT);

--- a/src/accountdialog.h
+++ b/src/accountdialog.h
@@ -38,7 +38,6 @@ public:
         , const wxPoint& pos
         , const wxSize& size
         , long style);
-    bool termAccountActivated();
 
 private:
     void CreateControls();
@@ -66,7 +65,6 @@ private:
     wxString m_accessInfo;
     wxString m_notesLabel;
     int m_currencyID;
-    bool m_termAccount;
     bool m_accessChanged;
 
     enum {

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -155,7 +155,7 @@ private:
     void createControls();
     void saveSettings();
     void menuEnableItems(bool enable);
-    void updateNavTreeControl(bool expandTermAccounts = false);
+    void updateNavTreeControl();
     void updateReportNavigation(wxTreeItemId& reports, wxTreeItemId& budgeting);
     void updateReportCategoryExpensesGoesNavigation(wxTreeItemId& categsOverTime);
     void updateReportCategoryExpensesComesNavigation(wxTreeItemId& posCategs);

--- a/src/mmframereport.cpp
+++ b/src/mmframereport.cpp
@@ -267,15 +267,11 @@ void mmGUIFrame::updateReportNavigation(wxTreeItemId& reports, wxTreeItemId& bud
     wxTreeItemId cashflowWithBankAccounts = navTreeCtrl_->AppendItem(cashFlow, _("Cash Flow - With Bank Accounts"), 4, 4);
     navTreeCtrl_->SetItemData(cashflowWithBankAccounts, new mmTreeItemData("Cash Flow - With Bank Accounts", new mmReportCashFlowBankAccounts()));
 
-    if (Model_Account::hasActiveTermAccount())
-    {
-        wxTreeItemId cashflowWithTermAccounts = navTreeCtrl_->AppendItem(cashFlow, _("Cash Flow - With Term Accounts"), 4, 4);
-        navTreeCtrl_->SetItemData(cashflowWithTermAccounts, new mmTreeItemData("Cash Flow - With Term Accounts", new mmReportCashFlowTermAccounts()));
-    }
+    wxTreeItemId cashflowWithTermAccounts = navTreeCtrl_->AppendItem(cashFlow, _("Cash Flow - With Term Accounts"), 4, 4);
+    navTreeCtrl_->SetItemData(cashflowWithTermAccounts, new mmTreeItemData("Cash Flow - With Term Accounts", new mmReportCashFlowTermAccounts()));
 
     wxTreeItemId cashflowSpecificAccounts = navTreeCtrl_->AppendItem(cashFlow, _("Cash Flow - Specific Accounts"), 4, 4);
     navTreeCtrl_->SetItemData(cashflowSpecificAccounts, new mmTreeItemData("Cash Flow - Specific Accounts", new mmReportCashFlowSpecificAccounts()));
-
 
     wxTreeItemId cashflowSpecificAccountsDaily = navTreeCtrl_->AppendItem(cashFlow, _("Daily Cash Flow - Specific Accounts"), 4, 4);
     navTreeCtrl_->SetItemData(cashflowSpecificAccountsDaily, new mmTreeItemData("Daily Cash Flow - Specific Accounts", new mmReportDailyCashFlowSpecificAccounts()));

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -530,12 +530,10 @@ void mmHomePagePanel::getData()
     get_account_stats(accountStats);
 
     m_frames["ACCOUNTS_INFO"] = displayAccounts(tBalance, accountStats);
-    if (Model_Account::hasActiveTermAccount())
-    {
-        double termBalance = 0.0;
-        m_frames["TERM_ACCOUNTS_INFO"] = displayAccounts(termBalance, accountStats, Model_Account::TERM);
-        tBalance += termBalance;
-    }
+    
+    double termBalance = 0.0;
+    m_frames["TERM_ACCOUNTS_INFO"] = displayAccounts(termBalance, accountStats, Model_Account::TERM);
+    tBalance += termBalance;
 
     //Stocks
     wxString stocks = "";

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -263,9 +263,3 @@ int Model_Account::checking_account_num()
 {
     return Model_Account::instance().find(ACCOUNTTYPE(all_type()[CHECKING])).size();
 }
-
-bool Model_Account::hasActiveTermAccount()
-{
-    return !Model_Account::instance().find(ACCOUNTTYPE(all_type()[TERM])
-        , DB_Table_ACCOUNTLIST_V1::STATUS(all_status()[OPEN])).empty(); 
-}

--- a/src/model/Model_Account.h
+++ b/src/model/Model_Account.h
@@ -104,7 +104,6 @@ public:
     static bool is_used(const Model_Currency::Data& c);
 
     static int checking_account_num();
-    static bool hasActiveTermAccount();
 };
 
 #endif // 


### PR DESCRIPTION
We have to keep the same behaviour everywhere in MMEX: my opinion is to always show all accounts and types so users will always show what there is in DB without strange code tricks..

Term tree is not expanded by default, so it will only thake one line on navtree
