### PR TITLE
refactor(linux.rpm): Improved RPM build script

### DIFF
--- a/resources/mmex.desktop
+++ b/resources/mmex.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Money Manager Ex
 Exec=mmex
 Type=Application

--- a/setup/linux/build_rpm.sh
+++ b/setup/linux/build_rpm.sh
@@ -18,11 +18,9 @@ Version:        $MMEX_VERSION
 Release:        1%{?dist}
 Source:         https://github.com/moneymanagerex/moneymanagerex/archive/v%{version}.tar.gz
 Summary:        $MMEX_SUMMARY
-Group:          Applications/Productivity
 License:        GPLv2+
 Icon:           mmex.xpm
 URL:            $MMEX_HOMEPAGE
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 #Requires:    	$MMEX_RPM_DEPENDS
 
 %description
@@ -30,9 +28,8 @@ $MMEX_DESCRIPTION
 
 
 %prep
-%setup -q
-./bootstrap.sh
-
+%autosetup
+%{_builddir}/%{name}-%{version}/bootstrap.sh
 
 %build
 %configure
@@ -40,24 +37,19 @@ make %{?_smp_mflags}
 
 
 %install
-rm -rf %{buildroot}
-make install DESTDIR=%{buildroot}
+%make_install
+desktop-file-validate %{buildroot}%{_datadir}/applications/mmex.desktop
 
 
-%clean
-rm -rf %{buildroot}
-
-%find_lang %{name}
-
-%files -f %{name}.lang
-%defattr(-,root,root,-)
+%files
 %{_bindir}/*
-%{_datadir}/*
-/usr/share/icons/hicolor/scalable/apps
-/usr/share/applications
-%docdir /usr/share/doc/mmex
-/usr/share/doc/mmex/*
-%{_mandir}/man1/*
+%{_datadir}/mmex/*
+%{_datadir}/icons/hicolor/scalable/apps/mmex.svg
+%{_datadir}/applications/mmex.desktop
+%{_defaultdocdir}/mmex/*
+%{_mandir}/man1/mmex.1.gz
+
+
 
 
 %changelog" > "$BUILD_DIR/SPECS/mmex.spec"
@@ -68,15 +60,13 @@ cd ../..
 cp resources/mmex.xpm "$BUILD_DIR/SOURCES"
 
 #Copy source
-cd ..
-cp -r moneymanagerex "$BUILD_DIR/SOURCES/$PACKAGE_NAME"
-#No need to copy the git stuff over
-rm -rf "$BUILD_DIR/SOURCES/$PACKAGE_NAME/.git"
+rm -rf "$BUILD_DIR/SOURCES/$PACKAGES_NAME"
+rsync -av --progress * "$BUILD_DIR/SOURCES/$PACKAGE_NAME" --exclude .git --exclude compile
 
 cd "$BUILD_DIR/SOURCES"
 
 #Compress the source
-tar -zcvf "$PACKAGE_NAME.tar.gz" $PACKAGE_NAME
+tar -zcvf "v$MMEX_VERSION.tar.gz" $PACKAGE_NAME
 
 #Build the package
 cd "$BUILD_DIR/SPECS"

--- a/setup/linux/variables.sh
+++ b/setup/linux/variables.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Specify the build version of mmex
-MMEX_VERSION="1.2.0"
+MMEX_VERSION="1.3.0"
 MMEX_RELEASE_DATE="2015-02-09"
 MMEX_EMAIL="moneymanagerex@moneymanagerex.org"
 MMEX_HOMEPAGE="http://www.moneymanagerex.org"   
@@ -9,7 +9,7 @@ MMEX_HOMEPAGE="http://www.moneymanagerex.org"
 MMEX_DEB_DEPENDS="libc6 (>= 2.3.5-1), libwxgtk3.0-0 (>= 3.0.0)"
 MMEX_RPM_DEPENDS=""
 MMEX_DEB_BUILD_DEPENDS="libwxgtk3.0-dev (>= 3.0.0), libwebkitgtk-dev (>= 3.0.0), debhelper (>= 8.0.0), autotools-dev, python-dev (>= 2.7.3), libreadline-dev (>=6.2), gcc-4.7-base (>=4.7)"
-MMEX_RPM_BUILD_DEPENDS=""
+MMEX_RPM_BUILD_DEPENDS="bakefile, automake, gcc, gcc-c++, gettext, desktop-file-utils, wxGTK3-devel >= 3.0.0"
 MMEX_SUMMARY="Simple to use financial management software"
 MMEX_DESCRIPTION="Simple to use financial management software
  Money Manager Ex (MMEX) is a free, open-source,


### PR DESCRIPTION
# Improvements
* Added some build-deps
* Removed some deprecated things from spec file and made more use of in built macros
* rpmlint now comes back clean

# Known Issues
* wxGTK3-devel provides wx-config-3.0 instead of wx-config as needed by the build scripts
* Problem with languages
* Don't think I've got all build-deps
* Haven't listed the runtime deps