### PR TITLE
fix(Code): passing primitive types by value not reference

### DIFF
--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -394,7 +394,7 @@ void mmBudgetingPanel::initVirtualListControl()
     }
     else
     {
-        int day, month;
+        int day = -1, month = -1;
         budgetDetails.AdjustYearValues(day, month, dtBegin);
         budgetDetails.AdjustDateForEndFinancialYear(dtEnd);
     }

--- a/src/model/Model_Attachment.cpp
+++ b/src/model/Model_Attachment.cpp
@@ -94,7 +94,7 @@ int Model_Attachment::LastAttachmentNumber(const wxString& RefType, const int Re
 }
 
 /** Return the description of the choice reftype */
-wxString Model_Attachment::reftype_desc(const int& RefTypeEnum)
+wxString Model_Attachment::reftype_desc(const int RefTypeEnum)
 {
 	const auto& item = REFTYPE_CHOICES[RefTypeEnum];
 	wxString reftype_desc = item.second;
@@ -115,7 +115,7 @@ std::map<int, Model_Attachment::Data_Set> Model_Attachment::get_all(REFTYPE reft
 }
 
 /** Return all attachments descriptions*/
-wxArrayString Model_Attachment::allDescriptions(const bool& RemoveDuplicated)
+wxArrayString Model_Attachment::allDescriptions(const bool RemoveDuplicated)
 {
     wxArrayString descriptions;
     wxString PreviousDescription;

--- a/src/model/Model_Attachment.h
+++ b/src/model/Model_Attachment.h
@@ -60,13 +60,13 @@ public:
     static int LastAttachmentNumber(const wxString& RefType, const int RefId);
 
 	/** Return the description of the choice reftype */
-	static wxString reftype_desc(const int& RefTypeEnum);
+	static wxString reftype_desc(const int RefTypeEnum);
 
     /** Return a dataset with attachments linked to a specific type*/
     std::map<int, Data_Set> get_all(REFTYPE reftype);
 
     /** Return all attachments descriptions*/
-    wxArrayString allDescriptions(const bool& RemoveDuplicated);
+    wxArrayString allDescriptions(const bool RemoveDuplicated);
 };
 
 #endif // 

--- a/src/model/Model_Category.cpp
+++ b/src/model/Model_Category.cpp
@@ -270,7 +270,7 @@ const wxString Model_Category::full_name(const Data* category, const Model_Subca
         return category->CATEGNAME + ":" + sub_category->SUBCATEGNAME;
 }
 
-const wxString Model_Category::full_name(const int &category_id, const int &subcategory_id)
+const wxString Model_Category::full_name(const int category_id, const int subcategory_id)
 {
     Data* category = Model_Category::instance().get(category_id);
     Model_Subcategory::Data* sub_category = Model_Subcategory::instance().get(subcategory_id);

--- a/src/model/Model_Category.h
+++ b/src/model/Model_Category.h
@@ -58,15 +58,15 @@ public:
     static const std::map<wxString, std::pair<int, int> > all_categories();
     static Model_Subcategory::Data_Set sub_category(const Data* r);
     static Model_Subcategory::Data_Set sub_category(const Data& r);
-    static const wxString full_name(const Data* category, const Model_Subcategory::Data* sub_category = 0);
-    static const wxString full_name(const int &category_id, const int &subcategory_id);
+    static const wxString full_name(const Data* category, const Model_Subcategory::Data* sub_category = nullptr);
+    static const wxString full_name(const int category_id, const int subcategory_id);
     static bool is_used(int id, int sub_id = -1);
     static bool has_income(int id, int sub_id = -1);
     static void getCategoryStats(
         std::map<int, std::map<int, std::map<int, double> > > &categoryStats
         , mmDateRange* date_range, bool ignoreFuture
         , bool group_by_month = true, bool with_date = true
-        , std::map<int, std::map<int, double> > *budgetAmt = 0);
+        , std::map<int, std::map<int, double> > *budgetAmt = nullptr);
 };
 
 #endif //

--- a/src/model/Model_Infotable.cpp
+++ b/src/model/Model_Infotable.cpp
@@ -187,7 +187,7 @@ bool Model_Infotable::checkDBVersion()
     return this->GetIntInfo("DATAVERSION", 0) >= mmex::MIN_DATAVERSION;
 }
 
-bool Model_Infotable::AtDatabaseVersion(const int& required_version)
+bool Model_Infotable::AtDatabaseVersion(const int required_version)
 {
     return GetIntInfo("DATAVERSION", 0) == required_version;
 }

