### PR TITLE
fix(cashflow): remove extra numRepeats decrement, fixes issue #459

### DIFF
--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -178,7 +178,6 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
 
             nextOccurDate = Model_Billsdeposits::nextOccurDate(repeatsType, numRepeats, nextOccurDate);
 
-            if (processNumRepeats) numRepeats--;
             if (repeatsType == Model_Billsdeposits::REPEAT_IN_X_DAYS) // repeat in numRepeats Days (Once only)
             {
                 if (numRepeats > 0)


### PR DESCRIPTION
It looks like there were extra numRepeats decrementation and caused a bug with double counting repetitions.