### PR TITLE
chore(Mac.Build): fixes to build commands for mac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -232,7 +232,7 @@ COND_PLATFORM_OS2_1___mmex___os2_emxbindcmd = $(NM) mmex$(EXEEXT) | if grep -q \
 @COND_PLATFORM_MACOSX_0@popath = $(datadir)/mmex/po/en
 @COND_PLATFORM_MACOSX_1@popath = $(datadir)/po/en
 @COND_PLATFORM_MACOSX_0@helppath = $(datadir)/doc/mmex/help
-@COND_PLATFORM_MACOSX_1@helppath = $(datadir)/help
+@COND_PLATFORM_MACOSX_1@helppath = $(datadir)/doc/mmex/help
 
 ### Targets: ###
 
@@ -258,7 +258,7 @@ install: install_mmex
 	$(INSTALL_DIR) $(DESTDIR)$(datadir)/doc/mmex
 	(cd $(srcdir)/doc ; $(INSTALL_DATA)  *.txt $(DESTDIR)$(datadir)/doc/mmex)
 	$(INSTALL_DIR) $(DESTDIR)$(helppath)
-	(cd $(srcdir)/doc/help ; $(INSTALL_DATA)  *.html *.png $(DESTDIR)$(helppath))
+	(cd $(srcdir)/doc/help ; $(INSTALL_DATA)  *.html *.png *.gif $(DESTDIR)$(helppath))
 	$(INSTALL_DIR) $(DESTDIR)$(helppath)/french
 	(cd $(srcdir)/doc/help/french ; $(INSTALL_DATA)  * $(DESTDIR)$(helppath)/french)
 	$(INSTALL_DIR) $(DESTDIR)$(helppath)/hungarian

--- a/build/bakefiles/mmex.bkl
+++ b/build/bakefiles/mmex.bkl
@@ -124,14 +124,13 @@
     </data-files>
 
     <set var="helppath">
-        <if cond="PLATFORM_MACOSX=='0'">$(DATADIR)/doc/mmex/help</if>
-        <if cond="PLATFORM_MACOSX=='1'">$(DATADIR)/help</if>
+        $(DATADIR)/doc/mmex/help
     </set>
     <!-- data-files-tree generates wrong commands in bakefile v.0.2.8 -->
     <data-files>
         <install-to>$(helppath)</install-to>
         <srcdir>$(SRCDIR)/doc/help</srcdir>
-            <files>*.html *.png</files>
+            <files>*.html *.png *.gif</files>
     </data-files>
 
     <data-files>


### PR DESCRIPTION
Put help files in the correct place for app bundle. Bakefile not tested, changes to Makefile.in work as expected.