### PR TITLE
Help clean

### DIFF
--- a/doc/help/budget.html
+++ b/doc/help/budget.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF8">
+    <meta charset="UTF-8">
 
     <title>Budget</title>
     <link href="master.css" rel="stylesheet" type="text/css">
@@ -19,14 +19,13 @@
 
 <body dir="ltr" lang="en-US">
     <a id="top"></a>
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <table>
         <tbody>
-            <tr valign="top">
-                <td width="75%">
+            <tr style="vertical-align: top">
+                <td>
                     <h1>Budgeting</h1>
                 </td>
-
-                <td width="25%">
+                <td>
                     <a href="./index.html" style=
                     "font-weight: bold">Home</a>
                 </td>
@@ -55,15 +54,14 @@
     Setup.</p>
     <p>Each category can then be edited by double clicking the selected
     category.</p>
-    <img alt="Bugget Entry Detail" src="./budget_entry_details.png" style=
-    "width: 266px; height: 330px;"><br>
+    <img alt="Bugget Entry Detail" src="./budget_entry_details.png"><br>
     <p>This is done for all subsequent categories.</p>
     <a href="#top">Back to Top</a>
     <hr>
     <h2>Budget Setup</h2>
     <p>This becomes the budget for that year. Subsequent months and/or years can
     then be derived from that year.</p>
-    <img alt="Budget Setup Grid" src="./budget_grid.png" style="width: 638px; height: 250px;">
+    <img alt="Budget Setup Grid" src="./budget_grid.png">
     <p>Category Summary Totals are displayed for each main category.</p>
     <p>When setting up a budget, the Budget Summary Totals can be turned off by
     activating the Menu Item:</p>

--- a/doc/help/budget.html
+++ b/doc/help/budget.html
@@ -1,77 +1,76 @@
-<!-- saved from url=(0022)http://internet.e-mail -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-<html><head>
-  
-  <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
-  <title>Budget</title>
-  
-</head><body dir="ltr" lang="en-US">
-<p><a name="budget_top"></a>
-<br>
-</p>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF8">
 
-<table border="0" cellpadding="0" cellspacing="0" width="100%">
-  <col width="192*"> <col width="64*"> <tbody>
-    <tr valign="top">
-      <td width="75%">
-      <h1><font face="Verdana"><font size="6">Budgeting</font></font></h1>
-      </td>
-      <td width="25%">
-      <p><a href="./index.html"><font face="Verdana"><font size="4"><b>Home</b></font></font></a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<hr>
-<b>MMEX</b> allows for the setting up of a budget for a Year and/or Month.<br>
-This would allow you to compare how you did versus your budget.<br>
-<br>
-Budgets can be displayed in Calendar Years or Financial Years.<br>
-<br>
-Use the Options Dialog to set the start of the Financial Year, and any permanent settings as required.<br>
-The <b>View->Budgets: As Financial Years</b> can also be used to switch between the 2 views<br>
-<hr>
-<b>Creating New Budgets:</b><br>
-<br>To set up a budget right click on the 'Budgeting' tree node and add a budget month or year.<br>
-<br>
-<img alt="Budget Editor" src="./budget_editor.png"><br><br>
-<hr>
-<b>Editing of Budget Categories:</b><br>
-<br>
-Once a year has been added, select the year to display the Budget Setup.<br>
-Each category can then be edited by double clicking the selected category.<br>
-<br>
-<img style="width: 266px; height: 330px;" alt="Bugget Entry Detail" src="./budget_entry_details.png"><br>
-<br>
-This is done for all subsequent categories.<br>
-<br>
-<hr>
-<b>Budget Setup:</b><br>
-<br>
-This becomes the budget for that year. Subsequent months and/or years can then be derived from that year.<br>
-<br>
-<img style="width: 638px; height: 250px;" alt="Budget Setup Grid" src="./budget_grid.png"><br>
-<br>
-Category Summary Totals are displayed for each main category. <br>
-When setting up a budget, the Budget Summary Totals can be turned off by activating the Menu Item:<br>
-<b>View->Budget Setup: Without Summaries</b><br>
-<br>
-<br>
-Using the reports under 'Budgeting', it is now possible to compare how you spent the money versus your actual budget.<br>
-<br>
-<br>
-<hr>
-<table border="0" cellpadding="4" cellspacing="0" width="100%">
-  <col width="199*"> <col width="57*"> <tbody>
-    <tr valign="top">
-      <td width="78%">
-      <p><a href="#budget_top"><font size="3">Back to Top</font></a></p>
-      </td>
-      <td width="22%">
-      <p><a href="./index.html"><font size="3">Home</font></a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <title>Budget</title>
+    <link href="master.css" rel="stylesheet" type="text/css">
+    <style>
+    dt {
+            font-weight: bold;   
+        }
+    @media print {
+            hr .pagebreak {
+                page-break-after: always;
+            }
+        }
+    </style>
+</head>
 
-</body></html>
+<body dir="ltr" lang="en-US">
+    <a id="top"></a>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tbody>
+            <tr valign="top">
+                <td width="75%">
+                    <h1>Budgeting</h1>
+                </td>
+
+                <td width="25%">
+                    <a href="./index.html" style=
+                    "font-weight: bold">Home</a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <hr>
+    <p><strong>MMEX</strong> allows for the setting up of a budget for a Year and/or
+    Month.</p>
+    <p>This would allow you to compare how you did versus your budget.</p>
+    <p>Budgets can be displayed in Calendar Years or Financial Years.</p>
+    <p>Use the Options Dialog to set the start of the Financial Year, and any
+    permanent settings as required.</p>
+    <p>The <strong>View&rarr;Budgets: As Financial Years</strong> can also be used to switch
+    between the 2 views</p>
+    <a href="#top">Back to Top</a>
+    <hr>
+    <h2>Creating New Budgets</h2>
+    <p>To set up a budget right click on the 'Budgeting' tree node and add a
+    budget month or year.</p>
+    <img alt="Budget Editor" src="./budget_editor.png"><br>
+    <a href="#top">Back to Top</a>
+    <hr>
+    <h2>Editing of Budget Categories:</h2>
+    <p>Once a year has been added, select the year to display the Budget
+    Setup.</p>
+    <p>Each category can then be edited by double clicking the selected
+    category.</p>
+    <img alt="Bugget Entry Detail" src="./budget_entry_details.png" style=
+    "width: 266px; height: 330px;"><br>
+    <p>This is done for all subsequent categories.</p>
+    <a href="#top">Back to Top</a>
+    <hr>
+    <h2>Budget Setup</h2>
+    <p>This becomes the budget for that year. Subsequent months and/or years can
+    then be derived from that year.</p>
+    <img alt="Budget Setup Grid" src="./budget_grid.png" style="width: 638px; height: 250px;">
+    <p>Category Summary Totals are displayed for each main category.</p>
+    <p>When setting up a budget, the Budget Summary Totals can be turned off by
+    activating the Menu Item:</p>
+    <p><b>View&rarr;Budget Setup: Without Summaries</b></p>
+    <p>Using the reports under 'Budgeting', it is now possible to compare how you
+    spent the money versus your actual budget.</p>
+    <a href="#top">Back to Top</a>
+    <hr>
+</body>
+</html>

--- a/doc/help/french/index.html
+++ b/doc/help/french/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE HTML>
 <html lang="fr"><head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+	<link href="../master.css" rel="stylesheet" type="text/css">
 
 <meta name="ProgId" content="FrontPage.Editor.Document"><title>Manuel utilisateur de Money Manager Ex</title></head><body>
 <font face="Verdana">

--- a/doc/help/french/investment.html
+++ b/doc/help/french/investment.html
@@ -1,14 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
 
 
-	<meta http-equiv="CONTENT-TYPE" content="text/html; charset=windows-1252"><title>Setting up an Investment Account</title>
+	<meta charset="UTF-8"><title>Setting up an Investment Account</title>
 	
 	<meta name="GENERATOR" content="OpenOffice.org 3.3  (Win32)">
 	<meta name="CREATED" content="0;0">
 	<meta name="CHANGEDBY" content="Stefano Giorgio">
 	<meta name="CHANGED" content="20110713;11361085">
-	<meta name="CHANGEDBY" content="Stefano Giorgio"></head><body dir="ltr" lang="en-US">
+	<meta name="CHANGEDBY" content="Stefano Giorgio"></head>
+		<link href="../master.css" rel="stylesheet" type="text/css"><body dir="ltr" lang="en-US">
 <p><a name="stock_top"></a><br><br>
 </p>
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -96,7 +97,7 @@ information.</font></p>
 				</li><li><p>The Stock Exchange suffix using Yahoo is '.BE'</p>
 				</li><li><p>The Stock Exchange suffix using Google is ':BER'</p>
 				</li><li><p>The Stock Exchange provider can be changed using the menu
-				item: <b>Tools –&gt;Options –&gt; Others</b> 
+				item: <b>Tools ï¿½&gt;Options ï¿½&gt; Others</b> 
 				</p>
 			</li></ul>
 		</td>
@@ -136,7 +137,7 @@ the Australian Stock Exchange</span></font></p>
 	Exchange suffix is: ':ASX'</span></font></p>
 </li></ul>
 <p>The Stock Exchange provider can be changed using the menu item:
-<b>Tools –&gt;Options –&gt; Others</b> 
+<b>Tools ï¿½&gt;Options ï¿½&gt; Others</b> 
 </p>
 <p><br><br>
 </p>

--- a/doc/help/general_report_manager.html
+++ b/doc/help/general_report_manager.html
@@ -1,14 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-    <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF8"/>
+    <META charset="UTF8">
     <TITLE>Money Manager Ex User Manual</TITLE>
-    <link rel="stylesheet" type="text/css" href="../res/master.css"/>
-      <style>
-        table {
-        font-size: 100%;
-        }
-      </style>
+    <link rel="stylesheet" type="text/css" href="master.css"/>
 </HEAD>
 <BODY LANG="en-US" DIR="LTR">
 

--- a/doc/help/general_report_manager.html
+++ b/doc/help/general_report_manager.html
@@ -1,44 +1,40 @@
 <!DOCTYPE HTML>
 <HTML>
-<HEAD>
-    <META charset="UTF8">
-    <TITLE>Money Manager Ex User Manual</TITLE>
-    <link rel="stylesheet" type="text/css" href="master.css"/>
-</HEAD>
-<BODY LANG="en-US" DIR="LTR">
+	<HEAD>
+		<META charset="UTF-8">
+		<TITLE>Money Manager Ex User Manual</TITLE>
+		<link rel="stylesheet" type="text/css" href="master.css" />
+	</HEAD>
+	<BODY LANG="en-US" DIR="LTR">
+		<h1>Creating a new report</h1>There are 2 options available:
+		<OL>
+			<li>Create the report from scratch;</li>
+			<li>Import the report;</li>
+		</OL>
+		<h2>Creating the report from scratch</h2>
+		<P>
+			<IMG SRC="GRM.gif" id="grm" alt="General Report Manager">
+		</P>
+		<ul>
+			<li>Using the navigation tree, mouse Right-Click on
+				<strong>Reports</strong> label.</li>
+			<li>Choose the menu item:
+				<strong>'New Empty Report'</strong>.</li>
+			<li>Enter the name for the new report group.</li>
+			<li>Three tabs will be displayed: 'SQL', 'Lua' and 'htt'.</li>
+			<li>Rename reports, as required, by right-click on menu item:
+				<strong>'Rename Report'</strong>.</li>
+			<li>Choose the tab:
+				<strong>SQL</strong>, insert the SQL script into the editor window, check that the SQL script finishes with semicolon.</li>
+			<li>Press the
+				<strong>Test</strong> button to execute the SQL script.</li>
+			<li>If the test is passed the
+				<strong>Create Template</strong> button will become available. Press it to generate html template for the report.</li>
+			<li>Press
+				<strong>Run</strong> to get the html report in the
+				<strong>Output</strong> window.</li>
+		</ul>
+		<h2>Import report</h2>
+		<h2>Export</h2>===========</BODY>
 
-<h3>Creating a new report</h3>
-
-There are 2 options available:
-<OL>
-  <li> Create the report from scratch;</li>
-  <li> Import the report;</li>
-</OL>
-
-<h4>Creating the report from scratch</h4>
-
-  <P>
-    <IMG SRC="GRM.gif" NAME="grm"/>
-  </P>
-  
-<li> Using the navigation tree, mouse Right-Click on <b>Reports</b> label.</li>
-<li> Choose the menu item: <b>'New Empty Report'</b>.</li>
-<li> Enter the name for the new report group.</li>
-<li> Three tabs will be displayed: 'SQL', 'Lua' and 'htt'.</li>
-<li> Rename reports, as required, by right-click on menu item: <b>'Rename Report'</b>.</li>
-<li> Choose the tab: <b>SQL</b>,  insert the SQL script into the editor window, check that the SQL script finishes with semicolon.</li>
-<li> Press the <b>Test</b> button to execute the SQL script.</li>
-<li> If the test is passed the <b>Create Template</b> button will become available. Press it to generate html template for the report.</li>
-<li> Press <b>Run</b> to get the html report in the <b>Output</b> window.</li>
-
-<h4>Import report</h4>
-
-
-
-<h3>Export</h3>
-===========
-
-
-
-</BODY>
 </HTML>

--- a/doc/help/hungarian/budget.html
+++ b/doc/help/hungarian/budget.html
@@ -1,13 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-	<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
+	<META charset="utf-8">
 	<TITLE>MMEX Budget</TITLE>
 	<META NAME="GENERATOR" CONTENT="LibreOffice 3.5  (Linux)">
 	<META NAME="CREATED" CONTENT="0;0">
 	<META NAME="CHANGEDBY" CONTENT="Török Árpád">
 	<META NAME="CHANGED" CONTENT="20120519;15504500">
-	<!-- saved from url=(0022)http://internet.e-mail -->
+	<link href="../master.css" rel="stylesheet" type="text/css">
 </HEAD>
 <BODY LANG="en-US" DIR="LTR">
 <P><A NAME="budget_top"></A><BR><BR>

--- a/doc/help/hungarian/index.html
+++ b/doc/help/hungarian/index.html
@@ -1,13 +1,14 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+﻿<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-	<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+	<meta charset="UTF-8" >
 	<TITLE>Money Manager Ex User Manual</TITLE>
 	<meta name="generator" content="Bluefish 2.2.2" >
 	<META NAME="CREATED" CONTENT="0;0">
 	<META NAME="CHANGEDBY" CONTENT="Stefano Giorgio">
 	<META NAME="CHANGED" CONTENT="20120304;17344045">
 	<META NAME="CHANGEDBY" CONTENT="Stefano Giorgio">
+	<link href="../master.css" rel="stylesheet" type="text/css">
 	<STYLE TYPE="text/css">
 	<!--
 		H2.cjk { font-family: "SimSun" }

--- a/doc/help/hungarian/investment.html
+++ b/doc/help/hungarian/investment.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-	<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
+	<META charset="utf-8">
 	<TITLE>Setting up an Investment Account</TITLE>
 	<META NAME="GENERATOR" CONTENT="LibreOffice 3.5  (Linux)">
 	<META NAME="CREATED" CONTENT="0;0">
@@ -9,6 +9,7 @@
 	<META NAME="CHANGED" CONTENT="20120519;18312600">
 	<META NAME="CHANGEDBY" CONTENT="Stefano Giorgio">
 	<META NAME="CHANGEDBY" CONTENT="Stefano Giorgio">
+	<link href="../master.css" rel="stylesheet" type="text/css">
 </HEAD>
 <BODY LANG="en-US" DIR="LTR">
 <P><A NAME="stock_top"></A><BR><BR>

--- a/doc/help/index.html
+++ b/doc/help/index.html
@@ -1,2120 +1,1954 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-<HTML>
-<HEAD>
-    <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF8"/>
-    <TITLE>Money Manager Ex User Manual</TITLE>
-    <link rel="stylesheet" type="text/css" href="../res/master.css">
-      <style>
-        table {
-        font-size: 100%;
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF8">
+
+    <title>Money Manager Ex User Manual</title>
+    <link href="master.css" rel="stylesheet" type="text/css">
+    <style>
+    dt {
+            font-weight: bold;   
         }
-      </style>
-</HEAD>
-<BODY LANG="en-US" DIR="LTR">
-<table class="table, small"><tr>
-    <TD><span class="label label-info">Languages:</span></TD>
-    <TD> </TD><TD><A HREF="french/index.html">French</A><BR>
-    <TD> </TD><TD><A HREF="italian/index.html">Italian</A></TD>
-    <TD> </TD><TD><A HREF="russian/index.html">Russian</A></TD>
-    <TD> </TD><TD><A HREF="spanish/index.html">Spanish</A></TD>
-    <TD> </TD><TD><A HREF="polish/index.html">Polish</A></TD>
-</tr></table>
-<div class="page-header">
-    <H2>Money Manager Ex User Manual <small>MMEX 1.2.0</small></H2>
-</div>
-  <UL>
-    <LI>
-      <A HREF="#introduction">Introduction</A>
-    </LI>
-    <LI>
-      <A HREF="#financial_health">Working towards better Financial Health</A>
-    </LI>
-    <LI>
-      <A HREF="#concepts">Money Manager Ex Concepts</A>
-    </LI>
-    <LI>
-      <A HREF="#recommendation">Recommendations</A>
-    </LI>
-  </UL>
-  <UL>
-    <LI>Database Management</LI>
-      <UL>
-        <li>
-          <A HREF="#create_database">Creating a New Database</A>
-        </li>
-        <li>
-          <A HREF="#encrypting_database">Encrypting a Database</A>
-        </li>
-        <li>
-          <A HREF="#switching_databases">Switching Databases</A>
-        </li>
-      </UL>
-    </UL>
-  <UL>
-    <LI>Working with:</LI>
-    <UL>
-      <li>
-        <A HREF="#currencies">Currencies</A>
-      </li>
-      <li>
-        <A HREF="#categories">Categories</A>
-      </li>
-      <li>
-        <A HREF="#payees">Payees</A>
-      </li>
-    </UL>
-  </UL>
-  <UL>
-    <LI>Account Management</LI>
-    <UL>
-      <LI>
-        <A HREF="#create_account">Creating New Accounts</A>
-      </LI>
-      <LI>
-        <A HREF="#editaccounts">Editing Account Information</A>
-      </LI>
-      <LI>
-        <A HREF="#creating_new_transaction">
-          Creating
-          New Transactions
-        </A>
-      </LI>
-      <LI>
-        <A HREF="#edittrans">Editing and Updating Transactions</A>
-      </LI>
-      <LI>
-        <A HREF="#rectrans">
-          Reconciling Balancing Transactions
-        </A>
-      </LI>
-      <LI>
-        <A HREF="#followup">
-          Flagging Transactions for Followup
-        </A>
-      </LI>
-      <LI>
-        <P>
-          <A HREF="#account_setup">
-            Account Setup Example
-          </A>
-      </LI>
-    </UL>
-  </UL>
-  <UL>
-    <LI>Import From</LI>
-    <UL>
-	  <LI>
-		<A HREF="#WebApp">WebApp</A>
-      <LI>
-        <A HREF="#importQIF">QIF Files</A>
-        <LI>
-          <A HREF="#importUnivCSV">
-            Universal CSV Importer
-          </A>
-        </LI>
-        <LI>
-          <A HREF="#importcsvtips">
-            Tips for creating CSV Files
-          </A>
-        </LI>
-    </UL>
-    <LI>Export To</LI>
-    <UL>
-      <LI>
-        <A HREF="#exportcsv">CSV Files</A>
-      </LI>
-      <LI>
-        <A HREF="#export_qif">QIF Files</A>
-      </LI>
-    </UL>
-  </UL>
-  <UL>
-    <LI>
-      <A HREF="#reports">Reports</A>
-    </LI>
-    <UL>
-      <LI>
-        <A HREF="#financialYearReport">Financial Year Reports</A>
-      </LI>
-      <LI>
-        <A HREF="#transaction_report">Transaction Reports</A>
-      </LI>
-      <LI>
-        <A HREF="#cashFlowReport">Cash Flow Reports</A>
-      </LI>
-      <LI>
-        <A HREF="general_report_manager.html">General Report Manager</A>
-      </LI>
-    </UL>
-  </UL>
-  <UL>
-    <LI><A HREF="investment.html">Stock Investments</A></LI>
-    <LI><A HREF="#assets">Assets</A></LI>
-    <LI>
-      <A HREF="#recurring_transactions">
-        Recurring Transactions</A>
-    </LI>
-    <LI>
-      <A HREF="#transfilter">Transaction Report Filter</A>
-    </LI>
-    <LI>
-      <A HREF="budget.html">Budgeting</A>
-      </li>
-      <LI>
-        <A HREF="#print">Printing</A>
-        </LI>
-    <LI>
-      <A HREF="#options">MMEX Options</A>
-    </LI>
-    <LI>
-      <A HREF="#faq">
-        Frequently Asked Questions
-      </A>
-    </LI>
-  </UL>
-  <HR>
-<H3><A NAME="introduction"></A>Introduction</H3>
-<P><B>Money Manager Ex (MMEX) </B>
-is a personal money management system, for any one starting out in
-keeping track of their money, and their spending habits. Based on
-simple principles, thus allowing anyone with little, to no knowledge
-of finance and general book keeping, to successfully manage their
-money. <SPAN STYLE="font-weight: normal">MMEX does this by attempting
-to models the real financial world, to help us (the user) maintain
-our personal finances.</SPAN> The Money Manager EX Software, is Open
-Source, and free to use.</P>
-<P>The primary goal of MMEX is to
-simplify the process of tracking financial information, in an easy to
-use program that can be used as regular as necessary, to help us keep
-track of where our money comes from and more importantly, where our
-money goes, in order to make better financial decisions for our
-future.</P>
-<P>Think of Money Manager Ex as a
-computer checkbook which enables you to balance your accounts,
-organize, manage and generate reports for your finances.</P>
-<P>It is also a great way to keep abreast of
-your financial worth.</P>
-<P>The purpose of this manual is to give you
-(the user) some basic instructions for using MMEX. This instruction
-manual will evolve as the program evolves. So check the help system
-with each update and see what's new and how to better utilize MMEX.</P>
-<H5><A HREF="#top">Back to Top</A><BR><BR><BR></H5>
-<HR>
-<H3><A NAME="financial_health"></A>
-<BR>Working towards better Financial Health</H3>
-<P>Becoming organized financially requires some
-amount of discipline. Financial management can become complicated
-when there is no clear understanding of how much money we are
-getting, regarded as income as opposed to our expenses which is how
-much money we spend. Debt usually results when our cash flow is
-restricted because our expenses exceed our income. Then we need to
-borrow money to maintain our cash flow to enable us to purchase our
-necessary items.</P>
-<P>The first step towards better Financial
-Health, is to maintain good financial records. It is only when we
-have a clear understanding of where our money goes, that we can make
-an informed decision of where to cut back on our expenses when our
-cash flow becomes tight. If we do need to borrow money, we can then
-better manage our debts as well.</P>
-<P>Did you realize you spent $600 in buying DVD
-movies last year? How many times did you watch them? Do you think now
-that the $600 would have been better spent on the unexpected
-maintenance on the auto that came up yesterday? Of course there is no
-right or wrong answer to how you should spend your money. After all,
-it is you who earned that money and the right to spend it whichever
-way you see fit. But you can always make your money work harder for
-you.<BR><BR>Here's where personal finance software comes in. They
-help you slice/dice the financial data to give you better insight
-into what is going on. Always remember the software can only be as
-good as the data it has to process. Garbage In Garbage Out. But if
-you have started thinking of even using Personal finance software,
-you are well on your way to making every dollar count.</P>
-<P>Read on how to work with Money Manager Ex.</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="concepts"></A><BR>Money
-Manager Ex Concepts</H3>
-<P>Money Manager EX models the real world to
-help us maintain our personal finances.</P>
-<P>Generally we receive money from someone for a
-service we provide, or a product that we sell. This is regarded as
-Income or as a <A HREF="#trans_types"><B>Deposit</B></A>
-to our system. When we purchase an item or use a
-service, the money that we spend is regarded as an expense or
-<A HREF="#trans_types"><B>Withdrawal</B></A>
-to our system. In MMEX, the people that give us
-money or receive our money are regarded as the <A HREF="#payees"><B>Payees</B></A>
-of the system.</P>
-<P>As we hopefully do not spend all the money we
-receive, we would obviously need a place to keep our money. This is
-generally, some financial institution, or several institutions or in
-our pocket. MMEX tags these places as
-<A HREF="#create_account"><B>Accounts</B></A>.
-</P>
-<P>When we spend or receive money, we see this
-as a <A HREF="#creating_new_transaction"><I><B>transaction</B></I></A><I><SPAN STYLE="font-weight: normal">,
-and the reason for our income or expense is our </SPAN></I><A HREF="#categories"><I><B>category</B></I></A><I><SPAN STYLE="font-weight: normal">.
-There will be times where we need to transfer money from one place to
-another, such as a withdrawal from an ATM, and this type of
-transaction is known as a </SPAN></I><A HREF="#trans_types"><I><B>transfer</B></I></A><I><SPAN STYLE="font-weight: normal">.</SPAN></I></P>
-<TABLE class="table, small">
-	<TR>
-		<TD>
-			<I>This can be simplified as shown in the following diagram:</I></P>
-		</TD>
-		<TD>
-			<P><IMG SRC="mmex_concept.png" NAME="graphics1"></P>
-		</TD>
-	</TR>
-</TABLE>
-<P>One other important thing to consider is the
-<A HREF="#currencies"><B>currency</B></A>
-we use to perform the transactions.</P>
-<P>With all of these things to keep track of,
-MMEX uses a <A HREF="#create_database"><B>database</B></A>
-to store and connect all these entities
-together.</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="recommendation"></A><BR>Recommendations</H3>
-<P>The database that MMEX generates, known as
-the <B>.mmb</B> file, becomes an important file for you to maintain.
-Depending on circumstances, security features such as encryption can
-be employed, which is recognized as a <B>.emb</B> file. This is where
-we can attach a password to the database, and will require a password
-every time MMEX is opened.</P>
-<P><B>When encrypting your database, Don't
-forget your password</B>.</P>
-<P>As with any computer system, the data we
-produce is important to us, and therefore need to safeguard against
-system malfunction. MMEX has a backup system where it can produce a
-dated copy when the database is opened, and/or produce a dated copy
-of the database when changes have been detected. Up to 4 backups are
-maintained for each database when the system is initialized and/or
-when system changes have been detected, and the system shuts down.</P>
-<UL>
-	<LI><P>Always backup your .mmb or .emb database
-	file regularly.</P>
-	<LI><P>Always keep backup copies on other
-	devices to protect against hardware failure.</P>
-	<LI><P>When upgrading to a new version of MMEX,
-	make sure you backup your .mmb or .emb database file before doing
-	so.</P>
-	<LI><P>Use the Menu Tools--&gt;Options... to
-	set up the level of backup required.</P>
-</UL>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="create_database"></A><BR>Creating
-a New Database</H3>
-<P>When MMEX initially starts up, it will
-attempt to load the last database that was opened. If no database
-existed, the user is presented with the option to either open an
-existing database, or create a new one.</P>
-<P>If you need to create a new database file,
-from the Menu, Select <B>File-&gt;New Database</B>.</P>
-<P>This will prompt you to specify a new name
-for your .mmb database file, at the location you specify. Your new
-database file is now created and the New Database Wizard will be
-displayed to help you initialize the new database and assist in
-<A HREF="#create_account">creating your first account</A>.</P>
-<P>The New Database Wizard will request you to
-set the Base <B>Currency</B> and
-a <B>User Name</B>.</P>
-<P>MMEX comes with a default set of currencies
-which you can use, to correspond to your countries currency settings.
-New accounts will then use this <B>Base
-Currency</B> setting as the default. This
-allows accounts from different countries to reflect the value in the
-base currency.</P>
-<P>To help identify the purpose of the database,
-a <B>User Name</B> is
-requested. This is optional, as it is only used as a title on the
-Home Page, and in reports.</P>
-<P>Both these settings can later be changed if
-required by selecting the menu: <B>Tools
--&gt;Options</B> 
-</P>
-<P>The database name will be displayed on the
-title bar which helps remind you which database file is open.<BR><B>The
-new .mmb database file is not encrypted.</B></P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="encrypting_database">
-</A><BR>Encrypting your database file.</H3>
-<P STYLE="font-weight: normal">The database can
-now be encrypted as follows: on the Menu, Select <B>File-&gt;Save
-Database As</B></P>
-<OL>
-	<LI><P STYLE="font-weight: normal">Select your
-	location, and select your .mmb file or create a new name for your
-	database.</P>
-	<LI><P STYLE="font-weight: normal">Change the
-	<B>Save As Type:</B> to Encrypted MMB Files (*.emb), then <B>Save</B></P>
-	<LI><P STYLE="font-weight: normal">Enter a
-	password for your file &ndash; <B>You will need the password when
-	opening the database file.</B></P>
-</OL>
-  <div class="col-xs-8">  
-  <span class="label label-info">Tips:</span>
-  <table class="table">
-    <tr class="success">
-      <td>
-        Remember to make backups of your .mmb or	.emb database files.
-      </td>
-    </TR>
-    <TR class="success">
-      <td>
-        Database file is not encrypted:</SPAN><BR>
-        That means anyone else having the proper know how, can actually open the file and read the contents.
-	    So make sure that if you are storing any sensitive financial information, it is properly guarded.
-      </td>
-    </tr>
-    <tr class="success">
-      <td>
-        For encrypted database files: <B>Remember your password</B>.
-      </td>
-      </TR>
+    @media print {
+            hr .pagebreak {
+                page-break-after: always;
+            }
+        }
+    </style>
+</head>
+
+<body dir="ltr" lang="en-US">
+    <table class="table, small">
+        <tr>
+            <td class="label label-info">Languages:</td>
+
+            <td>
+                <a href="french/index.html">French</a>
+            </td>
+
+            <td>
+                <a href="italian/index.html">Italian</a>
+            </td>
+
+            <td>
+                <a href="russian/index.html">Russian</a>
+            </td>
+
+            <td>
+                <a href="spanish/index.html">Spanish</a>
+            </td>
+
+            <td>
+                <a href="polish/index.html">Polish</a>
+            </td>
+        </tr>
     </table>
-  </div>
-<P><BR><BR><BR><BR><BR><BR><BR><BR><BR><BR></P>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="switching_databases"></A><BR>Switching
-Databases</H3>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<P STYLE="font-weight: normal">For users having
-multiple databases, the user can easily switch between the databases
-by using the Menu item: <B>File-&gt;Recent Files...</B></P>
-<P STYLE="font-weight: normal">This will save
-the last five recently used files. The list will show 6 entries as
-the first entry on the list is the file currently being used.</P>
-<P><B>Clearing the list.</B></P>
-<P STYLE="font-weight: normal">When the list is
-cleared, all the items in the list are cleared. When MMEX shuts down,
-the currently opened database will be saved as the last opened file.
-This will appear in the recent file list as the first entry when MMEX
-is restarted.</P>
-<P><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="create_account"></A><BR>Creating
-New Accounts</H3>
-<P>When creating a new database file, you will
-automatically be requested to create a new account.</P>
-<P><SPAN STYLE="font-weight: normal">To manually
-create a new account, from the Menu, Select </SPAN><B>Accounts-&gt;New
-Account</B><SPAN STYLE="font-weight: normal">.</SPAN></P>
-<P><SPAN STYLE="font-weight: normal">This will
-bring up the </SPAN><B>Add Account
-Wizard</B><SPAN STYLE="font-weight: normal">.
-The wizard will assist in collecting the important information of the
-Name and Type of Account. </SPAN><B>The
-Type of Account is not changeable</B><SPAN STYLE="font-weight: normal">,
-but the name can changed when <A HREF="#editaccounts">editing account
-information</A>.</SPAN></P>
-<P STYLE="margin-bottom: 0in"><B>Name of the
-Account:</B> This is a required field.
-The recommendation is to name your accounts uniquely and in relation
-to real world accounts. Example: With CitiBank, we have a Savings
-account and a credit card Visa account. You could name your accounts
-as &quot;CitiBank Savings&quot; and &ldquo;Citibank Visa&rdquo;.</P>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<P><B>Type of Account: </B>MMEX currently
-supports three types of accounts:</P>
-<OL>
-	<LI><P>&ldquo;<I><B>Checking&rdquo;</B></I>
-	<B>Account:</B> <SPAN STYLE="font-weight: normal">This
-	is the most common type of account used for MMEX, and can handle
-	most common account types, such as checking accounts, savings
-	accounts, and credit card accounts.</SPAN> Also
-	known as Bank Account, and supports three kinds of transactions.
-	These are withdrawal, deposit and transfers. 
-	</P>
-	<LI><P>&ldquo;<B>Term&rdquo; Accounts:</B>
-	similar to Checking Accounts with the exception
-	that they appear in their own section on the home page and can be
-	shown or hidden for normal day usage. For a better explanation see
-	the <A HREF="#account_setup">account setup example</A>.<BR><BR>These
-	kinds of accounts cover specialized accounts such as Cash Term
-	Accounts, Bank Mortgage accounts, Loan accounts, or investment
-	accounts with regular income or expenditure that you need to keep
-	track of. These accounts have their own balance section on the Home
-	Page. These accounts also, supports three kinds of transactions.</P>
-	<LI><P><B>&quot;</B><I><B>Investment</B></I><B>&quot;
-	Account:</B> The other type of account
-	that MMEX supports is an &quot;Investment&quot; Account. This type
-	of account allows you to track stock/bonds/mutual funds investments
-	and possibly other investments you may own.</P>
-</OL>
-<P>To properly setup accounts, you should have
-balance information for the accounts you want to add to MMEX. You can
-get this information from your most recent bank, investment and
-credit card statements. To track additional information about this
-account, optionally you can enter your account details such as
-Account Number, Held At, Website, Contact info and Access Info. You
-can enter additional notes about the account in the notes field.</P>
-<P>Most accounts have some kind of balance in
-them, for example say in a credit card account, you have a current
-balance of $2304.67, you could put that value in the initial balance
-field. Going forward you only need to add transactions beyond that
-date when you had the balance.</P>
-<P><B>The Account</B> <B>Status</B>
-can be set to &quot;Open&quot; or &quot;Closed&quot;.
-Closed accounts are just that. They are no longer active. Setting
-this status is just a way to de-clutter your view in your tree view
-navigation pane. Permanent settings are made by changing the View
-Options on the Menu, Tools-&gt;Options, you can hide the closed
-accounts. See <A HREF="#navTreeTips">Tips on Navigation
-Tree</A><BR><BR><B>Currency:</B>
-<SPAN STYLE="font-weight: normal">This is
-initially set to the database Base Currency setting which was
-initially set when creating the database. Y</SPAN>ou
-can set the currency that is associated with this account and can be
-different to the base currency. 
-</P>
-<P>The exchange rate for the currency can be
-changed using the menu: <B>Tools
--&gt;Organize Currency</B></P>
-<P STYLE="font-weight: normal">Example: You live
-in the USA using US Dollars, and have an Italian bank account using
-the Euro. Most of your accounts are in USD. What is the real value of
-your Italian bank account? By changing the exchange rate for the
-Italian Euro, you can get the correct value of your accounts.</P>
-<P>You also can mark accounts as a <SPAN LANG="en-US">'Favorite</SPAN>
-Account'. This again is used to change the
-accounts that are visible in the navigation bar. See <A HREF="#navTreeTips">Tips
-on Navigation Tree</A></P>
-<div class="col-xs-8">  
-  <span class="label label-info">Tips:</span>
-  <table class="table">
-    <tr class="success">
-      <td>
-	     Use the toolbar icon for quick selection of the Add Account Wizard.
-      </td>
-    </TR>
-  </table>
-</div>
-<P><BR><BR><BR></P>
+    <div class="page-header">
+        <a id="top"></a>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="account_setup"></A><B><BR>Account
-Setup Example:</B></H3>
-<P>We have a savings account with $1250, a check
-account with $500, a MasterCard owing $250, a Visa Card owing $475, a
-home mortgage loan of $230,965 and an education fund to send the
-children to college in the future currently at $5000 earning
-interest.<BR>We would set up the following accounts:</P>
-<TABLE WIDTH="615" BORDER="1" BORDERCOLOR="#000000" CELLPADDING="4" CELLSPACING="0" RULES="GROUPS">
-	<COL WIDTH="178">
-	<COL WIDTH="224">
-	<COL WIDTH="187">
-	<TBODY>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P><B>Account Type</B></P>
-			</TD>
-			<TD WIDTH="224">
-				<P><B>Account Name</B></P>
-			</TD>
-			<TD WIDTH="187">
-				<P><B>Initial Balance</B></P>
-			</TD>
-		</TR>
-	</TBODY>
-	<TBODY>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P>Check/Savings</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>Savings</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="1250" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P>$1,250.00</P>
-			</TD>
-		</TR>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P><BR>
-				</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>Check</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="500" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P>$500.00</P>
-			</TD>
-		</TR>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P><BR>
-				</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>MasterCard</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="-250" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P><FONT COLOR="#ff0000">-$250.00</FONT>
-            </P>
-			</TD>
-		</TR>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P><BR>
-				</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>Visa Card</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="-475" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P>
-                  <FONT COLOR="#ff0000">-$475.00</FONT>
-                </P>
-			</TD>
-		</TR>
-	</TBODY>
-	<TBODY>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P>Term</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>Home Mortgage</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="-230965" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P><FONT COLOR="#ff0000">-$230,965.00</FONT></P>
-			</TD>
-		</TR>
-		<TR VALIGN="TOP">
-			<TD WIDTH="178">
-				<P><BR>
-				</P>
-			</TD>
-			<TD WIDTH="224">
-				<P>Education Fund</P>
-			</TD>
-			<TD WIDTH="187" SDVAL="5000" SDNUM="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00">
-				<P>$5,000.00</P>
-			</TD>
-		</TR>
-	</TBODY>
-</TABLE>
-<P><BR>On the Home Page the balances would be
-$1025 for Bank accounts, and $-225,965 for Term Accounts</P>
-<P>When a payment is made from your Savings
-Account to your MasterCard with a <A HREF="#transfer">Transfer</A>
-Transaction the balance on the home page remains the same. When a
-payment is made from your savings to your home mortgage, the balance
-on the home page will reflect the payment. Now you can determine the
-amount of money you have on a day to day basis. Regular payments can
-also be set up from your savings account to your mortgage account
-using <A HREF="#recurring_transactions">Recurring Transactions</A>.</P>
-<H3><A NAME="navTreeTips"></A><B><BR>Tip
-on</B> using the Navigation Tree and Home
-page:</H3>
-<P>As more accounts are created the Navigation
-Tree and Home page can become very large.<BR>This views can be
-temporarily changed to show or hide the appropriate section:</P>
-<TABLE WIDTH="100%" BORDER="1" BORDERCOLOR="#000000" CELLPADDING=4 CELLSPACING=0 RULES=ROWS>
-	<COL WIDTH="40*">
-	<COL WIDTH="216*">
-	<TR VALIGN="TOP">
-		<TD WIDTH="15%">
-			<P>Navigation Tree:</P>
-		</TD>
-		<TD WIDTH="85%">
-			<P>Expand/Contract the Bank and Term Account
-			branches using the +/- nodes on the navigation tree.</P>
-		</TD>
-	</TR>
-	<TR VALIGN="TOP">
-		<TD WIDTH="15%">
-			<P>Home Page:</P>
-		</TD>
-		<TD WIDTH="85%">
-			<P>Using the menu: View -&gt;Bank Accounts
-			and/or menu: View -&gt;Term Accounts</P>
-		</TD>
-	</TR>
-</TABLE>
-<P>Using a mouse Right-Click on:</P>
-<UL>
-	<LI><P>Bank Accounts in the Navigation tree,
-	will allow all accounts or only favorite accounts to be shown,
-	temporarily changing the permanent settings, as well as other useful
-	options.</P>
-</UL>
-<UL>
-	<LI><P>Any account name under Bank or Term
-	accounts, to bring up other useful options.</P>
-</UL>
-<P>To make the change permanent, change the
-options using the menu: Tools -&gt;Options --&gt;View Options</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="editaccounts"></A><BR>Editing
-Account Information</H3>
-<P>Once you have created an account, you can
-edit any of the account information fields in the following ways:</P>
-<OL>
-	<LI><P>Using menu <B>Accounts</B> &ndash;&gt;
-	<B>Edit Account</B><BR>The list of account will be displayed where
-	the required account is selected.</P>
-	<LI><P>Selecting the account name in the
-	navigation pane<BR>Right click to bring up the pop-up menu and
-	select &quot;<B>Edit Account</B>&quot;</P>
-</OL>
-<P>This will bring up the account information
-dialog where the required fields can be changed.</P>
-<UL>
-	<LI><P>Edit the account details</P>
-	<LI><P>Use the &quot;OK&quot; button to save
-	the account information.</P>
-</UL>
-<P><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="creating_new_transaction"></A><BR>Creating
-New Transactions</H3>
-<P>Once you have created a new account, and
-selected the required account from the navigation tree, or the home
-page, the displayed account can have new transactions added as
-follows:</P>
-<UL>
-	<LI><P>Using the New button at the bottom of
-	the Account View screen,</P>
-	<LI><P>By selecting an existing transaction and
-	using the mouse Right-Click, and select the appropriate action on
-	the pop-up menu screen.</P>
-</UL>
-<P><B>New/Edit Transaction Dialog</B></P>
-<P>This dialog box will appear for new
-transactions. Use this dialog to enter the following details:</P>
-<UL>
-	<LI><P><B>Date</B> - This is generally the date of the transaction.
-	Defaults to current day and can be changed.</P>
-	<LI><P><B>Status</B> - The default is None, but can be changed to
-	Reconciled by the options settings.</P>
-	<LI><P><B>Type</B> - Refer to Transaction Types below.</P>
-	<LI><P><B>Amount</B> &ndash; Enter the amount fro the transaction.
-	The 2<SUP>nd</SUP> amount field is associated with the Advanced
-	Check-box and will be activated only for Transfer transactions.</P>
-	<LI><P><B>Advanced</B> &ndash; For a transfer transaction, when the
-	amount in the &ldquo;From&rdquo; Account is different to the &rdquo;To&rdquo;
-	Account, the difference is recorded in the separate fields. This can
-	for currency rate changes.</P>
-</UL>
-<P><I><B>Transaction Status:</B></I></P>
-<UL>
-	<LI><P STYLE="margin-bottom: 0in; font-weight: normal"><I><B>Unreconciled</B></I><I>:
-	When you enter a transaction, it initially is in the state of
-	&quot;Unreconciled&quot;. Which means the transaction has not been
-	reconciled with your bank/credit card company's balance.</I></P>
-	<LI><P STYLE="margin-bottom: 0in; font-weight: normal"><I><B>Reconciled:</B></I>
-	<I>Once the transaction is checked and verified with a credit card
-	company's balance information, it can be marked as reconciled.</I></P>
-	<LI><P STYLE="margin-bottom: 0in; font-weight: normal"><I><B>Void:</B></I>
-	<I>If you entered a transaction that later became invalid or you
-	canceled the transaction, instead of deleting the transaction you
-	can also mark it as void so you have a record of the transaction.</I></P>
-	<LI><P STYLE="margin-bottom: 0in; font-weight: normal"><I><B>Flag
-	For Followup:</B></I> <I>This status marks transactions as needing
-	more action. For example, you receive a balance statement from the
-	financial institution and you notice that the transaction amount is
-	different between what you recorded and what is in the statement.
-	You can mark it as flag for follow up so that you can followup with
-	the financial institution.</I></P>
-	<LI><P STYLE="margin-bottom: 0in"><A NAME="trans_types"></A><I><B>Duplicate:</B></I>
-	<I><SPAN STYLE="font-weight: normal">The status will be
-	automatically be changed to duplicate if it is recognized as such.</SPAN></I></P>
-</UL>
-<P><I><B>Transaction Types:</B></I> 
-</P>
-<UL>
-	<LI><P STYLE="margin-bottom: 0in"><I><B>Withdrawal:
-	</B></I>is one where one makes a payment and is an expense.</P>
-	<LI><P STYLE="margin-bottom: 0in"><I><B>Deposit:</B></I>
-	is one where money is received and is an income. 
-	</P>
-	<LI><P><A NAME="transfer"></A><I><B>Transfer:</B></I>
-	is one where a withdrawal is made from one
-	account and is deposited into another account.<BR>This type of
-	transaction is not included in Income/Expense calculations.</P>
-</UL>
-<P><A HREF="#payees"><I><B>Payee:</B></I></A>
-This is a person or an organization to whom the
-money goes or comes from. 
-</P>
-<UL>
-	<LI><P>Clicking the payee button opens up the
-	payee dialog. You can select the payee from that dialog or create a
-	new payee for immediate use.</P>
-</UL>
-<P><A HREF="#categories"><I><B>Category:</B></I></A>
-Category selects the kind of expense/income for
-the transaction. 
-</P>
-<UL>
-	<LI><P>Clicking the category button opens up
-	the category dialog. You can select the category from the dialog or
-	create a new category for immediate use.</P>
-</UL>
-<P><B>Split:</B> This
-check-box will activate the Split Transactions Dialog</P>
-<UL>
-	<LI><P>Split Transactions allows multiple categories to be recorded
-	for a single transaction.</P>
-	<LI><P>Can allow a transaction to have Income and Expense categories
-	recorded as deposit and withdrawals, provided the overall
-	transaction type is observed and remains positive, for Deposit and
-	Withdrawal transactions.</P>
-</UL>
-  <div class="col-xs-4">
-    <span class="label label-danger">Note:</span>
-    <table class="table">
-      <tr class="warning">
-        <td>
-          Do not use the same category for Deposit and Withdrawal transactions, as this will upset overall balance figures.
-        </td>
-      </tr>
-    </table>
-  </div>
-  <BR><BR><BR><BR><BR><BR>
-      <P><I><B>Transaction Number:</B></I>
-        is a field to enter any kind of number associated with the transaction
-        like check number.
-      </P>
+        <h1>Money Manager Ex User Manual <small>MMEX 1.2.0</small></h1>
+        <hr>
 
-      <P><B>Notes</B>:
-	This field can be used to record any special notes with regards to
-	the transaction. The button under Notes can be used to select
-	commonly used field notes.</P>
-</UL>
-<P><BR><BR><P><BR><BR></P>
+        <h2>Contents</h2>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="edittrans"></A><BR>Editing
-and Updating Transactions</H3>
-<P>Editing existing transactions can be achieved
-in a number of ways:</P>
-<UL>
-	<LI><P>select the transaction and then click
-	the edit button.</P>
-	<LI><P>double-click the selected transaction.</P>
-	<LI><P>press enter on the selection. 
-	</P>
-</UL>
-<P>Any of these actions will open the
-transaction dialog box containing the details of the selected
-transaction. Make the changes and click OK to save the changes.</P>
-<P><A NAME="transaction_filtering"></A><BR><B>Transaction
-Filtering in Accounts</B></P>
-<P>Transactions can be filtered by either fixed
-filters or, by using the Transaction Filter in the Account View. This
-will allow the user to limit the visible transactions to those
-defined by the appropriate filter. These filtered transactions can
-then be easily selected and individually modified.</P>
-<P>These visible transactions can also be
-deleted in bulk if so desired.
-  <div class="col-xs-4">
-    <span class="label label-danger">Note:</span>
-    <table class="table">
-      <tr class="warning">
-        <td>
-          Caution is advised when deleting transactions.
-        </td>
-      </tr>
-    </table>
-  </div>
-  <BR><BR><BR><BR><BR>
+        <div id="toc">
+            <!-- ToC generated by Javascript -->
+        </div>
+        <hr>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="rectrans"></A><BR>Reconciling
-and Balancing Transactions</H3>
-<P><B>Unreconciled Transactions:</B></P>
-<UL>
-	<LI><P>This means that they have not been
-	verified with the statement from the financial institution.</P>
-</UL>
-<P><B>Reconciled Transactions:</B></P>
-<UL>
-	<LI><P>A transaction can be considered
-	reconciled when the details of the transaction match that from the
-	financial institution.</P>
-</UL>
-<P>In MMEX, reconciled and unreconciled
-transactions are shown by different icons. When bank details are not
-checked against a bank statement, the user can select to set the
-default as Reconciled when creating transactions in the Options
-settings.</P>
-  <div class="col-xs-8">
-    <span class="label label-info">Tips:</span>
-    <table class="table">
-      <tr class="success">
-        <td>
-          To mark a transaction as reconciled, just select the transaction and hit the 'r' or 'R' key.
-          To mark a transaction as unreconciled, just select the transaction and hit the 'u' or 'U' key.
-        </td>
-      </tr>
-    </table>
-  </div>
-  <BR><BR><BR><BR><BR>
+        <div id="contents">
+            <h2>Introduction</h2>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="followup"></A><BR>Flagging
-transactions for followup</H3>
-<P>Some transactions might have some issues that
-you want to follow up on. Mark these as with status of flag for
-followup. This is indicated in MMEX with a different icon.</P>
-<P STYLE="font-style: normal; font-weight: normal; text-decoration: none">
-  <div class="col-xs-8">
-    <span class="label label-info">Tip:</span>
-    <table class="table">
-      <tr class="success">
-        <td>
-          To mark a transaction as requiring
-          followup, just select the transaction and hit the 'f or 'F' key.
-        </td>
-      </tr>
-    </table>
-  </div>
-  <BR><BR><BR><BR><BR>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="currencies"></A><BR>Working
-with Currencies</H3>
-<P STYLE="font-weight: normal">As MMEX can be
-used in many countries, MMEX need to consider the currency for the
-country of use. When creating a new database, the <B>Base
-Currency </B>is set to the currency used
-in the user's country. If the user's currency setting is not listed
-in the default currencies, the user can create their own currency
-Listing.</P>
-<P>MMEX allows us to work with more than one
-currency. Each account has its own currency setting, and will default
-to the base currency. When we set accounts with different currencies,
-the transactions we create in these accounts will reflect the
-currency of the account.</P>
-<P>When transactions in different currencies are
-detected, MMEX will display a Currency Summary on the Home Page. This
-will reflect the amount and conversion rate for each currency being
-used.</P>
-<P>You can manage Currencies by using the menu
-item: <B>Tools -&gt; Organize Currency</B>.</P>
-<P><B>To Add a new Currency</B>:</P>
-<UL>
-	<LI><P>Use the <B>Add</B>
-	button in the Currency Dialog</P>
-	<LI><P>Provide a suitable name for your new
-	currency.<BR>Note: This name is not changeable, but the currency can
-	be deleted if not being used.</P>
-	<LI><P>Adjust the currency values in the
-	<B>Currency Manager.</B><BR>The Currency Manager is also available
-	when editing a currency.</P>
-	<LI><P>Use the <B>Update</B> button to save the
-	changes before closing.<BR>Note: All changes will be lost if the
-	Update button is not used before Closing.</P>
-</UL>
-<P><SPAN STYLE="font-weight: normal">When more
-than one currency is being used, the </SPAN><B>Conversion to Base
-Rate</B> <SPAN STYLE="font-weight: normal">needs to be set. This will
-allow the value of the currency to properly reflect the value at the
-base rate.</SPAN></P>
-<P><SPAN STYLE="font-weight: normal">To allow
-Automatic Currency updates, the </SPAN><B>Currency Symbol</B> <SPAN STYLE="font-weight: normal">needs
-to be set for the particular currency being used.</SPAN></P>
-<P>To use the menu item: <B>Tools &ndash;&gt;
-Online Update Currency Rate</B>, the following must occur:</P>
-<UL>
-	<LI><P>Activate the option from the <B>Tools
-	&ndash;&gt; Options... Others</B> page.</P>
-	<LI><P>Set the Currency Symbol for all
-	currencies requiring update.</P>
-	<LI><P>Set the base currency value 1</P>
-</UL>
-<div class="col-xs-8">  
-  <span class="label label-info">Tips:</span>
-  <table class="table">
-    <tr class="success">
-      <td>
-        Use the toolbar icon for quick selection of the Organize Currencies dialog.
-      </td>
-    </TR>
-    <TR class="success">
-      <td>
-        Use the up/down keys to navigate the currency selection.
-      </td>
-    </tr>
-  </table>
-</div>
-<P><BR><BR><BR><BR><BR><BR><BR><BR></P>
+            <p>Money Manager Ex (MMEX) is a personal money management system,
+            for any one starting out in keeping track of their money, and their
+            spending habits. Based on simple principles, thus allowing anyone
+            with little, to no knowledge of finance and general book keeping,
+            to successfully manage their money. MMEX does this by attempting to
+            models the real financial world, to help us (the user) maintain our
+            personal finances. The Money Manager EX Software, is Open Source,
+            and free to use.</p>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="categories"></A><BR>Working
-with Categories</H3>
-<P><B>Categories indicate the reason an
-expenditure is made or an income is received.</B> 
-</P>
-<P>A Category is generally used to record Income
-or Expenses. Because MMEX allows us to transfer money between
-accounts, it is also recommended to use categories to record
-transfers. This will allow us to determine what money is being
-transferred for a specific reason, such as a repayment to a loan.
-This will not be seen as an income or expense in the overall picture.
-<B>Using the same category for an income
-and an expense will upset balance figures</B>.</P>
-<P>Example: If we want to record the the value
-of running a car, we would set up the following:<BR>Category:
-Car,<BR>Subcategory: Fuel, Maintenance, Registration, Insurance, <B>Fuel
-Reimbursed<BR></B>The first 4 subcategories are used to record
-expenses. If we are reimbursed for fuel costs for any reason, we
-would need to use <B>Fuel Reimbursed</B> as an Income subcategory.
-This would then allow us to determine the correct amount we are
-spending on fuel to run the car. This will become clearer when we are
-using Budgets.</P>
-<h3>Split Categories</h3>
-<P>When adding a new transaction, we can use
-more that one category to record a transaction. This is known as a
-split category.</P>
-<P>The overall split category transaction is
-either a withdrawal or a deposit. Although the categories within the
-split, need to reflect the overall transaction type, each category
-can be classified as a withdrawal or deposit within the split. 
-</P>
-<P>Split categories can easily be viewed for a
-transaction by using a pop-up menu selection when a split category
-entry exists.</P>
-<P><B>Note:</B><BR>Withdrawal Screen: Deposits
-are displayed as negative. <BR>Deposit Screen: Withdrawals are
-displayed as negative.</P>
-<P><B>Managing Our Categories</B></P>
-<P>You can manage Categories by using the menu
-item: <B>Tools -&gt; Organize
-Categories</B>.<BR>Once the category
-dialog opens, you can add new categories and subcategories.</P>
-<P><B>To Add a new Category</B>:</P>
-<UL>
-	<LI><P>Select <B>Categories</B>
-	at the root of the tree (At the top),</P>
-	<LI><P>type the new category name into the text
-	box</P>
-	<LI><P>Use the the <B>Add</B>
-	button.</P>
-</UL>
-<P>The new category will appear at the bottom,
-and will be resorted when the dialog box is re-opened.</P>
-<P><B>To Add a new Subcategory:</B></P>
-<UL>
-	<LI><P>Select the category that you wish the
-	subcategory to belong to</P>
-	<LI><P>type the new subcategory name into the
-	text box</P>
-	<LI><P>use the the <B>Add</B> button.</P>
-</UL>
-<P>You can also change the names by selecting
-the category/subcategory in the list , modify the name in the text
-box, then use the Edit button. Use a similar action to delete the
-category/subcategory in the list.</P>
-<P><B>Note:</B> You cannot delete categories
-which are being used by any transactions.</P>
-<P>Ensure that no transactions use this
-category/subcategory, combination. This can be done by:</P>
-<UL>
-	<LI><P>Editing the transaction and changing the
-	category/subcategory.</P>
-	<LI><P>Deleting the transaction using this
-	category/subcategory.</P>
-</UL>
-<UL>
-	<LI><P>using the menu item: <B>Tools
-	&ndash;&gt; Relocation of... Categories</B><SPAN STYLE="font-weight: normal">,
-	where you can move all categories of a particular name to an
-	alternate category/subcategory combination.</SPAN></P>
-</UL>
-<P STYLE="font-weight: normal">This would then
-make the category free so it can then be deleted.</P>
-<div class="col-xs-8">  
-  <span class="label label-info">Tips:</span>
-  <table class="table">
-    <tr class="success">
-      <td>
-      Use the toolbar icon for quick selection of the Organize Categories dialog.
-      </td>
-    </TR>
-    <TR class="success">
-      <td>
-      Use the up/down keys to navigate the tree selection.
-      </td>
-    </tr>
-  <TR class="success">
-    <td>
-      Don't use the same category for Income and Expense, as this will cause incorrect balance calculations.
-    </td>
-    </tr>
-    </table>
-</div>
-<P><BR><BR><BR><BR><BR><BR><BR><BR></P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="payees"></A><BR>Working
-with Payees</H3>
-<P><B>Payees are the people or institutions that
-give us money, or <BR>the people or institutions who we pay, for our
-goods and services.</B></P>
-<P>You can manage Payees by using the menu item:
-<B>Tools &ndash;&gt; Organize Payees</B>.
+            <p>The primary goal of MMEX is to simplify the process of tracking
+            financial information, in an easy to use program that can be used
+            as regular as necessary, to help us keep track of where our money
+            comes from and more importantly, where our money goes, in order to
+            make better financial decisions for our future.</p>
 
-</P>
-<P>Once the payee dialog opens you can add new
-payees, edit or delete existing payees.</P>
-<P>T<B>o Add a new Payee:</B></P>
-<UL>
-	<LI><P>Enter the name of the payee in the
-	Filter Payees box</P>
-	<LI><P>Use the Add button</P>
-</UL>
-<P>You can also select the payee in the list,
-then use the Edit or Delete button to perform the required action.</P>
-<P><B>Note:</B> You cannot delete payees which
-are being used by any transactions.</P>
-<P>To delete a payee, ensure that no
-transactions use this payee. This can be done by:</P>
-<UL>
-	<LI><P>Editing the transaction and changing the
-	payee.</P>
-	<LI><P>Deleting the transaction using this
-	payee.</P>
-	<LI><P>By using the menu item: <B>Tools
-	&ndash;&gt; Relocation of... Payees</B><SPAN STYLE="font-weight: normal">,
-	where you can move all payees of a particular name to an alternate
-	name. </SPAN>
-	</P>
-</UL>
-<P STYLE="font-weight: normal">This would then make the payee free so it can then be deleted.</P>
-  <div class="col-xs-8">
-    <span class="label label-info">Tips:</span>
-    <table class="table">
-      <tr class="success">
-        <td>
-          Use the toolbar icon for quick selection of the Organize Payees dialog.
-        </td>
-      </TR>
-  <tr class="success">
-    <td>
-      Use the up/down keys to navigate the payee selection.
-    </td>
-  </tr>
-  <tr class="success">
-    <td>
-      Use the % as a wild-card to match many characters in the filter.
-    </td>
-  </tr>
-  <tr class="success">
-    <td>
-      Use _ to match a single character in the filter.
-    </td>
-  </tr>
-  </table>
-</div>
-<P><BR><BR><BR><BR><BR><BR><BR><BR><BR></P>
+            <p>Think of Money Manager Ex as a computer checkbook which enables
+            you to balance your accounts, organize, manage and generate reports
+            for your finances.</p>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="WebApp"></A><BR>Importing From WebApp</H3>
-<P>MMEX has a light WebApp that can be installed on every PHP webserver
-like NAS, shared hosting or other PHP local installation.<BR>You can download all needed files
-<A href="https://sourceforge.net/projects/moneymanagerex-webapp/files/latest/download">
-from project page</A>.<BR><BR>
-To start-up WebApp you only have to:
-<UL>
-	<LI>unzip file in a folder on your webserver or upload files through FTP</LI>
-	<LI>rename htaccess.txt in .htaccess
-		(on Windows you need to do it from CMD and "rename" command)</LI>
-	<LI>enable PDO_SQLite if needed</LI>
-</UL>
-Then simply open your browser to the folder URL, fill first settings and 
-insert correct URL and GUID in MMEX settings (import/export tab).<BR>
-Now at every start-up MMEX will contact WebApp for new transaction that
-will be downloaded and imported in desktop database.<BR>
-All main transaction linked settings will be automatically synced to WebApp,
-in this way you can have all your account and payees ready to use
-inserting new transaction.<BR><BR>
-To obtain more information about set-up and installation see 
-<A href="https://sourceforge.net/p/moneymanagerex-webapp/wiki/">
-wiki pages.</A>
-<BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="importQIF"></A><BR>Importing
-From QIF Files</H3>
-<P>Quicken Interchange Format (QIF) is an open
-specification for reading and writing financial data to media (i.e.
-files). A QIF file typically has the following structure:<BR><BR>!Type:type
-identifier string<BR>[single character line code]Literal String
-Data<BR>...<BR>^<BR>[single character line code]Literal String
-Data<BR>...<BR>^<BR><BR>Each record ends with a ^ (caret). <BR>See
-example QIF transaction <BR><BR>!Type:Bank Header<BR>D6/ 1/94 Date
-<BR>T-1,000.00 Amount<BR>N1005 number<BR>PBank Of Mortgage Payee <BR>^
-End of transaction <BR><BR>QIF is older than Open Financial Exchange
-(OFX). The inability to reconcile imported transactions against the
-current account information is one of the primary shortcomings of
-QIF. It is commonly supported by financial institutions to supply
-down-loadable information to account holders. <BR><BR>MMEX can import
-transactions from specific types of QIF formats into an account.
-<BR><BR>The types are the following: (You can find the type of QIF by
-opening in a text editor) <BR>!Type:Bank Bank account transactions
-<BR>!Type:Cash Cash account transactions <BR>!Type:CCard Credit card
-account transactions <BR><BR><B>Important Note (1)</B>: The date
-format option has to match that of the date format in the QIF file,
-otherwise, date parsing by MMEX will fail and will result in
-transactions having incorrect dates. <BR><BR><B>Important Note (2)</B>:
-After importing from QIF, all transactions will have a &quot;Follow
-Flag&quot; as it its status. You can mark all transactions with this
-flag using the bulk status setting commands using the right click
-menu in the account view. 
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="importUnivCSV"></A><BR>Importing
-From Universal CSV Format</H3>
-<P>To alleviate the problem of users having to
-pre-format their bank transaction CSV files into the fixed format
-MMEX requires, MMEX also allows users to import CSV files where the
-order of fields is completely freeform. To use this importer, select
-the account you want to import into and then select the order of
-fields in the CSV file by picking and choosing from the list of
-possible fields. MMEX will now import the CSV file using the format
-information specified by the user. MMEX can import from a wide
-variety of formats. One of them is a fixed format CSV file. This file
-format exactly matches the CSV format that MMEX can export. So it can
-be useful to move data from one .mmb database file to another .mmb
-database file. To easily see the format of the CSV file, you can try
-exporting an account to a CSV file and then analyzing the format
-created.<BR><BR>The CSV field options are as follows:<BR><I><B>Date</B></I>
-- Date of the transaction (In the format specified in
-Options-&gt;DateFormat)<BR><I><B>Payee</B></I> - To whom the
-transaction was made. In the case of a transfer transaction, this
-indicates the name of the account from which the transfer was made or
-to the account the transfer was made.<BR><I><B>Amount (+/-)</B></I> -
-The transaction amount. If it is a positive value it is a deposit,
-negative value is a withdrawal.<BR><I><B>Category</B></I> - The
-category of the transaction<BR><I><B>SubCategory</B></I> - The
-subcategory of the transaction <BR><I><B>Notes</B></I> - Transaction
-Notes<BR><I><B>Number</B></I> - Transaction Number<BR><I><B>Withdrawal</B></I>
-- An +ive amount that is considered as a withdrawal. (Do not use if
-specifying Amount (+/-))<BR><I><B>Deposit</B></I> - An +ive amount
-that is considered as a deposit. (Do not use if specifying Amount
-(+/-))<BR><I><B>Don't Care</B></I> - Ignore this field<BR><BR>Note
-that the transactions from a CSV file can only be imported into a
-single MMEX account.<BR><BR><B>Important Note (1)</B>: The date
-format option has to match that of the date format in the QIF file,
-otherwise, date parsing by MMEX will fail and will result in
-transactions having incorrect dates. <BR><BR><B>Important Note (2)</B>:
-After importing from QIF, all transactions will have a &quot;Follow
-Flag&quot; as it its status. You can mark all transactions with this
-flag using the bulk status setting commands using the right click
-menu in the account view.</P>
-<P><!-- creating csv tips added by terry wick 9/14/2007 -->
-  <BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="importcsvtips"></A><BR>Tips
-for creating CSV Files</H3>
-<UL>
-	<LI><P>When creating your CSV file be sure that
-	you remove the commas from your deposits and withdrawals. This can
-	be done easily through a program such as Excel or OpenOffice Calc. 
-	</P>
-</UL>
-<UL>
-	<LI><P>Or you can change the delimiter to be
-	used by MMEX by choosing Tools &ndash;&gt; Options and changing the
-	&quot;Import/Export Settings&quot; in the &quot;General&quot; option
-	settings. 
-	</P>
-</UL>
-<UL>
-	<LI><P>You do not need to include balance
-	values in your CSV File.</P>
-</UL>
-<UL>
-	<LI><P>Note that the transactions from a CSV
-	file can only be imported into a single MMEX account.</P>
-</UL>
-<P><!-- end of tips addition from terry wick --><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="exportcsv"></A><BR>Exporting
-to CSV Files</H3>
-<P>MMEX can export to a fixed format CSV file.
-This file format exactly matches the CSV format that MMEX can import.
-So it can be useful to move data from one .mmb database file to
-another .mmb database file. To easily see the format of the CSV file,
-you can try exporting an account to a CSV file and then analyzing the
-format created.<BR><BR>The general format is as follows:<BR><I><B>Date</B></I>
-- Date of the transaction (Displayed in the format specified in
-Options-&gt;DateFormat)<BR><I><B>Payee</B></I> - To whom the
-transaction was made. In the case of a transfer transaction, this
-indicates the name of the account from which the transfer was made or
-to the account the transfer was made.<BR><I><B>Transaction Type</B></I>
-- This can either be &quot;<I>Withdrawal</I>&quot; or
-&quot;<I>Deposit</I>&quot;<BR><I><B>Amount</B></I> - The transaction
-amount as a positive value<BR><I><B>Category</B></I> - The category
-of the transaction<BR><I><B>SubCategory</B></I> - The subcategory of
-the transaction if any (otherwise blank)<BR><I><B>Notes</B></I> -
-Transaction Notes<BR><BR>Note that the transactions from an account
-can be exported to a single CSV file.</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="export_qif"></A><BR>Exporting
-to QIF Files</H3>
-<P>MMEX can export an account to a file of the
-format: QIF.</P>
-<P>This format can also be used by MMEX to
-<A HREF="#importQIF">reload into an account</A>.</P>
-<P>Caution: Although Transfer transactions will
-be reloaded into a single account, they will not function correctly.</P>
-<P><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="recurring_transactions"></A><BR>Recurring Transactions</H3>
-<P>These are special transactions that we set up
-in order to have the transaction entered into the data base at some
-future date. These transactions generally occur at regular intervals,
-such as the payment of a bill.</P>
-<P>These transactions:</P>
-<UL>
-	<LI><P>Are displayed as reminders on the Home
-	Page within 15 Days of the due date.</P>
-	<LI><P>Can be set up to activate automatically
-	on the due date.</P>
-	<LI><P>Can be set up to activate &ndash;
-	allowing the user to adjust any values on the due date.</P>
-</UL>
-<P><B>Recurring Transactions</B> <SPAN STYLE="font-weight: normal">can
-be accessed</SPAN> from the navigation
-tree or from the menu item Tools-&gt;Recurring Transactions. This
-will display the Recurring Transactions page.</P>
-<P>To create a new transaction, use the <B>New
-</B>button:</P>
-<UL>
-	<LI><P>Set up the Recurring Transactions
-	Details, defining which account the transaction will go to when the
-	transaction is entered.</P>
-	<LI><P>Set the date of the <B>Next
-	Occurrence</B><SPAN STYLE="font-weight: normal">,<BR>except
-	for Repeats: </SPAN><B>In x Days</B><SPAN STYLE="font-weight: normal">/Months.</SPAN></P>
-	<LI><P>Select the Repeats as &ldquo;daily&rdquo;,
-	&ldquo;weekly&rdquo; etc.</P>
-	<LI><P><B>Times Repeated:<BR></B>-
-	Enter the number of times this will occur.<BR><B>-
-	</B>No number means: Repeat
-	indefinitely.</P>
-	<LI><P STYLE="font-weight: normal">For Repeats:
-	<B>In x Days</B>/Months<BR>-
-	Set the Start date of the activity.<BR>- Set the period in Days or
-	months depending on the selection.<BR>- Use the <B>Next</B>
-	button to advance the date to the occurrence
-	Date.<BR>- Changes to the period will reactivate the <B>Next</B>
-	button. Once the transaction has been entered,
-	the activity becomes inactive.</P>
-	<LI><P STYLE="font-weight: normal">Repeats:
-	<B>Every x Days</B>/Months<BR>Similar
-	to regular repeats with the exception that the period is stated in
-	Days or Months</P>
-	<LI><P>Set up the Transaction Details section,
-	similar to <A HREF="#creating_new_transaction">creating new
-	transactions</A>.</P>
-</UL>
-<P><SPAN STYLE="font-weight: normal">These
-transaction will be displayed as:</SPAN> <B>Upcoming
-Transactions</B> <SPAN STYLE="font-weight: normal">on
-the home page within 15 days of the due date.</SPAN></P>
+            <p>It is also a great way to keep abreast of your financial
+            worth.</p>
 
-  <div class="col-xs-8">
-    <span class="label label-danger">Note:</span>
-    <table class="table">
-      <tr class="warning">
-        <td>
-          When we enter the transaction, we can
-          change the amount, payee, category, status and date if required.
-        </td>
-      </tr>
-      <tr class="warning">
-        <td>
-          <B>Entering a transaction before it is due</B>
-          , will gray out the transaction in the associated account until the day it becomes active.
-        </td>
-      </tr>
-      <tr class="warning">
-        <td>
-          To use the <A HREF="#cashFlowReport">
-            Cash
-            Flow Reports
-          </A> we need to set up recurring transactions.
-        </td>
-      </tr>
-    </table>
-  </div>
-  <BR><BR><BR><BR><BR><BR><BR><BR><BR><BR>
+            <p>The purpose of this manual is to give you (the user) some basic
+            instructions for using MMEX. This instruction manual will evolve as
+            the program evolves. So check the help system with each update and
+            see what's new and how to better utilize MMEX.</p><a href=
+            "#top">Back to Top</a>
+            <hr>
 
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="assets"></A><BR>Assets</H3>
-<P>MMEX allows you to track fixed assets like
-cars, houses, land and others. Each asset can have its value
-appreciate by a certain rate per year, depreciate by a certain rate
-per year, or not change in value. The total assets are added to your
-total financial worth. 
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="transfilter"></A><BR>Transaction
-Report Filter</H3>
-<P>MMEX allows you to search for transactions
-that meet certain criteria. This can be done using the <A HREF="#transaction_filtering">Transaction
-Filter</A>, located Account View or as a <A HREF="#transaction_report">Transaction
-Report.</A>  
-</P>
-<P>For a Transaction Report, the resulting list
-of transactions can be printed or saved as a HTML file.</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="reports"></A><A NAME="budgeting"></A><BR>Reports</H3>
-<P>MMEX allows a variety of reports. <BR>All the
-reports can also be printed if required using the menu:
-<B>File-&gt;Print... --&gt;Current View</B></P>
-<P>Select the appropriate report under the
-Reports node in the navigation tree. Some reports require some user
-input, some do not. Once you view a report, you can print the report
-using the print options in the menu.</P>
-<P><A NAME="financialYearReport"></A><BR><B>Financial
-Year Reports:</B> (Required by various countries)</P>
-<P>These reports generally do not start at the
-beginning of the calendar year, and appear as branches of the main
-report titles. These reports cover:</P>
-<OL>
-	<LI><P>Previous Financial Year.</P>
-	<LI><P>Current Financial Year.</P>
-</OL>
-<P>By default the start date of a financial year
-is 1<SUP>st</SUP> July
-of the year.</P>
-<P>The start date can be changed by the user to
-start on any day of any month, within a 12 month period by using the
-menu <B>Tools -&gt;Options</B>
-then selecting the <B>General</B>
-panel.</P>
-<P><A NAME="transaction_report"></A><B><BR>Transaction
-Reports:</B> 
-</P>
-<OL>
-	<LI><P>This allows the user to generate
-	specific reports based on selected user requirements.</P>
-	<LI><P>Also known as the <A HREF="#transfilter">Transaction
-	Report Filter</A>.</P>
-</OL>
-<P><A NAME="cashFlowReport"></A>A Transaction
-Report is generally used to locate specific transactions made within
-Bank or Term type accounts. This report can also be used to display
-specific details for a particular account.</P>
-<P><BR><BR>
-</P>
-<P><B>Transaction Report - transfer transactions
-may upset balance totals.</B> 
-</P>
-<P>Since a transfer transaction is a withdrawal
-from one account and a deposit to another account, a transaction
-report done on multiple accounts looses the reference point for
-determining weather the transaction is a deposit or withdrawal.</P>
-<P>When a transaction report is used for a
-specific account, it will generate a report that will match the
-account details. The reference point for transfers in known for this
-report, which will reflect in the report having correct balances
-displayed.</P>
-<P><BR><BR><BR><B>Cash flow Reports</B></P>
-<P>This report projects the amount of funds
-available, based on future commitments.</P>
-<P>Future commitments are determined from the
-<A HREF="#recurring_transactions">Recurring Transactions</A> that are
-set up for the various accounts. The report will then use the
-Recurring Transactions for the various accounts, and reflect forward
-10 years on a monthly basis. This becomes a prediction of the amount
-of money that may be available each month based on current payments.</P>
-<P><BR><BR>
-</P>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="print"></A><BR>Printing</H3>
-<P>MMEX supports printing of all reports that
-can be viewed. 
-</P>
-<P>The print options are available under the
-menu, File-&gt;Print... Current View</P>
-<P>Recommendations:</P>
-<UL>
-	<LI><P>Use the page setup option to reformat
-	the page if necessary</P>
-	<LI><P>Use the print preview option to check
-	the layout of the report before printing.</P>
-</UL>
-<H5><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="options"></A><BR>MMEX
-Options</H3>
-<P>You can modify some run time behavior of MMEX
-by changing the options in the Options Dialog.</P>
-<P>Access from the menu with <B>Tools-&gt;Options</B></P>
-<TABLE class="table table-striped">
-  <thead>
-		<TR>
-			<TH>
-				<P><B>General Panel</B></P>
-			</TH>
-			<TH>
-				<P><BR>
-				</P>
-			</TH>
-		</TR>
-    </thead>
-      <TR>
-			<TD>
-				<P><I><B>User Name<BR></B><SPAN STYLE="font-weight: normal">Optional</SPAN></I></P>
-			</TD>
-			<TD>
-				<P>This field is used as a title on the Home
-				Page, and on Reports.<BR>Leaving this field blank, will remove
-				the Home Page and Report titles.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><I><B>Language</B></I></P>
-			</TD>
-			<TD>
-				<P>This is the language used by the MMEX
-				GUI. MMEX might require a restart before all GUI elements have
-				the new language.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><I><B>Base Currency:</B></I></P>
-			</TD>
-			<TD>
-				<P>The base currency setting is used to set
-				the currency of the database. Individual accounts will use this
-				as the default, but can be changed if different currencies as
-				required.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><I><B>Date Format:</B></I></P>
-			</TD>
-			<TD>
-				<P>The date format setting is used to
-				control how dates should be displayed and also how dates should
-				be parsed when importing QIF, CSV files.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><B>Financial Year</B></P>
-			</TD>
-			<TD>
-				<P>Sets the start Day and Month for a
-				Financial Year period, as opposed to a calendar year. This is
-				used in Budgets and Reports.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><I><B>Database<BR>Backup</B></I></P>
-			</TD>
-			<TD>
-				<P>Sets the way the backups are performed
-				when MMEX starts.</P>
-				<UL>
-					<LI><P><B>Create a new backup when MMEX
-					Starts</B><BR>This copies the database to a new file with
-					today's date, when MMEX Starts.<BR>The file will not be over
-					written when MMEX starts up again. When there are more that 4
-					backup files, the oldest file is deleted.</P>
-					<LI><P><B>Update database changes to
-					database backup on exit.</B><BR>When MMEX shuts down, the
-					existing database will be copied to a backup database file for
-					that day when changes to the database have been detected. When
-					changes are made on the same day, the existing backup is over
-					written. When there are more that 4 backup files, the oldest
-					file is deleted.</P>
-				</UL>
-			</TD>
-		</TR>
-</TABLE>
-<P><BR><BR>
-</P>
-<TABLE class="table table-striped">
-  <thead>
-    <TR>
-      <TH>
-        <P>
-          <B>View Options Panel</B>
-        </P>
-      </TH>
-      <TH>
-      </TH>
-    </TR>
-  </thead>
-      <TR>
-			<TD>
-				<P><I><B>Account View</B></I></P>
-			</TD>
-			<TD>
-				<P>This sets the Navigation tree's visible
-				accounts, according to status.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><I><B>Transaction View</B></I></P>
-			</TD>
-			<TD>
-				<P>This determines which transactions are
-				seen as default in the Account View.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><B>Font Size</B></P>
-			</TD>
-			<TD>
-				<P>This will set the font being used on the
-				Home Page and in Reports.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><B>Tree View<BR>Expand Section</B></P>
-			</TD>
-			<TD>
-				<P>Sets the account types being expanded
-				when in the navigation tree is refreshed.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><B>Home Page</B><BR><B>Expand Section</B></P>
-			</TD>
-			<TD>
-				<P>Sets the account types being expanded when the home page is refreshed.</P>
-			</TD>
-		</TR>
-		<TR>
-			<TD>
-				<P><BR>
-				</P>
-			</TD>
-			<TD>
-				<P><BR>
-				</P>
-			</TD>
-		</TR>
-	</TBODY>
-</TABLE>
-<P><BR><BR>
-</P>
-<TABLE class="table table-striped">
-  <thead>
-    <TR>
-      <TH>
-        <P>
-          <B>Colors Panel</B>
-        </P>
-      </TH>
-      <TH>
-      </TH>
-    </TR>
-  </thead>
-  <TR>
-    <TD>
-    </TD>
-    <TD>
-    <P>
-      Allows the user to modify colors in MMEX to suit his/her style.
-    </P>
-  </TD>
-  </TR>
-</TABLE>
-<P><BR><BR>
-</P>
-<TABLE class="table table-striped">
-  <thead>
-	<TR>
-		<TH>
-			<B>Import/Export Panel</B>
-		</TH>
-      <TH>
-        </TH>
-	</TR>
-    </thead>
-	<TR>
-		<TD>
-			<P><I><B>CSV Limiter</B></I></P>
-		</TD>
-		<TD>
-			<P>This is used as the delimiting character
-			when parsing CSV files. This is useful to modify from the default
-			',' when dealing with currencies that use ',' to denote decimal
-			points in amounts. 
-			</P>
-		</TD>
-	</TR>
-	<TR>
-		<TD>
-			<P><I><B>WebApp settings</B></I></P>
-		</TD>
-		<TD>
-			<P>Set URL and GUID of your WebApp installation to allow data sync. Parameters can be found in WebApp 'Guide' page.
-			</P>
-		</TD>
-	</TR>
-</TABLE>
-<H5><BR><BR>
-</H5>
-<TABLE class="table table-striped">
-  <thead>
-    <TR>
-      <TH>Others Panel</TH>
-      <TH>
-        <P>
-          <BR>
-				
-        </P>
-      </TH>
-    </TR>
-  </thead>
-  <TR>
-    <TD>
-      <P>
-        <I>
-          <B>New Transactions</B>
-        </I>
-      </P>
-    </TD>
-    <TD>
-      <P>
-        Changes the default settings for the
-        New/Edit Transactions Dialog
-      </P>
-    </TD>
-  </TR>
-  <TR>
-    <TD>
-      <P>
-        <I>
-          <B>Stock Quote Web Page</B>
-        </I>
-      </P>
-    </TD>
-    <TD>
-      <P>
-        This URL is used by the Refresh button on
-        the Stock Investments page.
-      </P>
-      <P>
-        This URL is also used by the New/Edit
-        Stock dialog, to display the web page for the listed stock.
-      </P>
-      <P>
-        The default is yahoo finance.
-        Alternatively other sites can be used if necessary.
-      </P>
-    </TD>
-  </TR>
-  <TR>
-    <TD>
-      <P>
-        Use Original date...
-      </P>
-    </TD>
-    <TD>
-      <P>
-        Activate to use the date of the
-        transaction date when using paste transaction, in account view.
-      </P>
-    </TD>
-  </TR>
-  <TR>
-    <TD>
-      <P>Use sound...</P>
-    </TD>
-    <TD>
-      <P>
-        Activate to plays a sound when a
-        transaction is entered.
-      </P>
-    </TD>
-  </TR>
-  <TR>
-    <TD>
-      <P>Enable online currency...</P>
-    </TD>
-    <TD>
-      <P>
-        Activate to allow currencies to be
-        updated via the internet.
-      </P>
-    </TD>
-  </TR>
-</TABLE>
+            <h2>Working towards better Financial Health</h2>
 
-<H5><BR><A HREF="#top">Back to Top</A></H5>
-<HR>
-<H3><A NAME="faq"></A><BR>Frequently Asked Questions</H3>
-<OL>
-	<LI><P STYLE="margin-bottom: 0in"><A HREF="#contribute">
-      How can I contribute?</A> 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A HREF="#nameex">
-      What's the reason for the EX in the name of the software?</A> 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A HREF="#database1">
-      Is the .mmb file format proprietary? And is my data safe?</A> 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A HREF="#usbkey">
-      Can MMEX run from a USB Key?</A> 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A HREF="#safety">
-      How do I know MMEX is not trying to steal my sensitive financial information?</A> 
-	</P>
-	<LI><P><A HREF="#statements">How do I print account statements using MMEX?</A> 
-	</P>
-</OL>
-<HR>
-<H3><A NAME="contribute"></A><BR>How can I contribute?</H3>
-<P><A NAME="contribute1"></A>You can contribute by</P>
-<UL>
-	<LI><P STYLE="margin-bottom: 0in"><A NAME="contribute2"></A>
-    Reporting bugs 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A NAME="contribute3"></A>
-    Translating	to your language 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A NAME="contribute4"></A>
-    Helping	spread the word 
-	</P>
-	<LI><P STYLE="margin-bottom: 0in"><A NAME="contribute5"></A>
-    If you are a C++ expert, by helping extend MMEX developing code. 
-	</P>
-	<LI><P>If you are really very happy because you saved a lot of money by using MMEX, you can donate to the MMEX project. 
-	</P>
-</UL>
+            <p>Becoming organized financially requires some amount of
+            discipline. Financial management can become complicated when there
+            is no clear understanding of how much money we are getting,
+            regarded as income as opposed to our expenses which is how much
+            money we spend. Debt usually results when our cash flow is
+            restricted because our expenses exceed our income. Then we need to
+            borrow money to maintain our cash flow to enable us to purchase our
+            necessary items.</p>
 
-<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-<input type="hidden" name="cmd" value="_donations">
-<input type="hidden" name="business" value="moneymanagerex@moneymanagerex.org">
-<input type="hidden" name="lc" value="US">
-<input type="hidden" name="item_name" value="MoneyManagerEx">
-<input type="hidden" name="no_note" value="0">
-<input type="hidden" name="currency_code" value="USD">
-<input type="hidden" name="bn" value="PP-DonationsBF:btn_donateCC_LG.gif:NonHostedGuest">
-<input type="image" src="btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-</form>
+            <p>The first step towards better Financial Health, is to maintain
+            good financial records. It is only when we have a clear
+            understanding of where our money goes, that we can make an informed
+            decision of where to cut back on our expenses when our cash flow
+            becomes tight. If we do need to borrow money, we can then better
+            manage our debts as well.</p>
 
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H3><A NAME="nameex"></A><BR>What's
-the reason for the EX in the name of the software?</H3>
-<P>Originally I developed a personal finance
-software called Money Manager. It was written in .NET and more of a
-learning exercise than serious software development. It grew far
-beyond the original design. The software was frozen and work began on
-a new version which had a similar user interface and features, but
-written in C++.&nbsp; 
-</P>
-<P>Usually Microsoft names their second version
-of their improved software APIs with an Ex extension as in
-doSomething() and doSomethingEx(). So I just followed the model and
-tacked on a 'Ex' to the end. 
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H3><A NAME="database1"></A><BR>Is
-the .mmb format proprietary? And, Is my data safe? 
-</H3>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=13*>
-	<COL WIDTH=243*>
-	<TR>
-		<TD WIDTH=5%>
-			<P><B>No</B></P>
-		</TD>
-		<TD WIDTH=95%>
-			<P STYLE="font-weight: normal">.mmb file is
-			not proprietary.</P>
-		</TD>
-	</TR>
-	<TR>
-		<TD WIDTH=5%>
-			<P><BR>
-			</P>
-		</TD>
-		<TD WIDTH=95%>
-			<P STYLE="font-weight: normal">MMEX uses
-			SQLite databases to store user data. That means that the .mmb file
-			is a regular SQLite database. SQLite is one of the smallest, free
-			relational database systems around and there are tons of tools to
-			open and access SQLite databases. SQLiteSpy and SQLite Browser
-			(http://sqlitebrowser.sourceforge.net/) are two such utilities.
-			Once you open the database using these tools, you can do anything
-			you want with the data. 
-			</P>
-		</TD>
-	</TR>
-	<TR>
-		<TD WIDTH=5%>
-			<P><B>Yes</B></P>
-		</TD>
-		<TD WIDTH=95%>
-			<P>Your data is completely safe.</P>
-		</TD>
-	</TR>
-	<TR>
-		<TD WIDTH=5%>
-			<P><BR>
-			</P>
-		</TD>
-		<TD WIDTH=95%>
-			<P>The data is self contained on your PC, (or
-			<A HREF="#usbkey">USB stick</A> if you have made it portable). To
-			further protect your data, <A HREF="#encrypting_database">encryption
-			can now be added.</A> This applies a password to your database
-			file, and can only be opened by MMEX or any other software if you
-			have the correct password.</P>
-		</TD>
-	</TR>
-</TABLE>
-<P><BR><BR>
-</P>
-<P><BR><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H3><A NAME="usbkey"></A><BR>Can
-MMEX run from a USB Key?</H3>
-<P><A NAME="usbkey1"></A><B>Yes.</B></P>
-<P>MMEX is a portable application which means
-ability to run without installation, for example, from USB flash
-drive. If MMEX finds mmexini.db3 in its folder, it assumes portable
-mode. Copy mmex's files to USB Key and copy yours mmexini.db3 to
-mmex's folder on that drive.</P>
-<P>To make MMEX portable:</P>
-<OL>
-	<LI><P><B>On Windows (assume F:\ is USB flash
-	drive)</B><BR>Copy &quot;C:\Program
-	Files\MoneyManagerEx&quot; to <A HREF="../help">F:\</A><BR>Copy
-	&quot;%APPDATA%\MoneyManagerEx\mmexini.db3&quot; to
-	<A HREF="../help">F:\MoneyManagerEx</A><BR>Copy your database file
-	to any folder on <A HREF="../help">F:\</A><BR><BR><BR>
-	</P>
-	<LI><P><B>On Unix (assume /media/disk is
-	mounted USB flash drive)</B><BR>Compile
-	mmex from sources as usually,<BR>and make
-	install prefix=/media/disk<BR>cp ~/.mmex/mmexini.db3
-	/media/disk/mmex/share/mmex<BR><BR>or if you want to copy mmex which
-	has already installed in /usr<BR>cp /usr/bin/mmex
-	/media/disk/mmex/bin<BR>cp /usr/share/mmex /media/disk/mmex/share<BR>cp
-	/usr/share/doc/mmex /media/disk/mmex/share/doc<BR>cp
-	~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex<BR><BR><BR>
-	</P>
-</OL>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H3><A NAME="safety"></A><BR>How
-do I know MMEX is not trying to steal my sensitive financial
-information?</H3>
-<P><A NAME="safety1"></A>Generally, with any
-closed source program, you have to depend upon the vendor's word
-regarding safety of the data. But with MMEX being open source, you
-can verify this claim yourself.<BR>
-Even if you are not a C++ expert, you
-can rest assured that anyone can access the source code at any time
-and verify the legitimacy of MMEX's intentions.<BR>
-MMEX does connect to the internet only to send anonymous usage
-statistics or when checking for an update.<BR>
-You can disable this in Options->Network<BR>
-<BR>
-<BR>
-Here is a sample of data that MMEX will send:<BR>
-<BR>
-<table border=1 cellpadding=5>
-	<tr>
-		<th>Version</th>
-		<th>Operating System</th>
-		<th>Language</th>
-		<th>Country</th>
-		<th>Resolution</th>
-		<th>Start Time</th>
-		<th>End Time</th>
-	</tr>
-	<tr>
-		<td>1.2.0 Portable</td>
-		<td>Windows 8 (build 9200), 64-bit edition</td>
-		<td>english</td>
-		<td>United States</td>
-		<td>1366x768</td>
-		<td>2014-05-01 09:00:00</td>
-		<td>2014-05-01 09:01:30</td>
-	</tr>
-</TABLE>
-<BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H3><A NAME="statements"></A><BR>How
-do I print account statements using MMEX?</H3>
-<P><A NAME="statements1"></A>To print a
-statement with transactions from any arbitrary set of criteria, use
-the Transaction Filter to select the transactions you want and then
-do a print from the menu. File -&gt;Print... -&gt;Current View</P>
-<P>The Transaction Filter is accessed from
-Reports --&gt; Transaction Reports on the Navigation Tree, or<BR>from
-the Quick Navigation buttons in the top left hand corner of MMEX.</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P><BR><BR>
-</P>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=0 CELLSPACING=0>
-	<COL WIDTH=128*>
-	<COL WIDTH=128*>
-	<TR>
-		<TD WIDTH=50%>
-			<H5><A HREF="#top">Back to
-			Top</A></H5>
-		</TD>
-		<TD WIDTH=50%>
-			<H5><A HREF="#faq">Back to
-			Frequently Asked Questions</A></H5>
-		</TD>
-	</TR>
-</TABLE>
-<HR>
-<H5>Copyright &ordf; 2005-2013&nbsp;
-CodeLathe LLC. All rights reserved.</H5>
-</BODY>
-</HTML>
+            <p>Did you realize you spent $600 in buying DVD movies last year?
+            How many times did you watch them? Do you think now that the $600
+            would have been better spent on the unexpected maintenance on the
+            auto that came up yesterday? Of course there is no right or wrong
+            answer to how you should spend your money. After all, it is you who
+            earned that money and the right to spend it whichever way you see
+            fit. But you can always make your money work harder for you.</p>
+
+            <p>Here's where personal finance software comes in. They help you
+            slice/dice the financial data to give you better insight into what
+            is going on. Always remember the software can only be as good as
+            the data it has to process. Garbage In Garbage Out. But if you have
+            started thinking of even using Personal finance software, you are
+            well on your way to making every dollar count.</p>
+
+            <p>Read on how to work with Money Manager Ex.</p><a href=
+            "#top">Back to Top</a>
+            <hr>
+
+            <h2>Money Manager Ex Concepts</h2>
+
+            <p>Money Manager EX models the real world to help us maintain our
+            personal finances.</p>
+
+            <p>Generally we receive money from someone for a service we
+            provide, or a product that we sell. This is regarded as Income or
+            as a Deposit to our system. When we purchase an item or use a
+            service, the money that we spend is regarded as an expense or
+            Withdrawal to our system. In MMEX, the people that give us money or
+            receive our money are regarded as the Payees of the system.</p>
+
+            <p>As we hopefully do not spend all the money we receive, we would
+            obviously need a place to keep our money. This is generally, some
+            financial institution, or several institutions or in our pocket.
+            MMEX tags these places as Accounts.</p>
+
+            <p>When we spend or receive money, we see this as a
+            transaction&gt;, and the reason for our income or expense is our
+            category. There will be times where we need to transfer money from
+            one place to another, such as a withdrawal from an ATM, and this
+            type of transaction is known as a transfer.</p>
+
+            <table class="table, small">
+                <tr>
+                    <td>This can be simplified as shown in the following
+                    diagram:</td>
+
+                    <td><img alt="MMEX Concept" src="mmex_concept.png"></td>
+                </tr>
+            </table>
+
+            <p>One other important thing to consider is the currency we use to
+            perform the transactions.</p>
+
+            <p>With all of these things to keep track of, MMEX uses a database
+            to store and connect all these entities together.</p><a href=
+            "#top">Back to Top</a>
+            <hr>
+
+            <h3>Recommendations</h3>
+
+            <p>The database that MMEX generates, known as the .mmb file,
+            becomes an important file for you to maintain. Depending on
+            circumstances, security features such as encryption can be
+            employed, which is recognized as a .emb file. This is where we can
+            attach a password to the database, and will require a password
+            every time MMEX is opened.</p>
+
+            <p>When encrypting your database, Don't forget your password.</p>
+
+            <p>As with any computer system, the data we produce is important to
+            us, and therefore need to safeguard against system malfunction.
+            MMEX has a backup system where it can produce a dated copy when the
+            database is opened, and/or produce a dated copy of the database
+            when changes have been detected. Up to 4 backups are maintained for
+            each database when the system is initialized and/or when system
+            changes have been detected, and the system shuts down.</p>
+
+            <ul>
+                <li>Always backup your .mmb or .emb database file
+                regularly.</li>
+
+                <li>Always keep backup copies on other devices to protect
+                against hardware failure.</li>
+
+                <li>When upgrading to a new version of MMEX, make sure you
+                backup your .mmb or .emb database file before doing so.</li>
+
+                <li>Use the Menu Tools&rarr;Options... to set up the level of
+                backup required.</li>
+            </ul><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Creating a New Database</h2>
+
+            <p>When MMEX initially starts up, it will attempt to load the last
+            database that was opened. If no database existed, the user is
+            presented with the option to either open an existing database, or
+            create a new one.</p>
+
+            <p>If you need to create a new database file, from the Menu, Select
+            File&rarr;New Database.</p>
+
+            <p>This will prompt you to specify a new name for your .mmb
+            database file, at the location you specify. Your new database file
+            is now created and the New Database Wizard will be displayed to
+            help you initialize the new database and assist in creating your
+            first account.</p>
+
+            <p>The New Database Wizard will request you to set the Base
+            Currency and a User Name.</p>
+
+            <p>MMEX comes with a default set of currencies which you can use,
+            to correspond to your countries currency settings. New accounts
+            will then use this Base Currency setting as the default. This
+            allows accounts from different countries to reflect the value in
+            the base currency.</p>
+
+            <p>To help identify the purpose of the database, a User Name is
+            requested. This is optional, as it is only used as a title on the
+            Home Page, and in reports.</p>
+
+            <p>Both these settings can later be changed if required by
+            selecting the menu: Tools &rarr;Options</p>
+
+            <p>The database name will be displayed on the title bar which helps
+            remind you which database file is open.<br>
+            The new .mmb database file is not encrypted.</p><a href="#top">Back
+            to Top</a>
+            <hr>
+
+            <h3>Encrypting your database file.</h3>
+
+            <p>The database can now be encrypted as follows: on the Menu,
+            Select File&rarr;Save Database As</p>
+
+            <ol>
+                <li>Select your location, and select your .mmb file or create a
+                new name for your database.</li>
+
+                <li>Change the Save As Type: to Encrypted MMB Files (*.emb),
+                then Save</li>
+
+                <li>Enter a password for your file &ndash; You will need the
+                password when opening the database file.</li>
+            </ol>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>Remember to make backups of your .mmb or .emb
+                        database files.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Database file is not encrypted:<br>
+                        That means anyone else having the proper know how, can
+                        actually open the file and read the contents. So make
+                        sure that if you are storing any sensitive financial
+                        information, it is properly guarded.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>For encrypted database files: Remember your
+                        password.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Switching Databases</h3>
+
+            <p>For users having multiple databases, the user can easily switch
+            between the databases by using the Menu item: File&rarr;Recent
+            Files...</p>
+
+            <p>This will save the last five recently used files. The list will
+            show 6 entries as the first entry on the list is the file currently
+            being used.</p>
+
+            <p>Clearing the list.</p>
+
+            <p>When the list is cleared, all the items in the list are cleared.
+            When MMEX shuts down, the currently opened database will be saved
+            as the last opened file. This will appear in the recent file list
+            as the first entry when MMEX is restarted.</p><a href="#top">Back
+            to Top</a>
+            <hr>
+
+            <h2>Creating New Accounts</h2>
+
+            <p>When creating a new database file, you will automatically be
+            requested to create a new account.</p>
+
+            <p>To manually create a new account, from the Menu, Select
+            Accounts&rarr;New Account.</p>
+
+            <p>This will bring up the Add Account Wizard. The wizard will
+            assist in collecting the important information of the Name and Type
+            of Account. The Type of Account is not changeable, but the name can
+            changed when editing account information.</p>
+
+            <p>Name of the Account: This is a required field. The
+            recommendation is to name your accounts uniquely and in relation to
+            real world accounts. Example: With CitiBank, we have a Savings
+            account and a credit card Visa account. You could name your
+            accounts as ;CitiBank Savings; and ;Citibank Visa;.</p>
+
+            <p>Type of Account: MMEX currently supports three types of
+            accounts:</p>
+
+            <dl>
+                <dt>Checking Account</dt>
+
+                <dd>This is the most common type of account used for MMEX, and
+                can handle most common account types, such as checking
+                accounts, savings accounts, and credit card accounts. Also
+                known as Bank Account, and supports three kinds of
+                transactions. These are withdrawal, deposit and transfers.</dd>
+
+                <dt>Term Accounts</dt>
+
+                <dt></dt>
+
+                <dd>Similar to Checking Accounts with the exception that they
+                appear in their own section on the home page and can be shown
+                or hidden for normal day usage. For a better explanation see
+                the account setup example.<br>
+                <br>
+                These kinds of accounts cover specialized accounts such as Cash
+                Term Accounts, Bank Mortgage accounts, Loan accounts, or
+                investment accounts with regular income or expenditure that you
+                need to keep track of. These accounts have their own balance
+                section on the Home Page. These accounts also, supports three
+                kinds of transactions.</dd>
+
+                <dt>Investment Account</dt>
+
+                <dd>The other type of account that MMEX supports is an
+                ;Investment; Account. This type of account allows you to track
+                stock/bonds/mutual funds investments and possibly other
+                investments you may own.</dd>
+            </dl>
+
+            <p>To properly setup accounts, you should have balance information
+            for the accounts you want to add to MMEX. You can get this
+            information from your most recent bank, investment and credit card
+            statements. To track additional information about this account,
+            optionally you can enter your account details such as Account
+            Number, Held At, Website, Contact info and Access Info. You can
+            enter additional notes about the account in the notes field.</p>
+
+            <p>Most accounts have some kind of balance in them, for example say
+            in a credit card account, you have a current balance of $2304.67,
+            you could put that value in the initial balance field. Going
+            forward you only need to add transactions beyond that date when you
+            had the balance.</p>
+
+            <p>The Account Status can be set to ;Open; or ;Closed;. Closed
+            accounts are just that. They are no longer active. Setting this
+            status is just a way to de-clutter your view in your tree view
+            navigation pane. Permanent settings are made by changing the View
+            Options on the Menu, Tools&rarr;Options, you can hide the closed
+            accounts. See Tips on Navigation Tree<br>
+            <br>
+            Currency: This is initially set to the database Base Currency
+            setting which was initially set when creating the database. You can
+            set the currency that is associated with this account and can be
+            different to the base currency.</p>
+
+            <p>The exchange rate for the currency can be changed using the
+            menu: Tools &rarr;Organize Currency</p>
+
+            <p>Example: You live in the USA using US Dollars, and have an
+            Italian bank account using the Euro. Most of your accounts are in
+            USD. What is the real value of your Italian bank account? By
+            changing the exchange rate for the Italian Euro, you can get the
+            correct value of your accounts.</p>
+
+            <p>You also can mark accounts as a 'Favorite Account'. This again
+            is used to change the accounts that are visible in the navigation
+            bar. See Tips on Navigation Tree</p>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>Use the toolbar icon for quick selection of the Add
+                        Account Wizard.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Account Setup Example:</h3>
+
+            <p>We have a savings account with $1250, a check account with $500,
+            a MasterCard owing $250, a Visa Card owing $475, a home mortgage
+            loan of $230,965 and an education fund to send the children to
+            college in the future currently at $5000 earning interest.<br>
+            We would set up the following accounts:</p>
+
+            <table rules="GROUPS">
+                <tbody>
+                    <tr style="vertical-align: top;">
+                        <td>Account Type</td>
+
+                        <td>Account Name</td>
+
+                        <td>Initial Balance</td>
+                    </tr>
+                </tbody>
+
+                <tbody>
+                    <tr style="vertical-align: top;">
+                        <td>Check/Savings</td>
+
+                        <td>Savings</td>
+
+                        <td>$1,250.00</td>
+                    </tr>
+
+                    <tr style="vertical-align: top;">
+                        <td>&nbsp;</td>
+
+                        <td>Check</td>
+
+                        <td>$500.00</td>
+                    </tr>
+
+                    <tr style="vertical-align: top;">
+                        <td>&nbsp;</td>
+
+                        <td>MasterCard</td>
+
+                        <td style="font-color: red;">-$250.00</td>
+                    </tr>
+
+                    <tr style="vertical-align: top;">
+                        <td>&nbsp;</td>
+
+                        <td>Visa Card</td>
+
+                        <td style="font-color: red;">-$475.00</td>
+                    </tr>
+                </tbody>
+
+                <tbody>
+                    <tr style="vertical-align: top;">
+                        <td>Term</td>
+
+                        <td>Home Mortgage</td>
+
+                        <td style="font-color: red;">-$230,965.00</td>
+                    </tr>
+
+                    <tr style="vertical-align: top;">
+                        <td>&nbsp;</td>
+
+                        <td>Education Fund</td>
+
+                        <td>$5,000.00</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>On the Home Page the balances would be $1025 for Bank accounts,
+            and $-225,965 for Term Accounts</p>
+
+            <p>When a payment is made from your Savings Account to your
+            MasterCard with a Transfer Transaction the balance on the home page
+            remains the same. When a payment is made from your savings to your
+            home mortgage, the balance on the home page will reflect the
+            payment. Now you can determine the amount of money you have on a
+            day to day basis. Regular payments can also be set up from your
+            savings account to your mortgage account using Recurring
+            Transactions.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Tip on using the Navigation Tree and Home page:</h3>
+
+            <p>As more accounts are created the Navigation Tree and Home page
+            can become very large.<br>
+            This views can be temporarily changed to show or hide the
+            appropriate section:</p>
+
+            <table rules="ROWS">
+                <tr style="vertical-align: top;">
+                    <td>Navigation Tree:</td>
+
+                    <td>Expand/Contract the Bank and Term Account branches
+                    using the +/- nodes on the navigation tree.</td>
+                </tr>
+
+                <tr style="vertical-align: top;">
+                    <td>Home Page:</td>
+
+                    <td>Using the menu: View &rarr;Bank Accounts and/or menu:
+                    View&rarr;Term Accounts</td>
+                </tr>
+            </table>
+
+            <p>Using a mouse Right-Click on:</p>
+
+            <ul>
+                <li>Bank Accounts in the Navigation tree, will allow all
+                accounts or only favorite accounts to be shown, temporarily
+                changing the permanent settings, as well as other useful
+                options.</li>
+            </ul>
+
+            <ul>
+                <li>Any account name under Bank or Term accounts, to bring up
+                other useful options.</li>
+            </ul>
+
+            <p>To make the change permanent, change the options using the menu:
+            Tools&rarr;Options&rarr;View Options</p><a href="#top">Back to
+            Top</a>
+            <hr>
+
+            <h3>Editing Account Information</h3>
+
+            <p>Once you have created an account, you can edit any of the
+            account information fields in the following ways:</p>
+
+            <ol>
+                <li>
+                    <p>Using menu Accounts &rarr; Edit Account<br>
+                    The list of account will be displayed where the required
+                    account is selected.</p>
+                </li>
+
+                <li>
+                    <p>Selecting the account name in the navigation pane<br>
+                    Right click to bring up the pop-up menu and select ;Edit
+                    Account;</p>
+                </li>
+            </ol>
+
+            <p>This will bring up the account information dialog where the
+            required fields can be changed.</p>
+
+            <ul>
+                <li>
+                    <p>Edit the account details</p>
+                </li>
+
+                <li>
+                    <p>Use the ;OK; button to save the account information.</p>
+                </li>
+            </ul><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Creating New Transactions</h2>
+
+            <p>Once you have created a new account, and selected the required
+            account from the navigation tree, or the home page, the displayed
+            account can have new transactions added as follows:</p>
+
+            <ul>
+                <li>Using the New button at the bottom of the Account View
+                screen</li>
+
+                <li>By selecting an existing transaction and using the mouse
+                Right-Click, and select the appropriate action on the pop-up
+                menu screen.</li>
+            </ul><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>New/Edit Transaction Dialog</h3>
+
+            <p>This dialog box will appear for new transactions. Use this
+            dialog to enter the following details:</p>
+
+            <ul>
+                <li>Date - This is generally the date of the transaction.
+                Defaults to current day and can be changed.</li>
+
+                <li>Status - The default is None, but can be changed to
+                Reconciled by the options settings.</li>
+
+                <li>Type - Refer to Transaction Types below.</li>
+
+                <li>Amount &ndash; Enter the amount fro the transaction. The
+                2<sup>nd</sup> amount field is associated with the Advanced
+                Check-box and will be activated only for Transfer
+                transactions.</li>
+
+                <li>Advanced &ndash; For a transfer transaction, when the
+                amount in the ;From; Account is different to the ;To; Account,
+                the difference is recorded in the separate fields. This can for
+                currency rate changes.</li>
+            </ul>
+
+            <p>Transaction Status:</p>
+
+            <ul>
+                <li>Unreconciled: When you enter a transaction, it initially is
+                in the state of ;Unreconciled;. Which means the transaction has
+                not been reconciled with your bank/credit card company's
+                balance.</li>
+
+                <li>Reconciled: Once the transaction is checked and verified
+                with a credit card company's balance information, it can be
+                marked as reconciled.</li>
+
+                <li>Void: If you entered a transaction that later became
+                invalid or you canceled the transaction, instead of deleting
+                the transaction you can also mark it as void so you have a
+                record of the transaction.</li>
+
+                <li>Flag For Followup: This status marks transactions as
+                needing more action. For example, you receive a balance
+                statement from the financial institution and you notice that
+                the transaction amount is different between what you recorded
+                and what is in the statement. You can mark it as flag for
+                follow up so that you can followup with the financial
+                institution.</li>
+
+                <li>Duplicate: The status will be automatically be changed to
+                duplicate if it is recognized as such.</li>
+            </ul>
+
+            <p>Transaction Types:</p>
+
+            <ul>
+                <li>Withdrawal: is one where one makes a payment and is an
+                expense.</li>
+
+                <li>Deposit: is one where money is received and is an
+                income.</li>
+
+                <li>Transfer: is one where a withdrawal is made from one
+                account and is deposited into another account.<br>
+                This type of transaction is not included in Income/Expense
+                calculations.</li>
+            </ul>
+
+            <p>Payee: This is a person or an organization to whom the money
+            goes or comes from.</p>
+
+            <ul>
+                <li>Clicking the payee button opens up the payee dialog. You
+                can select the payee from that dialog or create a new payee for
+                immediate use.</li>
+            </ul>
+
+            <p>Category: Category selects the kind of expense/income for the
+            transaction.</p>
+
+            <ul>
+                <li>Clicking the category button opens up the category dialog.
+                You can select the category from the dialog or create a new
+                category for immediate use.</li>
+            </ul>
+
+            <p>Split: This check-box will activate the Split Transactions
+            Dialog</p>
+
+            <ul>
+                <li>Split Transactions allows multiple categories to be
+                recorded for a single transaction.</li>
+
+                <li>Can allow a transaction to have Income and Expense
+                categories recorded as deposit and withdrawals, provided the
+                overall transaction type is observed and remains positive, for
+                Deposit and Withdrawal transactions.</li>
+            </ul>
+
+            <div>
+                <span class="label label-danger">Note:</span>
+
+                <table class="table">
+                    <tr class="warning">
+                        <td>Do not use the same category for Deposit and
+                        Withdrawal transactions, as this will upset overall
+                        balance figures.</td>
+                    </tr>
+                </table>
+            </div>
+
+            <p>Transaction Number: is a field to enter any kind of number
+            associated with the transaction like check number.</p>
+
+            <p>Notes: This field can be used to record any special notes with
+            regards to the transaction. The button under Notes can be used to
+            select commonly used field notes.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Editing and Updating Transactions</h3>
+
+            <p>Editing existing transactions can be achieved in a number of
+            ways:</p>
+
+            <ul>
+                <li>By selecting the transaction and then clicking the edit
+                button.</li>
+
+                <li>Double-clicking the selected transaction.</li>
+
+                <li>Pressing enter on the selection.</li>
+            </ul>
+
+            <p>Any of these actions will open the transaction dialog box
+            containing the details of the selected transaction. Make the
+            changes and click OK to save the changes.</p><a href="#top">Back to
+            Top</a>
+            <hr>
+
+            <h3>Transaction Filtering in Accounts</h3>
+
+            <p>Transactions can be filtered by either fixed filters or, by
+            using the Transaction Filter in the Account View. This will allow
+            the user to limit the visible transactions to those defined by the
+            appropriate filter. These filtered transactions can then be easily
+            selected and individually modified.</p>
+
+            <p>These visible transactions can also be deleted in bulk if so
+            desired.</p>
+
+            <div>
+                <span class="label label-danger">Note:</span>
+
+                <table class="table">
+                    <tr class="warning">
+                        <td>Caution is advised when deleting transactions.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Reconciling and Balancing Transactions</h3>
+
+            <p>Unreconciled Transactions:</p>
+
+            <ul>
+                <li>This means that they have not been verified with the
+                statement from the financial institution.</li>
+            </ul>
+
+            <p>Reconciled Transactions:</p>
+
+            <ul>
+                <li>A transaction can be considered reconciled when the details
+                of the transaction match that from the financial
+                institution.</li>
+            </ul>
+
+            <p>In MMEX, reconciled and unreconciled transactions are shown by
+            different icons. When bank details are not checked against a bank
+            statement, the user can select to set the default as Reconciled
+            when creating transactions in the Options settings.</p>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>To mark a transaction as reconciled, just select
+                        the transaction and hit the 'r' or 'R' key. To mark a
+                        transaction as unreconciled, just select the
+                        transaction and hit the 'u' or 'U' key.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Flagging transactions for followup</h3>
+
+            <p>Some transactions might have some issues that you want to follow
+            up on. Mark these as with status of flag for followup. This is
+            indicated in MMEX with a different icon.</p>
+
+            <div>
+                <span class="label label-info">Tip:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>To mark a transaction as requiring followup, just
+                        select the transaction and hit the 'f or 'F' key.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Working with Currencies</h2>
+
+            <p>As MMEX can be used in many countries, MMEX need to consider the
+            currency for the country of use. When creating a new database, the
+            Base Currency is set to the currency used in the user's country. If
+            the user's currency setting is not listed in the default
+            currencies, the user can create their own currency Listing.</p>
+
+            <p>MMEX allows us to work with more than one currency. Each account
+            has its own currency setting, and will default to the base
+            currency. When we set accounts with different currencies, the
+            transactions we create in these accounts will reflect the currency
+            of the account.</p>
+
+            <p>When transactions in different currencies are detected, MMEX
+            will display a Currency Summary on the Home Page. This will reflect
+            the amount and conversion rate for each currency being used.</p>
+
+            <p>You can manage Currencies by using the menu item:
+            Tools&rarr;Organize Currency.</p>
+
+            <p>To Add a new Currency:</p>
+
+            <ul>
+                <li>Use the Add button in the Currency Dialog</li>
+
+                <li>Provide a suitable name for your new currency.<br>
+                Note: This name is not changeable, but the currency can be
+                deleted if not being used.</li>
+
+                <li>Adjust the currency values in the Currency Manager.<br>
+                The Currency Manager is also available when editing a
+                currency.</li>
+
+                <li>Use the Update button to save the changes before
+                closing.<br>
+                Note: All changes will be lost if the Update button is not used
+                before Closing.</li>
+            </ul>
+
+            <p>When more than one currency is being used, the Conversion to
+            Base Rate needs to be set. This will allow the value of the
+            currency to properly reflect the value at the base rate.</p>
+
+            <p>To allow Automatic Currency updates, the Currency Symbol needs
+            to be set for the particular currency being used.</p>
+
+            <p>To use the menu item: Tools&rarr;Online Update Currency Rate,
+            the following must occur:</p>
+
+            <ul>
+                <li>Activate the option from the Tools&rarr;Options... Others
+                page.</li>
+
+                <li>Set the Currency Symbol for all currencies requiring
+                update.</li>
+
+                <li>Set the base currency value 1</li>
+            </ul>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>Use the toolbar icon for quick selection of the
+                        Organize Currencies dialog.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Use the up/down keys to navigate the currency
+                        selection.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Working with Categories</h2>
+
+            <p>Categories indicate the reason an expenditure is made or an
+            income is received.</p>
+
+            <p>A Category is generally used to record Income or Expenses.
+            Because MMEX allows us to transfer money between accounts, it is
+            also recommended to use categories to record transfers. This will
+            allow us to determine what money is being transferred for a
+            specific reason, such as a repayment to a loan. This will not be
+            seen as an income or expense in the overall picture. Using the same
+            category for an income and an expense will upset balance
+            figures.</p>
+
+            <p>Example: If we want to record the the value of running a car, we
+            would set up the following:<br>
+            Category: Car,<br>
+            Subcategory: Fuel, Maintenance, Registration, Insurance, Fuel
+            Reimbursed<br>
+            The first 4 subcategories are used to record expenses. If we are
+            reimbursed for fuel costs for any reason, we would need to use Fuel
+            Reimbursed as an Income subcategory. This would then allow us to
+            determine the correct amount we are spending on fuel to run the
+            car. This will become clearer when we are using
+            Budgets.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Split Categories</h3>
+
+            <p>When adding a new transaction, we can use more that one category
+            to record a transaction. This is known as a split category.</p>
+
+            <p>The overall split category transaction is either a withdrawal or
+            a deposit. Although the categories within the split, need to
+            reflect the overall transaction type, each category can be
+            classified as a withdrawal or deposit within the split.</p>
+
+            <p>Split categories can easily be viewed for a transaction by using
+            a pop-up menu selection when a split category entry exists.</p>
+
+            <p>Note:<br>
+            Withdrawal Screen: Deposits are displayed as negative.<br>
+            Deposit Screen: Withdrawals are displayed as negative.</p>
+
+            <p>Managing Our Categories</p>
+
+            <p>You can manage Categories by using the menu item:
+            Tools&rarr;Organize Categories.<br>
+            Once the category dialog opens, you can add new categories and
+            subcategories.</p>
+
+            <p>To Add a new Category:</p>
+
+            <ol>
+                <li>Select Categories at the root of the tree (At the top)</li>
+
+                <li>Type the new category name into the text box</li>
+
+                <li>Use the the Add button</li>
+            </ol>
+
+            <p>The new category will appear at the bottom, and will be resorted
+            when the dialog box is re-opened.</p>
+
+            <p>To Add a new Subcategory:</p>
+
+            <ol>
+                <li>Select the category that you wish the subcategory to belong
+                to</li>
+
+                <li>Type the new subcategory name into the text box</li>
+
+                <li>Press the Add button</li>
+            </ol>
+
+            <p>You can also change the names by selecting the
+            category/subcategory in the list , modify the name in the text box,
+            then use the Edit button. Use a similar action to delete the
+            category/subcategory in the list.</p>
+
+            <p>Note: You cannot delete categories which are being used by any
+            transactions.</p>
+
+            <p>Ensure that no transactions use this category/subcategory,
+            combination. This can be done by:</p>
+
+            <ul>
+                <li>Editing the transaction and changing the
+                category/subcategory.</li>
+
+                <li>Deleting the transaction using this
+                category/subcategory.</li>
+
+                <li>Using the menu item: Tools &rarr;Relocation of...
+                Categories, where you can move all categories of a particular
+                name to an alternate category/subcategory combination.</li>
+            </ul>
+
+            <p>This would then make the category free so it can then be
+            deleted.</p>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>Use the toolbar icon for quick selection of the
+                        Organize Categories dialog.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Use the up/down keys to navigate the tree
+                        selection.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Don't use the same category for Income and Expense,
+                        as this will cause incorrect balance calculations.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Working with Payees</h2>
+
+            <p>Payees are the people or institutions that give us money, or<br>
+            the people or institutions who we pay, for our goods and
+            services.</p>
+
+            <p>You can manage Payees by using the menu item:
+            Tools&rarr;Organize Payees.</p>
+
+            <p>Once the payee dialog opens you can add new payees, edit or
+            delete existing payees.</p>
+
+            <p>To Add a new Payee:</p>
+
+            <ul>
+                <li>Enter the name of the payee in the Filter Payees box</li>
+
+                <li>Use the Add button</li>
+            </ul>
+
+            <p>You can also select the payee in the list, then use the Edit or
+            Delete button to perform the required action.</p>
+
+            <p>Note: You cannot delete payees which are being used by any
+            transactions.</p>
+
+            <p>To delete a payee, ensure that no transactions use this payee.
+            This can be done by:</p>
+
+            <ul>
+                <li>Editing the transaction and changing the payee.</li>
+
+                <li>Deleting the transaction using this payee.</li>
+
+                <li>By using the menu item: Tools&rarr;Relocation of... Payees,
+                where you can move all payees of a particular name to an
+                alternate name.</li>
+            </ul>
+
+            <p>This would then make the payee free so it can then be
+            deleted.</p>
+
+            <div>
+                <span class="label label-info">Tips:</span>
+
+                <table class="table">
+                    <tr class="success">
+                        <td>Use the toolbar icon for quick selection of the
+                        Organize Payees dialog.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Use the up/down keys to navigate the payee
+                        selection.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Use the % as a wild-card to match many characters
+                        in the filter.</td>
+                    </tr>
+
+                    <tr class="success">
+                        <td>Use _ to match a single character in the
+                        filter.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Importing From WebApp</h2>
+
+            <p>MMEX has a light WebApp that can be installed on every PHP
+            webserver like NAS, shared hosting or other PHP local
+            installation.<br>
+            You can download all needed files <a href=
+            "https://sourceforge.net/projects/moneymanagerex-webapp/files/latest/download">
+            from project page</a>.<br>
+            <br>
+            To start-up WebApp you only have to:</p>
+
+            <ul>
+                <li>unzip file in a folder on your webserver or upload files
+                through FTP</li>
+
+                <li>rename htaccess.txt in .htaccess (on Windows you need to do
+                it from CMD and "rename" command)</li>
+
+                <li>enable PDO_SQLite if needed</li>
+            </ul>
+
+            <p>Then simply open your browser to the folder URL, fill first
+            settings and insert correct URL and GUID in MMEX settings
+            (import/export tab).</p>
+
+            <p>Now at every start-up MMEX will contact WebApp for new
+            transaction that will be downloaded and imported in desktop
+            database.</p>
+
+            <p>All main transaction linked settings will be automatically
+            synced to WebApp, in this way you can have all your account and
+            payees ready to use inserting new transaction.</p>
+
+            <p>To obtain more information about set-up and installation see
+            <a href=
+            "https://sourceforge.net/p/moneymanagerex-webapp/wiki/">wiki
+            pages.</a></p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Importing From QIF Files</h2>
+
+            <p>Quicken Interchange Format (QIF) is an open specification for
+            reading and writing financial data to media (i.e. files). A QIF
+            file typically has the following structure:<br>
+            <br>
+            !Type:type identifier string<br>
+            [single character line code]Literal String Data<br>
+            ...<br>
+            ^<br>
+            [single character line code]Literal String Data<br>
+            ...<br>
+            ^<br>
+            <br>
+            Each record ends with a ^ (caret).<br>
+            See example QIF transaction<br>
+            <br>
+            !Type:Bank Header<br>
+            D6/ 1/94 Date<br>
+            T-1,000.00 Amount<br>
+            N1005 number<br>
+            PBank Of Mortgage Payee<br>
+            ^ End of transaction<br>
+            <br>
+            QIF is older than Open Financial Exchange (OFX). The inability to
+            reconcile imported transactions against the current account
+            information is one of the primary shortcomings of QIF. It is
+            commonly supported by financial institutions to supply
+            down-loadable information to account holders.<br>
+            <br>
+            MMEX can import transactions from specific types of QIF formats
+            into an account.<br>
+            <br>
+            The types are the following: (You can find the type of QIF by
+            opening in a text editor)<br>
+            !Type:Bank Bank account transactions<br>
+            !Type:Cash Cash account transactions<br>
+            !Type:CCard Credit card account transactions<br>
+            <br>
+            Important Note (1): The date format option has to match that of the
+            date format in the QIF file, otherwise, date parsing by MMEX will
+            fail and will result in transactions having incorrect dates.<br>
+            <br>
+            Important Note (2): After importing from QIF, all transactions will
+            have a ;Follow Flag; as it its status. You can mark all
+            transactions with this flag using the bulk status setting commands
+            using the right click menu in the account view.</p><a href=
+            "#top">Back to Top</a>
+            <hr>
+
+            <h2>Importing From Universal CSV Format</h2>
+
+            <p>To alleviate the problem of users having to pre-format their
+            bank transaction CSV files into the fixed format MMEX requires,
+            MMEX also allows users to import CSV files where the order of
+            fields is completely freeform. To use this importer, select the
+            account you want to import into and then select the order of fields
+            in the CSV file by picking and choosing from the list of possible
+            fields. MMEX will now import the CSV file using the format
+            information specified by the user. MMEX can import from a wide
+            variety of formats. One of them is a fixed format CSV file. This
+            file format exactly matches the CSV format that MMEX can export. So
+            it can be useful to move data from one .mmb database file to
+            another .mmb database file. To easily see the format of the CSV
+            file, you can try exporting an account to a CSV file and then
+            analyzing the format created.<br>
+            <br>
+            The CSV field options are as follows:<br>
+            Date - Date of the transaction (In the format specified in
+            Options&rarr;DateFormat)<br>
+            Payee - To whom the transaction was made. In the case of a transfer
+            transaction, this indicates the name of the account from which the
+            transfer was made or to the account the transfer was made.<br>
+            Amount (+/-) - The transaction amount. If it is a positive value it
+            is a deposit, negative value is a withdrawal.<br>
+            Category - The category of the transaction<br>
+            SubCategory - The subcategory of the transaction<br>
+            Notes - Transaction Notes<br>
+            Number - Transaction Number<br>
+            Withdrawal - An +ive amount that is considered as a withdrawal. (Do
+            not use if specifying Amount (+/-))<br>
+            Deposit - An +ive amount that is considered as a deposit. (Do not
+            use if specifying Amount (+/-))<br>
+            Don't Care - Ignore this field<br>
+            <br>
+            Note that the transactions from a CSV file can only be imported
+            into a single MMEX account.<br>
+            <br>
+            Important Note (1): The date format option has to match that of the
+            date format in the QIF file, otherwise, date parsing by MMEX will
+            fail and will result in transactions having incorrect dates.<br>
+            <br>
+            Important Note (2): After importing from QIF, all transactions will
+            have a ;Follow Flag; as it its status. You can mark all
+            transactions with this flag using the bulk status setting commands
+            using the right click menu in the account view.</p>
+            <!-- creating csv tips added by terry wick 9/14/2007 -->
+            <a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Tips for creating CSV Files</h3>
+
+            <ul>
+                <li>When creating your CSV file be sure that you remove the
+                commas from your deposits and withdrawals. This can be done
+                easily through a program such as Excel or OpenOffice Calc.</li>
+            </ul>
+
+            <ul>
+                <li>Or you can change the delimiter to be used by MMEX by
+                choosing Tools&rarr;Options and changing the ;Import/Export
+                Settings; in the ;General; option settings.</li>
+            </ul>
+
+            <ul>
+                <li>You do not need to include balance values in your CSV
+                File.</li>
+            </ul>
+
+            <ul>
+                <li>Note that the transactions from a CSV file can only be
+                imported into a single MMEX account.</li>
+            </ul><!-- end of tips addition from terry wick -->
+            <a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Exporting to CSV Files</h2>
+
+            <p>MMEX can export to a fixed format CSV file. This file format
+            exactly matches the CSV format that MMEX can import. So it can be
+            useful to move data from one .mmb database file to another .mmb
+            database file. To easily see the format of the CSV file, you can
+            try exporting an account to a CSV file and then analyzing the
+            format created.<br>
+            <br>
+            The general format is as follows:<br>
+            Date - Date of the transaction (Displayed in the format specified
+            in Options&rarr;DateFormat)<br>
+            Payee - To whom the transaction was made. In the case of a transfer
+            transaction, this indicates the name of the account from which the
+            transfer was made or to the account the transfer was made.<br>
+            Transaction Type - This can either be ;Withdrawal; or ;Deposit;<br>
+            Amount - The transaction amount as a positive value<br>
+            Category - The category of the transaction<br>
+            SubCategory - The subcategory of the transaction if any (otherwise
+            blank)<br>
+            Notes - Transaction Notes<br>
+            <br>
+            Note that the transactions from an account can be exported to a
+            single CSV file.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Exporting to QIF Files</h2>
+
+            <p>MMEX can export an account to a file of the format: QIF.</p>
+
+            <p>This format can also be used by MMEX to reload into an
+            account.</p>
+
+            <p>Caution: Although Transfer transactions will be reloaded into a
+            single account, they will not function correctly.</p><a href=
+            "#top">Back to Top</a>
+            <hr>
+
+            <h2>Recurring Transactions</h2>
+
+            <p>These are special transactions that we set up in order to have
+            the transaction entered into the data base at some future date.
+            These transactions generally occur at regular intervals, such as
+            the payment of a bill.</p>
+
+            <p>These transactions:</p>
+
+            <ul>
+                <li>Are displayed as reminders on the Home Page within 15 Days
+                of the due date.</li>
+
+                <li>Can be set up to activate automatically on the due
+                date.</li>
+
+                <li>Can be set up to activate &ndash; allowing the user to
+                adjust any values on the due date.</li>
+            </ul>
+
+            <p>Recurring Transactions can be accessed from the navigation tree
+            or from the menu item Tools&rarr;Recurring Transactions. This will
+            display the Recurring Transactions page.</p>
+
+            <p>To create a new transaction, use the New button:</p>
+
+            <ul>
+                <li>Set up the Recurring Transactions Details, defining which
+                account the transaction will go to when the transaction is
+                entered.</li>
+
+                <li>
+                    <p>Set the date of the Next Occurrence,<br>
+                    except for Repeats: In x Days/Months.</p>
+                </li>
+
+                <li>Select the Repeats as ;daily;, ;weekly; etc.</li>
+
+                <li>Times Repeated:<br>
+                - Enter the number of times this will occur.<br>
+                - No number means: Repeat indefinitely.</li>
+
+                <li>For Repeats: In x Days/Months<br>
+                - Set the Start date of the activity.<br>
+                - Set the period in Days or months depending on the
+                selection.<br>
+                - Use the Next button to advance the date to the occurrence
+                Date.<br>
+                - Changes to the period will reactivate the Next button. Once
+                the transaction has been entered, the activity becomes
+                inactive.</li>
+
+                <li>Repeats: Every x Days/Months<br>
+                Similar to regular repeats with the exception that the period
+                is stated in Days or Months</li>
+
+                <li>Set up the Transaction Details section, similar to creating
+                new transactions.</li>
+            </ul>
+
+            <p>These transaction will be displayed as: Upcoming Transactions
+            &gt;on the home page within 15 days of the due date.</p>
+
+            <div>
+                <span class="label label-danger">Note:</span>
+
+                <table class="table">
+                    <tr class="warning">
+                        <td>When we enter the transaction, we can change the
+                        amount, payee, category, status and date if
+                        required.</td>
+                    </tr>
+
+                    <tr class="warning">
+                        <td>Entering a transaction before it is due , will gray
+                        out the transaction in the associated account until the
+                        day it becomes active.</td>
+                    </tr>
+
+                    <tr class="warning">
+                        <td>To use the Cash Flow Reports we need to set up
+                        recurring transactions.</td>
+                    </tr>
+                </table>
+            </div><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Assets</h2>
+
+            <p>MMEX allows you to track fixed assets like cars, houses, land
+            and others. Each asset can have its value appreciate by a certain
+            rate per year, depreciate by a certain rate per year, or not change
+            in value. The total assets are added to your total financial
+            worth.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Transaction Report Filter</h2>
+
+            <p>MMEX allows you to search for transactions that meet certain
+            criteria. This can be done using the Transaction Filter, located
+            Account View or as a Transaction Report.</p>
+
+            <p>For a Transaction Report, the resulting list of transactions can
+            be printed or saved as a HTML file.</p><a href="#top">Back to
+            Top</a>
+            <hr>
+
+            <h2>Reports</h2>
+
+            <p>MMEX allows a variety of reports.<br>
+            All the reports can also be printed if required using the menu:
+            File&rarr;Print...&rarr;Current View</p>
+
+            <p>Select the appropriate report under the Reports node in the
+            navigation tree. Some reports require some user input, some do not.
+            Once you view a report, you can print the report using the print
+            options in the menu.</p>
+
+            <p>Financial Year Reports: (Required by various countries)</p>
+
+            <p>These reports generally do not start at the beginning of the
+            calendar year, and appear as branches of the main report titles.
+            These reports cover:</p>
+
+            <ol>
+                <li>
+                    <p>Previous Financial Year.</p>
+                </li>
+
+                <li>
+                    <p>Current Financial Year.</p>
+                </li>
+            </ol>
+
+            <p>By default the start date of a financial year is 1<sup>st</sup>
+            July of the year.</p>
+
+            <p>The start date can be changed by the user to start on any day of
+            any month, within a 12 month period by using the menu
+            Tools&rarr;Options then selecting the General panel.</p>
+
+            <p><br>
+            Transaction Reports:</p>
+
+            <ol>
+                <li>
+                    <p>This allows the user to generate specific reports based
+                    on selected user requirements.</p>
+                </li>
+
+                <li>
+                    <p>Also known as the Transaction Report Filter.</p>
+                </li>
+            </ol>
+
+            <p>A Transaction Report is generally used to locate specific
+            transactions made within Bank or Term type accounts. This report
+            can also be used to display specific details for a particular
+            account.</p><br>
+
+            <p>Transaction Report - transfer transactions may upset balance
+            totals.</p>
+
+            <p>Since a transfer transaction is a withdrawal from one account
+            and a deposit to another account, a transaction report done on
+            multiple accounts looses the reference point for determining
+            weather the transaction is a deposit or withdrawal.</p>
+
+            <p>When a transaction report is used for a specific account, it
+            will generate a report that will match the account details. The
+            reference point for transfers in known for this report, which will
+            reflect in the report having correct balances displayed.</p>
+
+            <p>Cash flow Reports</p>
+
+            <p>This report projects the amount of funds available, based on
+            future commitments.</p>
+
+            <p>Future commitments are determined from the Recurring
+            Transactions that are set up for the various accounts. The report
+            will then use the Recurring Transactions for the various accounts,
+            and reflect forward 10 years on a monthly basis. This becomes a
+            prediction of the amount of money that may be available each month
+            based on current payments.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Printing</h3>
+
+            <p>MMEX supports printing of all reports that can be viewed.</p>
+
+            <p>The print options are available under the menu,
+            File&rarr;Print... Current View</p>
+
+            <p>Recommendations:</p>
+
+            <ul>
+                <li>Use the page setup option to reformat the page if
+                necessary</li>
+
+                <li>Use the print preview option to check the layout of the
+                report before printing.</li>
+            </ul><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>MMEX Options</h2>
+
+            <p>You can modify some run time behavior of MMEX by changing the
+            options in the Options Dialog.</p>
+
+            <p>Access from the menu with Tools&rarr;Options</p>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>General Panel</th>
+
+                        <th></th>
+                    </tr>
+                </thead>
+
+                <tr>
+                    <td>
+                        <p>User Name<br>
+                        Optional</p>
+                    </td>
+
+                    <td>
+                        <p>This field is used as a title on the Home Page, and
+                        on Reports.<br>
+                        Leaving this field blank, will remove the Home Page and
+                        Report titles.</p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <p>Language</p>
+                    </td>
+
+                    <td>
+                        <p>This is the language used by the MMEX GUI. MMEX
+                        might require a restart before all GUI elements have
+                        the new language.</p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <p>Base Currency:</p>
+                    </td>
+
+                    <td>
+                        <p>The base currency setting is used to set the
+                        currency of the database. Individual accounts will use
+                        this as the default, but can be changed if different
+                        currencies as required.</p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>Date Format:</td>
+
+                    <td>The date format setting is used to control how dates
+                    should be displayed and also how dates should be parsed
+                    when importing QIF, CSV files.</td>
+                </tr>
+
+                <tr>
+                    <td>Financial Year</td>
+
+                    <td>Sets the start Day and Month for a Financial Year
+                    period, as opposed to a calendar year. This is used in
+                    Budgets and Reports.</td>
+                </tr>
+
+                <tr>
+                    <td>Database Backup</td>
+
+                    <td>
+                        <p>Sets the way the backups are performed when MMEX
+                        starts.</p>
+
+                        <ul>
+                            <li>Create a new backup when MMEX Starts<br>
+                            This copies the database to a new file with today's
+                            date, when MMEX Starts.<br>
+                            The file will not be over written when MMEX starts
+                            up again. When there are more that 4 backup files,
+                            the oldest file is deleted.</li>
+
+                            <li>Update database changes to database backup on
+                            exit.<br>
+                            When MMEX shuts down, the existing database will be
+                            copied to a backup database file for that day when
+                            changes to the database have been detected. When
+                            changes are made on the same day, the existing
+                            backup is over written. When there are more that 4
+                            backup files, the oldest file is deleted.</li>
+                        </ul>
+                    </td>
+                </tr>
+            </table><br>
+            <br>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>View Options Panel</th>
+
+                        <th></th>
+                    </tr>
+                </thead>
+
+                <tr>
+                    <td>
+                        <p>Account View</p>
+                    </td>
+
+                    <td>This sets the Navigation tree's visible accounts,
+                    according to status.</td>
+                </tr>
+
+                <tr>
+                    <td>Transaction View</td>
+
+                    <td>This determines which transactions are seen as default
+                    in the Account View.</td>
+                </tr>
+
+                <tr>
+                    <td>Font Size</td>
+
+                    <td>This will set the font being used on the Home Page and
+                    in Reports.</td>
+                </tr>
+
+                <tr>
+                    <td>Tree View<br>
+                    Expand Section</td>
+
+                    <td>Sets the account types being expanded when in the
+                    navigation tree is refreshed.</td>
+                </tr>
+
+                <tr>
+                    <td>Home Page<br>
+                    Expand Section</td>
+
+                    <td>Sets the account types being expanded when the home
+                    page is refreshed.</td>
+                </tr>
+
+                <tr>
+                    <td>&nbsp;</td>
+
+                    <td>&nbsp;</td>
+                </tr>
+            </table><br>
+            <br>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Colors Panel</th>
+
+                        <th></th>
+                    </tr>
+                </thead>
+
+                <tr>
+                    <td></td>
+
+                    <td>Allows the user to modify colors in MMEX to suit
+                    his/her style.</td>
+                </tr>
+            </table><br>
+            <br>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Import/Export Panel</th>
+
+                        <th></th>
+                    </tr>
+                </thead>
+
+                <tr>
+                    <td>CSV Limiter</td>
+
+                    <td>This is used as the delimiting character when parsing
+                    CSV files. This is useful to modify from the default ','
+                    when dealing with currencies that use ',' to denote decimal
+                    points in amounts.</td>
+                </tr>
+
+                <tr>
+                    <td>WebApp settings</td>
+
+                    <td>Set URL and GUID of your WebApp installation to allow
+                    data sync. Parameters can be found in WebApp 'Guide'
+                    page.</td>
+                </tr>
+            </table>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Others Panel</th>
+
+                        <th></th>
+                    </tr>
+                </thead>
+
+                <tr>
+                    <td>New Transactions</td>
+
+                    <td>Changes the default settings for the New/Edit
+                    Transactions Dialog</td>
+                </tr>
+
+                <tr>
+                    <td>Stock Quote Web Page</td>
+
+                    <td>This URL is used by the Refresh button on the Stock
+                    Investments page. This URL is also used by the New/Edit
+                    Stock dialog, to display the web page for the listed stock.
+                    The default is yahoo finance. Alternatively other sites can
+                    be used if necessary.</td>
+                </tr>
+
+                <tr>
+                    <td>Use Original date...</td>
+
+                    <td>Activate to use the date of the transaction date when
+                    using paste transaction, in account view.</td>
+                </tr>
+
+                <tr>
+                    <td>Use sound...</td>
+
+                    <td>Activate to plays a sound when a transaction is
+                    entered.</td>
+                </tr>
+
+                <tr>
+                    <td>Enable online currency...</td>
+
+                    <td>Activate to allow currencies to be updated via the
+                    internet.</td>
+                </tr>
+            </table><a href="#top">Back to Top</a>
+            <hr>
+
+            <h2>Frequently Asked Questions</h2>
+
+            <h3>How can I contribute?</h3>
+
+            <p>You can contribute by</p>
+
+            <ul>
+                <li>Reporting bugs</li>
+
+                <li>Translating to your language</li>
+
+                <li>Helping spread the word</li>
+
+                <li>If you are a C++ expert, by helping extend MMEX developing
+                code.</li>
+
+                <li>If you are really very happy because you saved a lot of
+                money by using MMEX, you can donate to the MMEX project.</li>
+            </ul>
+
+            <form action="https://www.paypal.com/cgi-bin/webscr" method="post"
+            target="_top">
+                <input name="cmd" type="hidden" value="_donations">
+                <input name="business" type="hidden" value=
+                "moneymanagerex@moneymanagerex.org"> <input name="lc" type=
+                "hidden" value="US"> <input name="item_name" type="hidden"
+                value="MoneyManagerEx"> <input name="no_note" type="hidden"
+                value="0"> <input name="currency_code" type="hidden" value=
+                "USD"> <input name="bn" type="hidden" value=
+                "PP-DonationsBF:btn_donateCC_LG.gif:NonHostedGuest">
+                <input alt="PayPal - The safer, easier way to pay online!"
+                name="submit" src="btn_donateCC_LG.gif" type="image">
+            </form><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>What's the reason for the EX in the name of the software?</h3>
+
+            <p>Originally I developed a personal finance software called Money
+            Manager. It was written in .NET and more of a learning exercise
+            than serious software development. It grew far beyond the original
+            design. The software was frozen and work began on a new version
+            which had a similar user interface and features, but written in
+            C++.&nbsp;</p>
+
+            <p>Usually Microsoft names their second version of their improved
+            software APIs with an Ex extension as in doSomething() and
+            doSomethingEx(). So I just followed the model and tacked on a 'Ex'
+            to the end.</p><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Is the .mmb format proprietary? And, Is my data safe?</h3>
+
+            <table>
+                <tr>
+                    <td>No</td>
+
+                    <td>.mmb file is not proprietary.</td>
+                </tr>
+
+                <tr>
+                    <td>&nbsp;</td>
+
+                    <td>MMEX uses SQLite databases to store user data. That
+                    means that the .mmb file is a regular SQLite database.
+                    SQLite is one of the smallest, free relational database
+                    systems around and there are tons of tools to open and
+                    access SQLite databases. SQLiteSpy and SQLite Browser
+                    (http://sqlitebrowser.sourceforge.net/) are two such
+                    utilities. Once you open the database using these tools,
+                    you can do anything you want with the data.</td>
+                </tr>
+
+                <tr>
+                    <td>Yes</td>
+
+                    <td>Your data is completely safe.</td>
+                </tr>
+
+                <tr>
+                    <td>&nbsp;</td>
+
+                    <td>The data is self contained on your PC, (or USB stick if
+                    you have made it portable). To further protect your data,
+                    encryption can now be added. This applies a password to
+                    your database file, and can only be opened by MMEX or any
+                    other software if you have the correct password.</td>
+                </tr>
+            </table><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>Can MMEX run from a USB Key?</h3>
+
+            <p>Yes.</p>
+
+            <p>MMEX is a portable application which means ability to run
+            without installation, for example, from USB flash drive. If MMEX
+            finds mmexini.db3 in its folder, it assumes portable mode. Copy
+            mmex's files to USB Key and copy yours mmexini.db3 to mmex's folder
+            on that drive.</p>
+
+            <p>To make MMEX portable:</p>
+
+            <ol>
+                <li>On Windows (assume F:\ is USB flash drive)<br>
+                Copy ;C:\Program Files\MoneyManagerEx; to F:\<br>
+                Copy ;%APPDATA%\MoneyManagerEx\mmexini.db3; to
+                F:\MoneyManagerEx<br>
+                Copy your database file to any folder on F:\<br>
+                <br>
+                <br></li>
+
+                <li>On Unix (assume /media/disk is mounted USB flash drive)<br>
+                Compile mmex from sources as usually,<br>
+                and make install prefix=/media/disk<br>
+                cp ~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex<br>
+                <br>
+                or if you want to copy mmex which has already installed in
+                /usr<br>
+                cp /usr/bin/mmex /media/disk/mmex/bin<br>
+                cp /usr/share/mmex /media/disk/mmex/share<br>
+                cp /usr/share/doc/mmex /media/disk/mmex/share/doc<br>
+                cp ~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex<br></li>
+            </ol><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>How do I know MMEX is not trying to steal my sensitive
+            financial information?</h3>
+
+            <p>Generally, with any closed source program, you have to depend
+            upon the vendor's word regarding safety of the data. But with MMEX
+            being open source, you can verify this claim yourself.<br>
+            Even if you are not a C++ expert, you can rest assured that anyone
+            can access the source code at any time and verify the legitimacy of
+            MMEX's intentions.<br>
+            MMEX does connect to the internet only to send anonymous usage
+            statistics or when checking for an update.<br>
+            You can disable this in Options-&gt;Network<br>
+            <br>
+            <br>
+            Here is a sample of data that MMEX will send:<br>
+            <br></p>
+
+            <table>
+                <tr>
+                    <th>Version</th>
+
+                    <th>Operating System</th>
+
+                    <th>Language</th>
+
+                    <th>Country</th>
+
+                    <th>Resolution</th>
+
+                    <th>Start Time</th>
+
+                    <th>End Time</th>
+                </tr>
+
+                <tr>
+                    <td>1.2.0 Portable</td>
+
+                    <td>Windows 8 (build 9200), 64-bit edition</td>
+
+                    <td>english</td>
+
+                    <td>United States</td>
+
+                    <td>1366x768</td>
+
+                    <td>2014-05-01 09:00:00</td>
+
+                    <td>2014-05-01 09:01:30</td>
+                </tr>
+            </table><a href="#top">Back to Top</a>
+            <hr>
+
+            <h3>How do I print account statements using MMEX?</h3>
+
+            <p>To print a statement with transactions from any arbitrary set of
+            criteria, use the Transaction Filter to select the transactions you
+            want and then do a print from the menu.
+            File&rarr;Print...&rarr;Current View</p>
+
+            <p>The Transaction Filter is accessed from Reports&rarr;Transaction
+            Reports on the Navigation Tree, or<br>
+            from the Quick Navigation buttons in the top left hand corner of
+            MMEX.</p><a href="#top">Back to Top</a>
+            <hr>
+            Copyright &copy; 2005-2013, CodeLathe LLC. All rights reserved.
+        </div><script>
+window.onload = function () {
+        var toc = "";
+        var level = 0;
+
+        document.getElementById("contents").innerHTML =
+        document.getElementById("contents").innerHTML.replace(
+            /<h([\d])>([^<]+)<\/h([\d])>/gi,
+            function (str, openLevel, titleText, closeLevel) {
+                if (openLevel != closeLevel) {
+                    return str;
+                }
+
+                if (openLevel > level) {
+                    toc += (new Array(openLevel - level + 1)).join("<ul>");
+                } else if (openLevel < level) {
+                    toc += (new Array(level - openLevel + 1)).join("<\/ul>");
+                }
+
+                level = parseInt(openLevel);
+
+                var anchor = titleText.replace(/ /g, "_");
+                toc += "<li><a href=\"#" + anchor + "\">" + titleText
+                    + "<\/a><\/li>";
+
+                return "<h" + openLevel + "><a name=\"" + anchor + "\">"
+                    + titleText + "<\/a><\/h" + closeLevel + ">";
+            }
+        );
+
+        if (level) {
+        toc += (new Array(level + 1)).join("<\/ul>");
+        }
+
+        document.getElementById("toc").innerHTML += toc;
+        };
+        </script> 
+    </div>
+</body>
+</html>

--- a/doc/help/index.html
+++ b/doc/help/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF8">
+    <meta charset="UTF-8">
 
     <title>Money Manager Ex User Manual</title>
     <link href="master.css" rel="stylesheet" type="text/css">
@@ -49,6 +49,7 @@
 
         <h1>Money Manager Ex User Manual <small>MMEX 1.2.0</small></h1>
         <hr>
+    </div>
 
         <h2>Contents</h2>
 
@@ -1949,6 +1950,5 @@ window.onload = function () {
         document.getElementById("toc").innerHTML += toc;
         };
         </script> 
-    </div>
 </body>
 </html>

--- a/doc/help/italian/index.html
+++ b/doc/help/italian/index.html
@@ -1,6 +1,6 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
-	<meta http-equiv="CONTENT-TYPE" content="text/html; charset=windows-1252"><title>Money Manager Ex User Manual</title>
+	<meta charset="utf-8"><title>Money Manager Ex User Manual</title>
 	
 	<meta name="GENERATOR" content="OpenOffice.org 3.3  (Win32)">
 	<meta name="CREATED" content="0;0">
@@ -9,6 +9,7 @@
 	<meta name="ProgId" content="FrontPage.Editor.Document">
 	<meta name="CHANGEDBY" content="Stefano Giorgio">
 	<meta name="CHANGEDBY" content="Stefano Giorgio">
+	<link href="../master.css" rel="stylesheet" type="text/css">
 	<style type="text/css">
 	<!--
 		H2.cjk { font-family: "SimSun" }
@@ -31,7 +32,7 @@ Manager Ex<br><font size="3">MMEX 0.9.9.0</font></font></h2>
 				<li><p style="margin-bottom: 0in;"><a href="#introduction"><font face="Verdana"><span style="font-weight: normal;">Introduzione</span></font></a></p>
 				</li><li><p style="margin-bottom: 0in;"><a href="#financial_health"><font face="Verdana">Ottenere un Miglior Rendimento Finanziario<br>
 </font></a></p>
-				</li><li><p style="margin-bottom: 0in;"><a href="#concepts"><font face="Verdana">Funzionalità di Money
+				</li><li><p style="margin-bottom: 0in;"><a href="#concepts"><font face="Verdana">Funzionalitï¿½ di Money
 				Manager Ex<br>
 </font></a></p>
 				</li><li><p><a href="#recommendation"><font face="Verdana">Raccomandazioni</font></a></p>
@@ -139,24 +140,24 @@ Manager Ex<br><font size="3">MMEX 0.9.9.0</font></font></h2>
 </p>
 <hr>
 <h3 class="western"><a name="introduction"></a><font face="Verdana"><br>Introduzione</font></h3>
-<p><font face="Verdana"><b>M</b>oney <b>M</b>anager <b>Ex</b> (<b>MMEX</b>)</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> è un programma 
+<p><font face="Verdana"><b>M</b>oney <b>M</b>anager <b>Ex</b> (<b>MMEX</b>)</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> ï¿½ un programma 
 libero e di facile utilizzo per la gestione dei vostri soldi e delle vostre Finanaze Personali.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">MMEX aiuta soprattutto ad organizzare le operazioni finanziarie e tiene traccia di dove, 
 quando e come il denaro esce ed entra.</font></span></p>
-<p><font face="Verdana">Il primo obiettivo di MMEX è semplificare i
+<p><font face="Verdana">Il primo obiettivo di MMEX ï¿½ semplificare i
 processi di gestione finanziaria senza renderli un operazione complessa
-come accade con programmi di gestione finanaziaria più diffusi e
+come accade con programmi di gestione finanaziaria piï¿½ diffusi e
 conosciuti.</font></p>
 <p><font face="Verdana">Pensate a Money Manager Ex come ad un registro computerizzato </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">che vi permette di organizzare e 
 bilanciare i vostri conti bancari, gestire e generare rendiconti, rapporti ed estratti conto delle vostre 
 finanze.</font></span><font face="Verdana"> </font>
 </p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">E 'anche un ottimo mezzo per tenere aggiornati le vostre attività finanziarie.</font></span></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Lo scopo di questo manuale è 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">E 'anche un ottimo mezzo per tenere aggiornati le vostre attivitï¿½ finanziarie.</font></span></p>
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Lo scopo di questo manuale ï¿½ 
 quello di darvi le istruzioni di base per l'utilizzo di MMEX.</font></span> 
-<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo manuale seguirà lo sviluppo del 
-programma e quindi con esso verà costantemente aggiornato. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Pertanto
+<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo manuale seguirï¿½ lo sviluppo del 
+programma e quindi con esso verï¿½ costantemente aggiornato. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Pertanto
 si consiglia di controllare regolarmente gli aggiornamento del
-programma per scoprire le ultime novità per una migliore fruizione di
+programma per scoprire le ultime novitï¿½ per una migliore fruizione di
 MMEX.</font></span>
 </p>
 <h5 class="western"><font face="Verdana"><a href="#top">Torna all'inizio</a><br></font><br><br>
@@ -167,29 +168,29 @@ MMEX.</font></span>
 certa conoscenza delle materie economiche. La gestione finanaziaria
 diventa complicata quando non si ha una chiara comprensione dei flussi
 finanaziari e di come questi siano influenzati da entrate ed uscite. Il
-debito, generalmente è la risultante del superamento, in eccesso, dell'ammontare delle uscite rispetto alle
+debito, generalmente ï¿½ la risultante del superamento, in eccesso, dell'ammontare delle uscite rispetto alle
 entrate. </font><font face="Verdana"><br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Il primo 
-passo verso una migliore organizzazione finanziaria è mantenere in ordine i propri archivi e dati finanaziari.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Solo
+passo verso una migliore organizzazione finanziaria ï¿½ mantenere in ordine i propri archivi e dati finanaziari.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Solo
 se si comprende come e cosa&nbsp; abbia generato le spese,
-anche su base giornaliera, si avrà la possibilità di poterle ridurre, o quantomeno limitarle al meglio.</font></span> </p>
+anche su base giornaliera, si avrï¿½ la possibilitï¿½ di poterle ridurre, o quantomeno limitarle al meglio.</font></span> </p>
 
 
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Vi accorgete analizzando i rendiconti che l'anno scorso avete speso 600 euro nell'acquisto di film DVD?</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Chiedetevi quante volte li avete utilizzati? </font></span></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">Pensate
-che ora che quei 600 € vi sarebbero tornati utili per una riparazione
-di un guasto imprevisto dell'auto avvenuto giusto due giorni fa?</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Naturalmente non c'è una 
+che ora che quei 600 ï¿½ vi sarebbero tornati utili per una riparazione
+di un guasto imprevisto dell'auto avvenuto giusto due giorni fa?</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Naturalmente non c'ï¿½ una 
 risposta giusta o sbagliata in assoluto su come si dovrebbero spendere i 
 soldi.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Dopo
 tutto, siete voi che avete guadagnato quei soldi e il diritto di
-spenderli è legato al modo di vedere le cose vostro e dei vostri
-familiari, se li avete.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Ma si può sempre cercare diottimizzare l'uso dei vostri soldi,</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">cercate
+spenderli ï¿½ legato al modo di vedere le cose vostro e dei vostri
+familiari, se li avete.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Ma si puï¿½ sempre cercare diottimizzare l'uso dei vostri soldi,</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">cercate
 di avere una miglior "ritorno" per ogni euro speso o investito
-("ritorno inteso come qualità e valore di un bene acquistato, tasso di
+("ritorno inteso come qualitï¿½ e valore di un bene acquistato, tasso di
 rendimento di un titolo, ecc.").</font></span> <font face="Verdana"><br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Qui</font></span> <font face="Verdana">entra
 in gioco questo programma di gestione finanziaria. Vi aiuta
 raggruppare e suddividere i vostri dati finanziari per darvi una migliore d'insieme di quanto sta accadendo.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Ricordate
-sempre che l'affidabilità del programma è proprozionale alla correttezza
+sempre che l'affidabilitï¿½ del programma ï¿½ proprozionale alla correttezza
 dei dati che inserite e che esso da solo non basta di certo a risanare delle finanaze disastrate ed in disordine.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Ma
-già l'aver cominciato ad utilizzare un programma di gestione
+giï¿½ l'aver cominciato ad utilizzare un programma di gestione
 finanaziaria vi mette sulla buona strada per gestire al meglio ogni
 euro guadagnato.</font></span> </p>
 
@@ -197,53 +198,53 @@ euro guadagnato.</font></span> </p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Continua a leggere come utilizzare Manager Ex Money.</font></span> </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
-<h3 class="western"><a name="concepts"></a><font face="Verdana"><br>Funzionalità di Money
+<h3 class="western"><a name="concepts"></a><font face="Verdana"><br>Funzionalitï¿½ di Money
 Manager Ex<br>
 </font></h3>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Money Manager Ex organizza la finananza reale attraverso i concetti di operazioni</font></span><font face="Verdana">.</font></p>
 <p><font face="Verdana">Generalmente riceviamo denaro da qualcuno per
-un servizio che forniamo, o un prodotto che vendiamo. Questa è
+un servizio che forniamo, o un prodotto che vendiamo. Questa ï¿½
 considerata come una Entrata o come un </font><a href="#trans_types"><font face="Verdana"><b>Deposito</b></font></a> <font face="Verdana">dal
 nostro sistema. Al contrario quando acquistiamo un prodotto o fruiamo
-di un servizio, il denaro che spendiamo è considerata un Uscita o </font><a href="#trans_types"><font face="Verdana"><b>Prelievo</b></font></a> <font face="Verdana">. In MMEX, le persone che danno o ricevono denaro da noi sono considerati dal sistema come </font><a href="#payees"><font face="Verdana"><b>Beneficiari</b></font></a> <font face="Verdana">.</font></p>
-<p><font face="Verdana">Così come ci auguriamo di non spendere tutto il
+di un servizio, il denaro che spendiamo ï¿½ considerata un Uscita o </font><a href="#trans_types"><font face="Verdana"><b>Prelievo</b></font></a> <font face="Verdana">. In MMEX, le persone che danno o ricevono denaro da noi sono considerati dal sistema come </font><a href="#payees"><font face="Verdana"><b>Beneficiari</b></font></a> <font face="Verdana">.</font></p>
+<p><font face="Verdana">Cosï¿½ come ci auguriamo di non spendere tutto il
 denaro che riceviamo a vario titolo, ovviamente abbiamo bisogno&nbsp;
-di una locazione in cui tenere il denaro. Questo generalmente è un
+di una locazione in cui tenere il denaro. Questo generalmente ï¿½ un
 Istituto Bancario o Finanaziario, Enti ed Istituzioni varie o le nostre
 tasche. MMEX etichetta queste locazioni come </font><a href="#create_account"><font face="Verdana"><b>Conti</b></font></a><font face="Verdana">.
 </font>
 </p>
 <p><font face="Verdana">Quando spendiamo o riceviamo del denaro, noi consideriamo questo come una <span style="text-decoration: underline;"><span style="font-style: italic;"><span style="font-weight: bold;"></span></span></span></font><a href="#creating_new_transaction"><font face="Verdana"><i><b>operazione</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;">, ed il motivo di tale operazione di entrata o uscita ci viene visualizzata dalla sua </span></i></font><a href="#categories"><font face="Verdana"><i><b>categoria</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;">.
-Talvolta possiamo avere necessità trasferire del denaro da una parte ad
+Talvolta possiamo avere necessitï¿½ trasferire del denaro da una parte ad
 un altra, come, per esempio, un prelievo Bancomat (ATM), questo tipo di
-operazione è chiamata </span></i></font><a href="#trans_types"><font face="Verdana"><i><b>trasferimento</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;">.</span></i></font></p><span style="font-family: Verdana;"><span style="font-style: italic;"><br>
-</span></span><table border="0" cellpadding="0" cellspacing="0" width="100%"><tbody><tr valign="top"><td width="20%"><p style="font-weight: normal;"><font face="Verdana"><i>Tali funzionalità possono essere riassunte come illustrato nel diagramma a lato:</i></font></p>
+operazione ï¿½ chiamata </span></i></font><a href="#trans_types"><font face="Verdana"><i><b>trasferimento</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;">.</span></i></font></p><span style="font-family: Verdana;"><span style="font-style: italic;"><br>
+</span></span><table border="0" cellpadding="0" cellspacing="0" width="100%"><tbody><tr valign="top"><td width="20%"><p style="font-weight: normal;"><font face="Verdana"><i>Tali funzionalitï¿½ possono essere riassunte come illustrato nel diagramma a lato:</i></font></p>
 		</td>
 		<td width="80%">
-			<p><img style="border: 0px solid ; width: 581px; height: 338px;" alt="Funzionalità di MMEX" src="./mmex_concept.png" name="graphics1">
+			<p><img style="border: 0px solid ; width: 581px; height: 338px;" alt="Funzionalitï¿½ di MMEX" src="./mmex_concept.png" name="graphics1">
 						</p>
 		</td>
 	</tr>
 </tbody></table>
-<p><font face="Verdana">Un altra cosa importante da considerare è la </font><a href="#currencies"><font face="Verdana"><b>Valuta</b></font></a><font face="Verdana"> che utilizziamo per eseguire le operazioni.</font></p>
+<p><font face="Verdana">Un altra cosa importante da considerare ï¿½ la </font><a href="#currencies"><font face="Verdana"><b>Valuta</b></font></a><font face="Verdana"> che utilizziamo per eseguire le operazioni.</font></p>
 <p><font face="Verdana">Per archiviare e tenere traccia di tutti questi dati,
 MMEX utilizza un </font><a href="#create_database"><font face="Verdana"><b>Database</b></font></a>&nbsp; <font face="Verdana">per archiviare e mettere in relazione tra loro tutti questi dati.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
 <h3 class="western"><a name="recommendation"></a><font face="Verdana"><br>Racommandazioni</font></h3>
 <p><font face="Verdana">Il database generato da MMEX, un file con estensione <b>.mmb</b>,
-è molto importante che lo custodiate con cura.
+ï¿½ molto importante che lo custodiate con cura.
 A seconda delle circostanze potrebbe essere necessario utilizzare
 funzioni di sicurezza come la crittografia del database, che viene
-generato sotto forma di file <b>.emb</b>. Questa funzione permetterà d'impostare una password per il database .emb che sarà richiesta ad ogni successiva apertura.</font></p>
+generato sotto forma di file <b>.emb</b>. Questa funzione permetterï¿½ d'impostare una password per il database .emb che sarï¿½ richiesta ad ogni successiva apertura.</font></p>
 <p><font face="Verdana"><b>Se crittografate il database, non perdete la password</b>.</font></p>
 <p><font face="Verdana">Come per qualsiasi altra sezione del computer,
-i nostri dati sono molto importanti, quindi è necessario
+i nostri dati sono molto importanti, quindi ï¿½ necessario
 metterli al riparo da possibili malfunzionamenti del sistema o
 dell'hardware o altre cancellazioni accidentali. MMEX ha un sistema di backup integrato che esegue una
 copia del database alla sua apertura, e, se necessario, provvede
 all'aggiornamento costante e giornaliero di detta copia, anche se il
-database è aperto più volte al giorno.</font></p>
+database ï¿½ aperto piï¿½ volte al giorno.</font></p>
 <ul>
 	<li><p><font face="Verdana">Eseguire regolarmente un backup del vostro database .mmb o .emb .</font></p>
 	</li><li><p><font face="Verdana">Tenere sempre una copia del backup su un supporto diverso per proteggerlo da crash di sistema o hardware.<br>
@@ -255,44 +256,44 @@ il backup del vostro database .mmb or .emb .</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
 <h3 class="western"><a name="create_database"></a><font face="Verdana"><br>Creare un&nbsp; Nuovo Database</font></h3>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Al primo avvio di MMEX, il programma tenterà di caricare l'ultimo database che è stato utilizzato.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se non esiste alcun database, all'utente verrà richiesto o di 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Al primo avvio di MMEX, il programma tenterï¿½ di caricare l'ultimo database che ï¿½ stato utilizzato.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se non esiste alcun database, all'utente verrï¿½ richiesto o di 
 aprire un database esistente (specificandone la posizione), o di crearne uno nuovo.</font></span></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se è necessario 
-creare un nuovo database, è possibile farlo anche dal menù selezionando <b>File-&gt; Nuovo 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se ï¿½ necessario 
+creare un nuovo database, ï¿½ possibile farlo anche dal menï¿½ selezionando <b>File-&gt; Nuovo 
 database.</b></font></span></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Come prima cosa verrà richiesto</font></span><font face="Verdana"> di specificare un nome ed una posizione in cui salvare il vostro nuovo database (.mmb).</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Il
-vostro nuovo database verrà ora creato e sarà visualizzata una
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Come prima cosa verrï¿½ richiesto</font></span><font face="Verdana"> di specificare un nome ed una posizione in cui salvare il vostro nuovo database (.mmb).</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Il
+vostro nuovo database verrï¿½ ora creato e sarï¿½ visualizzata una
 procedura guidata (wizard) per aiutarvi nella personalizzazione del
 nuovo database, aiutandovi nella</font></span><font face="Verdana"> <a href="#create_account">creazione del vostro primo conto<br>
 </a></font></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">La creazione guidata del </font></span><font face="Verdana">Nuovo Database richiederà di scegliere la <b>Valuta</b> di base in uso nei conti e un <b>Nome Utente.</b></font></span> </p>
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">La creazione guidata del </font></span><font face="Verdana">Nuovo Database richiederï¿½ di scegliere la <b>Valuta</b> di base in uso nei conti e un <b>Nome Utente.</b></font></span> </p>
 <p><font face="Verdana"></font></p>
 
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX viene fornito con un set predefinito di valute che è possibile 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX viene fornito con un set predefinito di valute che ï¿½ possibile 
 utilizzare, corrispondenti alle principali valute di internazionali.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">I nuovi conti potranno utilizzare una di 
 queste <b>Valuta Base</b> come impostazione predefinita.</font></span> 
 <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo consente ai conti intrattenuti in nazioni diverse di convertire il loro valore nella valuta di 
 base scelta.</font></span><font face="Verdana"></font></p>
-<p><font face="Verdana">Per aiutare ad identificare le finalità del database, è richiesto un </font><font face="Verdana"><b>Nome Utente</b></font><font face="Verdana">. Questo è opzionale ed utilizzato solo come</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> titolo nella Pagina Principale e nei rendiconti.</font></span></p>
+<p><font face="Verdana">Per aiutare ad identificare le finalitï¿½ del database, ï¿½ richiesto un </font><font face="Verdana"><b>Nome Utente</b></font><font face="Verdana">. Questo ï¿½ opzionale ed utilizzato solo come</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> titolo nella Pagina Principale e nei rendiconti.</font></span></p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Entrambe 
 queste impostazioni possono essere modificate in seguito, dal menu: <b>Strumenti -&gt; Opzioni</b></font></span><font face="Verdana"><b></b></font> 
 </p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Il nome 
-del database sarà visualizzato nella barra del titolo aiutando a ricordare quale database è visualizzato.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><b><font face="Verdana">Il nuovo file di database (.mmb) <span style="text-decoration: underline;">NON</span> è 
+del database sarï¿½ visualizzato nella barra del titolo aiutando a ricordare quale database ï¿½ visualizzato.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><b><font face="Verdana">Il nuovo file di database (.mmb) <span style="text-decoration: underline;">NON</span> ï¿½ 
 crittografato.</font></b></span><font face="Verdana"><b></b></font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
 <h3 class="western"><a name="encrypting_database"></a><font face="Verdana"><br>Crittografare il Database.</font></h3>
-<p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ll database può ora essere crittografato come segue: dal menu 
+<p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ll database puï¿½ ora essere crittografato come segue: dal menu 
 selezionare <b>File-&gt; Salva Database con nome...</b></font></span></p>
 <ol>
 	<li><p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Selezionate la posizione del file .mmb o create un 
 nuovo database.</font></span></p>
 	</li><li>
-    <p style="font-weight: normal;"><font face="Verdana">Cambiate nel menù a tendina del box di dialogo "<b>Salva come:"&nbsp;</b> l'estensione da File <span style="font-weight: bold;">.mmb</span> a File Crittografato <span style="font-weight: bold;">.emb</span>, e quindi cliccate su "<b>Salva"</b></font></p>
+    <p style="font-weight: normal;"><font face="Verdana">Cambiate nel menï¿½ a tendina del box di dialogo "<b>Salva come:"&nbsp;</b> l'estensione da File <span style="font-weight: bold;">.mmb</span> a File Crittografato <span style="font-weight: bold;">.emb</span>, e quindi cliccate su "<b>Salva"</b></font></p>
 
-	</li><li><p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Immettere una password per il file - <b>È necessaria la password 
-quando si vorrà aprire il database.</b></font></span></p>
+	</li><li><p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Immettere una password per il file - <b>ï¿½ necessaria la password 
+quando si vorrï¿½ aprire il database.</b></font></span></p>
 </li></ol>
 <p><font face="Verdana"><b>Suggerimenti:</b></font></p>
 <ol>
@@ -301,7 +302,7 @@ vostri file di database .mmb o .emb&nbsp;</font></span>
 	</p>
 	</li>
   <li>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr; font-weight: bold;" class="google-src-text"><span style="font-weight: normal;"><font face="Verdana">Il</font></span></span><span style="font-weight: bold;"> </span><span style="font-weight: normal;"><font face="Verdana"><span style="font-weight: bold;">normale file di database non è criptato</span>:</font></span></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo significa che chiunque ne conosca utilizzo e contenuto, può aprire il file e leggerne i dati in esso memorizzati.</font></span> 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr; font-weight: bold;" class="google-src-text"><span style="font-weight: normal;"><font face="Verdana">Il</font></span></span><span style="font-weight: bold;"> </span><span style="font-weight: normal;"><font face="Verdana"><span style="font-weight: bold;">normale file di database non ï¿½ criptato</span>:</font></span></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo significa che chiunque ne conosca utilizzo e contenuto, puï¿½ aprire il file e leggerne i dati in esso memorizzati.</font></span> 
 <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Quindi nel caso memorizzate informazioni finanziarie riservate e sensibili, che il file sia 
 adeguatamente custodito.</font></span> </p>
   </li>
@@ -314,32 +315,32 @@ ricordate <b>la vostra password.</b></font></span></p>
 un Nuovo Conto<br>
 </font></h3>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando si 
-crea un Nuovo Database, verrà automaticamente richiesto di creare un Nuovo Conto.</font></span></p>
+crea un Nuovo Database, verrï¿½ automaticamente richiesto di creare un Nuovo Conto.</font></span></p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><span style="font-weight: normal;">Per creare manualmente un nuovo conto, dal menu, 
 selezionare</span> <b>Conti-&gt; Nuovo Conto<span style="font-weight: normal;">.</span></b></font></span><font face="Verdana"><span style="font-weight: normal;"></span></font></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><span style="font-weight: normal;">Questa selezione aprirà la procedura di</span> <b>creazione guidata di un Nuovo Conto<span style="font-weight: normal;">.</span></b></font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><span style="font-weight: normal;">La procedura guidata aiuterà ad inserire le 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><span style="font-weight: normal;">Questa selezione aprirï¿½ la procedura di</span> <b>creazione guidata di un Nuovo Conto<span style="font-weight: normal;">.</span></b></font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><span style="font-weight: normal;">La procedura guidata aiuterï¿½ ad inserire le 
 informazioni essenziali del Conto, Nome e Tipologia.<span style="font-weight: bold;"> La</span></span><b> tipologia di conto 
-non sarà più</b> <span style="font-weight: normal;"><b>modificabile,</b> mentre il nome potrà essere 
+non sarï¿½ piï¿½</b> <span style="font-weight: normal;"><b>modificabile,</b> mentre il nome potrï¿½ essere 
 cambiato, vedi in proposito</span></font></span><font face="Verdana"><span style="font-weight: normal;"> <a href="#editaccounts">modificare le informazioni di un conto<br>
 </a></span></font></p>
-<p style="margin-bottom: 0in;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b>Nome del conto:</b> è 
+<p style="margin-bottom: 0in;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b>Nome del conto:</b> ï¿½ 
 un campo obbligatorio.</font></span> <span style="font-family: Verdana;">Si</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> raccomanda di scegliere un nome&nbsp; univoco 
 e che abbia una relazione col conto reale.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Ad esempio: per un conto corrente con un determinato Istituto Bancario invece del
-complicato codice IBAN o simile si può adoperare il nome dell'Istituto Bancario stesso, tipo Unicredit, Intesa, Poste, ecc.</font></span><font face="Verdana"></font></p>
+complicato codice IBAN o simile si puï¿½ adoperare il nome dell'Istituto Bancario stesso, tipo Unicredit, Intesa, Poste, ecc.</font></span><font face="Verdana"></font></p>
 <p style="margin-bottom: 0in;"><br>
 </p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b>Tipologie di Conto:</b> MMEX 
 attualmente supporta tre tipi di conto:</font></span></p>
 <ol>
-	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b><i>"Conto Corrente / Libretto Risparmio"</i>:</b> <span style="font-weight: normal;">Questo è il tipo più comune di conto utilizzato da 
-MMEX, e in grado di gestire conti del tipo più comune, come i conti correnti, 
+	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b><i>"Conto Corrente / Libretto Risparmio"</i>:</b> <span style="font-weight: normal;">Questo ï¿½ il tipo piï¿½ comune di conto utilizzato da 
+MMEX, e in grado di gestire conti del tipo piï¿½ comune, come i conti correnti, 
 conti di risparmio e libretti di risparmio.</span> Supporta tre tipi di operazioni: deposito, prelievo e trasferimento.</font></span><font face="Verdana"> </font>
 	</p>
 	</li><li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b><span style="font-style: italic;">"Conti a Termine"</span>:</b> analogo al conto corrente con l'eccezione che appaiono 
-in una loro specifica sezione della Pagina Principale e può essere visualizzato o nascosto nei giorni 
+in una loro specifica sezione della Pagina Principale e puï¿½ essere visualizzato o nascosto nei giorni 
 di normale utilizzo.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> Per ulteriori spiegazione vedere l'</font></span><font face="Verdana"> <a href="#account_setup">esempio di configurazione di un conto</a>.<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questi tipi di conti&nbsp; specifici conti a termine, conti di ammortamento bancario, conti 
 di prestito, conti ipotecari, conti di mutuo bancario o conti di investimento con reddito prestabilito.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana"> </font></span><font face="Verdana">Questi conti hanno una propria sezione di bilancio nella Pagina Principale.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><span style="font-family: Verdana;">Questo conto</span><font face="Verdana"> supporta tre 
-tipi di operazioni già citati.</font></span></p>
+tipi di operazioni giï¿½ citati.</font></span></p>
 	</li><li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b><i>"Conti d'Investimenti"</i>:</b> </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo
 tipo di conto consente di tenere traccia di titoli, obbligazioni,fondi
 comuni d'investimento, bond, ecc. o qualsiasi altro tipo d'investimento
@@ -348,35 +349,35 @@ possiate avere. </font></span><br>
 </li></ol>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Per una 
 corretta gestione si deve disporre del saldo 
-per i conti che si desidera aggiungere a MMEX.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">È possibile 
-ottenere queste informazioni tramite il più recente estratto conto della banca o della carta di credito.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Per tenere traccia di 
-ulteriori informazioni sui conti, è possibile inserire i 
+per i conti che si desidera aggiungere a MMEX.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">ï¿½ possibile 
+ottenere queste informazioni tramite il piï¿½ recente estratto conto della banca o della carta di credito.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Per tenere traccia di 
+ulteriori informazioni sui conti, ï¿½ possibile inserire i 
 dettagli opzionali del conto, come numero di conto, piazza, sito web, informazioni 
-di contatto e di accesso. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">È inoltre possibile inserire note aggiuntive 
+di contatto e di accesso. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ï¿½ inoltre possibile inserire note aggiuntive 
 sul conto nel campo 'Note'.</font></span></p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">La
-maggior parte dei conti è facilmente configurabile inserendo
+maggior parte dei conti ï¿½ facilmente configurabile inserendo
 semplicemente il saldo iniziale al momento della creazione del conto
 stesso.</font></span></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">In
-questo caso per tenere aggiornato il saldo del conto è sufficiente
+questo caso per tenere aggiornato il saldo del conto ï¿½ sufficiente
 aggiungere le operazioni e le transazioni che via via si effettuano
 oltre la data del saldo iniziale inserito.</font></span> </p>
 
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b>Lo stato del conto</b> può essere 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b>Lo stato del conto</b> puï¿½ essere 
 impostato su "Aperto" o "Chiuso".</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">I conti chiusi sono quelli</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> 
-non più attivi.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">L'impostazione di questo stato è solo un modo per semplificare la visione d'insieme nel tuo pannello di navigazione a discesa.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Per nascondere in modo permante i conti chiusi dal menù Strumenti-&gt; Opzioni-&gt; Visualizzazioni&nbsp; </font></span></span><font face="Verdana">Vedere <a href="#navTreeTips">Suggerimenti per il Pannello di Navigazione</a><br></font><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><b>Valuta:</b> <span style="font-weight: normal;">Questa è 
+non piï¿½ attivi.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">L'impostazione di questo stato ï¿½ solo un modo per semplificare la visione d'insieme nel tuo pannello di navigazione a discesa.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Per nascondere in modo permante i conti chiusi dal menï¿½ Strumenti-&gt; Opzioni-&gt; Visualizzazioni&nbsp; </font></span></span><font face="Verdana">Vedere <a href="#navTreeTips">Suggerimenti per il Pannello di Navigazione</a><br></font><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><b>Valuta:</b> <span style="font-weight: normal;">Questa ï¿½ 
 inizialmente impostata secondo la Valuta di Base scelta inizialmente al momento della creazione del 
 database.</span></font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana"><span style="font-weight: normal;">Y</span> ou can set the currency that is associated 
-with this account and can be different to the base currency.</font></span> <font face="Verdana">ou <span style="font-weight: normal;">Y</span> può impostare la 
-valuta che è associato a questo account e può essere diverso per la valuta di 
+with this account and can be different to the base currency.</font></span> <font face="Verdana">ou <span style="font-weight: normal;">Y</span> puï¿½ impostare la 
+valuta che ï¿½ associato a questo account e puï¿½ essere diverso per la valuta di 
 base.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Il tasso di 
-cambio della valuta può essere modificato utilizzando il menu:</font></span><font face="Verdana"> </font><font face="Verdana"><b>Strumenti
+cambio della valuta puï¿½ essere modificato utilizzando il menu:</font></span><font face="Verdana"> </font><font face="Verdana"><b>Strumenti
 -&gt;Gestione Valuta<br>
 </b></font></p>
 <p style="font-weight: normal;"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Esempio: Vivete Italia ed utilizzate gli Euro, ma avete anche un 
-conto bancario negli Stati Uniti in dollari USA. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">La maggior parte dei vostri conti sono quindi in Euro.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Qual'è il valore reale del vostro conto bancario statunitense?</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Cambiando o aggiornando il tasso di cambio Euro-Dollaro, è possibile 
+conto bancario negli Stati Uniti in dollari USA. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">La maggior parte dei vostri conti sono quindi in Euro.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Qual'ï¿½ il valore reale del vostro conto bancario statunitense?</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Cambiando o aggiornando il tasso di cambio Euro-Dollaro, ï¿½ possibile 
 ottenere il valore corretto del vostro conto.</font></span></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">È anche possibile contrassegnare i conti come 'Preferiti'.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> Questo viene utilizzato per modificare l'elenco dei conti che sono 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ï¿½ anche possibile contrassegnare i conti come 'Preferiti'.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> Questo viene utilizzato per modificare l'elenco dei conti che sono 
 visibili nel pannello di navigazione.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">Vedere</font></span><font face="Verdana"> <a href="#navTreeTips">Suggerimenti per il Pannello di Navigazione<br>
 </a></font></p>
 <p><font face="Verdana"><b>Suggerimenti:</b></font></p>
@@ -388,10 +389,10 @@ visibili nel pannello di navigazione.</font></span><span onmouseover="_tipon(thi
 <h3 class="western"><a name="account_setup"></a><font face="Verdana"><b><br>Esempio per l'Impostazione di un Conto<br>
 </b></font></h3>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Abbiamo
-un Conto di Deposito Postale con 1.250 €, un Conto Corrente Unicredit
-con 500 €, una MasterCard con un debito di 250 €, una Carta Si con un
-debito di 475 €, un Mutuo Ipotecario per la Casa di 230.965 € e un
-conto di risparmio (in questo esempio Conto Arancio) di 5.000 €.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Imposteremo i conti come segue</font></span><font face="Verdana">:</font></span></p>
+un Conto di Deposito Postale con 1.250 ï¿½, un Conto Corrente Unicredit
+con 500 ï¿½, una MasterCard con un debito di 250 ï¿½, una Carta Si con un
+debito di 475 ï¿½, un Mutuo Ipotecario per la Casa di 230.965 ï¿½ e un
+conto di risparmio (in questo esempio Conto Arancio) di 5.000 ï¿½.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Imposteremo i conti come segue</font></span><font face="Verdana">:</font></span></p>
 <table border="1" bordercolor="#000000" cellpadding="4" cellspacing="0" rules="groups" width="615">
 	<col width="178">
 	<col width="224">
@@ -424,7 +425,7 @@ Libretto di Risparmio<br>
 </p>
 			</td>
 			<td sdval="1250" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p>€ 1.250,00</p>
+				<p>ï¿½ 1.250,00</p>
 			</td>
 		</tr>
 		<tr valign="top">
@@ -437,7 +438,7 @@ Libretto di Risparmio<br>
 </p>
 			</td>
 			<td sdval="500" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p>€ 500,00</p>
+				<p>ï¿½ 500,00</p>
 			</td>
 		</tr>
 		<tr valign="top">
@@ -449,7 +450,7 @@ Libretto di Risparmio<br>
 				<p>MasterCard</p>
 			</td>
 			<td sdval="-250" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p><font color="#ff0000">€ -250,00</font></p>
+				<p><font color="#ff0000">ï¿½ -250,00</font></p>
 			</td>
 		</tr>
 		<tr valign="top">
@@ -462,7 +463,7 @@ Libretto di Risparmio<br>
 </p>
 			</td>
 			<td sdval="-475" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p><font color="#ff0000">€ -475,00</font></p>
+				<p><font color="#ff0000">ï¿½ -475,00</font></p>
 			</td>
 		</tr>
 	</tbody>
@@ -476,7 +477,7 @@ Libretto di Risparmio<br>
 </p>
 			</td>
 			<td sdval="-230965" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p><font color="#ff0000">€ -230.965,00</font></p>
+				<p><font color="#ff0000">ï¿½ -230.965,00</font></p>
 			</td>
 		</tr>
 		<tr valign="top">
@@ -489,17 +490,17 @@ Libretto di Risparmio<br>
 </p>
 			</td>
 			<td sdval="5000" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-				<p>€ 5.000,00</p>
+				<p>ï¿½ 5.000,00</p>
 			</td>
 		</tr>
 	</tbody>
 </table>
-<p><font face="Verdana"><br>Nella Pagina Principale il saldo sarà di € 1.025 per i Conti Bancari, e di € <span style="color: red;">-225.965</span> per i Conti a Termine<br>
+<p><font face="Verdana"><br>Nella Pagina Principale il saldo sarï¿½ di ï¿½ 1.025 per i Conti Bancari, e di ï¿½ <span style="color: red;">-225.965</span> per i Conti a Termine<br>
 </font></p>
-<p><font face="Verdana">Quando si effettua un pagamento dal Conto Corrente alla Carta Mastercard tramite un <a href="#transfer">Trasferimento</a> di denaro il saldo generale nella Pagina Principale rimarrà uguale. </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando
+<p><font face="Verdana">Quando si effettua un pagamento dal Conto Corrente alla Carta Mastercard tramite un <a href="#transfer">Trasferimento</a> di denaro il saldo generale nella Pagina Principale rimarrï¿½ uguale. </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando
 viene eseguito un pagamento dal Conto Corrente&nbsp; o Libretto di
-Risparmio al Mutuo Casa, il saldo nella Pagina Principale rifletterà il
-pagamento avvenuto.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Così è 
+Risparmio al Mutuo Casa, il saldo nella Pagina Principale rifletterï¿½ il
+pagamento avvenuto.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Cosï¿½ ï¿½ 
 possibile determinare l'ammontare dei propri averi giorno per 
 giorno.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">I</font></span> <font face="Verdana">pagamenti regolari con scadenze fisse come appunto la rata del Mutuo Casa, possono anche essere 
 impostati utilizzando la funzione</font></span><font face="Verdana"> <a href="#recurring_transactions">Operazioni Ricorrenti</a>.</font></p>
@@ -523,14 +524,14 @@ Bancari e Termine utilizzando +/- nel Pannello di Navigazione.</font></span></p>
 			<p><font face="Verdana">Pagina Principale:</font></p>
 		</td>
 		<td width="85%">
-			<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Utilizzando il menù: Visualizza -&gt; Conti Bancari o menù: Visualizza -&gt; Conti a Termine</font></span></p>
+			<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Utilizzando il menï¿½: Visualizza -&gt; Conti Bancari o menï¿½: Visualizza -&gt; Conti a Termine</font></span></p>
 		</td>
 	</tr>
 </tbody></table>
 <p><font face="Verdana">Utilizzando click destro del mouse su::</font></p>
 <ul>
 	<li><p><font face="Verdana">Conti Bancari nel Pannello di
-Navigazione, permetterà di visualizzare tutti i conti o solo quelli
+Navigazione, permetterï¿½ di visualizzare tutti i conti o solo quelli
 preferiti, di modificare temporaneamente le impostazioni permanenti ed
 ulteriori opzioni.</font></p>
 </li></ul>
@@ -548,11 +549,11 @@ Strumenti -&gt; Opzioni -&gt; Opzioni di visualizzazione</font></span></p>
 creato</span></span></span><span><span style="font-family: Verdana;"> un conto, 
 potete modificare uno qualsiasi dei campi del conto nei seguenti modi</span></span><font face="Verdana">:</font></p>
 <ol>
-	<li><p><font face="Verdana">Utilizzando il menù <b>Conti</b> –&gt; <span style="font-weight: bold;">Modifica Conto</span><b></b><br>Verrà visualizzato l'elenco dei conti da cui selezionare quello desiderato.<br>
+	<li><p><font face="Verdana">Utilizzando il menï¿½ <b>Conti</b> ï¿½&gt; <span style="font-weight: bold;">Modifica Conto</span><b></b><br>Verrï¿½ visualizzato l'elenco dei conti da cui selezionare quello desiderato.<br>
 </font></p>
-	</li><li><p><font face="Verdana">Selezionando il conto dal Pannello di Navigazione<br>Click sinistro sopra il conto scelto aprirà un menù pop-up quindi scegliere "</font><font face="Verdana"><b>Modifica conto</b></font><font face="Verdana">"</font></p>
+	</li><li><p><font face="Verdana">Selezionando il conto dal Pannello di Navigazione<br>Click sinistro sopra il conto scelto aprirï¿½ un menï¿½ pop-up quindi scegliere "</font><font face="Verdana"><b>Modifica conto</b></font><font face="Verdana">"</font></p>
 </li></ol>
-<p><font face="Verdana">Questo aprirà una finestra di dialogo con le informazioni del conto da cui modificare i campi desiderati<br>
+<p><font face="Verdana">Questo aprirï¿½ una finestra di dialogo con le informazioni del conto da cui modificare i campi desiderati<br>
 </font></p>
 <ul>
 	<li><p><font face="Verdana">Modicare dei dettagli del conto<br>
@@ -566,80 +567,80 @@ potete modificare uno qualsiasi dei campi del conto nei seguenti modi</span></sp
 </font></h3>
 <p><span><span class="GramE"><span style="font-family: Verdana;">Una volta 
 creato</span></span> </span><span><span style="font-family: Verdana;">un nuovo 
-conto, potete cominciare ad immettere le operazioni. Scegliete un conto dal Pannello di Navigazione.</span></span><font face="Verdana"> Il conto verrà visualizzato nella finestra principale e sarà quindi possibile inserire nuove operazioni:<br>
+conto, potete cominciare ad immettere le operazioni. Scegliete un conto dal Pannello di Navigazione.</span></span><font face="Verdana"> Il conto verrï¿½ visualizzato nella finestra principale e sarï¿½ quindi possibile inserire nuove operazioni:<br>
 </font></p>
 <ul>
 	<li><p><font face="Verdana">Dal pannello di navigazione, selezionando il conto desiderato.</font></p>
 	</li><li><p><font face="Verdana">Una volta visualizzato il conto in cui desidera effettuare delle operazioni, </font><span><span style="font-family: Verdana;">per creare una nuova 
 operazione, fare click sul pulsante "Nuova" per aprire la maschera <span class="GramE">di </span>immissione. Immettere i dettagli associati a <span class="GramE">questa </span>operazione. Scegliere il tipo <span class="GramE">di 
 </span>operazione tra "Pagamento", "Deposito" o "Trasferimento". <span class="GramE">Quindi</span> sceglie il beneficiario, la categoria, la data 
-dell’operazione, l’eventuale numero d'operazione, inserire eventuali note e 
-quindi l'importo dell’operazione. Infine, <span class="GramE">premere il pulsante</span></span></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> "<font face="Verdana">OK" per salvare.</font></span> <font face="Verdana"><br></font><br>
+dellï¿½operazione, lï¿½eventuale numero d'operazione, inserire eventuali note e 
+quindi l'importo dellï¿½operazione. Infine, <span class="GramE">premere il pulsante</span></span></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> "<font face="Verdana">OK" per salvare.</font></span> <font face="Verdana"><br></font><br>
     <font face="Verdana"><br>Seguono una serie di note sui campi relativi alla finestra di dialogo delle operazioni.</font></p>
 </li></ul>
 <p><a name="trans_types"></a><font face="Verdana"><br><i><b>Tipologia Operazioni:</b></i> </font>
 </p>
 <ul>
-	<li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Prelievo: </b></i>è, ad esempio, un pagamento ed è una Uscita.<br>
+	<li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Prelievo: </b></i>ï¿½, ad esempio, un pagamento ed ï¿½ una Uscita.<br>
 </font></p>
-	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Deposito:</b></i> è un qualsiasi ricevimento di denaro ed è una Entrata. </font>
+	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Deposito:</b></i> ï¿½ un qualsiasi ricevimento di denaro ed ï¿½ una Entrata. </font>
 	</p>
-	</li><li><p><a name="transfer"></a><font face="Verdana"><i><b>Trasferimento:</b></i> è un prelievo fatto da un conto e depositato in un altro, ad esempio un bonifico.<br>Questo tipo d'operazione non è inclusa nel calcolo Entrate/Uscite.<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Scegliendo <b>Trasferimento</b></font></span><font face="Verdana"> </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">si 
+	</li><li><p><a name="transfer"></a><font face="Verdana"><i><b>Trasferimento:</b></i> ï¿½ un prelievo fatto da un conto e depositato in un altro, ad esempio un bonifico.<br>Questo tipo d'operazione non ï¿½ inclusa nel calcolo Entrate/Uscite.<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Scegliendo <b>Trasferimento</b></font></span><font face="Verdana"> </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">si 
 attiva il pulsante <b>Avanzate</b></font></span><font face="Verdana">.
 Utilizzato per l'iserimento di ulteriori opzioni, come, ad esempio,
 quando l'importo prelevato dal conto di provenienza ("Da"), deve essere
 diverso dall'importo risultante sul conto di destinazione ("A") e
-viceversa.<br>Quando questa funzione è in uso viene visualizzato il messaggio "attivo!" accanto al punsante "Avanzate".</font></p>
+viceversa.<br>Quando questa funzione ï¿½ in uso viene visualizzato il messaggio "attivo!" accanto al punsante "Avanzate".</font></p>
 </li></ul>
 <p><a href="#payees"><font face="Verdana"><i><b>Beneficiario:</b></i></font></a>&nbsp;
 <font face="Verdana">E' il soggetto tramite cui il denaro entra o esce nelle vostre operazioni. </font>
 </p>
 <ul>
-	<li><p><span><span style="font-family: Verdana;">Clicando sul pulsante “Beneficiario” si apre la maschera di dialogo dei 
-beneficiari. Attraverso questa maschera di dialogo <span class="GramE">è possibile</span> scegliere un beneficiario tra quelli già presenti nell'elenco o crearne uno 
+	<li><p><span><span style="font-family: Verdana;">Clicando sul pulsante ï¿½Beneficiarioï¿½ si apre la maschera di dialogo dei 
+beneficiari. Attraverso questa maschera di dialogo <span class="GramE">ï¿½ possibile</span> scegliere un beneficiario tra quelli giï¿½ presenti nell'elenco o crearne uno 
 nuovo.<o:p></o:p></span></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">.</font></span>
 	</p>
 </li></ul>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><b><span style="text-decoration: underline;">Nota del traduttore</span>: </b></font></span><font face="Verdana">In Inglese il termine&nbsp; <span style="font-style: italic;">'Payee'</span> ha sia il significato di <span style="font-style: italic;">'Beneficiario'</span> che di&nbsp; <span style="font-style: italic;">'Debitore'</span> o <span style="font-style: italic;">'Pagatore'</span>&nbsp;
-ed in questo duplice significato il termine è usato in MMEX. Per
+ed in questo duplice significato il termine ï¿½ usato in MMEX. Per
 motivi&nbsp; tecnici&nbsp; legati alla lunghezza&nbsp; del termine
 inseribile nella traduzione,&nbsp; ho dovuto tradurlo semplicemente
 come <span style="font-style: italic;">Beneficiario</span>, intendendo con tale termine&nbsp; l'attore dell'operazione&nbsp; relativa, sia in entrata che in uscita di denaro.</font><a href="#categories"><span onmouseover="_tipon(this)" onmouseout="_tipoff()"></span></a></p>
-<p><a href="#categories"><font face="Verdana"><i><b>Categoria:</b></i></font></a>&nbsp; <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Tramite la scelta della categoria è possibile determinare la tipologia di spesa o introito dell'operazione.</font></span>
+<p><a href="#categories"><font face="Verdana"><i><b>Categoria:</b></i></font></a>&nbsp; <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Tramite la scelta della categoria ï¿½ possibile determinare la tipologia di spesa o introito dell'operazione.</font></span>
 </p>
 
 <ul>
-	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Cl</font></span></span><span><span style="font-family: Verdana;">iccando sul pulsante “Categoria” si apre la maschera di dialogo delle 
+	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">Cl</font></span></span><span><span style="font-family: Verdana;">iccando sul pulsante ï¿½Categoriaï¿½ si apre la maschera di dialogo delle 
 categorie. Attraverso questa maschera di dialogo <span class="GramE">potete</span> scegliere unaa categoria tra quelle esistenti nell'elenco oppure crearne una nuova.</span></span>
 	</p>
 </li></ul>
-<p><font face="Verdana"><i><b>Numero dell'Operazione:</b></i> </font><span><span style="font-family: Verdana;">questo campo è facoltativo e può essere utilizzato per immettere un numero da 
-associare ad un assegno o all’operazione come numero di 
+<p><font face="Verdana"><i><b>Numero dell'Operazione:</b></i> </font><span><span style="font-family: Verdana;">questo campo ï¿½ facoltativo e puï¿½ essere utilizzato per immettere un numero da 
+associare ad un assegno o allï¿½operazione come numero di 
 controllo.</span></span><br>
-<font face="Verdana"><i><b>Stato dell'Operazione:</b></i> </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">In questo campo è possibile scegliere tra "Non Riconciliata",
+<font face="Verdana"><i><b>Stato dell'Operazione:</b></i> </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">In questo campo ï¿½ possibile scegliere tra "Non Riconciliata",
 "Riconciliata", "Nulla" o "da Monitorare". Queste voci contrassegnano i
 diversi stati delle operazioni.</font></span>
 </p>
 <ul>
 
-	<li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Non Riconciliata:</b></i> </font><span style="font-family: Verdana;">Quando </span><span style="font-family: Verdana;" class="GramE">si </span><span style="font-family: Verdana;">immettete un’operazione, lo stato iniziale è 
-“Non riconciliata”</span><i style="font-family: Verdana;">.</i><span style="font-family: Verdana;"> </span><i style="font-family: Verdana;">Q</i><span style="font-family: Verdana;">uesto significa che l’operazione non</span><big style="font-family: Verdana;"> </big><span style="font-family: Verdana;">è stata verificata con il saldo o l’estratto conto della banca, della società emittente la carta </span><span style="font-family: Verdana;" class="GramE">di credito, ecc.</span>
+	<li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Non Riconciliata:</b></i> </font><span style="font-family: Verdana;">Quando </span><span style="font-family: Verdana;" class="GramE">si </span><span style="font-family: Verdana;">immettete unï¿½operazione, lo stato iniziale ï¿½ 
+ï¿½Non riconciliataï¿½</span><i style="font-family: Verdana;">.</i><span style="font-family: Verdana;"> </span><i style="font-family: Verdana;">Q</i><span style="font-family: Verdana;">uesto significa che lï¿½operazione non</span><big style="font-family: Verdana;"> </big><span style="font-family: Verdana;">ï¿½ stata verificata con il saldo o lï¿½estratto conto della banca, della societï¿½ emittente la carta </span><span style="font-family: Verdana;" class="GramE">di credito, ecc.</span>
 	</p>
 	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Riconciliata:</b></i> </font><span style="font-family: Verdana;" class="GramE">Una
-volta che l’operazione è stata controllata e verificata con il saldo
-della banca o della società emittente la carta di credito, può essere
+volta che lï¿½operazione ï¿½ stata controllata e verificata con il saldo
+della banca o della societï¿½ emittente la carta di credito, puï¿½ essere
 contrassegnata come "Riconciliata"</span><span style="font-family: Verdana;">.</span>
 	</p>
-	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Nulla:</b></i> </font><span style="font-family: Verdana;">Se avete immesso un’operazione diventata </span><span style="font-family: Verdana;" class="GramE">successivamente</span><span style="font-family: Verdana;">
-non valida (ad esempio un assegno risultato scoperto) oppure se avete annullato un’operazione, anziché eliminare
-l’operazione potete contrassegnarla come “Nulla”, cosicché rimane
-traccia dell’operazione ma non rientrerà nel conteggio finale del saldo.</span>
+	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Nulla:</b></i> </font><span style="font-family: Verdana;">Se avete immesso unï¿½operazione diventata </span><span style="font-family: Verdana;" class="GramE">successivamente</span><span style="font-family: Verdana;">
+non valida (ad esempio un assegno risultato scoperto) oppure se avete annullato unï¿½operazione, anzichï¿½ eliminare
+lï¿½operazione potete contrassegnarla come ï¿½Nullaï¿½, cosicchï¿½ rimane
+traccia dellï¿½operazione ma non rientrerï¿½ nel conteggio finale del saldo.</span>
 	</p>
-	</li><li><p><font face="Verdana"><i><b>Da Monitorare:</b></i> </font><span><span style="font-family: Verdana;">Questo stato indica operazioni che hanno bisogno di un’ulteriore controllo o verifica<i>.</i> 
-Ad esempio, se ricevete l’estratto conto dalla <span class="GramE">banca e vi accorgete</span>
-che l'importo dell’operazione che avete registrato su MMEX è diverso da
-quello presente nell’estratto conto della banca, potete contrassegnarla
-come “da Monitorare” in modo da poterla verificare in seguito presso la
+	</li><li><p><font face="Verdana"><i><b>Da Monitorare:</b></i> </font><span><span style="font-family: Verdana;">Questo stato indica operazioni che hanno bisogno di unï¿½ulteriore controllo o verifica<i>.</i> 
+Ad esempio, se ricevete lï¿½estratto conto dalla <span class="GramE">banca e vi accorgete</span>
+che l'importo dellï¿½operazione che avete registrato su MMEX ï¿½ diverso da
+quello presente nellï¿½estratto conto della banca, potete contrassegnarla
+come ï¿½da Monitorareï¿½ in modo da poterla verificare in seguito presso la
 banca.</span></span>
 	</p>
 </li>
@@ -651,24 +652,24 @@ banca.</span></span>
 <hr>
 <h3 class="western"><a name="edittrans"></a><font face="Verdana"><br>Modificare ed Aggiornare le Operazioni<br>
 </font></h3>
-<p><font face="Verdana">La modifica di un operazione già esistente può essere effuatta in diversi modi:</font></p>
+<p><font face="Verdana">La modifica di un operazione giï¿½ esistente puï¿½ essere effuatta in diversi modi:</font></p>
 <ul>
 	<li><p><font face="Verdana">selezionando l'operazione e quindi cliccando sul pulsante 'Modifica' in fondo alla schermata.</font></p>
 	</li><li><p><font face="Verdana">facendo doppio-click sull'operazione stessa.</font></p>
-	</li><li><p><font face="Verdana">premendo il tasto 'Invio' </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">quando l'operazione è evidenziata dalla 
+	</li><li><p><font face="Verdana">premendo il tasto 'Invio' </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">quando l'operazione ï¿½ evidenziata dalla 
 selezione.</font></span>
 	</p>
 </li></ul>
-<p><font face="Verdana">Ognuna di</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> queste azioni aprirà 
+<p><font face="Verdana">Ognuna di</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> queste azioni aprirï¿½ 
 la finestra di dialogo contenente i dettagli dell'operazione 
 selezionata.</font></span><font face="Verdana"> Una volta effettuate le modifiche desiderate cliccare su OK per salvare i cambiamenti apportati.</font></p>
-<p><font face="Verdana"><b>Il pulsante “Avanzate”<br>
+<p><font face="Verdana"><b>Il pulsante ï¿½Avanzateï¿½<br>
 </b></font></p>
 <ul>
-	<li><p><font face="Verdana">E' attivo quando è in uso un operazione di </font><font face="Verdana"><b>trasferimento</b></font><font face="Verdana">.</font></p>
-	</li><li><p><font face="Verdana">Il messaggio "</font><font face="Verdana"><b>attivo!</b></font>" <font face="Verdana">è visualizzato </font><font face="Verdana"><b>per indicare la presenza di informazioni Avanzata.</b></font></p>
+	<li><p><font face="Verdana">E' attivo quando ï¿½ in uso un operazione di </font><font face="Verdana"><b>trasferimento</b></font><font face="Verdana">.</font></p>
+	</li><li><p><font face="Verdana">Il messaggio "</font><font face="Verdana"><b>attivo!</b></font>" <font face="Verdana">ï¿½ visualizzato </font><font face="Verdana"><b>per indicare la presenza di informazioni Avanzata.</b></font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana">Questo
-è visualizzato accanto al pulsante Avanzate quando i campi importo (in
+ï¿½ visualizzato accanto al pulsante Avanzate quando i campi importo (in
 Avanzate) sono differenti tra il conto di provenienza e quello di
 destinazione.</font></p>
 </li></ul>
@@ -680,12 +681,12 @@ destinazione.</font></p>
 <h3 class="western"><a name="rectrans"></a><font face="Verdana"><br>Operazioni Riconciliate &amp; Saldo<br>
 </font></h3>
 <p><span><span style="font-family: Verdana;">Le operazioni inserite in MMEX sono 
-inizialmente considerate “Non Riconciliate”. Questo significa che non sono state verificate 
+inizialmente considerate ï¿½Non Riconciliateï¿½. Questo significa che non sono state verificate 
 con il saldo o un estratto conto della banca<span class="GramE"></span>. <span class="GramE">Una volta verificata l'operazione con l'etratto conto della banca</span>,
 oppure controllando le operazioni sul tramite il servizio on-line della
-banca, se i dettagli dell’operazione registrata su MMEX corrispondono a
-quelli dell’istituto bancario o finanziario, l’operazione può essere
-contrassegnata come “Riconciliata”. Attraverso tali contrassegni delle
+banca, se i dettagli dellï¿½operazione registrata su MMEX corrispondono a
+quelli dellï¿½istituto bancario o finanziario, lï¿½operazione puï¿½ essere
+contrassegnata come ï¿½Riconciliataï¿½. Attraverso tali contrassegni delle
 operazioni <span class="GramE">potete</span> tenere traccia delle
 operazioni immesse che hanno avuto riscontro con le operazioni
 effettivamente registrate ed approvate dalla banca. In MMEX, le
@@ -693,7 +694,7 @@ operazioni Riconciliate e non Riconciliate sono contraddistinte da
 icone diverse.</span></span>
 </p>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i>Suggerimento:</i> per contrassegnare un'operazione come <span style="font-style: italic;">Riconciliata</span>, basta selezionare l'operazione e premere il tasto 'r' o 
-'R'.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Per contrassegnare una transazione come <span style="font-style: italic;">non Riconciliata</span>, è 
+'R'.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Per contrassegnare una transazione come <span style="font-style: italic;">non Riconciliata</span>, ï¿½ 
 sufficiente selezionare l'operazione e premere l'u' o 'U'.</font></span>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio<br>
@@ -702,7 +703,7 @@ sufficiente selezionare l'operazione e premere l'u' o 'U'.</font></span>
 <h3 class="western"><a name="followup"></a><font face="Verdana"><br>Operazioni Da Monitorare<br>
 </font></h3>
 <p><span><span style="font-family: Verdana;">Alcune operazioni potrebbero avere informazioni o dettagli che volete seguire o ricontrollare. Queste operazioni possono essere 
-contrassegnate come “da Monitorare”. Questo contrassegno è indicato in MMEX con 
+contrassegnate come ï¿½da Monitorareï¿½. Questo contrassegno ï¿½ indicato in MMEX con 
 un ulteriore icona diversa da quelle degli altri stati.<o:p></o:p></span></span></p>
 
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"></span> </p>
@@ -716,7 +717,7 @@ un ulteriore icona diversa da quelle degli altri stati.<o:p></o:p></span></span>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><u><i><b><font face="Verdana"></font></b></i></u><u><i><b><font face="Verdana">Suggerimento:</font></b></i></u></span></p>
 <ul>
 	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Per 
-contrassegnare una transazione <span style="font-style: italic;">da Monitorare</span>, è sufficiente 
+contrassegnare una transazione <span style="font-style: italic;">da Monitorare</span>, ï¿½ sufficiente 
 selezionare l'operazione e premere il tasto 'f' o 'F'.</font></span>
 	</p>
 </li></ul>
@@ -726,33 +727,33 @@ selezionare l'operazione e premere il tasto 'f' o 'F'.</font></span>
 <h3 class="western"><a name="currencies"></a><font face="Verdana"><br>Utilizzo delle Valute<br>
 </font></h3>
 <p style="font-weight: normal;"><font face="Verdana">Dal momento che
-MMEX può essere utilizzato in tante differenti Nazioni, MMEX ha preso
+MMEX puï¿½ essere utilizzato in tante differenti Nazioni, MMEX ha preso
 in considerazione diverse valute per le differenti Nazioni degli
-utenti. When creating a new database, la </font><font face="Verdana"><b>Valuta Base </b></font><font face="Verdana">sarà
+utenti. When creating a new database, la </font><font face="Verdana"><b>Valuta Base </b></font><font face="Verdana">sarï¿½
 la valuta locale della Nazione dell'utente. Se la valuta locale
-dell'utente non è presente nell'elenco delle valute predefinite,
-l'utente può aggiungere una o più valute o creare un proprio elenco
+dell'utente non ï¿½ presente nell'elenco delle valute predefinite,
+l'utente puï¿½ aggiungere una o piï¿½ valute o creare un proprio elenco
 personalizzato delle valute.<br>
 </font></p>
-<p><font face="Verdana">MMEX se necessario permette di utilizzare più
-di una valuta, quando ciò accade un riepilogo delle valute in uso viene
+<p><font face="Verdana">MMEX se necessario permette di utilizzare piï¿½
+di una valuta, quando ciï¿½ accade un riepilogo delle valute in uso viene
 visualizzato nella Pagina Principale di Riepilogo.<br>
 </font></p>
-<p><font face="Verdana">E' possibile gestire le Valute utilizzando la vove del menù: </font><font face="Verdana"><b>Strumenti -&gt; Gestione Valute.<br>
+<p><font face="Verdana">E' possibile gestire le Valute utilizzando la vove del menï¿½: </font><font face="Verdana"><b>Strumenti -&gt; Gestione Valute.<br>
 </b></font></p>
 <p><font face="Verdana"><b>Per aggiungere una nuova valuta</b></font><font face="Verdana">:</font></p>
 <ul>
 	<li><p><font face="Verdana">Utilizzare il pulsante </font><font face="Verdana"><b>Aggiungi</b></font><font face="Verdana"> nella maschera di dialogo delle Valute<br>
 </font></p>
-	</li><li><p><font face="Verdana">Inserire un nome adatta per la nuova valuta.<br>Nota: Questo nome non può essere modificato in seguito, ma la valuta può essere eliminata se non utilizzata da nessun conto.</font></p>
-	</li><li><p><font face="Verdana">Aggiornare o correggere il valore della valuta dal menù <b>Gestione Valute.</b><br>L'opzione Gestione Valute è disponibile anche quando si modifica una valuta.</font></p>
+	</li><li><p><font face="Verdana">Inserire un nome adatta per la nuova valuta.<br>Nota: Questo nome non puï¿½ essere modificato in seguito, ma la valuta puï¿½ essere eliminata se non utilizzata da nessun conto.</font></p>
+	</li><li><p><font face="Verdana">Aggiornare o correggere il valore della valuta dal menï¿½ <b>Gestione Valute.</b><br>L'opzione Gestione Valute ï¿½ disponibile anche quando si modifica una valuta.</font></p>
 	</li><li><p><font face="Verdana">Utilizzare il pulsante <b>Aggiorna</b> per salvare i cambiamenti prima di chiudere la schermata.<br>Nota: Tutti i cambiamenti andranno persi se non si preme il pulsante Aggiorna prima di chiudere.</font></p>
 </li></ul>
-<p><font face="Verdana"><span style="font-weight: normal;">Quando sono utilizzate più di una Valuta, il </span><b>Tasso di Conversione Base</b> <span style="font-weight: normal;">va impostato al fine di consentire che i valori delle altre valute riflettano correttamente la proporzione con la valuta base. </span><span style="font-weight: normal;"></span></font></p>
-<p><font face="Verdana">L'utilizzo della voce di menù: <b>Strumenti –&gt; Aggiorna i Tassi di Cambio delle Valute online</b>, necessita delle seguenti impostazioni:</font></p>
+<p><font face="Verdana"><span style="font-weight: normal;">Quando sono utilizzate piï¿½ di una Valuta, il </span><b>Tasso di Conversione Base</b> <span style="font-weight: normal;">va impostato al fine di consentire che i valori delle altre valute riflettano correttamente la proporzione con la valuta base. </span><span style="font-weight: normal;"></span></font></p>
+<p><font face="Verdana">L'utilizzo della voce di menï¿½: <b>Strumenti ï¿½&gt; Aggiorna i Tassi di Cambio delle Valute online</b>, necessita delle seguenti impostazioni:</font></p>
 <ul>
 	<li><p><font face="Verdana">Attivare l'opzione dalla finestra di dialogo </font><font face="Verdana"><b>Strumenti
-	–&gt; Opzioni... Altro</b></font><font face="Verdana">.</font></p>
+	ï¿½&gt; Opzioni... Altro</b></font><font face="Verdana">.</font></p>
 	</li><li><p><font face="Verdana">Impostare tutti i <span style="font-weight: bold;">Simboli delle Valute</span> che desiderate aggionare online.</font></p>
 	</li><li><p><font face="Verdana">Impostare su 1 il valore della Valuta Base.<br>
 </font></p>
@@ -763,19 +764,19 @@ visualizzato nella Pagina Principale di Riepilogo.<br>
 simbolo del dollaro nella barra degli strumenti per una rapida
 selezione della maschera di dialogo per la Gestione delle Valute<br>
 </font></p>
-	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare i tasti Su e Giù per muoversi tra le valute da selezionare.</font></p>
+	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare i tasti Su e Giï¿½ per muoversi tra le valute da selezionare.</font></p>
 </li></ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio<br>
 </font></a></h5>
 <hr>
 <h3 class="western"><a name="categories"></a><font face="Verdana"><br>Utilizzo delle Categorie</font></h3>
-<p><font face="Verdana"><b>Le Categorie indicano la causa per cui si è verificata un Uscita o per cui si è ricevuta un Entrata.</b></font> 
+<p><font face="Verdana"><b>Le Categorie indicano la causa per cui si ï¿½ verificata un Uscita o per cui si ï¿½ ricevuta un Entrata.</b></font> 
 </p>
 <p><font face="Verdana">Esempio: Se si vuole memorizzare la spesa fatta
 per la riparazione dell'auto, bisognerebbe impostare 'Auto' come
 Categoria e 'Manutenzione' come Sottocategoria.</font></p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">È possibile 
-gestire le categorie aprendo il menù <b>Strumenti -&gt; Gestione Categorie.</b></font></span> <font face="Verdana"><br></font><span style="font-family: Verdana;">Una volta aperta la maschera di dialogo </span><span style="font-family: Verdana;" class="GramE">potete</span><span style="font-family: Verdana;"> 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ï¿½ possibile 
+gestire le categorie aprendo il menï¿½ <b>Strumenti -&gt; Gestione Categorie.</b></font></span> <font face="Verdana"><br></font><span style="font-family: Verdana;">Una volta aperta la maschera di dialogo </span><span style="font-family: Verdana;" class="GramE">potete</span><span style="font-family: Verdana;"> 
 aggiungere o modificare nuove Categorie e Sottocategorie</span><font face="Verdana">.</font></p>
 <p><font face="Verdana"><b>Per aggiungere una nuova Categoria</b>:</font></p>
 <ul>
@@ -785,8 +786,8 @@ aggiungere o modificare nuove Categorie e Sottocategorie</span><font face="Verda
 	</li><li><p><font face="Verdana">Cliccare sul pulsate </font><font face="Verdana"><b>Aggiungi</b></font> <font face="Verdana">per salvare<br>
 </font></p>
 </li></ul>
-<p><font face="Verdana">La nuova Categoria verrà visualizzata in basso
-sotto le altre, mentre sarà visualizzata in ordine alfabetico alla
+<p><font face="Verdana">La nuova Categoria verrï¿½ visualizzata in basso
+sotto le altre, mentre sarï¿½ visualizzata in ordine alfabetico alla
 successiva apertura dell'elenco<br>
 </font></p>
 <p><font face="Verdana"><b>Per aggiungere una nuova Sottocategoria:</b></font></p>
@@ -799,10 +800,10 @@ successiva apertura dell'elenco<br>
 <p><font face="Verdana">E' anche possibile cambiare il nome di
 categorie e sottocategorie selezionandole nell'elenco, quindi
 modificarne il nome che appare nel campo d'inserimento del testo e
-premere il pulsante Modifica. Allo stesso modo è possibile cancellare
+premere il pulsante Modifica. Allo stesso modo ï¿½ possibile cancellare
 categorie e sottocategorie.<br>
 </font></p>
-<p><font face="Verdana"><b>Nota:</b> Non è possibile cancellare categorie e sottocategorie già in uso in una o più operazioni.</font></p>
+<p><font face="Verdana"><b>Nota:</b> Non ï¿½ possibile cancellare categorie e sottocategorie giï¿½ in uso in una o piï¿½ operazioni.</font></p>
 <p><font face="Verdana">Per poter cancellare una categoria o sottocategoria in uso, utilizzare uno dei seguenti metodi:</font></p>
 <ul>
 	<li><p><font face="Verdana">Modificare l'operazione che la utilizza cambiando categoria o sottocategoria</font></p>
@@ -810,17 +811,17 @@ categorie e sottocategorie.<br>
 </font></p>
 </li></ul>
 <ul>
-	<li><p><font face="Verdana">Utilizzando la voce del menù: <span style="font-weight: bold;">Strumenti</span></font><font face="Verdana"><b>
-	–&gt; Sostituzione di -&gt; Categoria</b></font><font face="Verdana"><span style="font-weight: normal;">,
-con cui è possibile riassegnare la Categoria contemporaneamente a tutte
+	<li><p><font face="Verdana">Utilizzando la voce del menï¿½: <span style="font-weight: bold;">Strumenti</span></font><font face="Verdana"><b>
+	ï¿½&gt; Sostituzione di -&gt; Categoria</b></font><font face="Verdana"><span style="font-weight: normal;">,
+con cui ï¿½ possibile riassegnare la Categoria contemporaneamente a tutte
 le operazioni che hanno in uso una determinata categoria e/o
 sottocategoria.</span></font></p>
 </li></ul>
-<p style="font-weight: normal;"><font face="Verdana">Questo permetterà di poter cancellare categorie e sottocategorie precedentemente bloccate perchè già in uso.</font></p>
+<p style="font-weight: normal;"><font face="Verdana">Questo permetterï¿½ di poter cancellare categorie e sottocategorie precedentemente bloccate perchï¿½ giï¿½ in uso.</font></p>
 <p><font face="Verdana"><b>Suggerimento:</b></font></p>
 <ol>
 	<li><p><font face="Verdana">Utilizzare le icone nella toolbar per una rapida selezione di Gestione Categorie</font></p>
-	</li><li><p><font face="Verdana">Utilizzare i tasti Su e Giù per muoversi e selezionare le voci all'interno dell'elenco.</font></p>
+	</li><li><p><font face="Verdana">Utilizzare i tasti Su e Giï¿½ per muoversi e selezionare le voci all'interno dell'elenco.</font></p>
 </li></ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio<br>
 </font></a></h5>
@@ -828,16 +829,16 @@ sottocategoria.</span></font></p>
 <h3 class="western"><a name="payees"></a><font face="Verdana"><br>Utilizzo dei Beneficiari<br>
 </font></h3>
 <p><font face="Verdana"><b>I Beneficiari sono le persone fisiche, le
-società, gli enti, le istituzioni, ecc. da cui riceviamo a vario titolo
+societï¿½, gli enti, le istituzioni, ecc. da cui riceviamo a vario titolo
 del denaro o a cui versiamo dei pagamenti in cambio di beni e servizi. </b>(vedi "Nota del traduttore" nella sezione: Creare una Nuova Operazione)<b><br>
 </b></font></p>
-<p><font face="Verdana">E' possibile gestire i Beneficiari dal menù: </font><font face="Verdana"><b>Strumenti –&gt; Gestione Beneficiari</b></font><font face="Verdana">.
+<p><font face="Verdana">E' possibile gestire i Beneficiari dal menï¿½: </font><font face="Verdana"><b>Strumenti ï¿½&gt; Gestione Beneficiari</b></font><font face="Verdana">.
 </font>
 </p>
-<p><font face="Verdana">Nella finestra di dialogo che si aprirà sarà possibile aggiungere nuovi </font><font face="Verdana">Beneficiari</font><font face="Verdana">, modificare o cancellare quelli esistenti.</font></p>
+<p><font face="Verdana">Nella finestra di dialogo che si aprirï¿½ sarï¿½ possibile aggiungere nuovi </font><font face="Verdana">Beneficiari</font><font face="Verdana">, modificare o cancellare quelli esistenti.</font></p>
 <p><font face="Verdana"><span style="font-weight: bold;">Per aggiungere un nuovo Beneficiario</span><b>:</b></font></p>
 <ul>
-  <li><p><font style="font-weight: bold;" face="Verdana">Strumenti-&gt; </font><font style="font-weight: bold;" face="Verdana">Gestione Beneficiari</font> <font face="Verdana">per aprire la finestra di dialogo, in alternativa si può utilizzare il Filtro e selezionare beneficiari <br>
+  <li><p><font style="font-weight: bold;" face="Verdana">Strumenti-&gt; </font><font style="font-weight: bold;" face="Verdana">Gestione Beneficiari</font> <font face="Verdana">per aprire la finestra di dialogo, in alternativa si puï¿½ utilizzare il Filtro e selezionare beneficiari <br>
 </font></p></li>
   <li>
     <p><font face="Verdana">Nella finestra di dialogo </font><font face="Verdana">digitare il nome del nuovo Beneficiario nel campo testo in basso</font></p>
@@ -848,7 +849,7 @@ del denaro o a cui versiamo dei pagamenti in cambio di beni e servizi. </b>(vedi
 <p><font face="Verdana">E' possibile anche selezionare un beneficiario
 nella lista e poi utilizzare i pulsanti Modifica o Elimina per ottenere
 l'azione corrispondente.</font></p>
-<p><font face="Verdana"><b>Nota:</b> Come per le Categorie non è possibile cancellare beneficiari già in uso in una o più operazioni.</font></p>
+<p><font face="Verdana"><b>Nota:</b> Come per le Categorie non ï¿½ possibile cancellare beneficiari giï¿½ in uso in una o piï¿½ operazioni.</font></p>
 
 <p><font face="Verdana">Per poter cancellare un beneficiario in uso, utilizzare uno dei seguenti metodi:</font></p>
 
@@ -861,20 +862,20 @@ l'azione corrispondente.</font></p>
 </ul>
 
 <ul>
-<li><p><font face="Verdana">Utilizzando la voce del menù: <span style="font-weight: bold;">Strumenti</span></font><font face="Verdana"><b>
-	–&gt; Sostituzione di -&gt; Beneficiario</b></font><font face="Verdana"><span style="font-weight: normal;">,
-con cui è possibile riassegnare il Beneficiario contemporaneamente a tutte
+<li><p><font face="Verdana">Utilizzando la voce del menï¿½: <span style="font-weight: bold;">Strumenti</span></font><font face="Verdana"><b>
+	ï¿½&gt; Sostituzione di -&gt; Beneficiario</b></font><font face="Verdana"><span style="font-weight: normal;">,
+con cui ï¿½ possibile riassegnare il Beneficiario contemporaneamente a tutte
 le operazioni che hanno in uso un determinato beneficiario.<br>
 </span></font></p>
 </li>
 </ul>
 
-<p style="font-weight: normal;"><font face="Verdana">Questo permetterà di poter cancellare un beneficiario precedentemente bloccato perchè già in uso.</font></p>
+<p style="font-weight: normal;"><font face="Verdana">Questo permetterï¿½ di poter cancellare un beneficiario precedentemente bloccato perchï¿½ giï¿½ in uso.</font></p>
 <p><font face="Verdana"><b>Suggerimento:</b></font></p>
 <ol>
 	<li><p><font face="Verdana">Utilizzare l'icona nella toolbar per una rapida selezione di Gestione Beneficiari<br>
 </font></p>
-	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare i tasti Su e Giù per muoversi e selezionare le voci all'interno dell'elenco dei beneficiari</font><font face="Verdana">.</font></p>
+	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare i tasti Su e Giï¿½ per muoversi e selezionare le voci all'interno dell'elenco dei beneficiari</font><font face="Verdana">.</font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare % come carattere jolly nella finestra di dialogo Filtro.</font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana">Utilizzare _ per indicare un singolo carattere </font><font face="Verdana">nella finestra di dialogo Filtro.</font></p>
 </li></ol>
@@ -884,19 +885,19 @@ le operazioni che hanno in uso un determinato beneficiario.<br>
 <hr>
 <h3 class="western"><a name="importCSV"></a><font face="Verdana"><br>Importazione da file CSV<br>
 </font></h3>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX può importare un'ampia varietà di formati</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">, uno di questi è il formato fisso CSV che MMEX è anche in grado di esportare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span></span> <span style="font-family: Verdana;">Questo è</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX puï¿½ importare un'ampia varietï¿½ di formati</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">, uno di questi ï¿½ il formato fisso CSV che MMEX ï¿½ anche in grado di esportare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span></span> <span style="font-family: Verdana;">Questo ï¿½</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> 
 molto utile per spostare dati da un file di database .mmb a un altro file di 
 database .mmb. </font></span><span style="font-family: Verdana;"><br>
 Per osservare e controllare</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">
-un file CSV, un modo semplice è quello di esportare un conto in un file
+un file CSV, un modo semplice ï¿½ quello di esportare un conto in un file
 CSV pere poi analizzarne il contenuto e testarne l'efficacia.</font></span> <font face="Verdana"><br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"><font face="Verdana">G</font></span><font face="Verdana">eneralmente i formati dei dati in esso contenuti sono i 
 seguenti:</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Data</b></i> - Data dell'operazione (visualizzato nel 
 formato scelto in Opzioni-&gt; Formato Data)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Beneficiario</b></i> - il soggetto dell'operazione. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Nel caso di un'operazione di 
-trasferimento, questo indica il nome del conto 'da cui' o 'a cui' è stato effettuato il 
-trasferimento.</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Tipo di operazione</b></i> - Questa può essere 
+trasferimento, questo indica il nome del conto 'da cui' o 'a cui' ï¿½ stato effettuato il 
+trasferimento.</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Tipo di operazione</b></i> - Questa puï¿½ essere 
 <i>"Prelievo"</i> o <i>"Deposito"</i></font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Importo</b></i> - l'importo dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Categoria</b></i> - La 
 categoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana"><i><b>Sottocategoria</b></i> - La sottocategoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> 
-se presente (altrimenti è vuoto)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Numero - </b></i></font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Numero dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span> <font face="Verdana"><br><br>Notare che le operazioni contenute in un file CSV possono essere importate solo in un singolo conto di MMEX.</font></p>
+se presente (altrimenti ï¿½ vuoto)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Numero - </b></i></font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Numero dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span> <font face="Verdana"><br><br>Notare che le operazioni contenute in un file CSV possono essere importate solo in un singolo conto di MMEX.</font></p>
 
 <h5 class="western"><br><a href="#top"><font face="Verdana">Torna all'inizio</font></a> 
 </h5>
@@ -906,7 +907,7 @@ se presente (altrimenti è vuoto)</font></span> <font face="Verdana"><br></font><
 <h3 class="western"><font face="Verdana"><font face="Verdana">Importazione da file</font> QIF<br>
 </font></h3>
 
-<p><font face="Verdana">I file QIF (Quicken Interchange Format) </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">è un formato specifico per la 
+<p><font face="Verdana">I file QIF (Quicken Interchange Format) </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">ï¿½ un formato specifico per la 
 lettura e la scrittura di dati finanziari su di un supporto (ad es.: un 
 file).</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Un file QIF in genere ha la seguente struttura:</font></span> 
 <font face="Verdana"><br></font><br>
@@ -914,16 +915,16 @@ file).</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><sp
 <font face="Verdana">[linea di codice con carattere singolo]Stringa Letterale di Dati<br>...<br>^<br></font><font face="Verdana">[linea di codice con carattere singolo]Stringa Letterale di Dati</font><br>
 <font face="Verdana">...<br>^<br><br>Ogni serie di dati termina con ^ (accento circonflesso). <br>Vedere esempio do operazione QIF  <br><br>!Tipo:Banca<br>D6/ 1/94 Data
 <br>T-1,000.00 Importo<br>N1005 numero<br>PBanca emittente mutuo ipotecario <br>^
-Fine dell'operazione<br><br>Il formato QIF è più vecchio del formato OFX (Open Financial Exchange). </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">L'incapacità di riconciliare le operazioni importate contro le informazioni corrente del conto è una delle 
-carenze principali di QIF.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Esso è comunemente utilizzato dagli 
+Fine dell'operazione<br><br>Il formato QIF ï¿½ piï¿½ vecchio del formato OFX (Open Financial Exchange). </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">L'incapacitï¿½ di riconciliare le operazioni importate contro le informazioni corrente del conto ï¿½ una delle 
+carenze principali di QIF.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Esso ï¿½ comunemente utilizzato dagli 
 istituti finanziari per fornire informazioni scaricabili dai titolari 
 dei conti.</font></span><br>
-<font face="Verdana"><br>MMEX può importare operazioni in un conto da uno specifico tipo di formato.
-<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Le tipologie sono le seguenti: (È possibile trovare il tipo di QIF 
+<font face="Verdana"><br>MMEX puï¿½ importare operazioni in un conto da uno specifico tipo di formato.
+<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Le tipologie sono le seguenti: (ï¿½ possibile trovare il tipo di QIF 
 aprendolo in un editor di testo)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">!Type:Bank conto delle operazioni di Banca</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">!</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Type</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">:Cash conto delle 
 operazioni con Contanti</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">!</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Type</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">:CCard conto delle operazioni con Carta di Credito</font></span><font face="Verdana"><br></font><font face="Verdana"><br></font><font face="Verdana"><b>Nota Importante</b></font><font face="Verdana"><b> (1)</b>: </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">L'impostazione del 
 formato della data scelta da Opzioni di MMEX, deve corrispondere a quella del formato della data nel file QIF, 
-altrimenti lettura del file di MMEX sarà errata e si tradurrà in operazioni aventi 
+altrimenti lettura del file di MMEX sarï¿½ errata e si tradurrï¿½ in operazioni aventi 
 date non corrette.</font></span> <font face="Verdana"><br></font><font face="Verdana"> <br><b>Nota Importante (2)</b>:
 Dopo averle importate dal file QIF, tutte le operazioni avranno lo <span style="font-style: italic;">Stato</span>
 "Da Monitorare". E' possibile contrassegnare tutte le operazioni con
@@ -936,16 +937,16 @@ click destro del mouse sulla visualizzazione del conto. </font>
 <h3 class="western"><font face="Verdana"><font face="Verdana">Importazione da file</font> MM.NET CSV<br>
 </font></h3>
 
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX può anche 
-importare da file CSV esportati tramite il Money Manager.NET del programma.</font></span> <span style="font-family: Verdana;">Lo scopo</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> è </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">soprattutto </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">quello di aiutare gli utenti nella migrazione verso l'utilizzo di MMEX.</font></span>&nbsp;
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX puï¿½ anche 
+importare da file CSV esportati tramite il Money Manager.NET del programma.</font></span> <span style="font-family: Verdana;">Lo scopo</span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> ï¿½ </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">soprattutto </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">quello di aiutare gli utenti nella migrazione verso l'utilizzo di MMEX.</font></span>&nbsp;
 </p>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Il generale il formato è il 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Il generale il formato ï¿½ il 
 seguente:</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Data</b></i> - Data dell'operazione (visualizzata nel 
 formato specificato in Opzioni-&gt; Formato Data)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Beneficiario</b></i> - </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">il soggetto dell'operazione. </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Nel caso di un'operazione di 
-trasferimento, questo indica il nome del conto 'da cui' o 'a cui' è stato effettuato il 
-trasferimento.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Importo</b></i> - l'importo dell'operazione</font></span>. <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se è positivo, è considerato un deposito, se è negativo un prelievo</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Numero - </b></i>Numero dell'operazione </font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Stato</b></i> - Lo stato 
+trasferimento, questo indica il nome del conto 'da cui' o 'a cui' ï¿½ stato effettuato il 
+trasferimento.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Importo</b></i> - l'importo dell'operazione</font></span>. <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Se ï¿½ positivo, ï¿½ considerato un deposito, se ï¿½ negativo un prelievo</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Numero - </b></i>Numero dell'operazione </font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Stato</b></i> - Lo stato 
 dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Categoria</b></i> - La 
-categoria dell'operazione.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questa attualmente è la stringa composta da "Categoria: Sottocategoria"</font></span> 
+categoria dell'operazione.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questa attualmente ï¿½ la stringa composta da "Categoria: Sottocategoria"</font></span> 
 <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note dell'operazione</font></span>&nbsp;</p>
 
 <p><font face="Verdana">Notare che le operazioni contenute in un file CSV possono essere importate solo in un singolo conto di MMEX.</font> </p>
@@ -962,26 +963,26 @@ categoria dell'operazione.</font></span> <span onmouseover="_tipon(this)" onmous
 <p><font face="Verdana">Per agevolare gli utenti che avevano il problema di conversione dei file CSV</font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> delle loro operazioni bancarie nel formato richiesto da 
 MMEX, MMEX permette agli utenti di importare i file CSV scegliendo la corrispondenza di tutti i campi presenti nel file CSV.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">Per utilizzare 
 questo importatore, selezionare il conto da importare e quindi selezionare 
-l'ordine dei campi nel file CSV scegliendo dalla lista dei campi disponibili.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">MMEX importarà il file CSV utilizzando le informazioni sul 
-formato specificate dall'utente.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX può importare da un'ampia varietà 
-di formati.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Uno di questi è il formato di file CSV generico o universale.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo formato di file corrisponde 
-esattamente al formato CSV che MMEX può esportare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo è 
+l'ordine dei campi nel file CSV scegliendo dalla lista dei campi disponibili.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana">MMEX importarï¿½ il file CSV utilizzando le informazioni sul 
+formato specificate dall'utente.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX puï¿½ importare da un'ampia varietï¿½ 
+di formati.</font></span>&nbsp;<span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Uno di questi ï¿½ il formato di file CSV generico o universale.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo formato di file corrisponde 
+esattamente al formato CSV che MMEX puï¿½ esportare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo ï¿½ 
 utile per spostare i dati da un file di database .mmb ad un altro file di database con la medesima estensione .mmb.</font></span><font face="Verdana"><br></font><font face="Verdana">Per
-una più semplice comprensione si può&nbsp; provare ad esportare un
+una piï¿½ semplice comprensione si puï¿½&nbsp; provare ad esportare un
 qualsiasi conto in un file CSV per poi analizzare nel dettaglio il
 formato di file creato.<br><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Le opzioni dei campi CSV sono le 
 seguenti:</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span> <font face="Verdana"><i><b>Data</b></i> - Data della transazione (nel formato 
 scelto in Opzioni-&gt; Formato data)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Beneficiario</b></i> - Colui che fa o riceve l'operazione.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Nel caso di un'operazione di 
-trasferimento, questo indica il nome del conto 'da cui' o 'a cui' è stato effettuato il 
+trasferimento, questo indica il nome del conto 'da cui' o 'a cui' ï¿½ stato effettuato il 
 trasferimento.</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Importo (+/-)</b></i> 
 - L'importo dell'operazione.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Se si 
-tratta di un valore positivo, è un deposito, se il valore negativo è un prelievo.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Categoria</b></i> - La 
+tratta di un valore positivo, ï¿½ un deposito, se il valore negativo ï¿½ un prelievo.</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Categoria</b></i> - La 
 categoria dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Sottocategoria</b></i> - La 
-sottocategoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Numero - </b></i>Numero dell'operazione </font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Prelievo</b></i></font></span><font face="Verdana"> - Un importo negativo è considerato un prelievo. (Non utilizzare se specificato in <span style="font-weight: bold; font-style: italic;">Importo (+/-)</span>)<br><i><b>Deposito</b></i> - Un importo positivo è considerato un deposito. </font><font face="Verdana">(Non utilizzare se specificato in <span style="font-weight: bold; font-style: italic;">Importo (+/-)</span>)</font><br>
+sottocategoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Numero - </b></i>Numero dell'operazione </font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Prelievo</b></i></font></span><font face="Verdana"> - Un importo negativo ï¿½ considerato un prelievo. (Non utilizzare se specificato in <span style="font-weight: bold; font-style: italic;">Importo (+/-)</span>)<br><i><b>Deposito</b></i> - Un importo positivo ï¿½ considerato un deposito. </font><font face="Verdana">(Non utilizzare se specificato in <span style="font-weight: bold; font-style: italic;">Importo (+/-)</span>)</font><br>
 <font face="Verdana"><i><b>Ignora</b></i> - Ignorare questo campo<br><br></font><font face="Verdana">Notare che le operazioni contenute in un file CSV possono essere importate solo in un singolo conto di MMEX.</font><br>
 <font face="Verdana"><br></font><font face="Verdana"><b>Nota Importante</b></font><font face="Verdana"><b> (1)</b>: </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">L'impostazione del 
 formato della data scelta da Opzioni di MMEX, deve corrispondere a quella del formato della data nel file CSV, 
-altrimenti lettura del file di MMEX sarà errata e si tradurrà in operazioni aventi 
+altrimenti lettura del file di MMEX sarï¿½ errata e si tradurrï¿½ in operazioni aventi 
 date non corrette.</font></span> <font face="Verdana"><br></font><font face="Verdana"> <br><b>Nota Importante (2)</b>:
 Dopo averle importate dal file CSV, tutte le operazioni avranno lo <span style="font-style: italic;">Stato</span>
 "Da Monitorare". E' possibile contrassegnare tutte le operazioni con
@@ -994,17 +995,17 @@ destro del mouse sulla visualizzazione del conto.</font></p><p><!-- creating csv
 </font></h3>
 <ul>
 	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando si crea un file CSV bisogna assicurarsi di eliminare le virgole da depositi e 
-prelievi.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo può essere fatto facilmente attraverso un programma come 
+prelievi.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo puï¿½ essere fatto facilmente attraverso un programma come 
 Excel o OpenOffice.</font></span>
 	</p>
 </li></ul>
 <ul>
-	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Oppure si può cambiare il Separatore utilizzato da MMEX dal menù <span style="font-weight: bold;">Strumenti-&gt;Opzioni</span> quindi nella scheda "Generale" 
+	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Oppure si puï¿½ cambiare il Separatore utilizzato da MMEX dal menï¿½ <span style="font-weight: bold;">Strumenti-&gt;Opzioni</span> quindi nella scheda "Generale" 
 cambiare il Separatore di Campo in "Impostazioni per Importazione/Esportazione dati".</font></span>
 	</p>
 </li></ul>
 <ul>
-	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Non è necessario inserire i saldi nel file CSV.</font></span></p>
+	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Non ï¿½ necessario inserire i saldi nel file CSV.</font></span></p>
 </li></ul>
 <ul>
 	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Si noti che le 
@@ -1016,16 +1017,16 @@ operazioni da un file CSV possono essere importate in unico conto di MMEX.</font
 <hr>
 <h3 class="western"><a name="exportcsv"></a><font face="Verdana"><br>Esportazione in un file CSV<br>
 </font></h3>
-<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX può esportare in file CSV fisso.</font></span> 
+<p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX puï¿½ esportare in file CSV fisso.</font></span> 
 <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Questo formato di file corrisponde 
-esattamente al formato CSV che MMEX può importare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo permette di spostare facilmente dati da un database .mmb all'altro.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Il modo più semplice per vedere come e quali dati sono esportati da&nbsp; MMEX nel 
-formato di file CSV, è provare l'esportazione di un conto in un 
+esattamente al formato CSV che MMEX puï¿½ importare.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Questo permette di spostare facilmente dati da un database .mmb all'altro.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana">Il modo piï¿½ semplice per vedere come e quali dati sono esportati da&nbsp; MMEX nel 
+formato di file CSV, ï¿½ provare l'esportazione di un conto in un 
 file CSV e poi analizzarne i dati contenuti.</font></span> <br>
 </p>
-<p><font face="Verdana">Il formato generale è il seguente:<br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Data</b></i> - Data della transazione (nel formato 
+<p><font face="Verdana">Il formato generale ï¿½ il seguente:<br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Data</b></i> - Data della transazione (nel formato 
 scelto in Opzioni-&gt; Formato data)</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Beneficiario</b></i> - Colui che fa o riceve l'operazione.</font></span> <span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Nel caso di un'operazione di 
-trasferimento, questo indica il nome del conto 'da cui' o 'a cui' è stato effettuato il 
-trasferimento.</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Tipo Operazione</b></i> - Questa può essere 
+trasferimento, questo indica il nome del conto 'da cui' o 'a cui' ï¿½ stato effettuato il 
+trasferimento.</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Tipo Operazione</b></i> - Questa puï¿½ essere 
 <i>"Prelievo"</i> o <i>"Deposito"</i></font></span> <font face="Verdana"><br><i><b>Importo</b></i> - L'ammontare della operazione come valore positivo<br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"><i><b>Categoria</b></i> - La 
 categoria dell'operazione</font></span> <font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Sottocategoria</b></i> - La 
 sottocategoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione (se presente, altrimenti lasciare in bianco)</font></span><font face="Verdana"><br></font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><span style="text-align: left; direction: ltr;" class="google-src-text"></span><font face="Verdana"><i><b>Note</b></i> - Note </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">dell'operazione</font></span> <font face="Verdana"><br><br>Si noti che le operazioni di un conto devono essere esportate in un singolo file CSV.</font></p>
@@ -1034,8 +1035,8 @@ sottocategoria </font></span><span onmouseover="_tipon(this)" onmouseout="_tipof
 <hr>
 <h3 class="western"><a name="export_qif"></a><font face="Verdana"><br>Esportazione in un file QIF<br>
 </font></h3>
-<p><font face="Verdana">MMEX può esportare un conto in un formato di file QIF.</font></p>
-<p><font face="Verdana">Questo formato può essere utilizzato in MMEX anche per <a href="#importQIF">per caricare un&nbsp; conto</a>.</font></p>
+<p><font face="Verdana">MMEX puï¿½ esportare un conto in un formato di file QIF.</font></p>
+<p><font face="Verdana">Questo formato puï¿½ essere utilizzato in MMEX anche per <a href="#importQIF">per caricare un&nbsp; conto</a>.</font></p>
 <p><font face="Verdana">Attenzione: Sebbene le operazioni di Trasferimento saranno ricaricate in un singolo conto, non funzioneranno correttamente.</font></p>
 
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
@@ -1055,27 +1056,27 @@ Queste operazioni:</font></p>
 	</li><li><p><font face="Verdana">Potranno essere impostate per l'esecuzione con il consenso dell'utente<br>
     </font></p>
 </li></ul>
-<p><font face="Verdana">Vi si può accedere da </font><font face="Verdana"><b>Operazioni Ricorrenti</b></font> <font face="Verdana">dal pannello di navigazione.</font></p>
+<p><font face="Verdana">Vi si puï¿½ accedere da </font><font face="Verdana"><b>Operazioni Ricorrenti</b></font> <font face="Verdana">dal pannello di navigazione.</font></p>
 <ul>
 	<li><p><font face="Verdana">Per creare nuove operazioni, utilizzare il pulsante </font><font face="Verdana"><b>Nuova</b></font><font face="Verdana">.</font></p>
 	</li><li><p><font face="Verdana">Specificare il conto d'origine.</font></p>
-	</li><li><p><font face="Verdana">Il procedimento è simile alla <a href="#create_account">creazione di un nuovo conto</a>
+	</li><li><p><font face="Verdana">Il procedimento ï¿½ simile alla <a href="#create_account">creazione di un nuovo conto</a>
 tranne nel punto in cui bisogns collegare l'operazione ad un conto.
-Questo perchè per tali operazioni è necessario conoscere il conto di
+Questo perchï¿½ per tali operazioni ï¿½ necessario conoscere il conto di
 destinazione.</font></p>
 	</li><li><p><font face="Verdana">impostare la data </font><font face="Verdana"><b>Nuova Scadenza</b></font> <font face="Verdana">ad una data futura<br>
 </font></p>
-	</li><li><p><font face="Verdana">impostare la <span style="font-weight: bold;">Cadenza</span> come “<span style="font-style: italic;">giornaliera</span>”,
-	“<span style="font-style: italic;">settimanale</span>” ecc.</font></p>
+	</li><li><p><font face="Verdana">impostare la <span style="font-weight: bold;">Cadenza</span> come ï¿½<span style="font-style: italic;">giornaliera</span>ï¿½,
+	ï¿½<span style="font-style: italic;">settimanale</span>ï¿½ ecc.</font></p>
 	</li><li><p><font face="Verdana"><b>Numero di Operazioni:<br></b></font><font face="Verdana">-
-	inserire il numero delle volte che l'operazione si ripeterà.<br></font><font face="Verdana"><b>- </b></font><font face="Verdana">il campo lasciato in bianco significa che l'operazione si ripete a tempo indefinito.</font></p>
+	inserire il numero delle volte che l'operazione si ripeterï¿½.<br></font><font face="Verdana"><b>- </b></font><font face="Verdana">il campo lasciato in bianco significa che l'operazione si ripete a tempo indefinito.</font></p>
 </li></ul>
 <p><font face="Verdana"><span style="font-weight: normal;">Queste operazioni saranno visualizzate come:</span></font> <font face="Verdana"><b>Operazioni Imminenti</b></font> <font face="Verdana"><span style="font-weight: normal;">nella Pagina Principale da 14 giorni prima della scadenza.</span></font></p>
 <p><font face="Verdana"><b>Note:</b></font></p>
 <ol>
-	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando l'operazione diverrà attiva, alla data impostata, </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">se necessario</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> potremo cambiare o modificare importo, beneficiario, categoria, stato e data. </font></span></p>
-	</li><li><p><font face="Verdana"><b>Inserendo un'operazione prima della sua scadenza</b></font><font face="Verdana">, </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">nel conto associato </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">sarà di colore grigio</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">,
-fino al giorno in cui diverrà attiva</font></span><font face="Verdana">will gray out the transaction
+	<li><p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">Quando l'operazione diverrï¿½ attiva, alla data impostata, </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">se necessario</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana"> potremo cambiare o modificare importo, beneficiario, categoria, stato e data. </font></span></p>
+	</li><li><p><font face="Verdana"><b>Inserendo un'operazione prima della sua scadenza</b></font><font face="Verdana">, </font><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">nel conto associato </font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">sarï¿½ di colore grigio</font></span><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">,
+fino al giorno in cui diverrï¿½ attiva</font></span><font face="Verdana">will gray out the transaction
 	in the associated account until the day it becomes active.</font></p>
 	</li><li><p><font face="Verdana">Nell'utilizzo del <a href="#cashFlowReport">Rendiconto Flusso di Cassa</a> dovremo impostare le Operazioni Ricorrenti.</font></p>
 </li></ol>
@@ -1084,10 +1085,10 @@ fino al giorno in cui diverrà attiva</font></span><font face="Verdana">will gray
 <hr>
 <h3 class="western"><a name="assets"></a><font face="Verdana"><br>Beni</font></h3>
 <p><span onmouseover="_tipon(this)" onmouseout="_tipoff()"><font face="Verdana">MMEX ti permette di tenere traccia 
-di beni mobili ed immobili come automobili, case, terreni e altre proprietà.</font></span> <font face="Verdana">Ogni bene
-ha un valore che annualmente, secondo un certo tasso, si potrà
+di beni mobili ed immobili come automobili, case, terreni e altre proprietï¿½.</font></span> <font face="Verdana">Ogni bene
+ha un valore che annualmente, secondo un certo tasso, si potrï¿½
 rivalutare, svalutare o mantenere il suo valore inalterato. Il valore
-totale dei beni si aggiungerà al valore totale delle vostre finanze.</font>
+totale dei beni si aggiungerï¿½ al valore totale delle vostre finanze.</font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
@@ -1096,7 +1097,7 @@ totale dei beni si aggiungerà al valore totale delle vostre finanze.</font>
 <p><font face="Verdana">MMEX permette di eseguire ricerche di operazioni
 secondo determinati criteri. Questo si ottiene utilizzando le
 opzioni del filtro per la ricerca delle operazioni. La lista delle
-operazioni risultante può essere stampato o salvata come file HTML.</font>
+operazioni risultante puï¿½ essere stampato o salvata come file HTML.</font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
@@ -1108,17 +1109,17 @@ Una volta aggiunto il bilancio, selezionare l'anno per
 modificare, se necessario, gli importi per ciascuna categoria. Questo diventa il
 bilancio previsto per l'anno in corso.<br>
 <br>
-Utilizzando i rendiconti dei 'Budget', è possibile confrontare spese ed
+Utilizzando i rendiconti dei 'Budget', ï¿½ possibile confrontare spese ed
 entrate avendo come termine di paragone il bilancio dell'anno in corso.</font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
 <hr>
 <h3 class="western"><a name="reports"></a><font face="Verdana"><br>Rendiconti</font></h3>
-<p><font face="Verdana">MMEX consente di creare diversi tipi di rendiconti. <br>Tutti i rendiconti possono essere stampati dal menù: <b>File-&gt;Stampa... -&gt;Vista Attuale.</b></font></p>
+<p><font face="Verdana">MMEX consente di creare diversi tipi di rendiconti. <br>Tutti i rendiconti possono essere stampati dal menï¿½: <b>File-&gt;Stampa... -&gt;Vista Attuale.</b></font></p>
 <p><font face="Verdana">Selezionare la voce desiderata sotto
 "Rendiconti" dal Pannello di Navigazione. Alcuni rendiconti richiedono
 inserimenti da parte dell'utente, altri no, tutti comunque sono
-stampabile dall'apposito menù.</font></p>
+stampabile dall'apposito menï¿½.</font></p>
 <p><a name="financialYearReport"></a><font face="Verdana"><br><b>Rendiconto anno finanaziario:</b> (adatto a varie nazioni)</font></p>
 <p><font face="Verdana">Talvolta l'inizio questi rendiconti non
 corrisponde con l'inizio dell'anno solare, e appaiono come rami di un
@@ -1130,10 +1131,10 @@ rendiconto principale. Questi rendiconti coprono:<br>
 	</li><li><p><font face="Verdana">Anno Finanziario Attuale<br>
 </font></p>
 	</li><li><p><font face="Verdana">Per
-impostazione predefinita la data di inizio dell'anno finanziario è
-fissata al 1° luglio dell'anno.</font><font face="Verdana"></font></p>
+impostazione predefinita la data di inizio dell'anno finanziario ï¿½
+fissata al 1ï¿½ luglio dell'anno.</font><font face="Verdana"></font></p>
 </li></ol>
-<p><font face="Verdana">La data di inizio dell'anno finanziario può essere
+<p><font face="Verdana">La data di inizio dell'anno finanziario puï¿½ essere
 modificata dall'utente con qualsiasi giorno di qualsiasi
 mese, entro un periodo di 12 mesi. Per modificare la data d'inizio utilizzare il
 menu <b>Strumenti-&gt;Opzioni</b> e selezionare il riquadro <b>Altro</b>.</font><font face="Verdana"></font></p>
@@ -1145,9 +1146,9 @@ menu <b>Strumenti-&gt;Opzioni</b> e selezionare il riquadro <b>Altro</b>.</font>
 </li></ol>
 <p><a name="cashFlowReport"></a><font face="Verdana"><br><b>Rendiconto flusso di cassa<br>
 </b></font></p>
-<p><font face="Verdana">Per funzionare correttamente le <a href="#recurring_transactions">Operazione Ricorrenti</a> </font><font face="Verdana">devono essere impostate nei vari conti. Il rendiconto utilizzerà le
+<p><font face="Verdana">Per funzionare correttamente le <a href="#recurring_transactions">Operazione Ricorrenti</a> </font><font face="Verdana">devono essere impostate nei vari conti. Il rendiconto utilizzerï¿½ le
 Operazioni Ricorrenti dei diversi conti, per visualizzare la previsione
-dell'ammontare di denaro che sarà disponibile per i 12 mesi successivi
+dell'ammontare di denaro che sarï¿½ disponibile per i 12 mesi successivi
 sulla base delle operazioni previste.</font></p>
 
 <h5 class="western"><a href="#top"><font face="Verdana">Torna all'inizio</font></a></h5>
@@ -1155,7 +1156,7 @@ sulla base delle operazioni previste.</font></p>
 <h3 class="western"><a name="print"></a><font face="Verdana"><br>Stampa</font></h3>
 <p><font face="Verdana">MMEX supporta la stampa di tutti i rendiconti generati e visualizzati. </font>
 </p>
-<p><font face="Verdana">Le opzioni di Stampa sono disponibili dall'apposito menù, <span style="font-weight: bold;">File-&gt;Stampa... Vista Attuale</span><br>
+<p><font face="Verdana">Le opzioni di Stampa sono disponibili dall'apposito menï¿½, <span style="font-weight: bold;">File-&gt;Stampa... Vista Attuale</span><br>
 </font></p>
 <p><font face="Verdana">Racommandazioni:</font></p>
 <ul>
@@ -1191,8 +1192,8 @@ funzioni di MMEX tramite le 4 schede della finestra di dialogo
 			</td>
 			<td width="82%">
 				<p><font face="Verdana">Questa
-funzione imposta la Valuta Base del database. Ogni conto la utilizzerà
-come valuta&nbsp; predefinita, ma se necessario può essere cambiata con
+funzione imposta la Valuta Base del database. Ogni conto la utilizzerï¿½
+come valuta&nbsp; predefinita, ma se necessario puï¿½ essere cambiata con
 una diversa.<br>
 </font></p>
 			</td>
@@ -1213,7 +1214,7 @@ rendiconti o durante l'importazione dai file QIF e CSV.</font></p>
 </b></i></font></p>
 			</td>
 			<td width="82%">
-				<p><font face="Verdana">E' utilizzato come carattere di separazione tra campi durante la creazione di file CSV</font><font face="Verdana">. </font><font face="Verdana">Questo è utile per cambiare la predefinita ',' (virgola) con '.'
+				<p><font face="Verdana">E' utilizzato come carattere di separazione tra campi durante la creazione di file CSV</font><font face="Verdana">. </font><font face="Verdana">Questo ï¿½ utile per cambiare la predefinita ',' (virgola) con '.'
 (punto) per indicare i decimali negli importi delle valute</font><font face="Verdana">.</font>
 				</p>
 			</td>
@@ -1234,7 +1235,7 @@ rendiconti o durante l'importazione dai file QIF e CSV.</font></p>
 			<td width="82%">
 				<p><font face="Verdana">Questo campo visualizza la lingua scelta per
 l'interfaccia di MMEX. Cambiando lingua potrebbe essere necessario
-riavviare il programma affinché siano caricati tutti gli elementi della
+riavviare il programma affinchï¿½ siano caricati tutti gli elementi della
 nuova lingua
 selezionata.</font></p>
 			</td>
@@ -1370,10 +1371,10 @@ selezionata.</font></p>
 				<p><font face="Verdana"><i><b>Backup Database</b></i></font></p>
 			</td>
 			<td width="82%">
-				<p><font face="Verdana">Per impostare le modalità d'esecuzione del backup all'avvio di MMEX.</font></p>
+				<p><font face="Verdana">Per impostare le modalitï¿½ d'esecuzione del backup all'avvio di MMEX.</font></p>
 				<ul>
 					<li><p><font face="Verdana">Effettuare il Backup prima dell'Apertura: crea un backup del database, con data e ora, prima di aprirlo.</font></p>
-					</li><li><p><font face="Verdana">Aggiornamento Giornaliero...: se il database è aperto più di una volta al giorno, il backup verrà aggiornato ad ogni apertura.</font></p>
+					</li><li><p><font face="Verdana">Aggiornamento Giornaliero...: se il database ï¿½ aperto piï¿½ di una volta al giorno, il backup verrï¿½ aggiornato ad ogni apertura.</font></p>
 				</li></ul>
 			</td>
 		</tr>
@@ -1383,11 +1384,11 @@ selezionata.</font></p>
 </b></i></font></p>
 			</td>
 			<td width="82%">
-				<p><font face="Verdana">Questo URL è usato dal pulsante Aggiorna nella pagina dei Titoli<br>
+				<p><font face="Verdana">Questo URL ï¿½ usato dal pulsante Aggiorna nella pagina dei Titoli<br>
 </font></p>
 				
-				<p><font face="Verdana">Questo URL è usato per la schermata di modifica o creazione di nuovi titoli</font><font face="Verdana">, per aprire la pagina web dei titoli in elenco.<br>
-Per impostazione predefinita è yahoo finanza. Se necessario può essere utilizzato un altro sito a scelta dell'utente.</font></p>
+				<p><font face="Verdana">Questo URL ï¿½ usato per la schermata di modifica o creazione di nuovi titoli</font><font face="Verdana">, per aprire la pagina web dei titoli in elenco.<br>
+Per impostazione predefinita ï¿½ yahoo finanza. Se necessario puï¿½ essere utilizzato un altro sito a scelta dell'utente.</font></p>
 			</td>
 		</tr>
 		<tr valign="top">
@@ -1397,7 +1398,7 @@ Per impostazione predefinita è yahoo finanza. Se necessario può essere utilizzat
 			</td>
 			<td width="82%">
 				<p><font face="Verdana">Abilitata
-questa opzione farà utilizzare al programma la data originale durante
+questa opzione farï¿½ utilizzare al programma la data originale durante
 il Copia-Incolla di un'operazione, nella schermata del conto.</font></p>
 			</td>
 		</tr>
@@ -1428,9 +1429,9 @@ il Copia-Incolla di un'operazione, nella schermata del conto.</font></p>
 	</p>
 	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#nameex">Cosa significa EX nel nome del programma?</a> </font>
 	</p>
-	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#database1">Il formato di file .mmb è esclusivo? E i miei dati sono al sicuro?</a> </font>
+	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#database1">Il formato di file .mmb ï¿½ esclusivo? E i miei dati sono al sicuro?</a> </font>
 	</p>
-	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#usbkey">MMEX può essere eseguito da una chiavetta USB?</a> </font>
+	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#usbkey">MMEX puï¿½ essere eseguito da una chiavetta USB?</a> </font>
 	</p>
 	</li><li><p style="margin-bottom: 0in;"><font face="Verdana"><a href="#safety">Come posso essere certo che MMEX non stia tentando di accedere ai miei dati finanaziari?</a> </font>
 	</p>
@@ -1473,17 +1474,17 @@ il Copia-Incolla di un'operazione, nella schermata del conto.</font></p>
 </font></h3>
 <p class="MsoBodyText"><span style="font-family: Verdana;">Originariamente ho 
 sviluppato un programma di finanza personale chiamato <span class="GramE">Money</span> Manager. Era scritto in<span class="GramE"> 
-.</span>NET <span class="GramE"></span>più
+.</span>NET <span class="GramE"></span>piï¿½
 come esercizio di studio che come lo sviluppo di un software. Con il
-tempo è diventato inadeguato rispetto al progetto originale. Quindi ho
-“congelato” il vecchio programma ed è ho iniziato il lavoro per una
+tempo ï¿½ diventato inadeguato rispetto al progetto originale. Quindi ho
+ï¿½congelatoï¿½ il vecchio programma ed ï¿½ ho iniziato il lavoro per una
 nuova versione con caratteristiche e interfaccia simile alla versione
 precedente, ma scritto in C++. <o:p></o:p></span></p>
 
 
-<span style="font-family: Verdana;">Di</span> <span style="font-family: Verdana;">solito Microsoft <span class="GramE">dà</span> un 
+<span style="font-family: Verdana;">Di</span> <span style="font-family: Verdana;">solito Microsoft <span class="GramE">dï¿½</span> un 
 nome alla seconda versione migliorata dei loro software API con un'estensione 
-Ex come da <span class="SpellE">NomeProgramma</span>() a <span class="SpellE">NomeProgrammaEx</span>(). <span class="GramE">Così anch’io ho 
+Ex come da <span class="SpellE">NomeProgramma</span>() a <span class="SpellE">NomeProgrammaEx</span>(). <span class="GramE">Cosï¿½ anchï¿½io ho 
 seguito questo modello e ho riportato 'Ex' alla fine del nome</span>.</span><p><br><br>
 </p>
 <p><br><br>
@@ -1506,7 +1507,7 @@ seguito questo modello e ho riportato 'Ex' alla fine del nome</span>.</span><p><
 	</tr>
 </tbody></table>
 <hr>
-<h3 class="western"><a name="database1"></a><font face="Verdana"><br>Il formato .mmb è esclusivo per MMEX? E i miei dati sono al sicuro? </font>
+<h3 class="western"><a name="database1"></a><font face="Verdana"><br>Il formato .mmb ï¿½ esclusivo per MMEX? E i miei dati sono al sicuro? </font>
 </h3>
 
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -1517,7 +1518,7 @@ seguito questo modello e ho riportato 'Ex' alla fine del nome</span>.</span><p><
 			<p><font face="Verdana"><b>No</b></font></p>
 		</td>
 		<td width="95%">
-			<p style="font-weight: normal;"><font face="Verdana">il formato di file .mmb non è esclusivo<br>
+			<p style="font-weight: normal;"><font face="Verdana">il formato di file .mmb non ï¿½ esclusivo<br>
 </font></p>
 		</td>
 	</tr>
@@ -1527,9 +1528,9 @@ seguito questo modello e ho riportato 'Ex' alla fine del nome</span>.</span><p><
 			</p>
 		</td>
 		<td width="95%">
-			<p style="font-weight: normal;"><font face="Verdana">MMEX usa un database SQLite per memorizzare i dati.</font><font face="Verdana"> </font><font face="Verdana">Questo vuol dire che il file .mmb è come un normale database SQLite.</font><font face="Verdana"> </font><span style="font-family: Verdana;" class="SpellE">SQLite</span><span style="font-family: Verdana;"> è uno dei più piccoli sistemi di </span><span style="font-family: Verdana;" class="GramE">database gratuito</span><span style="font-family: Verdana;"> </span><span style="font-family: Verdana;" class="SpellE"></span><span style="font-family: Verdana;">disponibile,</span><font face="Verdana"> e ci sono moltissimi strumenti in grado di aprire ed accedere ai database SQLite.</font><font face="Verdana"> </font><font face="Verdana">SQLiteSpy e SQLite 
+			<p style="font-weight: normal;"><font face="Verdana">MMEX usa un database SQLite per memorizzare i dati.</font><font face="Verdana"> </font><font face="Verdana">Questo vuol dire che il file .mmb ï¿½ come un normale database SQLite.</font><font face="Verdana"> </font><span style="font-family: Verdana;" class="SpellE">SQLite</span><span style="font-family: Verdana;"> ï¿½ uno dei piï¿½ piccoli sistemi di </span><span style="font-family: Verdana;" class="GramE">database gratuito</span><span style="font-family: Verdana;"> </span><span style="font-family: Verdana;" class="SpellE"></span><span style="font-family: Verdana;">disponibile,</span><font face="Verdana"> e ci sono moltissimi strumenti in grado di aprire ed accedere ai database SQLite.</font><font face="Verdana"> </font><font face="Verdana">SQLiteSpy e SQLite 
 Browser sono due di questi strumenti</font><font face="Verdana">
-			(<a href="http://sqlitebrowser.sourceforge.net/">http://sqlitebrowser.sourceforge.net/</a>). </font><font face="Verdana">Una volta aperto il database con uno di questi strumenti, è possibile fare qualsiasi cosa si desideri con i dati.</font>
+			(<a href="http://sqlitebrowser.sourceforge.net/">http://sqlitebrowser.sourceforge.net/</a>). </font><font face="Verdana">Una volta aperto il database con uno di questi strumenti, ï¿½ possibile fare qualsiasi cosa si desideri con i dati.</font>
 			</p>
 		</td>
 	</tr>
@@ -1549,7 +1550,7 @@ Browser sono due di questi strumenti</font><font face="Verdana">
 		</td>
 		<td width="95%">
 			<p><font face="Verdana">I dati sono contenuti sul tuo PC</font><font face="Verdana">, (o <a href="#usbkey">Chiavetta USB</a> </font><font face="Verdana">se lo adoperi come portabile</font><font face="Verdana">). Per proteggere ulteriormente i tuoi dati <a href="#encryptDatabase">puoi crittografare il database.</a> </font><font face="Verdana">Questo permette di criptare il database aggiungendo una password,&nbsp;
-così che il database potrà essere aperto da MMEX o altro programma solo
+cosï¿½ che il database potrï¿½ essere aperto da MMEX o altro programma solo
 se si conosce la password corretta.</font></p>
 		</td>
 	</tr>
@@ -1576,21 +1577,21 @@ se si conosce la password corretta.</font></p>
 	</tr>
 </tbody></table>
 <hr>
-<h3 class="western"><a name="usbkey"></a><font face="Verdana"><br>MMEX può essere eseguito da una chiavetta USB?</font></h3>
+<h3 class="western"><a name="usbkey"></a><font face="Verdana"><br>MMEX puï¿½ essere eseguito da una chiavetta USB?</font></h3>
 <p><a name="usbkey1"></a><font face="Verdana"><b>Si.</b></font></p>
-<p><font face="Verdana">MMEX è un applicazione portabile, questo
-significa che può funzionare sensa installazione, per esempio, da una
+<p><font face="Verdana">MMEX ï¿½ un applicazione portabile, questo
+significa che puï¿½ funzionare sensa installazione, per esempio, da una
 chiavetta USB. Se MMEX trova il file mmexini.db3 nella sua cartella, si
-avvierà in modalità portabile. Copia i file di mmex in una cartella di
+avvierï¿½ in modalitï¿½ portabile. Copia i file di mmex in una cartella di
 una chiavetta USB, poi copia il file mmexini.db3 nella stessa cartella.</font></p>
 <p><font face="Verdana">Come rendere MMEX portabile:</font></p>
 <ol>
-	<li><p><font face="Verdana"><b>In ambiente Windows (supposto che F:\ è una chiavetta USB)</b></font><font face="Verdana"><br>Copia "C:\Programmi\MoneyManagerEx" to <a href="../help">F:\</a><br>Copia
+	<li><p><font face="Verdana"><b>In ambiente Windows (supposto che F:\ ï¿½ una chiavetta USB)</b></font><font face="Verdana"><br>Copia "C:\Programmi\MoneyManagerEx" to <a href="../help">F:\</a><br>Copia
 	"%APPDATA%\MoneyManagerEx\mmexini.db3" su
 	<a href="../help">F:\MoneyManagerEx</a><br>Copia il tuo file di database in una cartella su <a href="../help">F:\</a><br></font><br><br>
 	</p>
 	</li><li><p><font face="Verdana"><b>In ambiente Unix (supposto che /media/disk sia una chiavetta USB inserita)</b> </font><font face="Verdana"><br></font><font face="Verdana">Compila mmex dal suo file sorgente normalmente, <br>poi fai installare prefix=/media/disk <br>cp ~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex 
-<br><br>o se vuoi copia mmex già installato in /usr <br>cp 
+<br><br>o se vuoi copia mmex giï¿½ installato in /usr <br>cp 
 /usr/bin/mmex /media/disk/mmex/bin <br>cp /usr/share/mmex /media/disk/mmex/share 
 <br>cp /usr/share/doc/mmex /media/disk/mmex/share/doc <br>cp ~/.mmex/mmexini.db3 
 /media/disk/mmex/share/mmex </font><font face="Verdana"><br></font><br><br>
@@ -1614,11 +1615,11 @@ una chiavetta USB, poi copia il file mmexini.db3 nella stessa cartella.</font></
 <p><a name="safety1"></a><font face="Verdana">Generamente con qualsiasi
 programma con codice chiuso (closed source), in materia di sicurezza
 dei dati, ci si deve fidare di quanto afferma il produttore del
-software. Invece con MMEX essendo un codice aperto (open source), è
+software. Invece con MMEX essendo un codice aperto (open source), ï¿½
 possibile verificare personalmente le affermazioni fatte da chi ha
-scritto il programma. Anche se non si è un esperto di C++, è certo che
-chiunque può accedere al codice sorgente in qualsiasi momento
-e verificare la legittimità delle intenzioni di MMEX. Inoltre MMEX non
+scritto il programma. Anche se non si ï¿½ un esperto di C++, ï¿½ certo che
+chiunque puï¿½ accedere al codice sorgente in qualsiasi momento
+e verificare la legittimitï¿½ delle intenzioni di MMEX. Inoltre MMEX non
 si connette a Internet a meno che non esplicitamente richiesto
 dall'utente (come per il controllo degli aggiornamenti, aggiornamento
 quotazioni azionarie, ecc).</font><font face="Verdana"> <br></font><br><br>
@@ -1649,11 +1650,11 @@ quotazioni azionarie, ecc).</font><font face="Verdana"> <br></font><br><br>
 <p><a name="statements1"></a><font face="Verdana">Per stampare un
 Estratto Conto con le operazione scelte secondo uno specifico criterio,
 basta utilizzare il Filtro Operazioni per selezionare quali
-visualizzare e quindi stampare dal menù File -&gt;Stampa...-&gt;Vista
+visualizzare e quindi stampare dal menï¿½ File -&gt;Stampa...-&gt;Vista
 attuale</font></p>
-<p><font face="Verdana">Il Filtro Operazioni è accessibile da&nbsp;
+<p><font face="Verdana">Il Filtro Operazioni ï¿½ accessibile da&nbsp;
 Rendiconti--&gt;Rendiconto Operazioni nel pannello di navigazione, o
-cliccando sull'icona a forma d'imbuto posta nella barra sotto ai menù in alto a sinistra.</font></p>
+cliccando sull'icona a forma d'imbuto posta nella barra sotto ai menï¿½ in alto a sinistra.</font></p>
 <p><br><br>
 </p>
 <p><br><br>
@@ -1680,7 +1681,7 @@ cliccando sull'icona a forma d'imbuto posta nella barra sotto ai menù in alto a 
 	</tr>
 </tbody></table>
 <hr>
-<h5 class="western"><font face="Verdana">Copyright © 2005-2011&nbsp;
+<h5 class="western"><font face="Verdana">Copyright ï¿½ 2005-2011&nbsp;
 CodeLathe LLC. Tutti i diritti riservati. <br>
 </font></h5>
 <h5 class="western"><font face="Verdana">Traduzione Italiana di Maurizio.13 - email: xmaurizio.13<span style="color: rgb(153, 153, 153);">(AT)</span>hotmal<span style="color: rgb(153, 153, 153);">(DOT)</span>com - </font><font><font face="Verdana">[user: Mau.13]</font></font></h5>

--- a/doc/help/italian/investment.html
+++ b/doc/help/italian/investment.html
@@ -1,10 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
 
 
 
-	<meta http-equiv="CONTENT-TYPE" content="text/html; charset=windows-1252"><title>Setting up an Investment Account</title>
-	
+	<meta charset="utf-8"><title>Setting up an Investment Account</title>
+	<link href="../master.css" rel="stylesheet" type="text/css">
 	<meta name="GENERATOR" content="OpenOffice.org 3.3  (Win32)">
 	<meta name="CREATED" content="0;0">
 	<meta name="CHANGEDBY" content="Stefano Giorgio">
@@ -25,7 +25,7 @@
 		</td>
 	</tr>
 </tbody></table>
-<p><font face="Verdana">With MMEX è possibile tenere sotto controllo azioni e fondi comuni. </font>
+<p><font face="Verdana">With MMEX ï¿½ possibile tenere sotto controllo azioni e fondi comuni. </font>
 </p>
 <ul>
 	<li><p><font face="Verdana">Per utilizzare Titoli, creare un nuovo conto<br>
@@ -35,9 +35,9 @@
 </font></p>
 </li></ul>
 <ul>
-	<li><p><font face="Verdana">Questo nuovo conto verrà aggiunto nella sezione Titoli nel riquadro di Navigazione della Pagina Principale<br>
+	<li><p><font face="Verdana">Questo nuovo conto verrï¿½ aggiunto nella sezione Titoli nel riquadro di Navigazione della Pagina Principale<br>
 </font></p>
-	</li><li><p><font face="Verdana">Nella Pagina Principale, il conto sarà visualizzato come </font><font face="Verdana"><b>Titoli</b></font></p>
+	</li><li><p><font face="Verdana">Nella Pagina Principale, il conto sarï¿½ visualizzato come </font><font face="Verdana"><b>Titoli</b></font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana">I conti azionari in titoli saranno visualizzati nella schermata relativa ai Titoli.<br>
 </font></p>
 </li></ul>
@@ -51,7 +51,7 @@
 </font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Modifica<br></b>Permette di modificare dettagli e dati di ogni voce<br>
 </font></p>
-	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Elimina<br></b>Per eleiminare una o più voci dall'elenco<br>
+	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Elimina<br></b>Per eleiminare una o piï¿½ voci dall'elenco<br>
 </font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Aggiorna<br></b>Permette di aggiornare le quotazioni dei vari titoli azionari tramite internet<br>
 </font></p>
@@ -59,7 +59,7 @@
 </font></p>
 </li></ul>
 <hr>
-<p><font face="Verdana"><font size="4"><b>Il pulsante 'Nuovo'</b></font></font><font face="Verdana"><br>Cliccando sul pulsante 'Nuovo' si aprirà un box di dialogo per inserire i dati del titolo azionario.</font></p>
+<p><font face="Verdana"><font size="4"><b>Il pulsante 'Nuovo'</b></font></font><font face="Verdana"><br>Cliccando sul pulsante 'Nuovo' si aprirï¿½ un box di dialogo per inserire i dati del titolo azionario.</font></p>
 <table style="page-break-inside: avoid;" border="0" cellpadding="4" cellspacing="0" width="100%">
 	<col width="256*">
 	<tbody><tr>
@@ -80,7 +80,7 @@
 		<td width="66%">
 			<ul>
 				<li><p><font face="Verdana">Questo
-pulsante, tramite il codice indicato nel campo 'Simbolo', aprirà la
+pulsante, tramite il codice indicato nel campo 'Simbolo', aprirï¿½ la
 pagina web i dettagli del titolo azionario specificato.</font></p>
 			</li></ul>
 		</td>
@@ -92,15 +92,15 @@ pagina web i dettagli del titolo azionario specificato.</font></p>
 		</td>
 		<td width="66%">
 			<ul>
-				<li><p>Il Simbolo del titolo può essere inserico con o senza il suffisso di cambio (Stock
+				<li><p>Il Simbolo del titolo puï¿½ essere inserico con o senza il suffisso di cambio (Stock
 				Exchange Qualifier). - Esempio: AMP o AMP.BE</p>
 				</li><li><p>Quando
 i titoli sono negoziati su diversi mercati azionari, il suffisso di
-cambio, il suffisso può cambiare a seconda del provider fornitore delle
+cambio, il suffisso puï¿½ cambiare a seconda del provider fornitore delle
 Quotazioni Azionarie.</p>
-				</li><li><p>Il suffisso di cambio azionario utilizzato da&nbsp; Yahoo è '.BE'</p>
-				</li><li><p>Il suffisso di cambio azionario utilizzato da Google è ':BER'</p>
-				</li><li><p>Il provider fornitore delle Quotazioni Azionarie può essere cambiato utilizzando le voci del menù: <b>Strumenti –&gt;Opzioni –&gt; Altro</b> 
+				</li><li><p>Il suffisso di cambio azionario utilizzato da&nbsp; Yahoo ï¿½ '.BE'</p>
+				</li><li><p>Il suffisso di cambio azionario utilizzato da Google ï¿½ ':BER'</p>
+				</li><li><p>Il provider fornitore delle Quotazioni Azionarie puï¿½ essere cambiato utilizzando le voci del menï¿½: <b>Strumenti ï¿½&gt;Opzioni ï¿½&gt; Altro</b> 
 				</p>
 			</li></ul>
 		</td>
@@ -128,25 +128,25 @@ impostare le opzioni relative al sito d'aggiornamento dei titoli.</font></p>
 </tbody></table>
 <p><font face="Verdana">Quando tutti i titoli sono sul mercato
 azionario dello stesso paese, e le quotazioni sono prese dalla Borsa di
-quel paese, il suffisso Yahoo può essere aggiunto come un'impostazione
-globale predefinita per tutti i titoli. Questo imposterà lo stesso
-Codice di Borsa per tutti i titoli, così da permettere l'utilizzo del
+quel paese, il suffisso Yahoo puï¿½ essere aggiunto come un'impostazione
+globale predefinita per tutti i titoli. Questo imposterï¿½ lo stesso
+Codice di Borsa per tutti i titoli, cosï¿½ da permettere l'utilizzo del
 pulsante 'Aggiorna' nella schermata Titoli.<br>
 </font></p>
 <p><font face="Verdana"><b>Esempio: </b></font><font face="Verdana"><span style="font-weight: normal;">Per le quotazioni Italiane della Borsa di Milano (Indice FTSE MIB)<br>
 </span></font></p>
 <ul>
-	<li><p style="font-weight: normal;"><font face="Verdana">Utilizzando Yahoo il suffisso è: '.MI'</font></p>
+	<li><p style="font-weight: normal;"><font face="Verdana">Utilizzando Yahoo il suffisso ï¿½: '.MI'</font></p>
 	</li><li><p><font face="Verdana">Utilizzando il sito del Sole 24 Ore NON occorre aggiungere il suffisso</font><font face="Verdana"><span style="font-weight: normal;"></span></font></p></li></ul>
 <p><font face="Verdana"><b>Esempio 2: </b></font><font face="Verdana"><span style="font-weight: normal;">Per le quotazioni Australiane<br>
 </span></font></p>
 
 <ul>
-<li><p style="font-weight: normal;"><font face="Verdana">Utilizzando Yahoo il suffisso è</font><font face="Verdana">: '.AX'</font></p>
-	</li><li><p><font face="Verdana">Utilizzando Yahoo il suffisso è</font><font face="Verdana"><span style="font-weight: normal;">: ':ASX'</span></font></p>
+<li><p style="font-weight: normal;"><font face="Verdana">Utilizzando Yahoo il suffisso ï¿½</font><font face="Verdana">: '.AX'</font></p>
+	</li><li><p><font face="Verdana">Utilizzando Yahoo il suffisso ï¿½</font><font face="Verdana"><span style="font-weight: normal;">: ':ASX'</span></font></p>
 </li>
 </ul>
-<p>Il provider fornitore delle Quotazioni Azionarie può essere cambiato utilizzando le voci del menù: <b>Strumenti –&gt;Opzioni –&gt; Altro</b><b></b> 
+<p>Il provider fornitore delle Quotazioni Azionarie puï¿½ essere cambiato utilizzando le voci del menï¿½: <b>Strumenti ï¿½&gt;Opzioni ï¿½&gt; Altro</b><b></b> 
 </p>
 
 <p><br><br>

--- a/doc/help/polish/budget.html
+++ b/doc/help/polish/budget.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+﻿<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-    <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF8"/>
+    <META charset="UTF-8"/>
     <TITLE>Instrukcja użytkowania Money Manager Ex</TITLE>
-    <link rel="stylesheet" type="text/css" href="../../res/master.css">
+    <link href="../master.css" rel="stylesheet" type="text/css">
       <style>
         table {
         font-size: 100%;

--- a/doc/help/polish/index.html
+++ b/doc/help/polish/index.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+﻿<!DOCTYPE HTML>
 <HTML>
 <HEAD>
-    <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF8"/>
+    <META charset="UTF8"/>
     <TITLE>Instrukcja użytkowania Money Manager Ex</TITLE>
-    <link rel="stylesheet" type="text/css" href="../master.css">
+    <link href="../master.css" rel="stylesheet" type="text/css">
       <style>
         table {
         font-size: 100%;

--- a/doc/help/polish/index.html
+++ b/doc/help/polish/index.html
@@ -3,7 +3,7 @@
 <HEAD>
     <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF8"/>
     <TITLE>Instrukcja użytkowania Money Manager Ex</TITLE>
-    <link rel="stylesheet" type="text/css" href="../../res/master.css">
+    <link rel="stylesheet" type="text/css" href="../master.css">
       <style>
         table {
         font-size: 100%;

--- a/doc/help/russian/index.html
+++ b/doc/help/russian/index.html
@@ -1,11 +1,12 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+﻿<!DOCTYPE HTML>
 <html lang="ru-ru"><head>
   
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
 
   
   <meta name="ProgId" content="FrontPage.Editor.Document">
   <title>Руководство пользователя Money Manager Ex</title>
+  <link href="../master.css" rel="stylesheet" type="text/css">
 
   
 </head><body>

--- a/doc/help/russian/investment.html
+++ b/doc/help/russian/investment.html
@@ -1,8 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
   
-  <meta http-equiv="CONTENT-TYPE" content="text/html; charset=utf-8">
+  <meta charset="utf-8">
   <title>Setting up an Investment Account</title>
+  <link href="../master.css" rel="stylesheet" type="text/css">
 
   
 </head><body dir="ltr" lang="ru-RU">

--- a/doc/help/spanish/budget.html
+++ b/doc/help/spanish/budget.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-<html><head><!-- saved from url=(0022)http://internet.e-mail -->
+<!DOCTYPE html>
+<html><head>
   
-  <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
+  <meta charset="utf-8">
+  <link href="../master.css" rel="stylesheet" type="text/css">
   <title>Budget</title></head>
 <body dir="ltr" lang="en-US">
 <p><a name="budget_top"></a>
@@ -21,31 +22,31 @@
   </tbody>
 </table>
 <hr>
-<b>MMEX</b> permite la configuración de un presupuesto para un determinado año y/o mes.<br>Esto permite comparar lo que gasta con su presupuesto.<br>
-<br>Los presupuestos se pueden mostrar en años de calendario o años fiscales.<br>
-<br>Utilice las Opciones para seleccionar el inicio del año fiscal, y cualquier cambio permanente que necesite.<br>La opción <b>Ver-&gt;Presupuestos: Como años fisales</b> también se puede usar para cambiar entre las 2 vistas.<br>
+<b>MMEX</b> permite la configuraciï¿½n de un presupuesto para un determinado aï¿½o y/o mes.<br>Esto permite comparar lo que gasta con su presupuesto.<br>
+<br>Los presupuestos se pueden mostrar en aï¿½os de calendario o aï¿½os fiscales.<br>
+<br>Utilice las Opciones para seleccionar el inicio del aï¿½o fiscal, y cualquier cambio permanente que necesite.<br>La opciï¿½n <b>Ver-&gt;Presupuestos: Como aï¿½os fisales</b> tambiï¿½n se puede usar para cambiar entre las 2 vistas.<br>
 <hr>
 <b>Crear nuevos presupuestos:</b><br>
-<br>Para configurar un presupuesto haga click derecho en la rama 'Presupuestos' del árbol y añada un mes o un año.<br>
+<br>Para configurar un presupuesto haga click derecho en la rama 'Presupuestos' del ï¿½rbol y aï¿½ada un mes o un aï¿½o.<br>
 <br>
 <img alt="Budget Editor" src="../budget_editor.png"><br><br>
 <hr>
-<b>Edición de las categorías del presupuesto:</b><br>
-<br>Una vez añadido el año, selecciónelo para mostrar la configuración del presupuesto.<br>Se puede editar cada categoría haciendo doble click sobre ella.<br>
+<b>Ediciï¿½n de las categorï¿½as del presupuesto:</b><br>
+<br>Una vez aï¿½adido el aï¿½o, selecciï¿½nelo para mostrar la configuraciï¿½n del presupuesto.<br>Se puede editar cada categorï¿½a haciendo doble click sobre ella.<br>
 <br>
 <img style="width: 266px; height: 330px;" alt="Bugget Entry Detail" src="../budget_entry_details.png"><br>
 <br>
-Esto se realiza para todas las subsiguientes categorías.<br>
+Esto se realiza para todas las subsiguientes categorï¿½as.<br>
 <br>
 <hr>
-<b>Configuración del presupuesto:</b><br>
-<br>Esto se convierte en el presupuesto para ese año. Los meses y/o años posteriores pueden derivar de este año.<br>
+<b>Configuraciï¿½n del presupuesto:</b><br>
+<br>Esto se convierte en el presupuesto para ese aï¿½o. Los meses y/o aï¿½os posteriores pueden derivar de este aï¿½o.<br>
 <br>
 <img style="width: 638px; height: 250px;" alt="Budget Setup Grid" src="../budget_grid.png"><br>
-<br>El resumen total de categoría se muestra por cada categoría principial. <br>Al configurar un presupuesto, el resumen total del presupuesto se puede desactivar mediante la opción del menú:<br>
-<b>Ver-&gt;Organización de presupuesto: Sin resúmenes</b><br>
+<br>El resumen total de categorï¿½a se muestra por cada categorï¿½a principial. <br>Al configurar un presupuesto, el resumen total del presupuesto se puede desactivar mediante la opciï¿½n del menï¿½:<br>
+<b>Ver-&gt;Organizaciï¿½n de presupuesto: Sin resï¿½menes</b><br>
 <br>
-<br>Mediante los informes bajo 'Presupuestos', ahora es posible comparar cómo ha gastado el dinero frente a su presupuesto real.<br>
+<br>Mediante los informes bajo 'Presupuestos', ahora es posible comparar cï¿½mo ha gastado el dinero frente a su presupuesto real.<br>
 <br>
 <br>
 <hr>

--- a/doc/help/spanish/index.html
+++ b/doc/help/spanish/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
-<meta http-equiv="CONTENT-TYPE" content="text/html; charset=windows-1252"><title>Manual de usuario de Money Manager Ex</title>
+<meta charset="utf-8"><title>Manual de usuario de Money Manager Ex</title>
+<link href="../master.css" rel="stylesheet" type="text/css">
 
 <meta name="GENERATOR" content="OpenOffice.org 3.3 (Win32)">
 <meta name="CREATED" content="0;0">
@@ -31,7 +32,7 @@ Manager Ex<br>
 <td width="81%">
 <ul>
 <li>
-<p style="margin-bottom: 0in;"><a href="#introduction"><font face="Verdana"><span style="font-weight: normal;">Introducción</span></font></a></p>
+<p style="margin-bottom: 0in;"><a href="#introduction"><font face="Verdana"><span style="font-weight: normal;">Introducciï¿½n</span></font></a></p>
 </li>
 <li>
 <p style="margin-bottom: 0in;"><a href="#financial_health"><font face="Verdana">Trabajando
@@ -60,7 +61,7 @@ de Money Manager Ex</font></a></p>
 <td width="50%">
 <ul>
 <li>
-<p><font face="Verdana"><b>Gestión
+<p><font face="Verdana"><b>Gestiï¿½n
 de la base de datos</b></font><font face="Verdana"><span style="font-weight: normal;"><br>
 * <a href="#create_database">Crear una nueva base de datos</a><br>
 * <a href="#encrypting_database">Cifrar una base de datos</a></span></font></p>
@@ -73,7 +74,7 @@ de la base de datos</b></font><font face="Verdana"><span style="font-weight: nor
 <p><font face="Verdana"><b>Trabajar
 con</b></font><font face="Verdana">:<br>
 * <a href="#currencies">Divisas</a><br>
-* <a href="#categories">Categorías</a><br>
+* <a href="#categories">Categorï¿½as</a><br>
 *&nbsp;<a href="#payees">Beneficiarios</a></font></p>
 </li>
 </ul>
@@ -83,10 +84,10 @@ con</b></font><font face="Verdana">:<br>
 <td width="50%">
 <ul>
 <li>
-<p><font face="Verdana"><b>Gestión
+<p><font face="Verdana"><b>Gestiï¿½n
 de cuentas</b></font><font face="Verdana"><br>
 * <a href="#create_account">Crear cuentas nuevas</a><br>
-* <a href="#editaccounts">Editar información de cuenta</a><br>
+* <a href="#editaccounts">Editar informaciï¿½n de cuenta</a><br>
 * <a href="#creating_new_transaction">Crear nuevas
 transacciones</a><br>
 * <a href="#edittrans">Editar y actualizar transacciones</a><br>
@@ -95,7 +96,7 @@ transacciones</a><br>
 seguimiento</a></font></p>
 </li>
 <li>
-<p><a href="#account_setup"><font face="Verdana"><b>Ejemplo de configuración de cuenta</b></font></a></p>
+<p><a href="#account_setup"><font face="Verdana"><b>Ejemplo de configuraciï¿½n de cuenta</b></font></a></p>
 </li>
 </ul>
 </td>
@@ -126,7 +127,7 @@ Manager.NET CSV</a><br>
 <ul>
 <li>
 <p><a href="#reports"><font face="Verdana"><b>Informes</b></font></a><font face="Verdana"><br>
-* <a href="#financialYearReport">Informes de año fiscal</a><br>
+* <a href="#financialYearReport">Informes de aï¿½o fiscal</a><br>
 * <a href="#transaction_report">Informes de transacciones</a><br>
 * <a href="#cashFlowReport">Informes de flujo de caja</a></font></p>
 </li>
@@ -135,7 +136,7 @@ Manager.NET CSV</a><br>
 <td width="50%">
 <ul>
 <li>
-<p><a href="./investment.html"><font face="Verdana"><b>Inversión en acciones</b></font></a></p>
+<p><a href="./investment.html"><font face="Verdana"><b>Inversiï¿½n en acciones</b></font></a></p>
 </li>
 <li>
 <p><a href="#assets"><font face="Verdana"><b>Activos</b></font></a></p>
@@ -147,7 +148,7 @@ Manager.NET CSV</a><br>
 <td width="50%">
 <ul>
 <li>
-<p><a href="#recurring_transactions"><font face="Verdana"><b>Transacciones periódicas</b></font></a></p>
+<p><a href="#recurring_transactions"><font face="Verdana"><b>Transacciones periï¿½dicas</b></font></a></p>
 </li>
 <li>
 <p><a href="#transfilter"><font face="Verdana"><b>Filtro de transacciones</b></font></a></p>
@@ -160,7 +161,7 @@ Manager.NET CSV</a><br>
 <p><a href="./budget.html"><font face="Verdana"><b>Presupuesto</b></font></a></p>
 </li>
 <li>
-<p><a href="#print"><font face="Verdana"><b>Impresión</b></font></a></p>
+<p><a href="#print"><font face="Verdana"><b>Impresiï¿½n</b></font></a></p>
 </li>
 </ul>
 </td>
@@ -191,31 +192,31 @@ Manager.NET CSV</a><br>
 </p>
 <hr>
 <h3 class="western"><a name="introduction"></a><font face="Verdana"><br>
-Introducción</font></h3>
+Introducciï¿½n</font></h3>
 <p><font face="Verdana"><b>M</b>oney <b>M</b>anager
 <b>Ex</b> (<b>MMEX</b>)
 es un sistema que modela el mundo financiero real, para ayudar a los
 usuarios a mantener sus finanzas personales. El software Money Manager
-EX es de código abierto y de uso gratuito.</font></p>
+EX es de cï¿½digo abierto y de uso gratuito.</font></p>
 <p><font face="Verdana">El principal objetivo de
 MMEX es simplificar el
-proceso de seguimiento de la información financiera, en un programa de
-fácil uso que se pueda utilizar en cualquier momento, para ayudarnos a
-llevar un control de dónde viene nuestro dinero, y lo que es más
-importante, a dónde va, para poder tomar mejores decisiones financieras
+proceso de seguimiento de la informaciï¿½n financiera, en un programa de
+fï¿½cil uso que se pueda utilizar en cualquier momento, para ayudarnos a
+llevar un control de dï¿½nde viene nuestro dinero, y lo que es mï¿½s
+importante, a dï¿½nde va, para poder tomar mejores decisiones financieras
 en el futuro.</font></p>
 <p><font face="Verdana">Piense en Money Manager Ex
 como en un talonario
 de cheques informatizado que le permite cuadrar sus cuentas, organizar,
 gestionar y generar informes de sus finanzas. </font>
 </p>
-<p><font face="Verdana">También es una buena manera
+<p><font face="Verdana">Tambiï¿½n es una buena manera
 de mantenerse al tanto de su valor financiero.</font></p>
-<p><font face="Verdana">El propósito de este manual
+<p><font face="Verdana">El propï¿½sito de este manual
 es proporcionarle
-algunas instrucciones básicas para operar con MMEX. Este manual de
-instrucciones evolucionará a medida que lo haga el programa. Por lo que
-compruebe la ayuda en cada actualización y vea las novedades para poder
+algunas instrucciones bï¿½sicas para operar con MMEX. Este manual de
+instrucciones evolucionarï¿½ a medida que lo haga el programa. Por lo que
+compruebe la ayuda en cada actualizaciï¿½n y vea las novedades para poder
 aprovechar mejor MMEX. </font>
 </p>
 <h5 class="western"><font face="Verdana"><a href="#top">Volver arriba</a><br>
@@ -226,33 +227,33 @@ aprovechar mejor MMEX. </font>
 <h3 class="western"><a name="financial_health"></a><font face="Verdana"><br>
 Trabajando para conseguir una mejor salud financiera</font></h3>
 <p><font face="Verdana">Convertirse en una persona financieramente
-organizada require un poco de disciplina. La gestión financiera puede
+organizada require un poco de disciplina. La gestiï¿½n financiera puede
 tornarse complicada cuando no hay un conocimiento claro de cuanto
-dinero ingresamos en contraposición a nuestros gastos. Las deudas
+dinero ingresamos en contraposiciï¿½n a nuestros gastos. Las deudas
 normalmente llegan cuando nuestro flujo de caja es limitado porque
 nuestros gastos superan a nuestros ingresos. Entonces necesitamos que
 nos presten dinero para mantener nuestro flujo de caja y poder adquirir
 productos necesarios.</font></p>
 <p><font face="Verdana">El primer paso hacia una mejor salud
 financiera, es mantener un buen registro de datos financieros. Es
-entonces cuando tenemos un claro conocimiento de a dónde va nuestro
-dinero, por lo que podremos tomar una decisión bien fundada de donde
-recortar nuestros&nbsp;gastos cuando el flujo de caja esté más
-ajustado. Si necesitamos que nos presten dinero, también podemos
+entonces cuando tenemos un claro conocimiento de a dï¿½nde va nuestro
+dinero, por lo que podremos tomar una decisiï¿½n bien fundada de donde
+recortar nuestros&nbsp;gastos cuando el flujo de caja estï¿½ mï¿½s
+ajustado. Si necesitamos que nos presten dinero, tambiï¿½n podemos
 gestionar mejor nuestras deudas.</font></p>
-<p><font face="Verdana">¿Se ha dado cuenta que gastó 600€ en comprar
-películas en DVD el año pasado? ¿Cuántas veces las ha visto? ¿Piensa
-ahora que esos 600€ hubieran sido mejor invertidos en la avería del
-coche que le ocurrió ayer? Por supuesto que no hay una respuesta
-correcta o errónea sobre cómo debería gastar su dinero. Después de todo, es
+<p><font face="Verdana">ï¿½Se ha dado cuenta que gastï¿½ 600ï¿½ en comprar
+pelï¿½culas en DVD el aï¿½o pasado? ï¿½Cuï¿½ntas veces las ha visto? ï¿½Piensa
+ahora que esos 600ï¿½ hubieran sido mejor invertidos en la averï¿½a del
+coche que le ocurriï¿½ ayer? Por supuesto que no hay una respuesta
+correcta o errï¿½nea sobre cï¿½mo deberï¿½a gastar su dinero. Despuï¿½s de todo, es
 usted quien lo ha ganado y tiene el derecho a gastarlo como le
 convenga. Pero siempre puede encontrar una forma de aprovechar mejor el
 dinero.<br>
-<br>Aquí es donde el software de finanzas personales entra en juego. Le
+<br>Aquï¿½ es donde el software de finanzas personales entra en juego. Le
 ayuda a diseccionar los datos financieros para lograr un mejor
-entendimiento de lo que está pasando. Recuerde siempre que el software
-sólo es tan bueno como los datos que procesa. Si entra basura, sale
-basura. Pero si ha empezado a pensar en usar software financiero, está
+entendimiento de lo que estï¿½ pasando. Recuerde siempre que el software
+sï¿½lo es tan bueno como los datos que procesa. Si entra basura, sale
+basura. Pero si ha empezado a pensar en usar software financiero, estï¿½
 en el buen camino para hacer que cada moneda cuente.</font></p>
 <p><font face="Verdana">Lea como trabajar con
 Money Manager Ex.</font></p>
@@ -266,7 +267,7 @@ mundo real para ayudarnos a mantener nuestras finanzas personales.</font></p>
 <p><font face="Verdana">Generalmente recibimos
 dinero de alguien por
 proporcionarle un servicio o un producto que vendamos. El sistema
-considera esto como un ingreso o un </font><a href="index.html#trans_types"><font face="Verdana"><b>abono</b></font></a><font face="Verdana">. Cuando adquirimos un artículo o usamos un
+considera esto como un ingreso o un </font><a href="index.html#trans_types"><font face="Verdana"><b>abono</b></font></a><font face="Verdana">. Cuando adquirimos un artï¿½culo o usamos un
 servicio, el dinero que gastamos se considera un gasto o un </font><font><b><a href="index.html#trans_types"><font face="Verdana"><b>cargo</b></font></a></b></font><font face="Verdana">. En MMEX, la gente que nos da dinero o que
 recibe nuestro dinero se consideran </font><font><b><a href="index.html#payees"><font face="Verdana"><b>beneficiarios</b></font></a></b></font><font face="Verdana">.</font></p>
 <p><font face="Verdana">Como es de esperar no gastar
@@ -275,9 +276,9 @@ recibimos, obviamente se necesita un lugar para guardar nuestro dinero.
 Esto es, por lo general, alguna entidad financiera, o varias, o nuestro
 bolsillo. MMEX etiqueta estos lugares como </font><a href="#create_account"><font face="Verdana"><b>cuentas</b></font></a><font face="Verdana">.&nbsp;</font></p>
 <p><font face="Verdana">Cuando gastamos o recibimos
-dinero, lo vemos como una </font><a href="index.html#creating_new_transaction"><font face="Verdana"><i><b>transacción</b></i></font></a><font face="Verdana">, y el motivo del ingreso o gasto es la </font><a href="index.html#categories"><font face="Verdana"><i><b>categoría</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;"></span></i></font><font face="Verdana">.
-Habrá veces que será necesario transferir dinero de un lugar a otro,
-como retirar dinero de un cajero, y este tipo de transacción se conoce
+dinero, lo vemos como una </font><a href="index.html#creating_new_transaction"><font face="Verdana"><i><b>transacciï¿½n</b></i></font></a><font face="Verdana">, y el motivo del ingreso o gasto es la </font><a href="index.html#categories"><font face="Verdana"><i><b>categorï¿½a</b></i></font></a><font face="Verdana"><i><span style="font-weight: normal;"></span></i></font><font face="Verdana">.
+Habrï¿½ veces que serï¿½ necesario transferir dinero de un lugar a otro,
+como retirar dinero de un cajero, y este tipo de transacciï¿½n se conoce
 como </font><font><i><b><a href="index.html#trans_types"><font face="Verdana"><i><b>transferencia</b></i></font></a></b></i></font><font face="Verdana">.</font>
 </p>
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -300,7 +301,7 @@ es la
 transacciones.</font></p>
 <p><font face="Verdana">MMEX utiliza una </font><a href="#create_database"><font face="Verdana"><b>base
 de datos</b></font></a>&nbsp;<font face="Verdana">para almacenar y conectar todas estas
-entidades entre sí y poder realizar un seguimiento.</font></p>
+entidades entre sï¿½ y poder realizar un seguimiento.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="recommendation"></a><font face="Verdana"><br>
@@ -308,19 +309,19 @@ Recomendaciones</font></h3>
 <p><font face="Verdana">La base de datos que genera
 MMEX, conocida como
 fichero .mmb, se convierte en un fichero importante de mantener.
-Dependiendo de las circunstancias, se pueden emplear características de
+Dependiendo de las circunstancias, se pueden emplear caracterï¿½sticas de
 seguridad, como el cifrado, que se reconoce como un fichero .emb. En
-este punto podemos asociar una contraseña a la base de datos, que se
-solicitará cada vez que se abra MMEX.</font></p>
+este punto podemos asociar una contraseï¿½a a la base de datos, que se
+solicitarï¿½ cada vez que se abra MMEX.</font></p>
 <p><font face="Verdana"><b>Cuando cifre su
-base de datos, no olvide la contraseña</b>.</font></p>
+base de datos, no olvide la contraseï¿½a</b>.</font></p>
 <p><font face="Verdana">Como en cualquier sistema
 informatizado, los
 datos que se producen son importantes para nosotros, y por lo tanto es
 necesario protegerlos contra un error de funcionamiento del sistema.
 MMEX posee un sistema de copia de seguridad con el que puede generar
 una copia cuando se abre la base de datos, y actualizar la copia diaria
-si se abre más de una vez al día.</font></p>
+si se abre mï¿½s de una vez al dï¿½a.</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Realice&nbsp;regularmente
@@ -332,7 +333,7 @@ seguridad en otros dispositivos para protegerlos de un fallo hardware.</font></p
 </li>
 <li>
 <p><font face="Verdana">Antes de actualizar a
-una nueva versión de&nbsp;MMEX, asegúrese de realizar una copia de
+una nueva versiï¿½n de&nbsp;MMEX, asegï¿½rese de realizar una copia de
 seguridad de su fichero&nbsp;.mmb o .emb.</font></p>
 </li>
 </ul>
@@ -341,63 +342,63 @@ seguridad de su fichero&nbsp;.mmb o .emb.</font></p>
 <h3 class="western"><a name="create_database"></a><font face="Verdana"><br>
 Crear una nueva base de datos</font></h3>
 <p><font face="Verdana">Cuando se inicia MMEX,
-intentará cargar la
-última base datos que fue abierta. Si no existe esa base de datos, al
-usuario se le presenta la opción de abrir una base datos existente o
+intentarï¿½ cargar la
+ï¿½ltima base datos que fue abierta. Si no existe esa base de datos, al
+usuario se le presenta la opciï¿½n de abrir una base datos existente o
 crear una nueva.</font></p>
 <p><font face="Verdana">Si necesita crear un nuevo
-fichero de base de datos, seleccione el menú <b>Archivo-&gt;Nueva
+fichero de base de datos, seleccione el menï¿½ <b>Archivo-&gt;Nueva
 base de datos</b>.</font></p>
-<p><font face="Verdana">Se le pedirá especificar un
+<p><font face="Verdana">Se le pedirï¿½ especificar un
 nombre para el
-fichero .mmb de la base de datos en la ubicación que indique. Una vez
-creado el nuevo fichero de base de datos se mostrará un asistente para
+fichero .mmb de la base de datos en la ubicaciï¿½n que indique. Una vez
+creado el nuevo fichero de base de datos se mostrarï¿½ un asistente para
 ayudarle a inicializar la base de datos y <a href="#create_account">crear
 su primera cuenta</a>.</font></p>
 <p><font face="Verdana">El asistente para crear una
-nueva base de datos le pedirá que especifique una </font><font face="Verdana"><b>Moneda</b></font><font face="Verdana"> base y un</font><font face="Verdana"><b>
+nueva base de datos le pedirï¿½ que especifique una </font><font face="Verdana"><b>Moneda</b></font><font face="Verdana"> base y un</font><font face="Verdana"><b>
 Nombre de usuario</b></font><font face="Verdana">.</font></p>
 <p><font face="Verdana">MMEX viene con un conjunto
 de divisas
 predeterminadas, para que&nbsp;pueda usar la que corresponda con
 las
-características de la moneda de su país.
-Las nuevas cuentas utilizarán esta configuración de </font><font face="Verdana"><b>Moneda base</b></font> <font face="Verdana">por defecto. Esto permite que las cuentas de
-diferentes países reflejen sus valores en la moneda base.</font></p>
+caracterï¿½sticas de la moneda de su paï¿½s.
+Las nuevas cuentas utilizarï¿½n esta configuraciï¿½n de </font><font face="Verdana"><b>Moneda base</b></font> <font face="Verdana">por defecto. Esto permite que las cuentas de
+diferentes paï¿½ses reflejen sus valores en la moneda base.</font></p>
 <p><font face="Verdana">Para ayudar a identificar el
-propósito de la base de datos, se pide rellenar un </font><font face="Verdana"><b>Nombre de usuario</b></font><font face="Verdana">. Es opcional, y sólo se utiliza como título
-en la página de inicial y en los informes.</font></p>
+propï¿½sito de la base de datos, se pide rellenar un </font><font face="Verdana"><b>Nombre de usuario</b></font><font face="Verdana">. Es opcional, y sï¿½lo se utiliza como tï¿½tulo
+en la pï¿½gina de inicial y en los informes.</font></p>
 <p><font face="Verdana">Ambas configuraciones se
-pueden cambiar en cualquier momento seleccionando el menú: </font><font face="Verdana"><b>Herramientas-&gt;Opciones</b></font>
+pueden cambiar en cualquier momento seleccionando el menï¿½: </font><font face="Verdana"><b>Herramientas-&gt;Opciones</b></font>
 </p>
 <p><font face="Verdana">El nombre de la base de
-datos se mostrará en la
-barra de título para ayudarle a recordar qué fichero de base de datos
-está abierto.<br>
+datos se mostrarï¿½ en la
+barra de tï¿½tulo para ayudarle a recordar quï¿½ fichero de base de datos
+estï¿½ abierto.<br>
 </font><font face="Verdana"><b>El nuevo
-fichero .mmb de base de datos no está cifrado.</b></font></p>
+fichero .mmb de base de datos no estï¿½ cifrado.</b></font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="encrypting_database"></a><font face="Verdana"><br>
 Cifrar el fichero de base de datos</font></h3>
 <p style="font-weight: normal;"><font face="Verdana">La
-base de datos se puede cifrar de la siguiente manera: en el menú,
+base de datos se puede cifrar de la siguiente manera: en el menï¿½,
 seleccione <b>Archivo-&gt;Guardar base de datos&nbsp;
 como</b></font></p>
 <ol>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Seleccione
-su ubicación y el fichero .mmb, o cree un nuevo nombre para su base de
+su ubicaciï¿½n y el fichero .mmb, o cree un nuevo nombre para su base de
 datos.</font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Cambie
-el<b> Tipo:</b> a Encrypted MMB Files (*.emb). Después
+el<b> Tipo:</b> a Encrypted MMB Files (*.emb). Despuï¿½s
 pulse <b>Guardar.</b></font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Introduzca
-una contraseña para el fichero – <b>La necesitará cuando abra la
+una contraseï¿½a para el fichero ï¿½ <b>La necesitarï¿½ cuando abra la
 base de datos.</b></font></p>
 </li>
 </ol>
@@ -410,15 +411,15 @@ seguridad del fichero&nbsp;.mmb o .emb de la base de datos. </font>
 </li>
 <li>
 <p><font face="Verdana"><span style="font-weight: normal;">El fichero de base de datos no
-está cifrado:</span><br>
+estï¿½ cifrado:</span><br>
 Eso
 significa que cualquiera que tenga conocimientos puede abrir el fichero
-y leer su contenido. Así que asegúrese que si está almacenando
-información financiera sensible, se guarda debidamente.</font></p>
+y leer su contenido. Asï¿½ que asegï¿½rese que si estï¿½ almacenando
+informaciï¿½n financiera sensible, se guarda debidamente.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Para bases de datos
-cifradas: <b>Recuerde su contraseña</b>.</font></p>
+cifradas: <b>Recuerde su contraseï¿½a</b>.</font></p>
 </li>
 </ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
@@ -426,98 +427,98 @@ cifradas: <b>Recuerde su contraseña</b>.</font></p>
 <h3 class="western"><a name="create_account"></a><font face="Verdana"><br>
 Crear nuevas cuentas</font></h3>
 <p><font face="Verdana">Al crear un nuevo fichero de
-base de datos, automáticamente se le pedirá que cree una nueva cuenta.</font></p>
+base de datos, automï¿½ticamente se le pedirï¿½ que cree una nueva cuenta.</font></p>
 <p><font face="Verdana"><span style="font-weight: normal;">Para crear un nueva cuenta
-manualmente, seleccione el menú </span></font><font face="Verdana"><b>Cuentas-&gt;Nueva cuenta</b></font><font face="Verdana"><span style="font-weight: normal;">.</span></font></p>
-<p><font face="Verdana"><span style="font-weight: normal;">Esto abrirá el </span></font><font face="Verdana"><b>asistente para añadir una cuenta</b></font><font face="Verdana"><span style="font-weight: normal;">, el cual le guiará a través del proceso de asignar un nombre y un tipo de cuenta. </span></font><font face="Verdana"><b>El tipo de cuenta no se puede cambiar</b></font><font face="Verdana"><span style="font-weight: normal;">,
-pero el nombre se puede cambiar al <a href="#editaccounts">editar la información de la cuenta</a>.</span></font></p>
+manualmente, seleccione el menï¿½ </span></font><font face="Verdana"><b>Cuentas-&gt;Nueva cuenta</b></font><font face="Verdana"><span style="font-weight: normal;">.</span></font></p>
+<p><font face="Verdana"><span style="font-weight: normal;">Esto abrirï¿½ el </span></font><font face="Verdana"><b>asistente para aï¿½adir una cuenta</b></font><font face="Verdana"><span style="font-weight: normal;">, el cual le guiarï¿½ a travï¿½s del proceso de asignar un nombre y un tipo de cuenta. </span></font><font face="Verdana"><b>El tipo de cuenta no se puede cambiar</b></font><font face="Verdana"><span style="font-weight: normal;">,
+pero el nombre se puede cambiar al <a href="#editaccounts">editar la informaciï¿½n de la cuenta</a>.</span></font></p>
 <p style="margin-bottom: 0in;"><font face="Verdana"><b>Nombre de la cuenta:</b></font> <font face="Verdana">Es
 un campo obligatorio. Se recomienda que nombre a sus cuentas de forma
-única y que tenga relación con las cuentas reales. Ejemplo: Con
+ï¿½nica y que tenga relaciï¿½n con las cuentas reales. Ejemplo: Con
 CitiBank, tenemos una cuenta de ahorro y una tarjeta de
-crédito&nbsp;Visa. Podría nombrar a sus cuenta como "CitiBank Ahorro" y
-“Citibank Visa”.</font></p>
+crï¿½dito&nbsp;Visa. Podrï¿½a nombrar a sus cuenta como "CitiBank Ahorro" y
+ï¿½Citibank Visaï¿½.</font></p>
 <p style="margin-bottom: 0in;"><br>
 </p>
 <p><font face="Verdana"><b>Tipo de cuenta: </b>MMEX
 actualmente dispone de tres tipos de cuenta:</font></p>
 <ol>
 <li>
-<p><font face="Verdana"><b>Cuenta </b></font><span style="font-family: Verdana;"><span style="font-style: italic;"><span style="font-weight: bold;">"</span></span></span><font face="Verdana"><i><b>Corriente”</b></i></font><font face="Verdana"><b>:</b></font>
+<p><font face="Verdana"><b>Cuenta </b></font><span style="font-family: Verdana;"><span style="font-style: italic;"><span style="font-weight: bold;">"</span></span></span><font face="Verdana"><i><b>Corrienteï¿½</b></i></font><font face="Verdana"><b>:</b></font>
 <font face="Verdana"><span style="font-weight: normal;">Es el tipo de
-cuenta más utilizada por MMEX, y permite gestionar los tipos de cuenta
-más comunes, como cuentas corrientes, de ahorro, y de tarjeta de
-crédito. También se conoce como cuenta bancaria, y permite tres tipos
+cuenta mï¿½s utilizada por MMEX, y permite gestionar los tipos de cuenta
+mï¿½s comunes, como cuentas corrientes, de ahorro, y de tarjeta de
+crï¿½dito. Tambiï¿½n se conoce como cuenta bancaria, y permite tres tipos
 de transacciones: cargos, abonos y transferencias</span></font><font face="Verdana">. </font> </p>
 </li>
 <li>
-<p><font face="Verdana"><b>Cuenta </b></font><span style="font-family: Verdana; font-style: italic;"><span style="font-weight: bold;">"</span></span><font face="Verdana"><b><span style="font-style: italic;">A plazo”</span>:</b></font>
+<p><font face="Verdana"><b>Cuenta </b></font><span style="font-family: Verdana; font-style: italic;"><span style="font-weight: bold;">"</span></span><font face="Verdana"><b><span style="font-style: italic;">A plazoï¿½</span>:</b></font>
 <font face="Verdana">Similar a las cuentas corrientes excepto que
-aparecen en su propia sección de la página de inicio y se pueden
-mostrar u ocultar cuando sea necesario. Para una explicación más detallada
-vea el <a href="#account_setup">ejemplo de configuración de cuenta</a>.<br>
-<br>Este tipo de cuentas cubren cuentas especializadas como depósitos a
-plazo, hipotecas, préstamos o inversiones, con ingresos y gastos de los
+aparecen en su propia secciï¿½n de la pï¿½gina de inicio y se pueden
+mostrar u ocultar cuando sea necesario. Para una explicaciï¿½n mï¿½s detallada
+vea el <a href="#account_setup">ejemplo de configuraciï¿½n de cuenta</a>.<br>
+<br>Este tipo de cuentas cubren cuentas especializadas como depï¿½sitos a
+plazo, hipotecas, prï¿½stamos o inversiones, con ingresos y gastos de los
 que necesita llevar un control. Estas cuentas tienen su propio resumen
-en la página de inicio. También permiten tres tipos de transacciones.</font></p>
+en la pï¿½gina de inicio. Tambiï¿½n permiten tres tipos de transacciones.</font></p>
 </li>
 <li>
-<p><span style="font-family: Verdana;"><span style="font-weight: bold;">Cuenta </span></span><font face="Verdana"><b>de <span style="font-style: italic;">"</span></b></font><font style="font-style: italic;" face="Verdana"><b>Inversión</b></font><font face="Verdana"><b><span style="font-style: italic;">"</span>:</b></font> <font face="Verdana">El
-otro tipo de cuenta que permite MMEX son cuentas de "Inversión". Este
+<p><span style="font-family: Verdana;"><span style="font-weight: bold;">Cuenta </span></span><font face="Verdana"><b>de <span style="font-style: italic;">"</span></b></font><font style="font-style: italic;" face="Verdana"><b>Inversiï¿½n</b></font><font face="Verdana"><b><span style="font-style: italic;">"</span>:</b></font> <font face="Verdana">El
+otro tipo de cuenta que permite MMEX son cuentas de "Inversiï¿½n". Este
 tipo de cuenta le permite llevar un seguimiento de sus acciones, bonos
-y fondos de inversión u otro tipo de inversiones que tenga.</font></p>
+y fondos de inversiï¿½n u otro tipo de inversiones que tenga.</font></p>
 </li>
 </ol>
 <p><font face="Verdana">Para configurar correctamente las cuentas,
-debería tener información del saldo de las cuentas que quiera añadir a
-MMEX. Puede obtener esta información del último extracto de su cuenta
-bancaria, inversión o tarjeta de crédito. Para tener información
+deberï¿½a tener informaciï¿½n del saldo de las cuentas que quiera aï¿½adir a
+MMEX. Puede obtener esta informaciï¿½n del ï¿½ltimo extracto de su cuenta
+bancaria, inversiï¿½n o tarjeta de crï¿½dito. Para tener informaciï¿½n
 adicional sobre la cuenta, de forma opcional puede introducir otros
-detalles, como el número de cuenta, página web, e información de
-contacto y acceso. También puede introducir notas adicionales sore la
+detalles, como el nï¿½mero de cuenta, pï¿½gina web, e informaciï¿½n de
+contacto y acceso. Tambiï¿½n puede introducir notas adicionales sore la
 cuenta en el campo correspondiente.</font></p>
-<p><font face="Verdana">La mayoría de cuentas tienen un determinado saldo, por ejemplo, en una tarjeta de crédito puede tener un saldo actual de </font><font face="Verdana">2304,67 €</font><font face="Verdana">,
-el cual podría poner en el campo saldo inicial. De ahí en adelante sólo
-tendría que añadir las transacciones a partir de la fecha de ese saldo.</font></p>
+<p><font face="Verdana">La mayorï¿½a de cuentas tienen un determinado saldo, por ejemplo, en una tarjeta de crï¿½dito puede tener un saldo actual de </font><font face="Verdana">2304,67 ï¿½</font><font face="Verdana">,
+el cual podrï¿½a poner en el campo saldo inicial. De ahï¿½ en adelante sï¿½lo
+tendrï¿½a que aï¿½adir las transacciones a partir de la fecha de ese saldo.</font></p>
 <p><font face="Verdana"><b>El estado de la cuenta</b></font><font face="Verdana">
 puede ser "Abierta" o "Cerrada".
-Las cuentas cerrodas simplemente&nbsp;son eso. Ya no están activas.
-Seleccionar este estado es sólo una forma ordenar la vista del árbol de
-navegación. Los ajustes permanentes se realizan en las opciones de
-vista del menú, Herramientas-&gt;Opciones, donde puede ocultar las
-cuentas cerradas. Vea <a href="#navTreeTips">consejos del árbol de navegación.</a><br>
+Las cuentas cerrodas simplemente&nbsp;son eso. Ya no estï¿½n activas.
+Seleccionar este estado es sï¿½lo una forma ordenar la vista del ï¿½rbol de
+navegaciï¿½n. Los ajustes permanentes se realizan en las opciones de
+vista del menï¿½, Herramientas-&gt;Opciones, donde puede ocultar las
+cuentas cerradas. Vea <a href="#navTreeTips">consejos del ï¿½rbol de navegaciï¿½n.</a><br>
 <br>
-</font><font face="Verdana"><b>Moneda:</b></font> <font face="Verdana"><span style="font-weight: normal;">Está
-inicialmente fijada a la moneda base&nbsp;que se configuró al crear la
-base de datos. Puede seleccionar la moneda que está asociada con la
-cuenta y puede ser diferente de la moneda base</span></font><font face="Verdana">. La tasa de cambio de la moneda se puede cambiar mediante el menú: </font><font face="Verdana"><b>Herramientas
+</font><font face="Verdana"><b>Moneda:</b></font> <font face="Verdana"><span style="font-weight: normal;">Estï¿½
+inicialmente fijada a la moneda base&nbsp;que se configurï¿½ al crear la
+base de datos. Puede seleccionar la moneda que estï¿½ asociada con la
+cuenta y puede ser diferente de la moneda base</span></font><font face="Verdana">. La tasa de cambio de la moneda se puede cambiar mediante el menï¿½: </font><font face="Verdana"><b>Herramientas
 -&gt;Organizar divisas.</b></font></p>
 <p style="font-weight: normal;"><font face="Verdana">Ejemplo:
-Vive en EE.UU. y utiliza dólares, y tiene una cuenta en un banco
-italiano que utiliza euros. La mayoría de sus cuentas están en dólares.
-¿Cuál es el valor real de su cuenta italiana? Cambiando la tasa de
+Vive en EE.UU. y utiliza dï¿½lares, y tiene una cuenta en un banco
+italiano que utiliza euros. La mayorï¿½a de sus cuentas estï¿½n en dï¿½lares.
+ï¿½Cuï¿½l es el valor real de su cuenta italiana? Cambiando la tasa de
 cambio del euro italiano, puede obtener el valor correcto de sus
 cuentas.</font></p>
-<p><font face="Verdana">También puede marcar sus cuentas como
-'Favoritas'. Esto también se utiliza para cambiar las cuentas que son
-visibles en la barra de navegación.&nbsp;</font><a href="#navTreeTips"><font face="Verdana">Vea </font></a><font face="Verdana"><a href="index.html#navTreeTips">consejos del árbol de navegación.</a></font></p>
+<p><font face="Verdana">Tambiï¿½n puede marcar sus cuentas como
+'Favoritas'. Esto tambiï¿½n se utiliza para cambiar las cuentas que son
+visibles en la barra de navegaciï¿½n.&nbsp;</font><a href="#navTreeTips"><font face="Verdana">Vea </font></a><font face="Verdana"><a href="index.html#navTreeTips">consejos del ï¿½rbol de navegaciï¿½n.</a></font></p>
 <p><font face="Verdana"><b>Consejos:</b></font></p>
 <ol>
 <li>
 <p><font face="Verdana">Utilice el icono de la
-barra de herramientas para abrir rápidamente el asistente para añadir
+barra de herramientas para abrir rï¿½pidamente el asistente para aï¿½adir
 una cuenta.</font></p>
 </li>
 </ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="account_setup"></a><font face="Verdana"><b><br>
-Ejemplo de configuración de cuenta:</b></font></h3>
-<p><font face="Verdana">Tenemos una cuenta de ahorro con&nbsp;1.250€,
-una cuenta corriente con&nbsp;500€, una MasterCard que
-adeuda&nbsp;250€, una Visa adeudando&nbsp;475€, una hipoteca
-de&nbsp;230.965€ y un fondo de estudios para enviar a los niños a la
-universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configuraríamos las siguientes cuentas:</font></p>
+Ejemplo de configuraciï¿½n de cuenta:</b></font></h3>
+<p><font face="Verdana">Tenemos una cuenta de ahorro con&nbsp;1.250ï¿½,
+una cuenta corriente con&nbsp;500ï¿½, una MasterCard que
+adeuda&nbsp;250ï¿½, una Visa adeudando&nbsp;475ï¿½, una hipoteca
+de&nbsp;230.965ï¿½ y un fondo de estudios para enviar a los niï¿½os a la
+universidad en el futuro actualmente de&nbsp;5000ï¿½ ganando interï¿½s.<br>Configurarï¿½amos las siguientes cuentas:</font></p>
 <table border="1" bordercolor="#000000" cellpadding="4" cellspacing="0" rules="groups" width="615">
 <col width="178"> <col width="224"> <col width="187"> <tbody>
 <tr valign="top">
@@ -540,7 +541,7 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>Ahorros</p>
 </td>
 <td sdval="1250" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p>1.250,00€</p>
+<p>1.250,00ï¿½</p>
 </td>
 </tr>
 <tr valign="top">
@@ -552,7 +553,7 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>Corriente</p>
 </td>
 <td sdval="500" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p>500,00€</p>
+<p>500,00ï¿½</p>
 </td>
 </tr>
 <tr valign="top">
@@ -564,7 +565,7 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>MasterCard</p>
 </td>
 <td sdval="-250" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p><font color="#ff0000">-250,00€</font></p>
+<p><font color="#ff0000">-250,00ï¿½</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -576,7 +577,7 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>Visa</p>
 </td>
 <td sdval="-475" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p><font color="#ff0000">-475,00€</font></p>
+<p><font color="#ff0000">-475,00ï¿½</font></p>
 </td>
 </tr>
 </tbody> <tbody>
@@ -588,7 +589,7 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>Hipoteca</p>
 </td>
 <td sdval="-230965" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p><font color="#ff0000">-230.965,00€</font></p>
+<p><font color="#ff0000">-230.965,00ï¿½</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -600,50 +601,50 @@ universidad en el futuro actualmente de&nbsp;5000€ ganando interés.<br>Configura
 <p>Fondo de estudios</p>
 </td>
 <td sdval="5000" sdnum="3081;0;[$$-409]#,##0.00;[RED]-[$$-409]#,##0.00" width="187">
-<p>5.000,00€</p>
+<p>5.000,00ï¿½</p>
 </td>
 </tr>
 </tbody>
 </table>
-<p><font face="Verdana"><br>En la página de inicio los saldos serían
-de&nbsp;1.025€ para las cuentas bancarias, y de&nbsp;-225.965€ para las
+<p><font face="Verdana"><br>En la pï¿½gina de inicio los saldos serï¿½an
+de&nbsp;1.025ï¿½ para las cuentas bancarias, y de&nbsp;-225.965ï¿½ para las
 cuentas a plazo.</font></p>
 <p><font face="Verdana">Cuando se realiza un pago de su cuenta de ahorros a la de </font><font face="Verdana">MasterCard con una</font><font face="Verdana"> <a href="#transfer">transferencia</a>,
-el saldo en la página de inicio permanece inalterado. Cuando el pago se
-realiza de sus ahorros a la hipoteca, éste se verá reflejado en el
-saldo&nbsp;en la página de inicio. Ahora puede determinar la cantidad
-de dinero que tiene día a día. Los pagos regulares también se pueden
-configurar de su cuenta de ahorros a la de su hipoteca mediante <a href="#recurring_transactions">transacciones periódicas</a>.</font></p>
+el saldo en la pï¿½gina de inicio permanece inalterado. Cuando el pago se
+realiza de sus ahorros a la hipoteca, ï¿½ste se verï¿½ reflejado en el
+saldo&nbsp;en la pï¿½gina de inicio. Ahora puede determinar la cantidad
+de dinero que tiene dï¿½a a dï¿½a. Los pagos regulares tambiï¿½n se pueden
+configurar de su cuenta de ahorros a la de su hipoteca mediante <a href="#recurring_transactions">transacciones periï¿½dicas</a>.</font></p>
 <h3 class="western"><a name="navTreeTips"></a><font face="Verdana"><b><br>
-Consejo para utilizar el árbol de navegación y la página de inicio</b></font><font face="Verdana">:</font></h3>
-<p><font face="Verdana">Según se van creando más cuentas el árbol de navegación y la página de inicio se pueden volver muy grandes.<br>Estas vistas se pueden cambiar temporalmente para mostrar u ocultar las secciones necesarias:</font></p>
+Consejo para utilizar el ï¿½rbol de navegaciï¿½n y la pï¿½gina de inicio</b></font><font face="Verdana">:</font></h3>
+<p><font face="Verdana">Segï¿½n se van creando mï¿½s cuentas el ï¿½rbol de navegaciï¿½n y la pï¿½gina de inicio se pueden volver muy grandes.<br>Estas vistas se pueden cambiar temporalmente para mostrar u ocultar las secciones necesarias:</font></p>
 <table border="1" bordercolor="#000000" cellpadding="4" cellspacing="0" rules="rows" width="100%">
 <col width="40*"> <col width="216*"> <tbody>
 <tr valign="top">
 <td width="15%">
-<p><font face="Verdana">Árbol de navegación:</font></p>
+<p><font face="Verdana">ï¿½rbol de navegaciï¿½n:</font></p>
 </td>
 <td width="85%">
-<p><font face="Verdana">Expanda/Contraiga las ramas de cuentas bancarias y a plazo mediante los nodos +/- del árbol</font></p>
+<p><font face="Verdana">Expanda/Contraiga las ramas de cuentas bancarias y a plazo mediante los nodos +/- del ï¿½rbol</font></p>
 </td>
 </tr>
 <tr valign="top">
 <td width="15%">
-<p><font face="Verdana">Página de inicio:</font></p>
+<p><font face="Verdana">Pï¿½gina de inicio:</font></p>
 </td>
 <td width="85%">
-<p><font face="Verdana">Mediante el menú: Ver
--&gt;Cuentas bancarias y/o el menú: Ver -&gt;Cuentas a plazo</font></p>
+<p><font face="Verdana">Mediante el menï¿½: Ver
+-&gt;Cuentas bancarias y/o el menï¿½: Ver -&gt;Cuentas a plazo</font></p>
 </td>
 </tr>
 </tbody>
 </table>
-<p><font face="Verdana">Al utilizar el botón derecho sobre:</font></p>
+<p><font face="Verdana">Al utilizar el botï¿½n derecho sobre:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Cuentas bancarias en el árbol de navegación,
-permitirá mostrar todas las cuentas o sólo las favoritas de forma
-temporal, así como otras opciones útiles.</font></p>
+<p><font face="Verdana">Cuentas bancarias en el ï¿½rbol de navegaciï¿½n,
+permitirï¿½ mostrar todas las cuentas o sï¿½lo las favoritas de forma
+temporal, asï¿½ como otras opciones ï¿½tiles.</font></p>
 </li>
 </ul>
 <ul>
@@ -651,63 +652,63 @@ temporal, así como otras opciones útiles.</font></p>
 <p><font face="Verdana">Cualquier cuenta bancaria o a plazo, para acceder a otras opciones de utilidad.</font></p>
 </li>
 </ul>
-<p><font face="Verdana">Para hacer los cambios permanentes, cambie las opciones en el menú: Herramientas -&gt;Opciones --&gt;Opciones de vista.</font></p>
+<p><font face="Verdana">Para hacer los cambios permanentes, cambie las opciones en el menï¿½: Herramientas -&gt;Opciones --&gt;Opciones de vista.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="editaccounts"></a><font face="Verdana"><br>
-Editar información de cuenta</font></h3>
+Editar informaciï¿½n de cuenta</font></h3>
 <p><font face="Verdana">Una vez que ha creado una
-cuenta, puede editar&nbsp;la información de cualquier
+cuenta, puede editar&nbsp;la informaciï¿½n de cualquier
 campo&nbsp;de las siguientes maneras:</font></p>
 <ol>
 <li>
-<p><font face="Verdana">Mediante el menú <b>Cuentas</b>
-–&gt; <b>Editar cuenta</b><br>
-Se mostrará la lista de cuentas donde se seleccionará la cuenta deseada.</font></p>
+<p><font face="Verdana">Mediante el menï¿½ <b>Cuentas</b>
+ï¿½&gt; <b>Editar cuenta</b><br>
+Se mostrarï¿½ la lista de cuentas donde se seleccionarï¿½ la cuenta deseada.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Seleccionando el nombre
-de la cuenta en el panel de navegación<br>
-Botón derecho para que aparezca el menú emergente y
+de la cuenta en el panel de navegaciï¿½n<br>
+Botï¿½n derecho para que aparezca el menï¿½ emergente y
 seleccionar&nbsp;"</font><font face="Verdana"><b>Editar
 cuenta</b></font><font face="Verdana">"</font></p>
 </li>
 </ol>
-<p><font face="Verdana">Esto llevará a la ventana de
-información de cuenta donde se pueden cambiar los campos que desee.</font></p>
+<p><font face="Verdana">Esto llevarï¿½ a la ventana de
+informaciï¿½n de cuenta donde se pueden cambiar los campos que desee.</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Edite los detalles de la
 cuenta.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Utilice el botón
-"Aceptar" para guardar la información de la cuenta.</font></p>
+<p><font face="Verdana">Utilice el botï¿½n
+"Aceptar" para guardar la informaciï¿½n de la cuenta.</font></p>
 </li>
 </ul>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="creating_new_transaction"></a><font face="Verdana"><br>Crear nuevas transacciones</font></h3>
-<p><font face="Verdana">Una vez creada una nueva cuenta, selecciónela en el árbol de navegación. Es entonces cuando la cuenta se
+<p><font face="Verdana">Una vez creada una nueva cuenta, selecciï¿½nela en el ï¿½rbol de navegaciï¿½n. Es entonces cuando la cuenta se
 muestra en la ventana principal donde se puede empezar a crear
 transacciones:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Utilizando el botón "Nuevo" situado en la parte inferior de la pantalla,</font></p>
+<p><font face="Verdana">Utilizando el botï¿½n "Nuevo" situado en la parte inferior de la pantalla,</font></p>
 </li>
 <li>
-<p><font face="Verdana">En el árbol de navegación, seleccione la cuenta deseada.</font></p>
+<p><font face="Verdana">En el ï¿½rbol de navegaciï¿½n, seleccione la cuenta deseada.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Esto abre el registro de transacciones asociado
-a la cuenta. Para crear una nueva transacción, haga clic en el botón
-"Nuevo" para abrir la ventana de Nueva/Editar Transacción. Introduzca
-los detalles de la transacción. Comience seleccionando el tipo de
-transacción entre "cargo", "abono" o "transferencia". Después
-seleccione el beneficiario, la categoría, la fecha, número, si quiere
-añadir alguna nota, y finalmente el importe de la transacción. Pulse el
-botón "Aceptar" para guardar la transacción.<br>
-<br>Aquí se describen los campos asociados a la ventana de transacción.</font></p>
+a la cuenta. Para crear una nueva transacciï¿½n, haga clic en el botï¿½n
+"Nuevo" para abrir la ventana de Nueva/Editar Transacciï¿½n. Introduzca
+los detalles de la transacciï¿½n. Comience seleccionando el tipo de
+transacciï¿½n entre "cargo", "abono" o "transferencia". Despuï¿½s
+seleccione el beneficiario, la categorï¿½a, la fecha, nï¿½mero, si quiere
+aï¿½adir alguna nota, y finalmente el importe de la transacciï¿½n. Pulse el
+botï¿½n "Aceptar" para guardar la transacciï¿½n.<br>
+<br>Aquï¿½ se describen los campos asociados a la ventana de transacciï¿½n.</font></p>
 </li>
 </ul>
 <p><a name="trans_types"></a><font face="Verdana"><br>
@@ -724,60 +725,60 @@ se recibe dinero y es un ingreso. </font> </p>
 </li>
 <li>
 <p><a name="transfer"></a><font face="Verdana"><i><b>Transferencia:</b></i>
-se realiza un cargo en una cuenta y un abono en otra.<br>Este tipo de transacción no se incluye en los cáculos de ingresos/gastos.<br>
+se realiza un cargo en una cuenta y un abono en otra.<br>Este tipo de transacciï¿½n no se incluye en los cï¿½culos de ingresos/gastos.<br>
 <br>
-<b>Las transferencias</b> habilitan el botón <b>Avanzado</b>. Se
+<b>Las transferencias</b> habilitan el botï¿½n <b>Avanzado</b>. Se
 utiliza en las situaciones en las que es necesario que el importe
 cargado en la cuenta "origen", sea diferente del abonado en la cuenta
 "destino" o viceversa.<br>
-(Por eso es avanzado.) Cuando las cantidades difieren aparece el texto&nbsp;“¡activo!” junto al botón “Avanzado”.</font></p>
+(Por eso es avanzado.) Cuando las cantidades difieren aparece el texto&nbsp;ï¿½ï¿½activo!ï¿½ junto al botï¿½n ï¿½Avanzadoï¿½.</font></p>
 </li>
 </ul>
 <p><a href="#payees"><font face="Verdana"><i><b>Beneficiario:</b></i></font></a>
-<font face="Verdana">Es la persona u organización a la que va o de la que viene el dinero. </font>
+<font face="Verdana">Es la persona u organizaciï¿½n a la que va o de la que viene el dinero. </font>
 </p>
 <ul>
 <li>
-<p><font face="Verdana">Haciendo clic en el botón de beneficiario se
+<p><font face="Verdana">Haciendo clic en el botï¿½n de beneficiario se
 abre la ventana de beneficiarios. Puede seleccionar el beneficiario
 desde esa ventana o crear uno nuevo. </font> </p>
 </li>
 </ul>
-<p><a href="#categories"><font face="Verdana"><i><b>Categoría:</b></i></font></a> <font face="Verdana">Selecciona el tipo de ingreso o gasto de la transacción. </font>
+<p><a href="#categories"><font face="Verdana"><i><b>Categorï¿½a:</b></i></font></a> <font face="Verdana">Selecciona el tipo de ingreso o gasto de la transacciï¿½n. </font>
 </p>
 <ul>
 <li>
-<p><font face="Verdana">Haciendo clic en el botoón de categoría se abre la ventana de categorías.&nbsp;</font><font face="Verdana">Puede seleccionar la categoría desde esa ventana o crear una nueva.</font> </p>
+<p><font face="Verdana">Haciendo clic en el botoï¿½n de categorï¿½a se abre la ventana de categorï¿½as.&nbsp;</font><font face="Verdana">Puede seleccionar la categorï¿½a desde esa ventana o crear una nueva.</font> </p>
 </li>
 </ul>
-<p><font face="Verdana"><i><b>Número de transacción:</b></i> es un campo reservado para introducir cualquier número asociado con la transacción. <br>
-<i><b>Estado de la transacción:</b></i> Seleccione las opciones "no reconciliada", "reconciliada", "nula",
-"seguimiento". Esto marca la transacción con uno de estos estados. </font>
+<p><font face="Verdana"><i><b>Nï¿½mero de transacciï¿½n:</b></i> es un campo reservado para introducir cualquier nï¿½mero asociado con la transacciï¿½n. <br>
+<i><b>Estado de la transacciï¿½n:</b></i> Seleccione las opciones "no reconciliada", "reconciliada", "nula",
+"seguimiento". Esto marca la transacciï¿½n con uno de estos estados. </font>
 </p>
 <ul>
 <li>
 <p style="margin-bottom: 0in;"><font face="Verdana"><i><b>No reconciliada:</b></i>
-Cuando introduce una transacción, inicialmente está&nbsp;"no
+Cuando introduce una transacciï¿½n, inicialmente estï¿½&nbsp;"no
 reconciliada". Esto quiere decir que no ha sido reconciliada con el
-saldo de su banco o tarjeta de crédito. </font> </p>
+saldo de su banco o tarjeta de crï¿½dito. </font> </p>
 </li>
 <li>
 <p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Reconciliada:</b></i>
-Una vez que la transacción se ha comprobado y verificado con la
-información de saldo del banco, se puede marcar como reconciliada. </font>
+Una vez que la transacciï¿½n se ha comprobado y verificado con la
+informaciï¿½n de saldo del banco, se puede marcar como reconciliada. </font>
 </p>
 </li>
 <li>
 <p style="margin-bottom: 0in;"><font face="Verdana"><i><b>Nula:</b></i>
-Si introduce una transacción que más tarde se invalida o cancela por
-algún motivo, en lugar de eliminarla puede marcarla como nula, para así
-poder tener un registro de la transacción. </font> </p>
+Si introduce una transacciï¿½n que mï¿½s tarde se invalida o cancela por
+algï¿½n motivo, en lugar de eliminarla puede marcarla como nula, para asï¿½
+poder tener un registro de la transacciï¿½n. </font> </p>
 </li>
 <li>
 <p><font face="Verdana"><i><b>Marcar para segumiento:</b></i> Este
 estado marca las transacciones como pendientes de algo. Por ejemplo,
 recibe un extracto de saldo de su entidad financiera y se da cuenta que
-el importe de la transacción es diferente del que ha registrado. Puede
+el importe de la transacciï¿½n es diferente del que ha registrado. Puede
 marcarla para seguimiento hasta que lo aclare con el banco. </font> </p>
 </li>
 </ul>
@@ -788,41 +789,41 @@ marcarla para seguimiento hasta que lo aclare con el banco. </font> </p>
 <hr>
 <h3 class="western"><a name="edittrans"></a><font face="Verdana"><br>
 Editar y actualizar transacciones</font></h3>
-<p><font face="Verdana">La edición de transacciones
+<p><font face="Verdana">La ediciï¿½n de transacciones
 existentes se puede realizar de varias formas:</font></p>
 <ul>
 <li>
 <p><font face="Verdana">seleccione la
-transacción y haga clic en el botón de editar.</font></p>
+transacciï¿½n y haga clic en el botï¿½n de editar.</font></p>
 </li>
 <li>
 <p><font face="Verdana">haga doble clic sobre la
-transacción seleccionada.</font></p>
+transacciï¿½n seleccionada.</font></p>
 </li>
 <li>
 <p><font face="Verdana">presione intro sobre la
-selección. </font> </p>
+selecciï¿½n. </font> </p>
 </li>
 </ul>
 <p><font face="Verdana">Cualquiera de estas acciones
-abrirá la ventana
-de transacción que contiene los detalles de la transacción
+abrirï¿½ la ventana
+de transacciï¿½n que contiene los detalles de la transacciï¿½n
 seleccionada. Realice los cambios y pulse "Aceptar" para guardarlos.</font></p>
-<p><font face="Verdana"><b>El botón “Avanzado”</b></font></p>
+<p><font face="Verdana"><b>El botï¿½n ï¿½Avanzadoï¿½</b></font></p>
 <ul>
 <li>
 <p><font face="Verdana">Se activa cuando se
-utiliza una transacción de tipo&nbsp;</font><font face="Verdana"><b>transferencia</b></font><font face="Verdana">.</font></p>
+utiliza una transacciï¿½n de tipo&nbsp;</font><font face="Verdana"><b>transferencia</b></font><font face="Verdana">.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Se muestra el
-texto&nbsp;“</font><font face="Verdana"><b>¡activo!</b></font>”
-<font face="Verdana"><b>para indicar que se está
+texto&nbsp;ï¿½</font><font face="Verdana"><b>ï¿½activo!</b></font>ï¿½
+<font face="Verdana"><b>para indicar que se estï¿½
 utilizando.</b></font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Se
-muestra junto al botón "Avanzado" cuando el valor de la </font><font face="Verdana">“cuenta destino”&nbsp;es diferente al
+muestra junto al botï¿½n "Avanzado" cuando el valor de la </font><font face="Verdana">ï¿½cuenta destinoï¿½&nbsp;es diferente al
 campo importe</font><font face="Verdana">, (cuenta
 origen).</font></p>
 </li>
@@ -836,14 +837,14 @@ origen).</font></p>
 <p><font face="Verdana">Las transacciones introducidas en MMEX se
 consideran no reconciliadas. Esto significa que no se han verificado
 con el extracto de la entidad financiera. Una vez que se recibe el
-extracto o se consulta online la transacción se puede considerar
-reconciliada si coincide con la información de la entidad financiera.
-Entonces es cuando la transacción se puede marcar como reconciliada.
-Marcándolas así puede llevar un seguimiento de las transacciones que
+extracto o se consulta online la transacciï¿½n se puede considerar
+reconciliada si coincide con la informaciï¿½n de la entidad financiera.
+Entonces es cuando la transacciï¿½n se puede marcar como reconciliada.
+Marcï¿½ndolas asï¿½ puede llevar un seguimiento de las transacciones que
 coinciden con las transacciones reales. En MMEX, las transacciones
 reconciliadas y no reconciliadas se muestran con iconos diferentes. </font>
 </p>
-<p><font face="Verdana"><i>Consejo:</i> Para marcar una transacción como reconciliada, simplemente selecciónela y pulse la tecla 'r' o 'R'.
+<p><font face="Verdana"><i>Consejo:</i> Para marcar una transacciï¿½n como reconciliada, simplemente selecciï¿½nela y pulse la tecla 'r' o 'R'.
 Para marcarla como no reconciliada, pulse&nbsp;'u' o 'U'. </font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
@@ -852,7 +853,7 @@ Para marcarla como no reconciliada, pulse&nbsp;'u' o 'U'. </font>
 Marcar transacciones para seguimiento</font></h3>
 <p><font face="Verdana">Algunas transacciones pueden
 estar relacionadas
-con temas sobre los que quiera realizar un seguimiento. Márquelas
+con temas sobre los que quiera realizar un seguimiento. Mï¿½rquelas
 mediante el estado "marcar para seguimiento". Esto se indica en MMEX
 con un icono diferente. </font>
 </p>
@@ -860,7 +861,7 @@ con un icono diferente. </font>
 <ul>
 <li>
 <p><font face="Verdana">Para marcar una
-transacción para seguimiento, selecciónela y pulse la tecla 'f o 'F'. </font>
+transacciï¿½n para seguimiento, selecciï¿½nela y pulse la tecla 'f o 'F'. </font>
 </p>
 </li>
 </ul>
@@ -868,48 +869,48 @@ transacción para seguimiento, selecciónela y pulse la tecla 'f o 'F'. </font>
 <hr>
 <h3 class="western"><a name="currencies"></a><font face="Verdana"><br>Trabajar con divisas</font></h3>
 <p style="font-weight: normal;"><font face="Verdana">Ya que MMEX se
-puede usar en muchos países, tiene que tener en cuenta la moneda del
-país. Cuando se crea una nueva base de datos, se configura la </font><font face="Verdana"><b>Moneda base </b></font><font face="Verdana">como
-la moneda para el país del usuario. Si la configuración de moneda no
-está en la lista de divisas predeterminada, el usuario puede crear las
+puede usar en muchos paï¿½ses, tiene que tener en cuenta la moneda del
+paï¿½s. Cuando se crea una nueva base de datos, se configura la </font><font face="Verdana"><b>Moneda base </b></font><font face="Verdana">como
+la moneda para el paï¿½s del usuario. Si la configuraciï¿½n de moneda no
+estï¿½ en la lista de divisas predeterminada, el usuario puede crear las
 suyas propias.</font></p>
-<p><font face="Verdana">MMEX también nos permite trabajar con más de
-una moneda si es necesario. Si es así, se muestra un resumen de las
-divisas utilizadas en la página de inicio.</font></p>
-<p><font face="Verdana">Puede gestionar la divisas mediante el menú: </font><font face="Verdana"><b>Herramientas
+<p><font face="Verdana">MMEX tambiï¿½n nos permite trabajar con mï¿½s de
+una moneda si es necesario. Si es asï¿½, se muestra un resumen de las
+divisas utilizadas en la pï¿½gina de inicio.</font></p>
+<p><font face="Verdana">Puede gestionar la divisas mediante el menï¿½: </font><font face="Verdana"><b>Herramientas
 -&gt; Organizar divisas</b></font><font face="Verdana">.</font></p>
-<p><font face="Verdana"><b>Para añadir una nueva divisa</b></font><font face="Verdana">:</font></p>
+<p><font face="Verdana"><b>Para aï¿½adir una nueva divisa</b></font><font face="Verdana">:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Utilice el botón&nbsp;</font><font face="Verdana"><b>Añadir</b></font> <font face="Verdana">en la ventana de divisas.</font></p>
+<p><font face="Verdana">Utilice el botï¿½n&nbsp;</font><font face="Verdana"><b>Aï¿½adir</b></font> <font face="Verdana">en la ventana de divisas.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Proporcione un nombre adecuado para la nueva divisa.<br>
 Nota: Este nombre no se puede cambiar, pero la divisa se puede eliminar si no se utiliza.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Ajuste los valores de la divisa en el <b>Gestor de divisas.</b><br>El gestor de divisas también está disponible al editar una divisa.</font></p>
+<p><font face="Verdana">Ajuste los valores de la divisa en el <b>Gestor de divisas.</b><br>El gestor de divisas tambiï¿½n estï¿½ disponible al editar una divisa.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Utilice el botón <b>Actualizar</b>
+<p><font face="Verdana">Utilice el botï¿½n <b>Actualizar</b>
 para guardar los cambios antes de cerrar.<br>
-Nota: Todos los cambios se perderán si no utiliza el botón actualizar antes de cerrar.</font></p>
+Nota: Todos los cambios se perderï¿½n si no utiliza el botï¿½n actualizar antes de cerrar.</font></p>
 </li>
 </ul>
-<p><font face="Verdana"><span style="font-weight: normal;">Cuando se utiliza más de una divisa, es necesario configurar la </span><b>Conversión
+<p><font face="Verdana"><span style="font-weight: normal;">Cuando se utiliza mï¿½s de una divisa, es necesario configurar la </span><b>Conversiï¿½n
 a tasa base</b> <span style="font-weight: normal;">para
 permitir que el valor de la divisa se refleje correctamente. Para
-permitir la actualización automática de divisas, es necesario
-configurar la </span><b>Representación de la moneda</b><span style="font-weight: bold;"> </span><span style="font-weight: normal;">para la divisa en uso.</span></font></p>
-<p><font face="Verdana">Para usar el menú: <b>Herramientas
-–&gt; Actualización online del tipo de cambio</b>, se debe realizar lo siguiente:</font></p>
+permitir la actualizaciï¿½n automï¿½tica de divisas, es necesario
+configurar la </span><b>Representaciï¿½n de la moneda</b><span style="font-weight: bold;"> </span><span style="font-weight: normal;">para la divisa en uso.</span></font></p>
+<p><font face="Verdana">Para usar el menï¿½: <b>Herramientas
+ï¿½&gt; Actualizaciï¿½n online del tipo de cambio</b>, se debe realizar lo siguiente:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Activar la opción de </font><font face="Verdana"><b>Herramientas
-–&gt; Opciones... Otros</b></font><font face="Verdana">.</font></p>
+<p><font face="Verdana">Activar la opciï¿½n de </font><font face="Verdana"><b>Herramientas
+ï¿½&gt; Opciones... Otros</b></font><font face="Verdana">.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Configurar la representación de la moneda de todas las divisas que tengan que actualizarse.</font></p>
+<p><font face="Verdana">Configurar la representaciï¿½n de la moneda de todas las divisas que tengan que actualizarse.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Configurar el valor de la moneda base a 1.</font></p>
@@ -918,7 +919,7 @@ configurar la </span><b>Representación de la moneda</b><span style="font-weight:
 <p><font face="Verdana"><b>Consejos:</b></font></p>
 <ol>
 <li>
-<p><font face="Verdana">Utilize el icono de la barra de herramientas para acceder rápidamente a la ventana de organizar divisas.</font></p>
+<p><font face="Verdana">Utilize el icono de la barra de herramientas para acceder rï¿½pidamente a la ventana de organizar divisas.</font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Utilice
@@ -927,68 +928,68 @@ las teclas arriba/abajo para moverse entre las divisas</font><font face="Verdana
 </ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
-<h3 class="western"><a name="categories"></a><font face="Verdana"><br>Trabajar con categorías</font></h3>
-<p><font face="Verdana"><b>Las categorías indican el motivo por el que se realiza un pago o por el que se recibe un ingreso.</b></font> </p>
-<p><font face="Verdana">Ejemplo: Si queremos reflejar la reparación de
-nuestro coche, podemos escoger la categoría: Automóvil, y la
-subcategoría: Mantenimiento.</font></p>
-<p><font face="Verdana">Puede gestionar las categorías mediante el menú: </font><font face="Verdana"><b>Herramientas
--&gt; Organizar categorías</b></font><font face="Verdana">.<br>Una vez abierta la ventana, puede añadir nuevas categorías y subcategorías.</font></p>
-<p><font face="Verdana"><b>Para añadir una nueva categoría</b>:</font></p>
+<h3 class="western"><a name="categories"></a><font face="Verdana"><br>Trabajar con categorï¿½as</font></h3>
+<p><font face="Verdana"><b>Las categorï¿½as indican el motivo por el que se realiza un pago o por el que se recibe un ingreso.</b></font> </p>
+<p><font face="Verdana">Ejemplo: Si queremos reflejar la reparaciï¿½n de
+nuestro coche, podemos escoger la categorï¿½a: Automï¿½vil, y la
+subcategorï¿½a: Mantenimiento.</font></p>
+<p><font face="Verdana">Puede gestionar las categorï¿½as mediante el menï¿½: </font><font face="Verdana"><b>Herramientas
+-&gt; Organizar categorï¿½as</b></font><font face="Verdana">.<br>Una vez abierta la ventana, puede aï¿½adir nuevas categorï¿½as y subcategorï¿½as.</font></p>
+<p><font face="Verdana"><b>Para aï¿½adir una nueva categorï¿½a</b>:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Seleccione </font><font face="Verdana"><b>Categorías</b></font> <font face="Verdana">en la raíz del árbol (en la parte superior),</font></p>
+<p><font face="Verdana">Seleccione </font><font face="Verdana"><b>Categorï¿½as</b></font> <font face="Verdana">en la raï¿½z del ï¿½rbol (en la parte superior),</font></p>
 </li>
 <li>
-<p><font face="Verdana">teclee el nombre de la nueva categoría en el campo de texto.</font></p>
+<p><font face="Verdana">teclee el nombre de la nueva categorï¿½a en el campo de texto.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Pulse el botón </font><font face="Verdana"><b>Añadir</b></font><font face="Verdana">.</font></p>
+<p><font face="Verdana">Pulse el botï¿½n </font><font face="Verdana"><b>Aï¿½adir</b></font><font face="Verdana">.</font></p>
 </li>
 </ul>
-<p><font face="Verdana">La nueva categoría aparecerá al final, y se reordenará cuando se vuelva a abrir la ventana de categorías.</font></p>
-<p><font face="Verdana"><b>Para añadir una nueva subcategoría:</b></font></p>
+<p><font face="Verdana">La nueva categorï¿½a aparecerï¿½ al final, y se reordenarï¿½ cuando se vuelva a abrir la ventana de categorï¿½as.</font></p>
+<p><font face="Verdana"><b>Para aï¿½adir una nueva subcategorï¿½a:</b></font></p>
 <ul>
 <li>
-<p><font face="Verdana">Seleccione la categoría a la que quiera que pertenezca la subcategoría</font></p>
+<p><font face="Verdana">Seleccione la categorï¿½a a la que quiera que pertenezca la subcategorï¿½a</font></p>
 </li>
 <li>
-<p><font face="Verdana">teclee el nombre de la nueva subcategoría en el campo de texto</font></p>
+<p><font face="Verdana">teclee el nombre de la nueva subcategorï¿½a en el campo de texto</font></p>
 </li>
 <li>
-<p><font face="Verdana">Pulse el botón <b>Añadir</b>.</font></p>
+<p><font face="Verdana">Pulse el botï¿½n <b>Aï¿½adir</b>.</font></p>
 </li>
 </ul>
-<p><font face="Verdana">También puede cambiar los nombres seleccionando
-la categoría/subcategoría en la lista, modifique el nombre en el campo
-de texto y pulse el botón Editar. Puede borrar la
-categoría/subcategoría de una manera similar.</font></p>
-<p><font face="Verdana"><b>Nota:</b> No puede borrar categorías que estén en uso por alguna transacción.</font></p>
-<p><font face="Verdana">Asegúrese de que ninguna transacción utilice esa combinación de categoría/subcategoría. Puede hacerlo de varias maneras:</font></p>
+<p><font face="Verdana">Tambiï¿½n puede cambiar los nombres seleccionando
+la categorï¿½a/subcategorï¿½a en la lista, modifique el nombre en el campo
+de texto y pulse el botï¿½n Editar. Puede borrar la
+categorï¿½a/subcategorï¿½a de una manera similar.</font></p>
+<p><font face="Verdana"><b>Nota:</b> No puede borrar categorï¿½as que estï¿½n en uso por alguna transacciï¿½n.</font></p>
+<p><font face="Verdana">Asegï¿½rese de que ninguna transacciï¿½n utilice esa combinaciï¿½n de categorï¿½a/subcategorï¿½a. Puede hacerlo de varias maneras:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Editando la transacción y cambiando la categoría/subcategoría.</font></p>
+<p><font face="Verdana">Editando la transacciï¿½n y cambiando la categorï¿½a/subcategorï¿½a.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Borrando la transacción que utilice esa&nbsp;</font><font face="Verdana">categoría/subcategoría.</font></p>
+<p><font face="Verdana">Borrando la transacciï¿½n que utilice esa&nbsp;</font><font face="Verdana">categorï¿½a/subcategorï¿½a.</font></p>
 </li>
 </ul>
 <ul>
 <li>
-<p><font face="Verdana">Mediante el menú: </font><font face="Verdana"><b>Herramientas –&gt; Reorganización de...
-Categorías</b></font><font face="Verdana"><span style="font-weight: normal;">, donde puede mover todas las categorías con un determinado nombre a otra combinación de categoría/subcategoría.</span></font></p>
+<p><font face="Verdana">Mediante el menï¿½: </font><font face="Verdana"><b>Herramientas ï¿½&gt; Reorganizaciï¿½n de...
+Categorï¿½as</b></font><font face="Verdana"><span style="font-weight: normal;">, donde puede mover todas las categorï¿½as con un determinado nombre a otra combinaciï¿½n de categorï¿½a/subcategorï¿½a.</span></font></p>
 </li>
 </ul>
 <p style="font-weight: normal;"><font face="Verdana">Esto
-liberaría la categoría para que pueda ser borrada.</font></p>
+liberarï¿½a la categorï¿½a para que pueda ser borrada.</font></p>
 <p><font face="Verdana"><b>Consejos:</b></font></p>
 <ol>
 <li>
-<p><font face="Verdana">Utilice el icono de la barra de herramientas para abrir rápidamente la ventana para organizar categorías</font></p>
+<p><font face="Verdana">Utilice el icono de la barra de herramientas para abrir rï¿½pidamente la ventana para organizar categorï¿½as</font></p>
 </li>
 <li>
 <p><font face="Verdana">Utilice
-las teclas arriba/abajo para moverse entre las categorías.</font></p>
+las teclas arriba/abajo para moverse entre las categorï¿½as.</font></p>
 </li>
 </ol>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
@@ -1000,13 +1001,13 @@ son personas o instituciones de las que recibimos dinero, o<br>
 las personas o instituciones a las que pagamos, a cambio de bienes o
 servicios.</b></font></p>
 <p><font face="Verdana">Puede gestionar los
-beneficiarios mediante el menú:
+beneficiarios mediante el menï¿½:
 </font><font face="Verdana"><b>Herramientas
-–&gt; Organizar beneficiarios</b></font><font face="Verdana">.
+ï¿½&gt; Organizar beneficiarios</b></font><font face="Verdana">.
 </font></p>
 <p><font face="Verdana">Una vez abierta la ventana
-puede añadir, editar o borrar beneficiarios.</font></p>
-<p><font face="Verdana"><b>Para añadir un
+puede aï¿½adir, editar o borrar beneficiarios.</font></p>
+<p><font face="Verdana"><b>Para aï¿½adir un
 nuevo beneficiario:</b></font></p>
 <ul>
 <li>
@@ -1014,40 +1015,40 @@ nuevo beneficiario:</b></font></p>
 beneficiario en el campo "Filtrar beneficiarios"</font></p>
 </li>
 <li>
-<p><font face="Verdana">Pulse el botón "Añadir"</font></p>
+<p><font face="Verdana">Pulse el botï¿½n "Aï¿½adir"</font></p>
 </li>
 </ul>
-<p><font face="Verdana">También puede seleccionar el
-beneficiario de la lista y usar el botón "Editar" o "Borrar" para
-realizar la acción deseada.</font></p>
+<p><font face="Verdana">Tambiï¿½n puede seleccionar el
+beneficiario de la lista y usar el botï¿½n "Editar" o "Borrar" para
+realizar la acciï¿½n deseada.</font></p>
 <p><font face="Verdana"><b>Nota:</b> No
-puede borrar los beneficiarios que estén en uso por alguna transacción.</font></p>
+puede borrar los beneficiarios que estï¿½n en uso por alguna transacciï¿½n.</font></p>
 <p><font face="Verdana">Para borrar un beneficiario,
-asegúrese de que no está en uso por ninguna transacción. Puede hacerlo
+asegï¿½rese de que no estï¿½ en uso por ninguna transacciï¿½n. Puede hacerlo
 de varias maneras:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Editando la transacción
+<p><font face="Verdana">Editando la transacciï¿½n
 y cambiando el beneficiario.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Borrando la transacción
+<p><font face="Verdana">Borrando la transacciï¿½n
 que utilice ese beneficiario.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Mediante el menú: </font><font face="Verdana"><b>Herramientas –&gt;
-Reorganización de... Beneficiarios</b></font><font face="Verdana"><span style="font-weight: normal;">,
+<p><font face="Verdana">Mediante el menï¿½: </font><font face="Verdana"><b>Herramientas ï¿½&gt;
+Reorganizaciï¿½n de... Beneficiarios</b></font><font face="Verdana"><span style="font-weight: normal;">,
 donde puede mover todos los beneficiarios con un determinado nombre a
 otro diferente. </span></font> </p>
 </li>
 </ul>
 <p style="font-weight: normal;"><font face="Verdana">Esto
-liberaría el beneficiario para que pueda ser borrado.</font></p>
+liberarï¿½a el beneficiario para que pueda ser borrado.</font></p>
 <p><font face="Verdana"><b>Consejos:</b></font></p>
 <ol>
 <li>
 <p><font face="Verdana">Utilice en icono de la
-barra de herramientas para abrir rápidamente la ventana para organizar
+barra de herramientas para abrir rï¿½pidamente la ventana para organizar
 beneficiarios.</font></p>
 </li>
 <li>
@@ -1056,11 +1057,11 @@ las teclas arriba/abajo para moverse entre los beneficiarios.</font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Utilice
-el símbolo % como comodín para sustituir varios caracteres en el filtro.</font></p>
+el sï¿½mbolo % como comodï¿½n para sustituir varios caracteres en el filtro.</font></p>
 </li>
 <li>
 <p style="font-weight: normal;"><font face="Verdana">Utilice
-el símbolo _ para sustituir un único carácter en el filtro.</font></p>
+el sï¿½mbolo _ para sustituir un ï¿½nico carï¿½cter en el filtro.</font></p>
 </li>
 </ol>
 <p><br>
@@ -1073,85 +1074,85 @@ Importar de ficheros CSV</font></h3>
 <p><font face="Verdana">MMEX puede importar de una
 amplia variedad de
 formatos. Uno de ellos es el fichero CSV de formato fijo. Este formato
-de fichero coincide exáctamente con el formato CSV que MMEX puede
-exportar. Así que puede ser útil para mover datos de una base de datos
-.mmb a otra. Para ver fácilmente el formato del fichero CSV, puede
+de fichero coincide exï¿½ctamente con el formato CSV que MMEX puede
+exportar. Asï¿½ que puede ser ï¿½til para mover datos de una base de datos
+.mmb a otra. Para ver fï¿½cilmente el formato del fichero CSV, puede
 probar exportando una cuenta a CSV y analizar el fichero creado.<br>
 <br>
 El formato general es como sigue:<br>
 <span style="font-style: italic;"><span style="font-weight: bold;">Fecha</span></span> -
-Fecha de la transacción (mostrado en el formato especificado en
+Fecha de la transacciï¿½n (mostrado en el formato especificado en
 Opciones-&gt;Formato de fecha).<br>
 <span style="font-style: italic;"><span style="font-weight: bold;">Beneficiario</span></span>
-- A quien se realiza la transacción. En el caso de una transferencia,
+- A quien se realiza la transacciï¿½n. En el caso de una transferencia,
 indica el nombre de la cuenta de la que se hace o a la que se hace.<br>
-<i><b>Tipo de transacción</b></i>
+<i><b>Tipo de transacciï¿½n</b></i>
 - Puede ser tanto un "<span style="font-style: italic;">cargo</span>"
 como un
 "<span style="font-style: italic;">abono</span>".<br>
 <span style="font-style: italic;"><span style="font-weight: bold;">Cantidad</span></span>
-- El importe de la transacción como un valor positivo.<br>
-<i><b>Categoría</b></i> - La categoría de la
-transacción.<br>
-<i><b>Subcategoría</b></i> - La subcategoría de
-la transacción si existe alguna (en caso contrario en blanco).<br>
-<i><b>Número</b></i> - Número de la transacción.<br>
-<i><b>Notas</b></i> - Notas de la transacción.<br>
+- El importe de la transacciï¿½n como un valor positivo.<br>
+<i><b>Categorï¿½a</b></i> - La categorï¿½a de la
+transacciï¿½n.<br>
+<i><b>Subcategorï¿½a</b></i> - La subcategorï¿½a de
+la transacciï¿½n si existe alguna (en caso contrario en blanco).<br>
+<i><b>Nï¿½mero</b></i> - Nï¿½mero de la transacciï¿½n.<br>
+<i><b>Notas</b></i> - Notas de la transacciï¿½n.<br>
 <br>
-Tenga en cuenta que las transacciones de un fichero CSV sólo se pueden
-importar a una única cuenta de MMEX.</font></p>
+Tenga en cuenta que las transacciones de un fichero CSV sï¿½lo se pueden
+importar a una ï¿½nica cuenta de MMEX.</font></p>
 <h5 class="western"><br>
 <a href="#top"><font face="Verdana">Volver
 arriba</font></a> </h5>
 <hr>
 <h3 class="western"><a name="importQIF"></a><font face="Verdana"><br>Importar de ficheros QIF</font></h3>
 <p><font face="Verdana">Quicken Interchange Format
-(QIF) es una especificación abierta que permite&nbsp;leer y escribir
+(QIF) es una especificaciï¿½n abierta que permite&nbsp;leer y escribir
 datos financieros a diferentes medios (p.e. ficheros). Un fichero QIF
 suele tener la siguiente estructura:<br>
 <br>
 !Type:identificador de tipo<br>
-[código de un único carácter]Datos de la cadena<br>
+[cï¿½digo de un ï¿½nico carï¿½cter]Datos de la cadena<br>
 ...<br>
 ^<br></font><font face="Verdana">
-[código de un único carácter]Datos de la cadena</font><br><font face="Verdana">
+[cï¿½digo de un ï¿½nico carï¿½cter]Datos de la cadena</font><br><font face="Verdana">
 ...<br>
 ^<br>
-<br>Cada registro termina con un ^ (acento circunflejo). <br>Vea una transacción QIF de ejemplo<br>
+<br>Cada registro termina con un ^ (acento circunflejo). <br>Vea una transacciï¿½n QIF de ejemplo<br>
 <br>
 !Type:Bank Cabecera<br>
 D6/ 1/94 Fecha<br>
 T-1,000.00 Importe<br>
 N1005 numero<br>
 PBank Of Mortgage Beneficiario<br>
-^ Fin de transacción <br>
-<br>QIF es más antiguo que Open Financial Exchange
+^ Fin de transacciï¿½n <br>
+<br>QIF es mï¿½s antiguo que Open Financial Exchange
 (OFX). La imposibilidad de reconciliar las transacciones importadas
-contra la información actual de la cuenta es una de las principales
+contra la informaciï¿½n actual de la cuenta es una de las principales
 deficiencias de QIF. Normalmente lo ofrecen entidades financieras para
-proporcionar información descargable a los titulares de las cuentas. <br>
-<br>MMEX puede importar transacciones de tipos de QIF específicos a una cuenta.
+proporcionar informaciï¿½n descargable a los titulares de las cuentas. <br>
+<br>MMEX puede importar transacciones de tipos de QIF especï¿½ficos a una cuenta.
 <br>
-<br>Los tipos son los siguientes: (Puede averiguar el tipo de QIF abriéndolo en un editor de texto) <br>
+<br>Los tipos son los siguientes: (Puede averiguar el tipo de QIF abriï¿½ndolo en un editor de texto) <br>
 !Type:Bank Transacciones de cuentas bancarias<br>
 !Type:Cash Transacciones de cuentas de efectivo<br>
-!Type:CCard Transacciones de cuentas de tarjeta de crédito<br>
+!Type:CCard Transacciones de cuentas de tarjeta de crï¿½dito<br>
 <br>
-<b>Nota importante (1)</b>: La opción de formato de fecha tiene que
+<b>Nota importante (1)</b>: La opciï¿½n de formato de fecha tiene que
 coincidir con el formato de fecha del fichero QIF, de lo contrario las
-transacciones tendrían fechas incorrectas. <br>
+transacciones tendrï¿½an fechas incorrectas. <br>
 <br>
 <b>Nota importante (2)</b>:
-Después de importar de QIF, todas las transacciones estarán marcadas
+Despuï¿½s de importar de QIF, todas las transacciones estarï¿½n marcadas
 como "Seguimiento". Puede marcar todas las transacciones de este tipo
-mediante las opciones del menú al hacer clic derecho en la vista de
+mediante las opciones del menï¿½ al hacer clic derecho en la vista de
 cuenta. </font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="importMMNET"></a><font face="Verdana"><br>
 Importar de ficheros MM.NET CSV</font></h3>
-<p><font face="Verdana">MMEX también puede importar
+<p><font face="Verdana">MMEX tambiï¿½n puede importar
 de ficheros CSV que
 se hayan exportado con el programa Money Manager.NET. Principalmente
 para ayudar a los usuarios de ese programa a migrar a MMEX. <br>
@@ -1159,70 +1160,70 @@ para ayudar a los usuarios de ese programa a migrar a MMEX. <br>
 </font><font face="Verdana">El formato general es
 como sigue:</font><br>
 <font face="Verdana"><i><b>Fecha</b></i></font>
-<font face="Verdana">- Fecha de la transacción (mostrado
+<font face="Verdana">- Fecha de la transacciï¿½n (mostrado
 en el formato especificado en Opciones-&gt;Formato de fecha).<br>
 </font><font face="Verdana"><i><b>Beneficiario</b></i></font>&nbsp;<font face="Verdana">-
-A quien se realiza la transacción. En el caso de una transferencia,
+A quien se realiza la transacciï¿½n. En el caso de una transferencia,
 indica el nombre de la cuenta de la que se hace o a la que se hace.<br>
-</font><strong><em><font face="Verdana">Cantidad</font></em></strong>&nbsp;<font face="Verdana">- El importe de la transacción. Si es
+</font><strong><em><font face="Verdana">Cantidad</font></em></strong>&nbsp;<font face="Verdana">- El importe de la transacciï¿½n. Si es
 positivo, se considera un abono, si es negativo, un cargo.
 <br>
-</font><font face="Verdana"><i><b>Número</b></i></font>&nbsp;<font face="Verdana">- Número de la transacción.<br>
+</font><font face="Verdana"><i><b>Nï¿½mero</b></i></font>&nbsp;<font face="Verdana">- Nï¿½mero de la transacciï¿½n.<br>
 </font><font face="Verdana"><i><b>Estado</b></i></font>
-<font face="Verdana">- Estado de la transacción.<br>
-</font><font face="Verdana"><i><b>Categoría</b></i></font>&nbsp;<font face="Verdana">- La categoría de la transacción. Realmente
-es una cadena compuesta del tipo "Categoría:Subcategoría"<br>
+<font face="Verdana">- Estado de la transacciï¿½n.<br>
+</font><font face="Verdana"><i><b>Categorï¿½a</b></i></font>&nbsp;<font face="Verdana">- La categorï¿½a de la transacciï¿½n. Realmente
+es una cadena compuesta del tipo "Categorï¿½a:Subcategorï¿½a"<br>
 </font><font face="Verdana"><i><b>Notas</b></i></font>
-<font face="Verdana">- Notas de la transacción.<br>
+<font face="Verdana">- Notas de la transacciï¿½n.<br>
 <br>
 </font><font face="Verdana">Tenga en cuenta que las
-transacciones de un fichero CSV sólo se pueden importar a una única
+transacciones de un fichero CSV sï¿½lo se pueden importar a una ï¿½nica
 cuenta de MMEX.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="importUnivCSV"></a><font face="Verdana"><br>Importar de formato CSV Universal</font></h3>
 <p><font face="Verdana">Para mitigar el problema de que los usuarios
 tengan que cambiar el formato de sus ficheros CSV de transacciones
-bancarias al formato fijo que necesita MMEX, también se permite a los
+bancarias al formato fijo que necesita MMEX, tambiï¿½n se permite a los
 usuarios importar ficheros CSV donde el orden de los campos es
 completamente libre. Para hacer esto, seleccione la cuenta a la que
-quiere importar y después elija el orden de los campos del fichero CSV
-escogiendo de la lista de campos disponibles. MMEX importará el fichero
-CSV utilizando la información de formato especificada por el
+quiere importar y despuï¿½s elija el orden de los campos del fichero CSV
+escogiendo de la lista de campos disponibles. MMEX importarï¿½ el fichero
+CSV utilizando la informaciï¿½n de formato especificada por el
 usuario.&nbsp;</font><font face="Verdana">MMEX puede importar de una
 amplia variedad de
 formatos. Uno de ellos es el fichero CSV de formato fijo. Este formato
-de fichero coincide exáctamente con el formato CSV que MMEX puede
-exportar. Así que puede ser útil para mover datos de una base de datos
-.mmb a otra. Para ver fácilmente el formato del fichero CSV, puede
+de fichero coincide exï¿½ctamente con el formato CSV que MMEX puede
+exportar. Asï¿½ que puede ser ï¿½til para mover datos de una base de datos
+.mmb a otra. Para ver fï¿½cilmente el formato del fichero CSV, puede
 probar exportando una cuenta a CSV y analizar el fichero creado.</font><br><font face="Verdana">
 <br>Las opciones de campos CSV son las siguientes:<br>
-<span style="font-style: italic;"><span style="font-weight: bold;">Fecha</span></span> - La fecha de la transacción (en el formato especificado en Opciones-&gt;Formato de fecha)<br>
-<span style="font-style: italic;"><span style="font-weight: bold;">Beneficiario</span></span> -&nbsp;</font><font face="Verdana">A quien se realiza la transacción. En el caso de una transferencia,
+<span style="font-style: italic;"><span style="font-weight: bold;">Fecha</span></span> - La fecha de la transacciï¿½n (en el formato especificado en Opciones-&gt;Formato de fecha)<br>
+<span style="font-style: italic;"><span style="font-weight: bold;">Beneficiario</span></span> -&nbsp;</font><font face="Verdana">A quien se realiza la transacciï¿½n. En el caso de una transferencia,
 indica el nombre de la cuenta de la que se hace o a la que se hace.</font><br><font face="Verdana">
-<i><b>Cantidad (+/-)</b></i> -&nbsp;</font><font face="Verdana">El importe de la transacción. Si es
+<i><b>Cantidad (+/-)</b></i> -&nbsp;</font><font face="Verdana">El importe de la transacciï¿½n. Si es
 positivo, se considera un abono, si es negativo, un cargo.</font><br><font face="Verdana">
-<i><b>Categoría</b></i> -&nbsp;</font><font face="Verdana">La categoría de la transacción.</font><br><font face="Verdana">
-<i><b>Subcategoría</b></i> -&nbsp;</font><font face="Verdana">La subcategoría de
-la transacción.</font><font face="Verdana"> <br>
-<i><b>Notas</b></i> - Notas de la transacción.<br>
-<i><b>Número</b></i> -&nbsp;</font><font face="Verdana">Número de la transacción.</font><br><font face="Verdana">
+<i><b>Categorï¿½a</b></i> -&nbsp;</font><font face="Verdana">La categorï¿½a de la transacciï¿½n.</font><br><font face="Verdana">
+<i><b>Subcategorï¿½a</b></i> -&nbsp;</font><font face="Verdana">La subcategorï¿½a de
+la transacciï¿½n.</font><font face="Verdana"> <br>
+<i><b>Notas</b></i> - Notas de la transacciï¿½n.<br>
+<i><b>Nï¿½mero</b></i> -&nbsp;</font><font face="Verdana">Nï¿½mero de la transacciï¿½n.</font><br><font face="Verdana">
 <span style="font-style: italic;"><span style="font-weight: bold;">Cargo</span></span> - Un importe positivo que se considera un cargo. (No utilizar si se especifica cantidad&nbsp;(+/-))<br>
 <span style="font-style: italic;"><span style="font-weight: bold;">Abono</span></span> -&nbsp;</font><font face="Verdana">Un importe positivo que se considera un abono</font><font face="Verdana">. (</font><font face="Verdana">No utilizar si se especifica cantidad</font><font face="Verdana">
 (+/-))<br>
 <span style="font-style: italic;"><span style="font-weight: bold;">Sin importancia</span></span> - Ignorar este campo.<br>
 <br></font><font face="Verdana">Tenga en cuenta que las
-transacciones de un fichero CSV sólo se pueden importar a una única
+transacciones de un fichero CSV sï¿½lo se pueden importar a una ï¿½nica
 cuenta de MMEX.</font><br><font face="Verdana">
 <br>
-</font><font face="Verdana"><b>Nota importante (1)</b>: La opción de formato de fecha tiene que
+</font><font face="Verdana"><b>Nota importante (1)</b>: La opciï¿½n de formato de fecha tiene que
 coincidir con el formato de fecha del fichero QIF, de lo contrario las
-transacciones tendrían fechas incorrectas. <br>
+transacciones tendrï¿½an fechas incorrectas. <br>
 <br>
 <b>Nota importante (2)</b>:
-Después de importar de QIF, todas las transacciones estarán marcadas
+Despuï¿½s de importar de QIF, todas las transacciones estarï¿½n marcadas
 como "Seguimiento". Puede marcar todas las transacciones de este tipo
-mediante las opciones del menú al hacer clic derecho en la vista de
+mediante las opciones del menï¿½ al hacer clic derecho en la vista de
 cuenta.</font></p>
 <p><!-- creating csv tips added by terry wick 9/14/2007 --><br>
 <br>
@@ -1234,9 +1235,9 @@ Consejos para crear ficheros CSV</font></h3>
 <ul>
 <li>
 <p><font face="Verdana">Cuando cree un fichero
-CSV asegúrese
+CSV asegï¿½rese
 que elimina las comas de sus cargos y abonos. Esto se puede realizar
-fácilmente a través de programas como&nbsp;Excel u OpenOffice Calc.
+fï¿½cilmente a travï¿½s de programas como&nbsp;Excel u OpenOffice Calc.
 </font> </p>
 </li>
 </ul>
@@ -1244,7 +1245,7 @@ fácilmente a través de programas como&nbsp;Excel u OpenOffice Calc.
 <li>
 <p><font face="Verdana">O puede cambiar el
 delimitador a
-utilizar mediante Herramientas –&gt; Opciones y cambiando las
+utilizar mediante Herramientas ï¿½&gt; Opciones y cambiando las
 preferencias de importar/exportar en el panel&nbsp;"General". </font>
 </p>
 </li>
@@ -1258,7 +1259,7 @@ valores de saldo en el fichero CSV.</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Tenga en cuenta que las
-transacciones de un fichero CSV sólo se pueden importar a una única
+transacciones de un fichero CSV sï¿½lo se pueden importar a una ï¿½nica
 cuenta de MMEX.</font></p>
 </li>
 </ul>
@@ -1271,43 +1272,43 @@ cuenta de MMEX.</font></p>
 Exportar a ficheros CSV</font></h3>
 <p><font face="Verdana">MMEX puede exportar a un
 fichero CSV de formato
-fijo. Este formato de fichero coincide exáctamente con el formato CSV
-que MMEX puede importar. Así que puede ser útil para mover datos de una
-base de datos .mmb a otra. Para ver fácilmente el formato del fichero
+fijo. Este formato de fichero coincide exï¿½ctamente con el formato CSV
+que MMEX puede importar. Asï¿½ que puede ser ï¿½til para mover datos de una
+base de datos .mmb a otra. Para ver fï¿½cilmente el formato del fichero
 CSV, puede probar exportando una cuenta a CSV y analizar el fichero
 creado.<br>
 <br>
 El formato general es como sigue:<br>
-<i><b>Fecha</b></i> - Fecha de la transacción
+<i><b>Fecha</b></i> - Fecha de la transacciï¿½n
 (mostrado en el formato especificado en Opciones-&gt;Formato de
 fecha).<br>
 <i><b>Beneficiario</b></i>
-- A quien se realiza la transacción. En el caso de una transferencia,
+- A quien se realiza la transacciï¿½n. En el caso de una transferencia,
 indica el nombre de la cuenta de la que se hace o a la que se hace.<br>
-<i><b>Tipo de transacción</b></i>&nbsp;-
+<i><b>Tipo de transacciï¿½n</b></i>&nbsp;-
 Puede ser tanto un "cargo" como un "abono".<br>
 <i><b>Cantidad</b></i>&nbsp;- El importe
-de la transacción como un valor positivo.<br>
-<i><b>Categoría</b></i>&nbsp;- La categoría
-de la transacción.<br>
-<i><b>Subcategoría</b></i>&nbsp;- La
-subcategoría de la transacción si existe alguna (en caso contrario en
+de la transacciï¿½n como un valor positivo.<br>
+<i><b>Categorï¿½a</b></i>&nbsp;- La categorï¿½a
+de la transacciï¿½n.<br>
+<i><b>Subcategorï¿½a</b></i>&nbsp;- La
+subcategorï¿½a de la transacciï¿½n si existe alguna (en caso contrario en
 blanco).<br>
-<i><b>Notas</b></i> - Notas de la transacción.<br>
+<i><b>Notas</b></i> - Notas de la transacciï¿½n.<br>
 <br>
 </font><font face="Verdana">Tenga en cuenta que las
-transacciones de una cuenta se pueden importar a un único fichero CSV.</font></p>
+transacciones de una cuenta se pueden importar a un ï¿½nico fichero CSV.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="export_qif"></a><font face="Verdana"><br>
 Exportar a ficheros QIF</font></h3>
 <p><font face="Verdana">MMEX puede exportar una
 cuenta a un fichero con formato QIF.</font></p>
-<p><font face="Verdana">MMEX también puede usar este
+<p><font face="Verdana">MMEX tambiï¿½n puede usar este
 formato para
 <a href="#importQIF">recargar en una cuenta</a>.</font></p>
-<p><font face="Verdana">Precaución: Aunque las
-transferencias se recargarán en una sola cuenta, no funcionarán
+<p><font face="Verdana">Precauciï¿½n: Aunque las
+transferencias se recargarï¿½n en una sola cuenta, no funcionarï¿½n
 correctamente.</font></p>
 <p><br>
 <br>
@@ -1315,20 +1316,20 @@ correctamente.</font></p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="recurring_transactions"></a><font face="Verdana"><br>
-Transacciones periódicas</font></h3>
+Transacciones periï¿½dicas</font></h3>
 <p><font face="Verdana">Cuando tenemos transacciones
 que se realizan en
 intervalos regulares, como el pago de facturas, MMEX nos permite
-configurarlas como transacciones periódicas. Estas transacciones:</font></p>
+configurarlas como transacciones periï¿½dicas. Estas transacciones:</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Se muestran como
-recordatorios en la página inicial 14 días antes de la fecha de
+recordatorios en la pï¿½gina inicial 14 dï¿½as antes de la fecha de
 vencimiento.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Se pueden configurar
-para que se activen automáticamente en la fecha de vencimiento.</font></p>
+para que se activen automï¿½ticamente en la fecha de vencimiento.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Se pueden configurar
@@ -1336,12 +1337,12 @@ para que se activen permitiendo al usuario ajustar cualquier valor en
 la fecha de vencimiento</font><font face="Verdana">.</font></p>
 </li>
 </ul>
-<p><font face="Verdana">Se accede seleccionando </font><font face="Verdana"><b>Transacciones periódicas</b></font>
-<font face="Verdana">en el árbol de navegación.</font></p>
+<p><font face="Verdana">Se accede seleccionando </font><font face="Verdana"><b>Transacciones periï¿½dicas</b></font>
+<font face="Verdana">en el ï¿½rbol de navegaciï¿½n.</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Para crear nuevas
-transacciones, utilice el botón </font><font face="Verdana"><b>Nuevo</b></font><font face="Verdana">.</font></p>
+transacciones, utilice el botï¿½n </font><font face="Verdana"><b>Nuevo</b></font><font face="Verdana">.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Especifique la cuenta.</font></p>
@@ -1357,35 +1358,35 @@ que necesita conocer la cuenta sobre la que opera.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Seleccione si se
-repite “diariamente”, “semanalmente”, etc.</font></p>
+repite ï¿½diariamenteï¿½, ï¿½semanalmenteï¿½, etc.</font></p>
 </li>
 <li>
 <p><font face="Verdana"><b>Veces repetido:<br>
 </b></font><font face="Verdana">-
-Introduzca el número de veces que se repite.<br>
+Introduzca el nï¿½mero de veces que se repite.<br>
 </font><font face="Verdana"><b>- </b></font><font face="Verdana">Dejarlo en blanco significa indefinidamente.</font></p>
 </li>
 </ul>
 <p><font face="Verdana"><span style="font-weight: normal;">Esta transacciones se muestran
-como </span></font><font face="Verdana"><b>Próximas
-transacciones</b></font> <font face="Verdana"><span style="font-weight: normal;">en la página de inicio los 15
-días anteriores a la fecha de vencimiento.</span></font></p>
+como </span></font><font face="Verdana"><b>Prï¿½ximas
+transacciones</b></font> <font face="Verdana"><span style="font-weight: normal;">en la pï¿½gina de inicio los 15
+dï¿½as anteriores a la fecha de vencimiento.</span></font></p>
 <p><font face="Verdana"><b>Nota:</b></font></p>
 <ol>
 <li>
 <p><font face="Verdana">Cuando efectuamos la
-transacción,
-podemos cambiar el importe, el beneficiario, la categoría, el estado y
+transacciï¿½n,
+podemos cambiar el importe, el beneficiario, la categorï¿½a, el estado y
 la fecha si es necesario.</font></p>
 </li>
 <li>
 <p><font face="Verdana"><b>Efectuar una
-transacción antes de su vencimiento</b></font><font face="Verdana"> hará que se muestre en tono gris en la
-cuenta asociada hasta el día que se vuelva activa.</font></p>
+transacciï¿½n antes de su vencimiento</b></font><font face="Verdana"> harï¿½ que se muestre en tono gris en la
+cuenta asociada hasta el dï¿½a que se vuelva activa.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Para utilizar los <a href="#cashFlowReport">informes de flujo de caja</a>
-es necesario configurar transacciones periódicas.</font></p>
+es necesario configurar transacciones periï¿½dicas.</font></p>
 </li>
 </ol>
 <p><br>
@@ -1397,9 +1398,9 @@ es necesario configurar transacciones periódicas.</font></p>
 Activos</font></h3>
 <p><font face="Verdana">MMEX permite mantener
 activos fijos, como
-coches, casas, terrenos y demás. Cada activo puede tener su valor de
-apreciación o depreciación por un cierto índice al año, o no cambiar
-nada. Todos los activos se añaden al valor financiero total. </font>
+coches, casas, terrenos y demï¿½s. Cada activo puede tener su valor de
+apreciaciï¿½n o depreciaciï¿½n por un cierto ï¿½ndice al aï¿½o, o no cambiar
+nada. Todos los activos se aï¿½aden al valor financiero total. </font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
@@ -1407,7 +1408,7 @@ nada. Todos los activos se añaden al valor financiero total. </font>
 Filtro de transacciones</font></h3>
 <p><font face="Verdana">MMEX le permite buscar
 transacciones que
-cumplan ciertos criterios. Para ello puede utilizar la opción de filtro
+cumplan ciertos criterios. Para ello puede utilizar la opciï¿½n de filtro
 de transacciones. La lista de transacciones resultante se puede
 imprimir o guardar como un fichero HTML. </font>
 </p>
@@ -1418,12 +1419,12 @@ Presupuesto</font></h3>
 <p><font face="Verdana">MMEX le permite configurar
 un presupuesto anual
 y compararlo con sus gastos. Para configurar un presupuesto haga clic
-en la opción 'Presupuestos' del árbol de navegación y añada un
-presupuesto anual. Una vez que se ha añadido el año, selecciónelo y
-edite las cantidades de cada categoría.
-Esto se convierte en el presupuesto para ese año.<br>
+en la opciï¿½n 'Presupuestos' del ï¿½rbol de navegaciï¿½n y aï¿½ada un
+presupuesto anual. Una vez que se ha aï¿½adido el aï¿½o, selecciï¿½nelo y
+edite las cantidades de cada categorï¿½a.
+Esto se convierte en el presupuesto para ese aï¿½o.<br>
 <br>
-Mediante los informes de 'Presupuestos' es posible comparar cómo se ha
+Mediante los informes de 'Presupuestos' es posible comparar cï¿½mo se ha
 gastado el dinero con respecto al presupuesto. </font>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
@@ -1432,80 +1433,80 @@ gastado el dinero con respecto al presupuesto. </font>
 Informes</font></h3>
 <p><font face="Verdana">MMEX permite una gran
 variedad de informes. <br>
-Todos los informes se pueden imprimir mediante el menú: <b>Archivo-&gt;Imprimir...
+Todos los informes se pueden imprimir mediante el menï¿½: <b>Archivo-&gt;Imprimir...
 --&gt;Vista actual</b></font></p>
 <p><font face="Verdana">Seleccione el informe
 deseado bajo el nodo
-"Informes" del árbol del navegación. Algunos informes necesitan de la
-introducción de datos por parte del usuario, otros no. Una vez que se
-muestra el informe, puede imprimirlo mediante las opciones de impresión
-del menú.</font></p>
+"Informes" del ï¿½rbol del navegaciï¿½n. Algunos informes necesitan de la
+introducciï¿½n de datos por parte del usuario, otros no. Una vez que se
+muestra el informe, puede imprimirlo mediante las opciones de impresiï¿½n
+del menï¿½.</font></p>
 <p><a name="financialYearReport"></a><font face="Verdana"><br>
-<b>Informes de año fiscal:</b> (Necesario para algunos países)</font></p>
+<b>Informes de aï¿½o fiscal:</b> (Necesario para algunos paï¿½ses)</font></p>
 <p><font face="Verdana">Son informes que
 generalmente no comienzan al
-inicio del año de calendario, y aparecen como ramas del informe
+inicio del aï¿½o de calendario, y aparecen como ramas del informe
 principal. Estos informes cubren:</font></p>
 <ol>
 <li>
-<p><font face="Verdana">Año fiscal anterior.</font></p>
+<p><font face="Verdana">Aï¿½o fiscal anterior.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Periodos del año fiscal
+<p><font face="Verdana">Periodos del aï¿½o fiscal
 actual.</font></p>
 </li>
 <li>
 <p><font face="Verdana">Por defecto el inicio
-del año fiscal es el 1 de julio</font><font face="Verdana">.</font></p>
+del aï¿½o fiscal es el 1 de julio</font><font face="Verdana">.</font></p>
 </li>
 </ol>
 <p><font face="Verdana">La fecha de inicio se puede
-modificar por cualquier día de cualquier mes, dentro de un periodo de
+modificar por cualquier dï¿½a de cualquier mes, dentro de un periodo de
 12 meses mediante </font><font face="Verdana"><b>Herramientas
 -&gt;Opciones</b></font>
-<font face="Verdana">y después seleccionando </font><font face="Verdana"><b>Otros</b></font><font face="Verdana">.</font></p>
+<font face="Verdana">y despuï¿½s seleccionando </font><font face="Verdana"><b>Otros</b></font><font face="Verdana">.</font></p>
 <p><a name="transaction_report"></a><font face="Verdana"><b><br>
 Informe de transacciones:</b> </font>
 </p>
 <ol>
 <li>
 <p><font face="Verdana">Permite al usuario
-generar informes específicos con unos determinados criterios.</font></p>
+generar informes especï¿½ficos con unos determinados criterios.</font></p>
 </li>
 <li>
-<p><font face="Verdana">También denominado <a href="#transfilter">filtro de transacciones</a>.</font></p>
+<p><font face="Verdana">Tambiï¿½n denominado <a href="#transfilter">filtro de transacciones</a>.</font></p>
 </li>
 </ol>
 <p><a name="cashFlowReport"></a><font face="Verdana"><br>
 <b>Informe de flujo de caja</b></font></p>
 <p><font face="Verdana">Para que funcione
 correctamente las <a href="#recurring_transactions">transacciones
-periódicas</a>
-tienen que estar configuradas para las cuentas. El informe utilizará
-esta información para reflejar los meses de los próximos 10 años y
-predecir la cantidad de dinero que estará disponible cada mes futuro.</font></p>
+periï¿½dicas</a>
+tienen que estar configuradas para las cuentas. El informe utilizarï¿½
+esta informaciï¿½n para reflejar los meses de los prï¿½ximos 10 aï¿½os y
+predecir la cantidad de dinero que estarï¿½ disponible cada mes futuro.</font></p>
 <p><br>
 <br>
 </p>
 <h5 class="western"><a href="#top"><font face="Verdana">Volver arriba</font></a></h5>
 <hr>
 <h3 class="western"><a name="print"></a><font face="Verdana"><br>
-Impresión</font></h3>
+Impresiï¿½n</font></h3>
 <p><font face="Verdana">MMEX permite imprimir todos
 los informes que se pueden generar. </font>
 </p>
-<p><font face="Verdana">Las opciones de impresión se
-encuentran bajo el menú, Archivo-&gt;Imprimir... Vista actual</font></p>
+<p><font face="Verdana">Las opciones de impresiï¿½n se
+encuentran bajo el menï¿½, Archivo-&gt;Imprimir... Vista actual</font></p>
 <p><font face="Verdana">Recomendaciones:</font></p>
 <ul>
 <li>
-<p><font face="Verdana">Utilice la opción de
-configurar página para realizar cambios en el formato si lo considera
+<p><font face="Verdana">Utilice la opciï¿½n de
+configurar pï¿½gina para realizar cambios en el formato si lo considera
 necesario.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Utilice la opción de
-vista preliminar para comprobar la disposición del informe antes de
+<p><font face="Verdana">Utilice la opciï¿½n de
+vista preliminar para comprobar la disposiciï¿½n del informe antes de
 imprimirlo.</font></p>
 </li>
 </ul>
@@ -1516,7 +1517,7 @@ Opciones de MMEX</font></h3>
 <p><font face="Verdana">Puede modificar el
 comportamiento de MMEX cambiando algunos ajustes de la ventana de
 opciones.</font></p>
-<p><font face="Verdana">Se accede desde el menú <b>Herramientas-&gt;Opciones</b></font></p>
+<p><font face="Verdana">Se accede desde el menï¿½ <b>Herramientas-&gt;Opciones</b></font></p>
 <table border="1" bordercolor="#000000" cellpadding="4" cellspacing="0" rules="groups" width="100%">
 <col width="45*"> <col width="211*"> <tbody>
 <tr valign="top">
@@ -1535,7 +1536,7 @@ opciones.</font></p>
 </td>
 <td width="82%">
 <p><font face="Verdana">Se utiliza para seleccionar la moneda de la
-base de datos. Cada cuenta la usará por defecto, pero se puede
+base de datos. Cada cuenta la usarï¿½ por defecto, pero se puede
 modificar si son necesarias otras divisas.</font></p>
 </td>
 </tr>
@@ -1544,7 +1545,7 @@ modificar si son necesarias otras divisas.</font></p>
 <p><font face="Verdana"><i><b>Formato de fecha:</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Se utiliza para controlar cómo se muestran las fechas y también cómo analizarlas al importar de ficheros QIF y CSV.</font></p>
+<p><font face="Verdana">Se utiliza para controlar cï¿½mo se muestran las fechas y tambiï¿½n cï¿½mo analizarlas al importar de ficheros QIF y CSV.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1552,9 +1553,9 @@ modificar si son necesarias otras divisas.</font></p>
 <p><font face="Verdana"><i><b>Delimitador CSV</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Se utiliza como carácter delimitador de los
-ficheros CSV. Es útil para modificar el carácter predeterminado ','
-cuando hay que tratar con divisas que utilizan ',' como carácter
+<p><font face="Verdana">Se utiliza como carï¿½cter delimitador de los
+ficheros CSV. Es ï¿½til para modificar el carï¿½cter predeterminado ','
+cuando hay que tratar con divisas que utilizan ',' como carï¿½cter
 decimal en las cantidades. </font> </p>
 </td>
 </tr>
@@ -1563,7 +1564,7 @@ decimal en las cantidades. </font> </p>
 <p><font face="Verdana"><i><b>Nombre de usuario</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana"><b>Opcional </b>Este campo sólo se utiliza como título en la página de inicio y en los informes.</font></p>
+<p><font face="Verdana"><b>Opcional </b>Este campo sï¿½lo se utiliza como tï¿½tulo en la pï¿½gina de inicio y en los informes.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1598,7 +1599,7 @@ nuevo idioma a todos los elementos.</font></p>
 <p><font face="Verdana"><i><b>Cuentas visibles</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Indica las cuentas visibles en el árbol de navegación dependiendo de su estado.</font></p>
+<p><font face="Verdana">Indica las cuentas visibles en el ï¿½rbol de navegaciï¿½n dependiendo de su estado.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1611,26 +1612,26 @@ nuevo idioma a todos los elementos.</font></p>
 </tr>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana"><b>Tamaño de fuente</b></font></p>
+<p><font face="Verdana"><b>Tamaï¿½o de fuente</b></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Indica la fuente que se usará en la página de inicio y los informes.</font></p>
+<p><font face="Verdana">Indica la fuente que se usarï¿½ en la pï¿½gina de inicio y los informes.</font></p>
 </td>
 </tr>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana"><b>Expandir sección de vista en árbol</b></font></p>
+<p><font face="Verdana"><b>Expandir secciï¿½n de vista en ï¿½rbol</b></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Selecciona los tipos de cuenta que aparecerán expandidos cuando se refresque el árbol de navegación.</font></p>
+<p><font face="Verdana">Selecciona los tipos de cuenta que aparecerï¿½n expandidos cuando se refresque el ï¿½rbol de navegaciï¿½n.</font></p>
 </td>
 </tr>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana"><b>Expandir sección de página de inicio</b></font></p>
+<p><font face="Verdana"><b>Expandir secciï¿½n de pï¿½gina de inicio</b></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Selecciona los tipos de cuenta que aparecerán expandidos cuando se refresque página de inicio.</font></p>
+<p><font face="Verdana">Selecciona los tipos de cuenta que aparecerï¿½n expandidos cuando se refresque pï¿½gina de inicio.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1677,10 +1678,10 @@ nuevo idioma a todos los elementos.</font></p>
 </tbody> <tbody>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana"><b>Preferencias del año fiscal</b></font></p>
+<p><font face="Verdana"><b>Preferencias del aï¿½o fiscal</b></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Selecciona un día y un mes de inicio para un periodo de 12 meses para los informes de año fiscal </font> </p>
+<p><font face="Verdana">Selecciona un dï¿½a y un mes de inicio para un periodo de 12 meses para los informes de aï¿½o fiscal </font> </p>
 </td>
 </tr>
 <tr valign="top">
@@ -1688,7 +1689,7 @@ nuevo idioma a todos los elementos.</font></p>
 <p><font face="Verdana"><i><b>Nuevas transacciones</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Cambia la configuración predeterminada para la ventana de Nueva/Editar Transacción</font></p>
+<p><font face="Verdana">Cambia la configuraciï¿½n predeterminada para la ventana de Nueva/Editar Transacciï¿½n</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1696,25 +1697,25 @@ nuevo idioma a todos los elementos.</font></p>
 <p><font face="Verdana"><i><b>Copia de seguridad</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Selecciona cómo se realizan las copias de seguridad cuando se inicia MMEX.</font></p>
+<p><font face="Verdana">Selecciona cï¿½mo se realizan las copias de seguridad cuando se inicia MMEX.</font></p>
 <ul>
 <li>
 <p><font face="Verdana">Copia de seguridad antes de abrir: genera un fichero de copia de seguridad con la fecha antes de abrir.</font></p>
 </li>
 <li>
-<p><font face="Verdana">Actualización diaria...:
-si la base de datos se abre más de una vez al día, la copia de seguridad se actualiza antes de abrir.</font></p>
+<p><font face="Verdana">Actualizaciï¿½n diaria...:
+si la base de datos se abre mï¿½s de una vez al dï¿½a, la copia de seguridad se actualiza antes de abrir.</font></p>
 </li>
 </ul>
 </td>
 </tr>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana"><i><b>Página web de cotización de acciones</b></i></font></p>
+<p><font face="Verdana"><i><b>Pï¿½gina web de cotizaciï¿½n de acciones</b></i></font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Esta URL se utiliza para el botón Actualizar de la página de inversión en acciones.</font></p>
-<p><font face="Verdana">También es utilizada por la ventana Nuevo/Editar Innversión en acciones, para mostrar la página web de las acciones.</font></p>
+<p><font face="Verdana">Esta URL se utiliza para el botï¿½n Actualizar de la pï¿½gina de inversiï¿½n en acciones.</font></p>
+<p><font face="Verdana">Tambiï¿½n es utilizada por la ventana Nuevo/Editar Innversiï¿½n en acciones, para mostrar la pï¿½gina web de las acciones.</font></p>
 <p><font face="Verdana">Por defecto es yahoo
 finance. Se pueden utilizar otros sitios alternativos.</font></p>
 </td>
@@ -1725,7 +1726,7 @@ finance. Se pueden utilizar otros sitios alternativos.</font></p>
 </p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Actívelo para utilizar la fecha de la transacción cuando pegue transacciones, en la vista de cuenta.</font></p>
+<p><font face="Verdana">Actï¿½velo para utilizar la fecha de la transacciï¿½n cuando pegue transacciones, en la vista de cuenta.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1733,15 +1734,15 @@ finance. Se pueden utilizar otros sitios alternativos.</font></p>
 <p><font face="Verdana">Utilizar sonido...</font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Actívelo para reproducir un sonido cuando introduzca una transacción.</font></p>
+<p><font face="Verdana">Actï¿½velo para reproducir un sonido cuando introduzca una transacciï¿½n.</font></p>
 </td>
 </tr>
 <tr valign="top">
 <td width="18%">
-<p><font face="Verdana">Habilitar actualización de moneda...</font></p>
+<p><font face="Verdana">Habilitar actualizaciï¿½n de moneda...</font></p>
 </td>
 <td width="82%">
-<p><font face="Verdana">Actívelo para permitir que las divisas se actualicen a través de Internet.</font></p>
+<p><font face="Verdana">Actï¿½velo para permitir que las divisas se actualicen a travï¿½s de Internet.</font></p>
 </td>
 </tr>
 </tbody>
@@ -1753,32 +1754,32 @@ finance. Se pueden utilizar otros sitios alternativos.</font></p>
 Preguntas frecuentes</font></h3>
 <ol>
 <li>
-<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#contribute">¿Cómo puedo colaborar?</a> </font>
+<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#contribute">ï¿½Cï¿½mo puedo colaborar?</a> </font>
 </p>
 </li>
 <li>
-<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#nameex">¿Cuál es el motivo del EX en el nombre del
+<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#nameex">ï¿½Cuï¿½l es el motivo del EX en el nombre del
 software?</a> </font> </p>
 </li>
 <li>
-<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#database1">¿El fichero .mmb tiene un formato
-propietario? ¿Están mis datos seguros?</a> </font> </p>
+<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#database1">ï¿½El fichero .mmb tiene un formato
+propietario? ï¿½Estï¿½n mis datos seguros?</a> </font> </p>
 </li>
 <li>
-<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#usbkey">¿Se puede ejecutar MMEX desde un dispositivo
+<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#usbkey">ï¿½Se puede ejecutar MMEX desde un dispositivo
 USB?</a> </font> </p>
 </li>
 <li>
-<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#safety">¿Cómo puedo saber que MMEX no intenta robar
-mi información financiera?</a> </font> </p>
+<p style="margin-bottom: 0in;"><font face="Verdana"><a href="#safety">ï¿½Cï¿½mo puedo saber que MMEX no intenta robar
+mi informaciï¿½n financiera?</a> </font> </p>
 </li>
 <li>
-<p><font face="Verdana"><a href="#statements">¿Cómo imprimo extractos de cuenta usando&nbsp;MMEX?</a> </font> </p>
+<p><font face="Verdana"><a href="#statements">ï¿½Cï¿½mo imprimo extractos de cuenta usando&nbsp;MMEX?</a> </font> </p>
 </li>
 </ol>
 <hr>
 <h3 class="western"><a name="contribute"></a><font face="Verdana"><br>
-¿Cómo puedo colaborar?</font></h3>
+ï¿½Cï¿½mo puedo colaborar?</font></h3>
 <p><a name="contribute1"></a><font face="Verdana">Puedes colaborar </font>
 </p>
 <ul>
@@ -1792,13 +1793,13 @@ mi información financiera?</a> </font> </p>
 <p style="margin-bottom: 0in;"><a name="contribute4"></a><font face="Verdana">Ayudando a difundirlo</font> </p>
 </li>
 <li>
-<p style="margin-bottom: 0in;"><a name="contribute5"></a><font face="Verdana">Si es un experto en C++, desarrollando código
+<p style="margin-bottom: 0in;"><a name="contribute5"></a><font face="Verdana">Si es un experto en C++, desarrollando cï¿½digo
 para&nbsp;MMEX </font> </p>
 </li>
 <li>
-<p><font face="Verdana">Si está muy contento
+<p><font face="Verdana">Si estï¿½ muy contento
 porque ha ahorrado mucho dinero usando MMEX, puede realizar una
-donación al proyecto </font> </p>
+donaciï¿½n al proyecto </font> </p>
 </li>
 </ul>
 <p style="margin-bottom: 0in;"><br>
@@ -1816,17 +1817,17 @@ donación al proyecto </font> </p>
 </tbody>
 </table>
 <hr>
-<h3 class="western"><a name="nameex"></a><font face="Verdana"><br>¿Cuál es el motivo del EX en el nombre del software?</font></h3>
-<p><font face="Verdana">Originalmente desarrollé un software de
+<h3 class="western"><a name="nameex"></a><font face="Verdana"><br>ï¿½Cuï¿½l es el motivo del EX en el nombre del software?</font></h3>
+<p><font face="Verdana">Originalmente desarrollï¿½ un software de
 finanzas personales llamado Money Manager. Estaba escrito en .NET y fue
-más un ejercicio de aprendizaje que un desarrollo serio. Creció mucho
-más allá del diseño original. El desarrolló se congeló y se empezó a
-trabajar en una nueva versión que tendría una interfaz y
-características similares, pero escrito en C++.&nbsp; </font>
+mï¿½s un ejercicio de aprendizaje que un desarrollo serio. Creciï¿½ mucho
+mï¿½s allï¿½ del diseï¿½o original. El desarrollï¿½ se congelï¿½ y se empezï¿½ a
+trabajar en una nueva versiï¿½n que tendrï¿½a una interfaz y
+caracterï¿½sticas similares, pero escrito en C++.&nbsp; </font>
 </p>
 <p><font face="Verdana">Normalmente Microsoft llama a la segunda
-versión de sus API mejoradas con una extensión EX, como en hazAlgo() y
-hazAlgoEX(). Así que&nbsp;seguí la misma fórmula y le coloqué
+versiï¿½n de sus API mejoradas con una extensiï¿½n EX, como en hazAlgo() y
+hazAlgoEX(). Asï¿½ que&nbsp;seguï¿½ la misma fï¿½rmula y le coloquï¿½
 un&nbsp;'Ex' al final. </font>
 </p>
 <p><br>
@@ -1853,7 +1854,7 @@ un&nbsp;'Ex' al final. </font>
 </tbody>
 </table>
 <hr>
-<h3 class="western"><a name="database1"></a><font face="Verdana"><br>¿El fichero .mmb tiene un formato propietario?&nbsp;¿Están mis datos seguros? </font>
+<h3 class="western"><a name="database1"></a><font face="Verdana"><br>ï¿½El fichero .mmb tiene un formato propietario?&nbsp;ï¿½Estï¿½n mis datos seguros? </font>
 </h3>
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
 <col width="13*"> <col width="243*"> <tbody>
@@ -1874,7 +1875,7 @@ un&nbsp;'Ex' al final. </font>
 <p style="font-weight: normal;"><font face="Verdana">MMEX utiliza una
 base de datos&nbsp;SQLite para almacenar los datos. Eso significa que
 el fichero .mmb es una base de datos SQLite corriente.
-SQLite es uno de los sistemas de base de datos más ligero y de libre
+SQLite es uno de los sistemas de base de datos mï¿½s ligero y de libre
 uso que se pueden encontrar, y hay montones de herramientas para abrir
 y acceder a estas bases de datos.
 SQLiteSpy y SQLite Browser (http://sqlitebrowser.sourceforge.net/)
@@ -1884,10 +1885,10 @@ herramientas, puede hacer lo que quiera con los datos. </font> </p>
 </tr>
 <tr valign="top">
 <td width="5%">
-<p><span style="font-family: Verdana;"><span style="font-weight: bold;">Sí</span></span></p>
+<p><span style="font-family: Verdana;"><span style="font-weight: bold;">Sï¿½</span></span></p>
 </td>
 <td width="95%">
-<p><font face="Verdana">Sus datos están completamente seguros.</font></p>
+<p><font face="Verdana">Sus datos estï¿½n completamente seguros.</font></p>
 </td>
 </tr>
 <tr valign="top">
@@ -1897,9 +1898,9 @@ herramientas, puede hacer lo que quiera con los datos. </font> </p>
 </td>
 <td width="95%">
 <p><font face="Verdana">Los datos se guardan en su propio PC, (o su <a href="#usbkey">dispositivo USB</a>
-si utiliza el modo portable). Para proteger mejor sus datos, <a href="#encryptDatabase">ahora puede añadir cifrado.</a>
-Esto aplica una contraseña a su base de datos, y sólo se puede abrir si
-tiene la contraseña correcta, tanto con MMEX como con cualquier otro
+si utiliza el modo portable). Para proteger mejor sus datos, <a href="#encryptDatabase">ahora puede aï¿½adir cifrado.</a>
+Esto aplica una contraseï¿½a a su base de datos, y sï¿½lo se puede abrir si
+tiene la contraseï¿½a correcta, tanto con MMEX como con cualquier otro
 software.</font></p>
 </td>
 </tr>
@@ -1931,10 +1932,10 @@ software.</font></p>
 </table>
 <hr>
 <h3 class="western"><a name="usbkey"></a><font face="Verdana"><br>
-¿Se puede ejecutar MMEX desde un dispositivo USB?</font></h3>
-<p><a name="usbkey1"></a><font face="Verdana"><b>Sí.</b></font></p>
-<p><font face="Verdana">MMEX es una aplicación portable, lo que
-significa que puede ejecutarse sin instalación, por ejemplo, desde un
+ï¿½Se puede ejecutar MMEX desde un dispositivo USB?</font></h3>
+<p><a name="usbkey1"></a><font face="Verdana"><b>Sï¿½.</b></font></p>
+<p><font face="Verdana">MMEX es una aplicaciï¿½n portable, lo que
+significa que puede ejecutarse sin instalaciï¿½n, por ejemplo, desde un
 dispositivo USB. Si MMEX encuentra el fichero mmexini.db3 en su
 carpeta, se asume el modo portable. Copie los ficheros de MMEX a un
 dispositivo USB y su fichero mmexini.db3 a la carpeta de MMEX en ese
@@ -1952,7 +1953,7 @@ Copie su fichero de base de datos a cualquier carpeta de <a href="../help">F:\</
 </p>
 </li>
 <li>
-<p><font face="Verdana"><b>En Unix (se asume que /media/disk es donde está montado el dispositivo USB)</b></font><font face="Verdana"><br>Compile MMEX de sus fuentes como de costumbre,<br>y haga</font> <font face="Verdana">make install
+<p><font face="Verdana"><b>En Unix (se asume que /media/disk es donde estï¿½ montado el dispositivo USB)</b></font><font face="Verdana"><br>Compile MMEX de sus fuentes como de costumbre,<br>y haga</font> <font face="Verdana">make install
 prefix=/media/disk<br>
 cp ~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex<br>
 <br>o si quiere copiar MMEX estando ya instalado en&nbsp;/usr<br>
@@ -1978,15 +1979,15 @@ cp ~/.mmex/mmexini.db3 /media/disk/mmex/share/mmex<br>
 </tbody>
 </table>
 <hr>
-<h3 class="western"><a name="safety"></a><font face="Verdana"><br>¿Cómo puedo saber que MMEX no intenta robar mi información financiera?</font></h3>
+<h3 class="western"><a name="safety"></a><font face="Verdana"><br>ï¿½Cï¿½mo puedo saber que MMEX no intenta robar mi informaciï¿½n financiera?</font></h3>
 <p><a name="safety1"></a><font face="Verdana">Generalmente, con
-cualquier programa de código cerrado, tiene que fiarse de la palabra
+cualquier programa de cï¿½digo cerrado, tiene que fiarse de la palabra
 del fabricante respecto a la seguridad de los datos. Pero con MMEX, al
-ser de código abierto, puede verificarlo usted mismo. Aunque no sea un
+ser de cï¿½digo abierto, puede verificarlo usted mismo. Aunque no sea un
 experto en C++, puede estar seguro de que cualquiera puede acceder al
-código fuente en cualquier momento y verificar la legitimidad de las
+cï¿½digo fuente en cualquier momento y verificar la legitimidad de las
 intenciones de MMEX. MMEX no se conecta a Internet a menos que se le
-pida explícitamente (como comprobar actualizaciones,&nbsp; etc). <br>
+pida explï¿½citamente (como comprobar actualizaciones,&nbsp; etc). <br>
 </font><br>
 <br>
 </p>
@@ -2015,14 +2016,14 @@ pida explícitamente (como comprobar actualizaciones,&nbsp; etc). <br>
 </tbody>
 </table>
 <hr>
-<h3 class="western"><a name="statements"></a><font face="Verdana"><br>¿Cómo imprimo extractos de cuenta usando MMEX?</font></h3>
+<h3 class="western"><a name="statements"></a><font face="Verdana"><br>ï¿½Cï¿½mo imprimo extractos de cuenta usando MMEX?</font></h3>
 <p><a name="statements1"></a><font face="Verdana">Para imprimir un
 extracto con transacciones utilizando unos determinados criterios,
 utilice el filtro de transacciones para seleccionar las que desee y
-después imprima desde el menú. Archivo -&gt;Imprimir... -&gt;Vista
+despuï¿½s imprima desde el menï¿½. Archivo -&gt;Imprimir... -&gt;Vista
 actual.</font></p>
-<p><font face="Verdana">Al filtro de transacciones de puede acceder desde Informes --&gt; Informe de transacciones en el árbol de navegación, o<br>
-desde los botones de navegación rápida en la parte superior izquierda de MMEX..</font></p>
+<p><font face="Verdana">Al filtro de transacciones de puede acceder desde Informes --&gt; Informe de transacciones en el ï¿½rbol de navegaciï¿½n, o<br>
+desde los botones de navegaciï¿½n rï¿½pida en la parte superior izquierda de MMEX..</font></p>
 <p><br>
 <br>
 </p>
@@ -2054,6 +2055,6 @@ desde los botones de navegación rápida en la parte superior izquierda de MMEX..<
 </table>
 <hr>
 <h5 class="western"><font face="Verdana">Copyright
-ª 2005-2011&nbsp;
+ï¿½ 2005-2011&nbsp;
 CodeLathe LLC. Todos los derechos reservados.</font></h5>
 </body></html>

--- a/doc/help/spanish/investment.html
+++ b/doc/help/spanish/investment.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html><head>
-	<meta http-equiv="CONTENT-TYPE" content="text/html; charset=windows-1252">
-	
+	<meta charset="utf-8">
+	<link href="../master.css" rel="stylesheet" type="text/css">
 	<title>Setting up an Investment Account</title><meta name="GENERATOR" content="OpenOffice.org 3.3  (Win32)">
 	<meta name="CREATED" content="0;0">
 	<meta name="CHANGEDBY" content="Stefano Giorgio">
@@ -15,37 +15,37 @@
 	<col width="64*">
 	<tbody><tr valign="top">
 		<td width="75%">
-			<h1><font face="Verdana"><font size="6">Inversión en acciones</font></font></h1>
+			<h1><font face="Verdana"><font size="6">Inversiï¿½n en acciones</font></font></h1>
 		</td>
 		<td width="25%">
 			<p><a href="./index.html"><font face="Verdana"><font size="4"><b>Inicio</b></font></font></a></p>
 		</td>
 	</tr>
 </tbody></table>
-<p><font face="Verdana">Con MMEX es posible hacer un seguimiento de las acciones y fondos de inversión. </font>
+<p><font face="Verdana">Con MMEX es posible hacer un seguimiento de las acciones y fondos de inversiï¿½n. </font>
 </p>
 <ul>
 	<li><p><font face="Verdana">Para utilizar acciones, cree una nueva cuenta</font></p>
-	</li><li><p><font face="Verdana">En el asistener para añadir cuentas, seleccióne el </font><font face="Verdana"><b>tipo de cuenta&nbsp;</b></font><font face="Verdana">'Inversión'</font></p>
+	</li><li><p><font face="Verdana">En el asistener para aï¿½adir cuentas, selecciï¿½ne el </font><font face="Verdana"><b>tipo de cuenta&nbsp;</b></font><font face="Verdana">'Inversiï¿½n'</font></p>
 </li></ul>
 <ul>
-	<li><p><font face="Verdana">Este tipo de cuenta se añade a la sección "Acciones" del árbol de navegación</font></p>
-	</li><li><p><font face="Verdana">En la página de inicio, la cuenta aparece como
+	<li><p><font face="Verdana">Este tipo de cuenta se aï¿½ade a la secciï¿½n "Acciones" del ï¿½rbol de navegaciï¿½n</font></p>
+	</li><li><p><font face="Verdana">En la pï¿½gina de inicio, la cuenta aparece como
 	</font><font face="Verdana"><b>Acciones</b></font></p>
-	</li><li><p style="font-weight: normal;"><font face="Verdana">Estas cuentas aparecen en su propia página, llamada 'Inversión en acciones'</font></p>
+	</li><li><p style="font-weight: normal;"><font face="Verdana">Estas cuentas aparecen en su propia pï¿½gina, llamada 'Inversiï¿½n en acciones'</font></p>
 </li></ul>
 <hr>
-<p><font face="Verdana"><font size="4"><b>La página de Inversión en acciones</b></font></font></p>
-<p style="font-weight: normal;"><img src="../stock_view.png" name="graphics3" align="left" border="0"><br clear="left"></p><p style="font-weight: normal;"><font face="Verdana">En la página de inversión en acciones, se encuentran los siguientes botones</font></p>
+<p><font face="Verdana"><font size="4"><b>La pï¿½gina de Inversiï¿½n en acciones</b></font></font></p>
+<p style="font-weight: normal;"><img src="../stock_view.png" name="graphics3" align="left" border="0"><br clear="left"></p><p style="font-weight: normal;"><font face="Verdana">En la pï¿½gina de inversiï¿½n en acciones, se encuentran los siguientes botones</font></p>
 <ul>
-	<li><p style="font-weight: normal;"><font face="Verdana"><b>Nuevo<br></b>Permite añadir nuevas acciones.</font></p>
+	<li><p style="font-weight: normal;"><font face="Verdana"><b>Nuevo<br></b>Permite aï¿½adir nuevas acciones.</font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Editar<br></b>Permite cambiar detalles</font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Borrar<br></b>Permites borrar acciones</font></p>
-	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Actualizar<br></b>Permite actualizar los precios de las acciones a través de Internet.</font></p>
+	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Actualizar<br></b>Permite actualizar los precios de las acciones a travï¿½s de Internet.</font></p>
 	</li><li><p style="font-weight: normal;"><font face="Verdana"><b>Preferencias<br></b>Abre la ventana de opciones de las acciones.</font></p>
 </li></ul>
 <hr>
-<p><font face="Verdana"><font size="4"><b>El botón Nuevo</b></font></font><font face="Verdana"><br>Cuando hace clic en el botón 'Nuevo' aparece una ventana para introducir la información de la participación.</font></p>
+<p><font face="Verdana"><font size="4"><b>El botï¿½n Nuevo</b></font></font><font face="Verdana"><br>Cuando hace clic en el botï¿½n 'Nuevo' aparece una ventana para introducir la informaciï¿½n de la participaciï¿½n.</font></p>
 <table style="page-break-inside: avoid;" border="0" cellpadding="4" cellspacing="0" width="100%">
 	<col width="256*">
 	<tbody><tr>
@@ -60,27 +60,27 @@
 	<col width="170*">
 	<tbody><tr valign="top">
 		<td width="34%">
-			<p><font face="Verdana">Botón 'Mostrar página web de acciones'</font></p>
+			<p><font face="Verdana">Botï¿½n 'Mostrar pï¿½gina web de acciones'</font></p>
 		</td>
 		<td width="66%">
 			<ul>
-				<li><p><font face="Verdana">Accede a Internet para mostrar detalles de la acción, utilizando el código de símbolo.</font></p>
+				<li><p><font face="Verdana">Accede a Internet para mostrar detalles de la acciï¿½n, utilizando el cï¿½digo de sï¿½mbolo.</font></p>
 			</li></ul>
 		</td>
 	</tr>
 	<tr valign="top">
 		<td width="34%">
-			<p>Campo 'Símbolo'</p>
+			<p>Campo 'Sï¿½mbolo'</p>
 		</td>
 		<td width="66%">
 			<ul>
-				<li><p>El símbolo de la ación se puede introducir con o sin identificador de la bolsa..<br>Ej: AMP o AMP.BE</p>
+				<li><p>El sï¿½mbolo de la aciï¿½n se puede introducir con o sin identificador de la bolsa..<br>Ej: AMP o AMP.BE</p>
 				</li><li><p>Cuando
 las acciones cotizan en diferentes mercados, el sufijo puede cambiar
-dependiendo del proveedor de la cotización de acciones por Internet..</p>
+dependiendo del proveedor de la cotizaciï¿½n de acciones por Internet..</p>
 				</li><li><p>El sufijo de la bolsa de valores si se utiliza&nbsp;Yahoo es '.BE'</p>
 				</li><li><p>El sufijo de la bolsa de valores si se utiliza&nbsp;Google es ':BER'</p>
-				</li><li><p>El proveedor de la&nbsp;cotización de acciones se puede cambiar mediante la opción del menú: <b>Herramientas –&gt;Opciones –&gt; Otros</b> 
+				</li><li><p>El proveedor de la&nbsp;cotizaciï¿½n de acciones se puede cambiar mediante la opciï¿½n del menï¿½: <b>Herramientas ï¿½&gt;Opciones ï¿½&gt; Otros</b> 
 				</p>
 			</li></ul>
 		</td>
@@ -89,12 +89,12 @@ dependiendo del proveedor de la cotización de acciones por Internet..</p>
 <p><br><br>
 </p>
 <hr>
-<p><font face="Verdana"><font size="4"><b>El botón Actualizar<br></b></font></font><font face="Verdana">Si
-tiene todos los símbolos configurados correctamente para cada acción,
-cuando pulse el botón 'Actualizar', se actualizará el precio actual de
-cada acción.</font></p>
+<p><font face="Verdana"><font size="4"><b>El botï¿½n Actualizar<br></b></font></font><font face="Verdana">Si
+tiene todos los sï¿½mbolos configurados correctamente para cada acciï¿½n,
+cuando pulse el botï¿½n 'Actualizar', se actualizarï¿½ el precio actual de
+cada acciï¿½n.</font></p>
 <hr>
-<p><font face="Verdana"><font size="4"><b>El botón Preferencias</b></font></font><font face="Verdana"><br>Cuando pulse el botón 'Preferencias' aparecerá una ventana para introducir las&nbsp;opciones de configuración.</font></p>
+<p><font face="Verdana"><font size="4"><b>El botï¿½n Preferencias</b></font></font><font face="Verdana"><br>Cuando pulse el botï¿½n 'Preferencias' aparecerï¿½ una ventana para introducir las&nbsp;opciones de configuraciï¿½n.</font></p>
 <table border="0" cellpadding="4" cellspacing="0" width="100%">
 	<col width="256*">
 	<tbody><tr>
@@ -104,18 +104,18 @@ cada acción.</font></p>
 		</td>
 	</tr>
 </tbody></table>
-<p><font face="Verdana">Cuando todas sus acciones con del mismo país y
-cotizan en la misma bolsa de valores, se puede añadir el sufijo de
-Yahoo como un ajuste global para todas las acciones. Estó configurará
-el código del mercado de cotización de acciones para todas las acciones
-para permitir el uso del botón Actualizar en la página de inversión en
+<p><font face="Verdana">Cuando todas sus acciones con del mismo paï¿½s y
+cotizan en la misma bolsa de valores, se puede aï¿½adir el sufijo de
+Yahoo como un ajuste global para todas las acciones. Estï¿½ configurarï¿½
+el cï¿½digo del mercado de cotizaciï¿½n de acciones para todas las acciones
+para permitir el uso del botï¿½n Actualizar en la pï¿½gina de inversiï¿½n en
 acciones.</font></p>
 <p><font face="Verdana"><b>Ejemplo: </b></font><font face="Verdana"><span style="font-weight: normal;">Para la bolsa de valores australiana</span></font></p>
 <ul>
-	<li><p style="font-weight: normal;"><font face="Verdana">Con la cotización de Yahoo, el sufijo de la bolsa es: '.AX'</font></p>
-	</li><li><p><font face="Verdana">Con la cotización de&nbsp;Google,&nbsp;</font><font face="Verdana">el sufijo de la bolsa es</font><font face="Verdana"><span style="font-weight: normal;">: ':ASX'</span></font></p>
+	<li><p style="font-weight: normal;"><font face="Verdana">Con la cotizaciï¿½n de Yahoo, el sufijo de la bolsa es: '.AX'</font></p>
+	</li><li><p><font face="Verdana">Con la cotizaciï¿½n de&nbsp;Google,&nbsp;</font><font face="Verdana">el sufijo de la bolsa es</font><font face="Verdana"><span style="font-weight: normal;">: ':ASX'</span></font></p>
 </li></ul>
-<p>El proveedor de la cotización de acciones se puede cambiar mediante el menú: <b>Herramientas –&gt;Opciones –&gt; Otros.</b> 
+<p>El proveedor de la cotizaciï¿½n de acciones se puede cambiar mediante el menï¿½: <b>Herramientas ï¿½&gt;Opciones ï¿½&gt; Otros.</b> 
 </p>
 <p><br><br>
 </p>


### PR DESCRIPTION
* Removed absolutely redundant formatting in English help files
* Table of Contents in English help files is now generated by Javascript
* Redid the <h*> formatting in the English to generate above table of contents
* English files are virtually HMTL5 compliant
* All languages now link to the stylesheet