--- a/src/model/Model_Infotable.h
+++ b/src/model/Model_Infotable.h
@@ -68,7 +68,7 @@ public:
     /* Check database at minimum revision*/
     bool checkDBVersion();
     /* Check that the database is at this version*/
-    bool AtDatabaseVersion(const int& required_version);
+    bool AtDatabaseVersion(const int required_version);
     /* Set the database version counter to this version.
        Refer to the value of mmex::DATAVERSION */
     void SetDatabaseVersion(const wxString& required_version);

--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -50,7 +50,7 @@ wxBEGIN_EVENT_TABLE(mmPayeeDialog, wxDialog)
 wxEND_EVENT_TABLE()
 
 
-mmPayeeDialog::mmPayeeDialog(wxWindow *parent, const bool& payee_choose) :
+mmPayeeDialog::mmPayeeDialog(wxWindow *parent, const bool payee_choose) :
     m_payee_id(-1)
     , m_maskTextCtrl()
     , payeeListBox_()

--- a/src/payeedialog.h
+++ b/src/payeedialog.h
@@ -30,7 +30,7 @@ class mmPayeeDialog : public wxDialog
     wxDECLARE_EVENT_TABLE();
 
 public:
-    mmPayeeDialog(wxWindow* parent, const bool& payee_choose);
+    mmPayeeDialog(wxWindow* parent, const bool payee_choose);
 
     int getPayeeId() const {return m_payee_id;}
     bool getRefreshRequested() const {return refreshRequested_;}

--- a/src/reports/budget.cpp
+++ b/src/reports/budget.cpp
@@ -34,7 +34,7 @@ void mmReportBudget::SetDateToEndOfMonth(int month, wxDateTime& date)
     date.SetToLastMonthDay();
 }
 
-void mmReportBudget::SetDateToEndOfYear(int day, int month, wxDateTime& date, bool isEndDate)
+void mmReportBudget::SetDateToEndOfYear(const int day, const int month, wxDateTime& date, bool isEndDate)
 {
     date.SetDay(day);
     date.SetMonth((wxDateTime::Month)month);
@@ -86,11 +86,11 @@ wxString mmReportBudget::AdjustYearValues(int& day, int& month, long year, const
     return ret;
 }
 
-void mmReportBudget::AdjustYearValues(int& day, int& month, wxDateTime& year)
+void mmReportBudget::AdjustYearValues(int& day, int& month, wxDateTime& date)
 {
     if (mmIniOptions::instance().budgetFinancialYears_) {
         GetFinancialYearValues(day, month);
-        SetDateToEndOfYear(day, month, year, false);
+        SetDateToEndOfYear(day, month, date, false);
     }
 }
 

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -88,7 +88,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     Model_Budget::instance().getBudgetEntry(budgetYearID_, budgetPeriod, budgetAmt);
     std::map<int, std::map<int, std::map<int, double> > > categoryStats;
     Model_Category::instance().getCategoryStats(categoryStats, &date_range, mmIniOptions::instance().ignoreFutureTransactions_,
-        false, true, (evaluateTransfer ? &budgetAmt : 0));
+        false, true, (evaluateTransfer ? &budgetAmt : nullptr));
 
     mmHTMLBuilder hb;
     hb.init();

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -71,7 +71,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     wxString startYearStr = Model_Budgetyear::instance().Get(budgetYearID_);
     startYearStr.ToLong(&startYear);
 
-    wxString headingStr = AdjustYearValues(startDay, startMonth, startYear, startYearStr);
+    const wxString& headingStr = AdjustYearValues(startDay, startMonth, startYear, startYearStr);
     wxDateTime yearBegin(startDay, (wxDateTime::Month)startMonth, startYear);
     wxDateTime yearEnd(endDay, (wxDateTime::Month)endMonth, startYear);
 
@@ -89,7 +89,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     Model_Budget::instance().getBudgetEntry(budgetYearID_, budgetPeriod, budgetAmt);
     std::map<int, std::map<int, std::map<int, double> > > categoryStats;
     Model_Category::instance().getCategoryStats(categoryStats, &date_range, mmIniOptions::instance().ignoreFutureTransactions_,
-        true, true, (evaluateTransfer ? &budgetAmt : 0));
+        true, true, (evaluateTransfer ? &budgetAmt : nullptr));
     //Init totals
     const auto &allCategories = Model_Category::instance().all(Model_Category::COL_CATEGNAME);
     const auto &allSubcategories = Model_Subcategory::instance().all(Model_Subcategory::COL_SUBCATEGNAME);

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -201,7 +201,7 @@ void mmHTMLBuilder::addTotalRow(const wxString& caption, int cols, const std::ve
     this->addTotalRow(caption, cols, data_str);
 }
 
