### PR TITLE
fix(aboutdialog): Show privacy tab at startup

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -310,7 +310,7 @@ mmGUIFrame::mmGUIFrame(mmGUIApp* app, const wxString& title
     // Show license agreement at first open
     if (Model_Setting::instance().GetStringSetting(INIDB_SEND_USAGE_STATS, "") == "")
     {
-        mmAboutDialog(this, 4).ShowModal();
+        mmAboutDialog(this, 5).ShowModal();
         Model_Setting::instance().Set(INIDB_SEND_USAGE_STATS, "TRUE");
     }
 


### PR DESCRIPTION
@loki36 please check where a function\code is used befor change it (#454).

Here we need to show privacy at startup to inform users that we will collect usage statistics.

Thanks