### PR TITLE
Make timeout a user setting (bugs #469)

### DIFF
--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -801,9 +801,28 @@ void mmOptionsDialog::CreateControls()
 
     usageStaticBoxSizer->Add(cbSendData_, g_flags);
 
-    networkPanel->SetSizer(networkPanelSizer);
+    // Communication timeout
+    networkPanelSizer->AddSpacer(15);
 
-   /**********************************************************************************************
+    wxStaticBox* timeoutStaticBox = new wxStaticBox(networkPanel, wxID_STATIC, _("Timeout"));
+    timeoutStaticBox->SetFont(staticBoxFontSetting);
+    wxStaticBoxSizer* timeoutStaticBoxSizer = new wxStaticBoxSizer(timeoutStaticBox, wxVERTICAL);
+    networkPanelSizer->Add(timeoutStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
+
+    int nTimeout = Model_Setting::instance().GetIntSetting("NETWORKTIMEOUT", 10);
+    scNetworkTimeout_ = new wxSpinCtrl(networkPanel, ID_DIALOG_OPTIONS_NETWORK_TIMEOUT,
+        wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 150, nTimeout);
+    scNetworkTimeout_->SetToolTip(_("Specify a network communication timeout value to use."));
+
+    wxFlexGridSizer* flex_sizer5 = new wxFlexGridSizer(0, 2, 0, 0);
+    flex_sizer5->Add(new wxStaticText(networkPanel, wxID_STATIC, _("Seconds")), g_flags);
+    flex_sizer5->Add(scNetworkTimeout_, g_flags);
+
+    timeoutStaticBoxSizer->Add(flex_sizer5, g_flags);
+
+    networkPanel->SetSizer(networkPanelSizer);
+    
+    /**********************************************************************************************
     Setting up the notebook with the 5 pages
     **********************************************************************************************/
     newBook->SetImageList(m_imageList);
@@ -1166,6 +1185,8 @@ void mmOptionsDialog::SaveNetworkPanelSettings()
     Model_Setting::instance().Set("WEBSERVERPORT", scWebServerPort_->GetValue());
 
     Model_Setting::instance().Set("SENDUSAGESTATS", cbSendData_->GetValue());
+    
+    Model_Setting::instance().Set("NETWORKTIMEOUT", scNetworkTimeout_->GetValue());
 }
 
 void mmOptionsDialog::OnOk(wxCommandEvent& /*event*/)

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -124,6 +124,8 @@ private:
 
 	wxCheckBox* cbSendData_;
 
+    wxSpinCtrl *scNetworkTimeout_;
+
     int currencyId_;
     wxString dateFormat_;
     wxString currentLanguage_;
@@ -182,7 +184,8 @@ private:
 		ID_DIALOG_OPTIONS_CHECKBOX_ATTACHMENTSSUBFOLDER,
         ID_DIALOG_OPTIONS_ENABLE_WEB_SERVER,
         ID_DIALOG_OPTIONS_WEB_SERVER_PORT,
-		ID_DIALOG_OPTIONS_ALLOW_SEND_USAGE
+		ID_DIALOG_OPTIONS_ALLOW_SEND_USAGE,
+        ID_DIALOG_OPTIONS_NETWORK_TIMEOUT
     };
 };
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -187,7 +187,8 @@ int site_content(const wxString& sSite, wxString& sOutput)
     int err_code = url.GetError();
     if (err_code == wxURL_NOERR)
     {
-        url.GetProtocol().SetTimeout(10); // 10 secs
+        int networkTimeout = Model_Setting::instance().GetIntSetting("NETWORKTIMEOUT", 10); // default 10 secs
+        url.GetProtocol().SetTimeout(networkTimeout);
         wxInputStream* in_stream = url.GetInputStream();
         if (in_stream)
         {


### PR DESCRIPTION
Browser timeout values are much greater than the 10 seconds that was a hard coded value. This change allows the user to specify a longer timeout (up to 2 1/2 minutes) if needed.

For an example here is the receive data timeout values from the Microsoft WinINet API:
WinINet.dll version 4.x 5 minutes
WinINet.dll versions 5.x and 6.x 60 minutes
WinINet.dll versions 7.x and 8.x 30 seconds

Timeouts vary between the different browsers and sometimes revisions as noted above.