-void mmHTMLBuilder::addTableHeaderCell(const wxString& value, const bool& numeric, const bool& sortable)
+void mmHTMLBuilder::addTableHeaderCell(const wxString& value, const bool numeric, const bool sortable)
 {
     const wxString align = sortable ? "" : "class='sorttable_nosort'"
         + numeric ? " class='text-right'" : " class='text-left'";
@@ -239,7 +239,7 @@ void mmHTMLBuilder::addTableCell(const wxDateTime& date)
     this->addTableCell(date_str);
 }
 
-void mmHTMLBuilder::addTableCell(const wxString& value, const bool& numeric)
+void mmHTMLBuilder::addTableCell(const wxString& value, const bool numeric)
 {
     const wxString align = numeric ? "class='text-right'" : "class='text-left'";
     html_ += wxString::Format(tags::TABLE_CELL, align);
@@ -395,7 +395,7 @@ void mmHTMLBuilder::endTableCell()
     html_+= tags::TABLE_CELL_END;
 }
 
-void mmHTMLBuilder::addPieChart(std::vector<ValueTrio>& valueList, const wxString& id, const int& x, const int& y)
+void mmHTMLBuilder::addPieChart(std::vector<ValueTrio>& valueList, const wxString& id, const int x, const int y)
 {
     static const wxString data_item =
         "{\n"
@@ -423,7 +423,7 @@ void mmHTMLBuilder::addPieChart(std::vector<ValueTrio>& valueList, const wxStrin
     this->addText(wxString::Format(js, data, id));
 }
 
-void mmHTMLBuilder::addBarChart(const wxString &labels, const std::vector<ValueTrio>& data, const wxString& id, const int& x, const int& y)
+void mmHTMLBuilder::addBarChart(const wxString &labels, const std::vector<ValueTrio>& data, const wxString& id, const int x, const int y)
 {
     static const wxString data_item =
         "{\n"
@@ -470,7 +470,7 @@ void mmHTMLBuilder::addBarChart(const wxString &labels, const std::vector<ValueT
     this->addText(wxString::Format(js, labels, values, (int)scaleStepWidth, id));
 }
 
-void mmHTMLBuilder::addLineChart(const std::vector<ValueTrio>& data, const wxString& id, const int& index, const int& x, const int& y, bool pointDot, bool showGridLines, bool datasetFill)
+void mmHTMLBuilder::addLineChart(const std::vector<ValueTrio>& data, const wxString& id, const int index, const int x, const int y, bool pointDot, bool showGridLines, bool datasetFill)
 {
     static const wxString data_item =
         "{\n"

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -61,7 +61,7 @@ public:
     void addTotalRow(const wxString& caption, int cols, const std::vector<double>& data);
 
     /** Add a Table header cell */
-    void addTableHeaderCell(const wxString& value, const bool& numeric = false, const bool& sortable = true);
+    void addTableHeaderCell(const wxString& value, const bool numeric = false, const bool sortable = true);
 
     void addCurrencyCell(double amount, const Model_Currency::Data *currency = Model_Currency::instance().GetBaseCurrency(), int precision = -1);
     void addMoneyCell(double amount, int precision = -1);
@@ -72,7 +72,7 @@ public:
 
     /** Add a Cell value */
     void addTableCell(const wxDateTime& date);
-    void addTableCell(const wxString& value, const bool& numeric = false);
+    void addTableCell(const wxString& value, const bool numeric = false);
 
     /** Add a Cell value */
     void addTableCellLink(const wxString& href, const wxString& value);
@@ -109,9 +109,9 @@ public:
     void addTableRow(const wxString& label, double data);
     void addTableRowBold(const wxString& label, double data);
 
-    void addPieChart(std::vector<ValueTrio>& valueList, const wxString& id, const int& x = 300, const int& y = 300);
-    void addLineChart(const std::vector<ValueTrio>& data, const wxString& id, const int& index, const int& x = 640, const int& y = 256, bool pointDot = false, bool showGridLines = true, bool datasetFill = false);
-    void addBarChart(const wxString & labels, const std::vector<ValueTrio>& data, const wxString& id, const int& x = 192, const int& y = 256);
+    void addPieChart(std::vector<ValueTrio>& valueList, const wxString& id, const int x = 300, const int y = 300);
+    void addLineChart(const std::vector<ValueTrio>& data, const wxString& id, const int index, const int x = 640, const int y = 256, bool pointDot = false, bool showGridLines = true, bool datasetFill = false);
+    void addBarChart(const wxString & labels, const std::vector<ValueTrio>& data, const wxString& id, const int x = 192, const int y = 256);
 
 private:
     wxString html_;

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -347,7 +347,7 @@ bool mmWebApp::WebApp_UpdateCategory()
 }
 
 //Download new transactions
-bool mmWebApp::WebApp_DownloadNewTransaction(WebTranVector& WebAppTransactions_, const bool& CheckOnly)
+bool mmWebApp::WebApp_DownloadNewTransaction(WebTranVector& WebAppTransactions_, const bool CheckOnly)
 {
     wxString NewTransactionJSON;
     int ErrorCode = site_content(mmWebApp::getServicesPageURL() + "&" + WebAppParam::DownloadNewTransaction, NewTransactionJSON);

--- a/src/webapp.h
+++ b/src/webapp.h
@@ -101,7 +101,7 @@ public:
     static bool WebApp_UpdateCategory();
 
     /** Download new transaction */
-    static bool WebApp_DownloadNewTransaction(WebTranVector& WebAppTransactions_, const bool& CheckOnly);
+    static bool WebApp_DownloadNewTransaction(WebTranVector& WebAppTransactions_, const bool CheckOnly);
 
     /** Insert transaction in MMEX desktop, returns transaction ID */
     static int MMEX_InsertNewTransaction(webtran_holder& WebAppTrans);

--- a/src/webappdialog.cpp
+++ b/src/webappdialog.cpp
@@ -277,7 +277,7 @@ void mmWebAppDialog::OnItemRightClick(wxDataViewEvent& event)
 }
 
 
-void mmWebAppDialog::ImportAllWebTr(const bool& open)
+void mmWebAppDialog::ImportAllWebTr(const bool open)
 {
     for (int i = 0; i < webtranListBox_->GetItemCount(); i++)
     {

--- a/src/webappdialog.h
+++ b/src/webappdialog.h
@@ -75,7 +75,7 @@ private:
     void OnOk(wxCommandEvent& /*event*/);
 
     bool ImportWebTr(int WebTrID, bool open);
-    void ImportAllWebTr(const bool& open);
+    void ImportAllWebTr(const bool open);
 
     void OnListItemActivated(wxDataViewEvent& event);
     void OnMenuSelected(wxCommandEvent& event);

--- a/src/wizard_update.cpp
+++ b/src/wizard_update.cpp
@@ -204,7 +204,7 @@ void mmUpdateWizardPage2::OnDownload()
 //--------------
 //mmUpdate Class
 //--------------
-const bool mmUpdate::IsUpdateAvailable(const bool& bSilent, wxString& NewVersion)
+const bool mmUpdate::IsUpdateAvailable(const bool bSilent, wxString& NewVersion)
 {
     bool isUpdateAvailable = false;
     NewVersion = "error";
@@ -314,7 +314,7 @@ const bool mmUpdate::IsUpdateAvailable(const bool& bSilent, wxString& NewVersion
     return isUpdateAvailable;
 }
 
-void mmUpdate::checkUpdates(const bool& bSilent, wxFrame *frame)
+void mmUpdate::checkUpdates(const bool bSilent, wxFrame *frame)
 {
     wxString NewVersion = wxEmptyString;
     if (IsUpdateAvailable(bSilent, NewVersion) && NewVersion != "error")

--- a/src/wizard_update.h
+++ b/src/wizard_update.h
@@ -26,10 +26,10 @@
 class mmUpdate
 {
 public:
-    static void checkUpdates(const bool& bSilent, wxFrame *frame);
+    static void checkUpdates(const bool bSilent, wxFrame *frame);
 
 private:
-    static const bool IsUpdateAvailable(const bool& bSilent, wxString& NewVersion);
+    static const bool IsUpdateAvailable(const bool bSilent, wxString& NewVersion);
 };
 
 class mmUpdateWizard : public wxWizard


### PR DESCRIPTION
We get the best performance from passing primitive types by value. This is because:

- primitives are blitable, so the cost of the copy depends on the size
- primitives are small, only double and long long are bigger than a reference in most environments
- pass-by-value avoids aliasing, allowing the optimizer to really do its thing