### PR TITLE
sync panel controls enabled with list control selection & updates from static analysis tool

### DIFF
--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -41,12 +41,11 @@
 BEGIN_EVENT_TABLE(mmAssetsListCtrl, mmListCtrl)
     EVT_LIST_ITEM_ACTIVATED(wxID_ANY,   mmAssetsListCtrl::OnListItemActivated)
     EVT_LIST_ITEM_SELECTED(wxID_ANY,    mmAssetsListCtrl::OnListItemSelected)
-    EVT_LIST_ITEM_DESELECTED(wxID_ANY,  mmAssetsListCtrl::OnListItemDeselected)
     EVT_LIST_COL_END_DRAG(wxID_ANY,     mmAssetsListCtrl::OnItemResize)
     EVT_LIST_COL_CLICK(wxID_ANY,        mmAssetsListCtrl::OnColClick)
     EVT_LIST_END_LABEL_EDIT(wxID_ANY,   mmAssetsListCtrl::OnEndLabelEdit)
     EVT_RIGHT_DOWN(mmAssetsListCtrl::OnMouseRightClick)
-    EVT_LEFT_DOWN(mmAssetsListCtrl::OnMouseLeftClick)
+    EVT_LEFT_DOWN(mmAssetsListCtrl::OnListLeftClick)
 
     EVT_MENU(MENU_TREEPOPUP_NEW,    mmAssetsListCtrl::OnNewAsset)
     EVT_MENU(MENU_TREEPOPUP_EDIT,   mmAssetsListCtrl::OnEditAsset)
