### PR TITLE
fix(ColumnWidthSettings): saving settings in list destructor

### DIFF
--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -202,18 +202,6 @@ mmBillsDepositsPanel::~mmBillsDepositsPanel()
         delete m_imageList;
     if (transFilterDlg_)
         delete transFilterDlg_;
-    /*
-      Save the column widths of bill_deposit list control. This should ensure
-      that column's get set incase the OnItemResize does not work on some systems.
-    */
-    for (int bd_col_num = 0; bd_col_num < COL_MAX; ++bd_col_num)
-    {
-        int bd_col_width = listCtrlAccount_->GetColumnWidth(bd_col_num);
-        if (listCtrlAccount_->GetColumnWidthSetting(bd_col_num) != bd_col_width)
-        {
-            listCtrlAccount_->SetColumnWidthSetting(bd_col_num, bd_col_width);
-        }
-    }
 }
 
 void mmBillsDepositsPanel::CreateControls()

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -991,12 +991,6 @@ TransactionListCtrl::TransactionListCtrl(
 
 TransactionListCtrl::~TransactionListCtrl()
 {
-    for (int column_number = 0; column_number < COL_MAX; ++column_number)
-    {
-        int column_width = GetColumnWidth(column_number);
-        if (GetColumnWidthSetting(column_number) != column_width)
-            SetColumnWidthSetting(column_number, column_width);
-    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -47,7 +47,11 @@ mmListCtrl::~mmListCtrl()
       Save the column widths of the list control. This will ensure that the
       column widths get set incase the OnItemResize does not work on some systems.
     */
+#ifdef __WXMSW__ 
     for (int column_number = 0; column_number < m_colCount; ++column_number)
+#else
+    for (int column_number = 0; column_number < GetColumnCount(); ++column_number)
+#endif
     {
         int column_width = GetColumnWidth(column_number);
         if (GetColumnWidthSetting(column_number) != column_width)

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -43,6 +43,18 @@ mmListCtrl::~mmListCtrl()
 {
     if (attr1_) delete attr1_;
     if (attr2_) delete attr2_;
+    /*
+      Save the column widths of the list control. This will ensure that the
+      column widths get set incase the OnItemResize does not work on some systems.
+    */
+    for (int column_number = 0; column_number < m_colCount; ++column_number)
+    {
+        int column_width = GetColumnWidth(column_number);
+        if (GetColumnWidthSetting(column_number) != column_width)
+        {
+            SetColumnWidthSetting(column_number, column_width);
+        }
+    }
 }
 
 wxListItemAttr* mmListCtrl::OnGetItemAttr(long row) const


### PR DESCRIPTION
This is common to all panels