### PR TITLE
fix(GitHub.Issue.422): Recurring transactions layout grid

### DIFF
--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -198,15 +198,26 @@ bool mmBillsDepositsPanel::Create(wxWindow *parent
 
 mmBillsDepositsPanel::~mmBillsDepositsPanel()
 {
-   if (m_imageList)
+    if (m_imageList)
         delete m_imageList;
-   if (transFilterDlg_)
-       delete transFilterDlg_;
+    if (transFilterDlg_)
+        delete transFilterDlg_;
+    /*
+      Save the column widths of bill_deposit list control. This should ensure
+      that column's get set incase the OnItemResize does not work on some systems.
+    */
+    for (int bd_col_num = 0; bd_col_num < COL_MAX; ++bd_col_num)
+    {
+        int bd_col_width = listCtrlAccount_->GetColumnWidth(bd_col_num);
+        if (listCtrlAccount_->GetColumnWidthSetting(bd_col_num) != bd_col_width)
+        {
+            listCtrlAccount_->SetColumnWidthSetting(bd_col_num, bd_col_width);
+        }
+    }
 }
 
 void mmBillsDepositsPanel::CreateControls()
 {
-
     wxBoxSizer* itemBoxSizer9 = new wxBoxSizer(wxVERTICAL);
     this->SetSizer(itemBoxSizer9);
 
@@ -256,15 +267,14 @@ void mmBillsDepositsPanel::CreateControls()
 
     listCtrlAccount_->SetImageList(m_imageList, wxIMAGE_LIST_SMALL);
     listCtrlAccount_->InsertColumn(COL_ICON, " ", wxLIST_FORMAT_LEFT
-        , Model_Setting::instance().GetIntSetting(wxString::Format(listCtrlAccount_->m_col_width, COL_ICON),
-        std::get<1>(listCtrlAccount_->m_columns[COL_ICON])));
+        , listCtrlAccount_->GetColumnWidthSetting(COL_ICON, std::get<1>(listCtrlAccount_->m_columns[COL_ICON])));
     for (int i = 1; i < (int)listCtrlAccount_->m_columns.size(); i++)
     {
         int item_format = wxLIST_FORMAT_LEFT;
         if ((i == COL_PAYMENT_DATE) || (i == COL_AMOUNT) || (i == COL_ID) || (i == COL_REPEATS))
             item_format = wxLIST_FORMAT_RIGHT;
         listCtrlAccount_->InsertColumn(i, std::get<0>(listCtrlAccount_->m_columns[i]), item_format,
-            Model_Setting::instance().GetIntSetting(wxString::Format(listCtrlAccount_->m_col_width, i), std::get<1>(listCtrlAccount_->m_columns[i])));
+            listCtrlAccount_->GetColumnWidthSetting(i, std::get<1>(listCtrlAccount_->m_columns[i])));
     }
 
     wxPanel* bdPanel = new wxPanel(itemSplitterWindowBillsDeposit, wxID_ANY

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -1243,17 +1243,6 @@ void TransactionListCtrl::OnMarkAllTransactions(wxCommandEvent& event)
 }
 //----------------------------------------------------------------------------
 
-int TransactionListCtrl::GetColumnWidthSetting(const int& column_number, int default_size)
-{
-    return Model_Setting::instance().GetIntSetting(wxString::Format(m_col_width, column_number), default_size);
-}
-
-void TransactionListCtrl::SetColumnWidthSetting(const int& column_number, int column_width)
-{
-    Model_Setting::instance().Set(wxString::Format(m_col_width, column_number), column_width);
-}
-//-------------------------------------------------------------------
-
 void TransactionListCtrl::OnColClick(wxListEvent& event)
 {
     int ColumnNr;

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -197,9 +197,6 @@ private:
     void OnPaste(wxCommandEvent& WXUNUSED(event));
     int OnPaste(Model_Checking::Data* tran);
 
-    int GetColumnWidthSetting(const int& column_number, int default_size = wxLIST_AUTOSIZE);
-    void SetColumnWidthSetting(const int& column_number, int column_width);
-
     /* The topmost visible item - this will be used to set
     where to display the list again after refresh */
     long topItemIndex_;

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -199,6 +199,16 @@ void mmListCtrl::OnHeaderColumn(wxCommandEvent& event)
     }
 }
 
+int mmListCtrl::GetColumnWidthSetting(const int& column_number, int default_size)
+{
+    return Model_Setting::instance().GetIntSetting(wxString::Format(m_col_width, column_number), default_size);
+}
+
+void mmListCtrl::SetColumnWidthSetting(const int& column_number, int column_width)
+{
+    Model_Setting::instance().Set(wxString::Format(m_col_width, column_number), column_width);
+}
+
 mmPanelBase::mmPanelBase()
 {
 }

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -46,6 +46,8 @@ public:
 
     virtual wxListItemAttr* OnGetItemAttr(long row) const;
     wxString BuildPage(const wxString &title) const;
+    int GetColumnWidthSetting(const int& column_number, int default_size = wxLIST_AUTOSIZE);
+    void SetColumnWidthSetting(const int& column_number, int column_width);
 
 protected:
     void OnItemResize(wxListEvent& event);


### PR DESCRIPTION
Ref: https://github.com/moneymanagerex/moneymanagerex/issues/422
This fix has been provided, but on my system the SetColumnWidthSetting(...) command in the destructor does not appear to get executed.

Please test to see if this corrects the problem.