@@ -78,6 +77,17 @@ void mmAssetsListCtrl::OnItemResize(wxListEvent& event)
 
 void mmAssetsListCtrl::OnMouseRightClick(wxMouseEvent& event)
 {
+    if (m_selected_row > -1)
+        SetItemState(m_selected_row, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+    int Flags = wxLIST_HITTEST_ONITEM;
+    m_selected_row = HitTest(wxPoint(event.m_x, event.m_y), Flags);
+
+    if (m_selected_row >= 0)
+    {
+        SetItemState(m_selected_row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+        SetItemState(m_selected_row, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+    }
+    m_panel->updateExtraAssetData(m_selected_row);
     wxMenu menu;
     menu.Append(MENU_TREEPOPUP_NEW, _("&New Asset"));
     menu.AppendSeparator();
@@ -97,9 +107,15 @@ void mmAssetsListCtrl::OnMouseRightClick(wxMouseEvent& event)
     PopupMenu(&menu, event.GetPosition());
 }
 
-void mmAssetsListCtrl::OnMouseLeftClick(wxMouseEvent& event)
+void mmAssetsListCtrl::OnListLeftClick(wxMouseEvent& event)
 {
-    m_selected_row = -1;
+    int Flags = wxLIST_HITTEST_ONITEM;
+    long index = HitTest(wxPoint(event.m_x, event.m_y), Flags);
+    if (index == -1)
+    {
+        m_selected_row = -1;
+        m_panel->updateExtraAssetData(m_selected_row);
+    }
     event.Skip();
 }
 
@@ -111,12 +127,6 @@ wxString mmAssetsListCtrl::OnGetItemText(long item, long column) const
 void mmAssetsListCtrl::OnListItemSelected(wxListEvent& event)
 {
     m_selected_row = event.GetIndex();
-    m_panel->updateExtraAssetData(m_selected_row);
-}
-
-void mmAssetsListCtrl::OnListItemDeselected(wxListEvent& /*event*/)
-{
-    m_selected_row = -1;
     m_panel->updateExtraAssetData(m_selected_row);
 }
 

--- a/src/assetspanel.h
+++ b/src/assetspanel.h
@@ -47,11 +47,10 @@ private:
     virtual int OnGetItemImage(long item) const;
 
     void OnMouseRightClick(wxMouseEvent& event);
-    void OnMouseLeftClick(wxMouseEvent& event);
+    void OnListLeftClick(wxMouseEvent& event);
     void OnListItemActivated(wxListEvent& event);
     void OnListKeyDown(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
-    void OnListItemDeselected(wxListEvent& event);
     void OnColClick(wxListEvent& event);
     void OnEndLabelEdit(wxListEvent& event);
     void OnItemResize(wxListEvent& event);

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -85,8 +85,8 @@ END_EVENT_TABLE()
 BEGIN_EVENT_TABLE(billsDepositsListCtrl, mmListCtrl)
     EVT_LIST_ITEM_ACTIVATED(wxID_ANY,   billsDepositsListCtrl::OnListItemActivated)
     EVT_RIGHT_DOWN(billsDepositsListCtrl::OnItemRightClick)
-    EVT_LIST_ITEM_SELECTED(wxID_ANY,    billsDepositsListCtrl::OnListItemSelected)
-    EVT_LIST_ITEM_DESELECTED(wxID_ANY,    billsDepositsListCtrl::OnListItemDeselected)
+    EVT_LEFT_DOWN(billsDepositsListCtrl::OnListLeftClick)
+    EVT_LIST_ITEM_SELECTED(wxID_ANY, billsDepositsListCtrl::OnListItemSelected)
     EVT_LIST_COL_END_DRAG(wxID_ANY, billsDepositsListCtrl::OnItemResize)
     EVT_LIST_COL_CLICK(wxID_ANY, billsDepositsListCtrl::OnColClick)
 
@@ -408,6 +408,8 @@ void billsDepositsListCtrl::OnItemResize(wxListEvent& event)
 
 void billsDepositsListCtrl::OnItemRightClick(wxMouseEvent& event)
 {
+    if (m_selected_row > -1)
+        SetItemState(m_selected_row, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
     int Flags = wxLIST_HITTEST_ONITEM;
     m_selected_row = HitTest(wxPoint(event.m_x, event.m_y), Flags);
 
@@ -416,6 +418,7 @@ void billsDepositsListCtrl::OnItemRightClick(wxMouseEvent& event)
         SetItemState(m_selected_row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
         SetItemState(m_selected_row, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
     }
+    cp_->updateBottomPanelData(m_selected_row);
     bool item_active = (m_selected_row >= 0);
     wxMenu menu;
     menu.Append(MENU_POPUP_BD_ENTER_OCCUR, _("Enter next Occurrence..."));
@@ -434,7 +437,6 @@ void billsDepositsListCtrl::OnItemRightClick(wxMouseEvent& event)
     menu.Enable(MENU_TREEPOPUP_DELETE, item_active);
 	menu.Enable(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, item_active);
 
-    cp_->enableEditDeleteButtons(item_active);
     PopupMenu(&menu, event.GetPosition());
     this->SetFocus();
 }
@@ -532,10 +534,16 @@ void billsDepositsListCtrl::OnListItemSelected(wxListEvent& event)
     cp_->updateBottomPanelData(m_selected_row);
 }
 
-void billsDepositsListCtrl::OnListItemDeselected(wxListEvent& /*event*/)
+void billsDepositsListCtrl::OnListLeftClick(wxMouseEvent& event)
 {
-    m_selected_row = -1;
-    cp_->updateBottomPanelData(m_selected_row);
+    int Flags = wxLIST_HITTEST_ONITEM;
+    long index = HitTest(wxPoint(event.m_x, event.m_y), Flags);
+    if (index == -1)
+    {
+        m_selected_row = -1;
+        cp_->updateBottomPanelData(m_selected_row);
+    }
+    event.Skip();
 }
 
 int billsDepositsListCtrl::OnGetItemImage(long item) const

--- a/src/billsdepositspanel.h
+++ b/src/billsdepositspanel.h
@@ -53,12 +53,12 @@ private:
     virtual int OnGetItemImage(long item) const;
 
     void OnItemRightClick(wxMouseEvent& event);
+    void OnListLeftClick(wxMouseEvent& event);
     void OnListItemActivated(wxListEvent& event);
     void OnMarkTransaction(wxCommandEvent& event);
     void OnMarkAllTransactions(wxCommandEvent& event);
     void OnListKeyDown(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
-    void OnListItemDeselected(wxListEvent& event);
     void OnItemResize(wxListEvent& event);
     void OnColClick(wxListEvent& event);
 

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -158,10 +158,10 @@ wxString mmExportTransaction::getAccountHeaderQIF()
     wxString buffer = "";
     wxString account_name = "";
     wxString currency_symbol = "";
-    double dInitBalance = 0;
     Model_Checking::Data_Set enties = Model_Checking::instance().find_or(Model_Checking::ACCOUNTID(m_account_id), Model_Checking::TOACCOUNTID(m_account_id));
     if (!enties.empty())
     {
+        double dInitBalance = 0;
         Model_Account::Data *account = Model_Account::instance().get(m_account_id);
         if (account)
         {

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -71,7 +71,6 @@ END_EVENT_TABLE()
 BEGIN_EVENT_TABLE(TransactionListCtrl, wxListCtrl)
 
     EVT_LIST_ITEM_SELECTED(wxID_ANY, TransactionListCtrl::OnListItemSelected)
-    EVT_LIST_ITEM_DESELECTED(wxID_ANY, TransactionListCtrl::OnListItemDeselected)
     EVT_LIST_ITEM_ACTIVATED(wxID_ANY, TransactionListCtrl::OnListItemActivated)
     EVT_RIGHT_DOWN(TransactionListCtrl::OnMouseRightClick)
     EVT_LEFT_DOWN(TransactionListCtrl::OnListLeftClick)
@@ -899,6 +898,8 @@ void mmCheckingPanel::DisplayAccountDetails(int accountID)
 
     initViewTransactionsHeader();
     initFilterSettings();
+    if (m_listCtrlAccount->m_selectedIndex > -1)
+        m_listCtrlAccount->SetItemState(m_listCtrlAccount->m_selectedIndex, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
     m_listCtrlAccount->m_selectedIndex = -1;
     RefreshList();
     showTips();
@@ -1005,15 +1006,6 @@ void TransactionListCtrl::OnListItemSelected(wxListEvent& event)
 }
 //----------------------------------------------------------------------------
 
-void TransactionListCtrl::OnListItemDeselected(wxListEvent& /*event*/)
-{
-//    long deselected = event.GetIndex();
-
-    m_selectedIndex = -1;
-    m_cp->updateExtraTransactionData(m_selectedIndex);
-
-}
-
 void TransactionListCtrl::OnItemResize(wxListEvent& event)
 {
     int i = event.GetColumn();
@@ -1024,16 +1016,20 @@ void TransactionListCtrl::OnItemResize(wxListEvent& event)
 
 void TransactionListCtrl::OnListLeftClick(wxMouseEvent& event)
 {
-    if (m_selectedIndex > -1)
+    int Flags = wxLIST_HITTEST_ONITEM;
+    long index = HitTest(wxPoint(event.m_x, event.m_y), Flags);
+    if (index == -1)
     {
-        if (GetItemState(m_selectedIndex, wxLIST_STATE_SELECTED) == 0)
-            m_cp->updateExtraTransactionData(-1);
+        m_selectedIndex = -1;
+        m_cp->updateExtraTransactionData(m_selectedIndex);
     }
     event.Skip();
 }
 
 void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
 {
+    if (m_selectedIndex > -1)
+        SetItemState(m_selectedIndex, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
     int Flags = wxLIST_HITTEST_ONITEM;
     m_selectedIndex = HitTest(wxPoint(event.m_x, event.m_y), Flags);
 
@@ -1042,6 +1038,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
         SetItemState(m_selectedIndex, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
         SetItemState(m_selectedIndex, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
     }
+    m_cp->updateExtraTransactionData(m_selectedIndex);
 
     bool hide_menu_item = (m_selectedIndex < 0);
     bool type_transfer = false;

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -178,7 +178,6 @@ private:
     void OnListLeftClick(wxMouseEvent& event);
     void OnItemResize(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
-    void OnListItemDeselected(wxListEvent& event);
     void OnListItemActivated(wxListEvent& event);
     void OnMarkTransaction(wxCommandEvent& event);
     void OnShowChbClick(wxCommandEvent& /*event*/);

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -766,11 +766,9 @@ const wxString mmHomePagePanel::displayIncomeVsExpenses()
 //* Assets *//
 const wxString mmHomePagePanel::displayAssets(double& tBalance)
 {
-    wxString output = "";
-
     double asset_balance = Model_Asset::instance().balance();
     tBalance += asset_balance;
-    output = "<table class = 'table'><tfoot><tr class = \"total\">";
+    wxString output = "<table class = 'table'><tfoot><tr class = \"total\">";
     output += wxString::Format("<td><a href = \"Assets:\">%s</a></td>", _("Assets"));
     output += wxString::Format("<td class = 'money'>%s</td></tr>", Model_Currency::toCurrency(asset_balance));
     output += "</tfoot></table>";

--- a/src/stockspanel.h
+++ b/src/stockspanel.h
@@ -66,13 +66,13 @@ private:
     virtual int OnGetItemImage(long item) const;
 
     void OnMouseRightClick(wxMouseEvent& event);
+    void OnListLeftClick(wxMouseEvent& event);
     void OnListItemActivated(wxListEvent& event);
     void OnColClick(wxListEvent& event);
     void OnMarkTransaction(wxCommandEvent& event);
     void OnMarkAllTransactions(wxCommandEvent& event);
     void OnListKeyDown(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
-    void OnListItemDeselected(wxListEvent& event);
     void OnItemResize(wxListEvent& event);
 
     mmStocksPanel* stock_panel_;


### PR DESCRIPTION
EVT_LIST_ITEM_DESELECTED was not being called on Windows platform (unknown if called on other platforms) causing panel controls to be out of sync with list control selection.
