### PR TITLE
refactor(help.bakefile): Allow help files to access css

### DIFF
--- a/build/bakefiles/mmex.bkl
+++ b/build/bakefiles/mmex.bkl
@@ -121,6 +121,11 @@
         <!-- data-files-tree generates wrong commands in bakefile v.0.2.8 -->
         <data-files>
             <install-to>$(helppath)</install-to>
+            <srcdir>$(SRCDIR)/resources</srcdir>
+            <files>master.css</files>
+        </data-files>
+        <data-files>
+            <install-to>$(helppath)</install-to>
             <srcdir>$(SRCDIR)/doc/help</srcdir>
                 <files>*.*</files>
         </data-files>


### PR DESCRIPTION
Help files currently can't access master.css. This provides a copy of it in the same location as the help files so they can access it