### PR TITLE
Revert "use partial index for performance"

### DIFF
--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -61,22 +61,6 @@ wxArrayString Model_Checking::all_status()
     return status;
 }
 
-bool Model_Checking::extra_index()
-{
-    try
-    {
-        for (int i = 1; i <= 100; ++i)
-            db_->ExecuteUpdate(wxString::Format("CREATE INDEX IF NOT EXISTS IDX_CHECKINGACCOUNT_ACCOUNT_%d ON CHECKINGACCOUNT_V1 (ACCOUNTID, TOACCOUNTID) WHERE ACCOUNTID = %d OR TOACCOUNTID = %d", i, i, i));
-    }
-    catch(const wxSQLite3Exception &e) 
-    { 
-        wxLogError("CHECKINGACCOUNT_V1: Exception %s", e.GetMessage().c_str());
-        return false;
-    }
-
-    return true;
-}
-
 /**
 * Initialize the global Model_Checking table.
 * Reset the Model_Checking table or create the table if it does not exist.
@@ -87,7 +71,6 @@ Model_Checking& Model_Checking::instance(wxSQLite3Database* db)
     ins.db_ = db;
     ins.destroy_cache();
     ins.ensure(db);
-    ins.extra_index();
 
     return ins;
 }

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -101,9 +101,6 @@ public:
     static wxArrayString all_type();
     static wxArrayString all_status();
 
-private:
-    bool extra_index(); 
-
 public:
     /**
     Initialize the global Model_Checking table on initial call.


### PR DESCRIPTION
This reverts commit 0703f06afb2e068738d663b5f8a8ff83fb7b23fe.

Reason: Restore older tool recognizing xx.mmb as a database.

To fix affected databases, all added indexes need to be removed. This MMEX version will replace all necessary, indexes.
