### PR TITLE
Ensure line endings are correct for different OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# REF: https://help.github.com/articles/dealing-with-line-endings
+# Set the default behavior, in case people don't have core.autocrlf set.
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and
+# converted to native line endings on checkout.
+*.cpp  text
+*.h    text
+*.blk  text
+*.xpm  text
+*.po   text
+*.pot  text
+*.html text
+
+# Declare files that will always have LF line endings on checkout.
+sql/tables_v1.sql text eol=lf
+*.sh              text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat     text eol=crlf
+*.iss     text eol=crlf
+*.sln     text eol=crlf
+*.vcproj  text eol=crlf
+*.vcxproj text eol=crlf
+*.filters text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+# The binary setting is an alias for -text -diff.
+*.png binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
The file sql/tables_v1.sql must have lf line endings for correct
operation of util/sqlite2cpp.pl
