### PR TITLE
feat(currency.history): Download history from BCE

### DIFF
--- a/po/italian.po
+++ b/po/italian.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Money Manager Ex Italian Translation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-12 19:17+0100\n"
-"PO-Revision-Date: 2015-01-12 19:18+0100\n"
+"POT-Creation-Date: 2015-07-05 09:54+0200\n"
+"PO-Revision-Date: 2015-07-05 10:08+0200\n"
 "Last-Translator: Nikolay Akimov <vomikan@mail.ru>\n"
 "Language-Team: amaseb <amaseb@tiscali.it>\n"
 "Language: it\n"
@@ -11,188 +11,198 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2013-03-26 09:16+0000\n"
-"X-Generator: Poedit 1.6.10\n"
+"X-Generator: Poedit 1.8.2\n"
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: wxTRANSLATE;_\n"
 "X-Poedit-SearchPath-0: src\n"
 
-#: src/aboutdialog.cpp:42 src/aboutdialog.cpp:168
-msgid "About"
-msgstr "Informazioni"
-
 #: src/aboutdialog.cpp:44
 msgid "License agreement"
 msgstr "Contratto di licenza"
 
-#: src/aboutdialog.cpp:85
+#: src/aboutdialog.cpp:44
+#, c-format
+msgid "About %s"
+msgstr "About %s"
+
+#: src/aboutdialog.cpp:87
 msgid "Website"
 msgstr "Sito Web"
 
-#: src/aboutdialog.cpp:87
+#: src/aboutdialog.cpp:89
 msgid "Forum"
 msgstr "Forum"
 
-#: src/aboutdialog.cpp:89
+#: src/aboutdialog.cpp:91
 msgid "Wiki page"
 msgstr "Pagina wiki"
 
-#: src/aboutdialog.cpp:91
+#: src/aboutdialog.cpp:93
 msgid "Bug reports"
 msgstr "Segnalazioni bug"
 
-#: src/aboutdialog.cpp:94
+#: src/aboutdialog.cpp:96
 msgid "Follow MMEX on Facebook"
 msgstr "Segui MMEX su Facebook"
 
-#: src/aboutdialog.cpp:96
+#: src/aboutdialog.cpp:98
 msgid "Follow MMEX on Twitter"
 msgstr "Segui MMEX su Twitter"
 
-#: src/aboutdialog.cpp:98
+#: src/aboutdialog.cpp:100
 msgid "Donate"
 msgstr "Donazioni"
 
-#: src/aboutdialog.cpp:173
+#: src/aboutdialog.cpp:169
+msgid "About"
+msgstr "Informazioni"
+
+#: src/aboutdialog.cpp:174
 msgid "Developers"
 msgstr "Sviluppatori"
 
-#: src/aboutdialog.cpp:178
+#: src/aboutdialog.cpp:179
 msgid "Artwork"
 msgstr "Illustrazioni"
 
-#: src/aboutdialog.cpp:183
+#: src/aboutdialog.cpp:184
 msgid "Sponsors"
 msgstr "Promotori"
 
-#: src/aboutdialog.cpp:188
+#: src/aboutdialog.cpp:189
 msgid "License"
 msgstr "Licenza"
 
-#: src/aboutdialog.cpp:224 src/accountdialog.cpp:281
-#: src/appstartdialog.cpp:135 src/assetdialog.cpp:195
-#: src/attachmentdialog.cpp:121 src/billsdepositsdialog.cpp:609
-#: src/budgetentrydialog.cpp:158 src/budgetyeardialog.cpp:117
-#: src/budgetyearentrydialog.cpp:125 src/filtertransdialog.cpp:341
-#: src/import_export/qif_export.cpp:196 src/import_export/qif_export.cpp:220
-#: src/import_export/qif_import_gui.cpp:258 src/optionsdialog.cpp:149
-#: src/payeedialog.cpp:130 src/relocatecategorydialog.cpp:114
-#: src/relocatepayeedialog.cpp:111 src/reports/reportbase.cpp:76
-#: src/splitdetailsdialog.cpp:143 src/splittransactionsdialog.cpp:173
-#: src/transdialog.cpp:467 src/mmsinglechoicedialog.h:57
+#: src/aboutdialog.cpp:194
+msgid "Privacy"
+msgstr "Privacy"
+
+#: src/aboutdialog.cpp:232 src/accountdialog.cpp:296
+#: src/appstartdialog.cpp:136 src/assetdialog.cpp:196
+#: src/attachmentdialog.cpp:119 src/billsdepositsdialog.cpp:629
+#: src/budgetentrydialog.cpp:156 src/budgetyeardialog.cpp:115
+#: src/budgetyearentrydialog.cpp:124 src/currencydialog.cpp:221
+#: src/filtertransdialog.cpp:340 src/import_export/qif_export.cpp:208
+#: src/import_export/qif_export.cpp:232
+#: src/import_export/qif_import_gui.cpp:285 src/mmSimpleDialogs.cpp:51
+#: src/optionsdialog.cpp:149 src/payeedialog.cpp:130
+#: src/relocatecategorydialog.cpp:114 src/relocatepayeedialog.cpp:111
+#: src/reports/reportbase.cpp:76 src/splitdetailsdialog.cpp:151
+#: src/splittransactionsdialog.cpp:165 src/transdialog.cpp:475
 msgid "&OK "
 msgstr "&OK "
 
-#: src/accountdialog.cpp:61 src/mmframe.cpp:1432 src/mmframe.cpp:1621
+#: src/accountdialog.cpp:80 src/mmframe.cpp:1410 src/mmframe.cpp:1601
 #: src/wizard_newaccount.cpp:70 src/wizard_newaccount.cpp:77
 #: src/wizard_newaccount.cpp:143
 msgid "New Account"
 msgstr "Nuovo Conto"
 
-#: src/accountdialog.cpp:97 src/mmframe.cpp:1441
+#: src/accountdialog.cpp:98 src/mmframe.cpp:1419
 msgid "Edit Account"
 msgstr "Modifica Conto"
 
-#: src/accountdialog.cpp:154
+#: src/accountdialog.cpp:171
 msgid "Account Name:"
 msgstr "Nome del Conto:"
 
-#: src/accountdialog.cpp:159
+#: src/accountdialog.cpp:176
 msgid "Account Type:"
 msgstr "Tipo di Conto:"
 
-#: src/accountdialog.cpp:168
+#: src/accountdialog.cpp:185
 msgid "Account Status:"
 msgstr "Stato del Conto:"
 
-#: src/accountdialog.cpp:177
+#: src/accountdialog.cpp:194
 #, c-format
 msgid "Initial Balance: %s"
 msgstr "Saldo iniziale: %s"
 
-#: src/accountdialog.cpp:186 src/import_export/univcsvdialog.cpp:1232
+#: src/accountdialog.cpp:201 src/import_export/univcsvdialog.cpp:1229
 msgid "Currency:"
 msgstr "Valuta:"
 
-#: src/accountdialog.cpp:188 src/currencydialog.cpp:74
+#: src/accountdialog.cpp:203 src/currencydialog.cpp:85
 msgid "Select Currency"
 msgstr "Seleziona Valuta"
 
-#: src/accountdialog.cpp:199
+#: src/accountdialog.cpp:214
 msgid "Favorite Account"
 msgstr "Conto Preferito"
 
-#: src/accountdialog.cpp:209 src/assetdialog.cpp:177 src/assetspanel.cpp:488
-#: src/billsdepositsdialog.cpp:576 src/billsdepositspanel.cpp:215
-#: src/filtertransdialog.cpp:306 src/import_export/qif_import_gui.cpp:84
-#: src/import_export/univcsvdialog.cpp:77
-#: src/import_export/univcsvdialog.cpp:933 src/mmcheckingpanel.cpp:1019
-#: src/reports/transactions.cpp:72 src/stockdialog.cpp:245
-#: src/stockspanel.cpp:97 src/transdialog.cpp:436 src/webappdialog.cpp:86
+#: src/accountdialog.cpp:224 src/assetdialog.cpp:178 src/assetspanel.cpp:78
+#: src/billsdepositsdialog.cpp:596 src/billsdepositspanel.cpp:122
+#: src/filtertransdialog.cpp:305 src/import_export/qif_import_gui.cpp:99
+#: src/import_export/univcsvdialog.cpp:82
+#: src/import_export/univcsvdialog.cpp:930 src/mmcheckingpanel.cpp:982
+#: src/reports/transactions.cpp:72 src/stockdialog.cpp:249
+#: src/stockspanel.cpp:105 src/transdialog.cpp:444 src/webappdialog.cpp:86
 msgid "Notes"
 msgstr "Note"
 
-#: src/accountdialog.cpp:219 src/model/Model_Category.cpp:111
+#: src/accountdialog.cpp:234 src/model/Model_Category.cpp:111
 #: src/model/Model_Category.cpp:121 src/model/Model_Category.cpp:165
 #: src/optionsdialog.cpp:133
 msgid "Others"
 msgstr "Altro"
 
-#: src/accountdialog.cpp:228
+#: src/accountdialog.cpp:243
 msgid "Card Number:"
 msgstr "Numero Carta:"
 
-#: src/accountdialog.cpp:228
+#: src/accountdialog.cpp:243
 msgid "Account Number:"
 msgstr "Numero del Conto:"
 
-#: src/accountdialog.cpp:234
+#: src/accountdialog.cpp:249
 msgid "Held At:"
 msgstr "Tenuto presso:"
 
-#: src/accountdialog.cpp:240
+#: src/accountdialog.cpp:255
 msgid "Website:"
 msgstr "Sito Web:"
 
-#: src/accountdialog.cpp:246
+#: src/accountdialog.cpp:261
 msgid "Contact:"
 msgstr "Contatto:"
 
-#: src/accountdialog.cpp:252
+#: src/accountdialog.cpp:267
 msgid "Access Info:"
 msgstr "Informazioni di Accesso:"
 
-#: src/accountdialog.cpp:276
+#: src/accountdialog.cpp:291
 msgid "Organize attachments of this account"
 msgstr "Organizza gli allegati di questo conto"
 
-#: src/accountdialog.cpp:284 src/assetdialog.cpp:198
-#: src/attachmentdialog.cpp:122 src/billsdepositsdialog.cpp:612
-#: src/budgetentrydialog.cpp:161 src/budgetyeardialog.cpp:120
-#: src/budgetyearentrydialog.cpp:128 src/categdialog.cpp:242
-#: src/filtertransdialog.cpp:343 src/import_export/qif_export.cpp:197
-#: src/import_export/qif_export.cpp:222
-#: src/import_export/qif_import_gui.cpp:259
-#: src/import_export/univcsvdialog.cpp:324 src/maincurrencydialog.cpp:202
-#: src/optionsdialog.cpp:151 src/payeedialog.cpp:131
-#: src/relocatecategorydialog.cpp:115 src/relocatepayeedialog.cpp:112
-#: src/reports/reportbase.cpp:78 src/splitdetailsdialog.cpp:146
-#: src/splittransactionsdialog.cpp:174 src/transdialog.cpp:468
-#: src/webappdialog.cpp:99 src/mmsinglechoicedialog.h:59
+#: src/accountdialog.cpp:299 src/assetdialog.cpp:199
+#: src/attachmentdialog.cpp:120 src/billsdepositsdialog.cpp:632
+#: src/budgetentrydialog.cpp:159 src/budgetyeardialog.cpp:118
+#: src/budgetyearentrydialog.cpp:127 src/categdialog.cpp:238
+#: src/filtertransdialog.cpp:342 src/import_export/qif_export.cpp:209
+#: src/import_export/qif_export.cpp:234
+#: src/import_export/qif_import_gui.cpp:286
+#: src/import_export/univcsvdialog.cpp:327 src/maincurrencydialog.cpp:219
+#: src/mmSimpleDialogs.cpp:53 src/optionsdialog.cpp:151
+#: src/payeedialog.cpp:131 src/relocatecategorydialog.cpp:115
+#: src/relocatepayeedialog.cpp:112 src/reports/reportbase.cpp:78
+#: src/splitdetailsdialog.cpp:154 src/splittransactionsdialog.cpp:166
+#: src/transdialog.cpp:476 src/webappdialog.cpp:99
 msgid "&Cancel "
 msgstr "&Cancella"
 
-#: src/accountdialog.cpp:291
+#: src/accountdialog.cpp:304
 msgid "Enter the Name of the Account. This name can be renamed at any time."
 msgstr ""
 "Inserire il nome del Conto. Questo nome può essere cambiato in qualsiasi "
 "momento"
 
-#: src/accountdialog.cpp:292 src/wizard_newaccount.cpp:110
+#: src/accountdialog.cpp:305 src/wizard_newaccount.cpp:110
 msgid "Specify the type of account to be created."
 msgstr "Specificare il tipo di conto da creare"
 
-#: src/accountdialog.cpp:293
+#: src/accountdialog.cpp:306
 msgid ""
 "Specify if this account has been closed. Closed accounts are inactive in "
 "most calculations, reporting etc."
@@ -200,15 +210,15 @@ msgstr ""
 "Specificare se questo conto è chiuso. I conti chiusi sono inattivi nella "
 "maggior parte delle analisi, resoconti, ecc."
 
-#: src/accountdialog.cpp:294
+#: src/accountdialog.cpp:307
 msgid "Enter the initial balance in this account."
 msgstr "Inserire il saldo iniziale di questo conto"
 
-#: src/accountdialog.cpp:295
+#: src/accountdialog.cpp:308
 msgid "Specify the currency to be used by this account."
 msgstr "Specificare la valuta da utilizzare in questo conto"
 
-#: src/accountdialog.cpp:296
+#: src/accountdialog.cpp:309
 msgid ""
 "Select whether this is an account that is used often. This is used to filter "
 "accounts display view."
@@ -216,29 +226,29 @@ msgstr ""
 "Da selezionare se è un conto di utilizzo frequente. Questa opzione è "
 "utilizzata per filtrare i dati da visualizzare"
 
-#: src/accountdialog.cpp:297
+#: src/accountdialog.cpp:310
 msgid "Enter user notes and details about this account."
 msgstr "Inserire commenti e dettagli su questo conto"
 
-#: src/accountdialog.cpp:298
+#: src/accountdialog.cpp:311
 msgid "Enter the Account Number associated with this account."
 msgstr "Inserire il numero di Conto associato a questo conto"
 
-#: src/accountdialog.cpp:299
+#: src/accountdialog.cpp:312
 msgid ""
 "Enter the name of the financial institution in which the account is held."
 msgstr ""
 "Inserire il nome dell'istituto finanziario presso cui è tenuto il conto"
 
-#: src/accountdialog.cpp:300
+#: src/accountdialog.cpp:313
 msgid "Enter the URL of the website for the financial institution."
 msgstr "Inserire l'URL del sito dell'istituto finanziario"
 
-#: src/accountdialog.cpp:301
+#: src/accountdialog.cpp:314
 msgid "Enter any contact information for the financial institution."
 msgstr "Inserire le informazioni di contatto con l'istituto finanziario"
 
-#: src/accountdialog.cpp:302
+#: src/accountdialog.cpp:315
 msgid ""
 "Enter any login/access information for the financial institution. This is "
 "not secure as anyone with access to the mmb file can access it."
@@ -246,200 +256,208 @@ msgstr ""
 "Inserire il login per l'accesso alle informazioni dell'istituto finanziario. "
 "Non è sicuro, dato che chiunque abbia accesso al file MMB può accedervi"
 
-#: src/accountdialog.cpp:335
+#: src/accountdialog.cpp:349
 msgid "Account Name "
 msgstr "Nome del Conto "
 
-#: src/accountdialog.cpp:341 src/import_export/qif_import_gui.cpp:215
-#: src/mmOptionGeneralSettings.cpp:71
+#: src/accountdialog.cpp:353 src/import_export/qif_import_gui.cpp:238
+#: src/mmOptionGeneralSettings.cpp:92
 msgid "Currency"
 msgstr "Valuta"
 
-#: src/accountdialog.cpp:392
+#: src/accountdialog.cpp:400
 msgid "Default Image"
 msgstr "Immagine predefinita:"
 
-#: src/accountdialog.cpp:399
+#: src/accountdialog.cpp:407
 #, c-format
 msgid "Image #%i"
 msgstr "Immagine #%i"
 
-#: src/appstartdialog.cpp:98
+#: src/appstartdialog.cpp:99
 msgid "Open Last Opened Database"
 msgstr "Apri l'ultimo Database aperto"
 
-#: src/appstartdialog.cpp:101
+#: src/appstartdialog.cpp:102
 msgid "Create a New Database"
 msgstr "Crea un Nuovo Database"
 
-#: src/appstartdialog.cpp:102
+#: src/appstartdialog.cpp:103
 msgid "Create a new database file to get started"
 msgstr "Per iniziare, crea un nuovo Database"
 
-#: src/appstartdialog.cpp:105
+#: src/appstartdialog.cpp:106
 msgid "Open Existing Database"
 msgstr "Apri un Database esistente"
 
-#: src/appstartdialog.cpp:106
+#: src/appstartdialog.cpp:107
 msgid "Open an already created database file with extension (*.mmb)"
 msgstr "Apri un Database con estensione (*.mmb) precedentemente creato"
 
-#: src/appstartdialog.cpp:109
+#: src/appstartdialog.cpp:110
 msgid "Read Documentation"
 msgstr "Documentazione"
 
-#: src/appstartdialog.cpp:110
+#: src/appstartdialog.cpp:111
 msgid "Read the user manual"
 msgstr "Manuale utente"
 
-#: src/appstartdialog.cpp:113
+#: src/appstartdialog.cpp:114
 msgid "Visit Website for more information"
 msgstr "Visita il sito web per ulteriori informazioni"
 
-#: src/appstartdialog.cpp:114
+#: src/appstartdialog.cpp:115
 #, c-format
 msgid "Open the %s website for latest news, updates etc"
 msgstr "Apri il sito %s per le ultime novità, aggiornamenti ecc."
 
-#: src/appstartdialog.cpp:122
+#: src/appstartdialog.cpp:123
 #, c-format
 msgid "Show this window next time %s starts"
 msgstr "Mostra questa finestra ai prossimi avvii di %s"
 
-#: src/appstartdialog.cpp:136
+#: src/appstartdialog.cpp:137
 msgid "&Exit "
 msgstr "&Esci "
 
-#: src/appstartdialog.cpp:152
+#: src/appstartdialog.cpp:153
 #, c-format
 msgid "Open the previously opened database : %s"
 msgstr "Apri il database precedentemente aperto : %s"
 
-#: src/assetdialog.cpp:52
+#: src/assetdialog.cpp:55
 msgid "New/Edit Asset"
 msgstr "Nuovo/Modifica Bene"
 
-#: src/assetdialog.cpp:105
+#: src/assetdialog.cpp:106
 msgid "Asset Details"
 msgstr "Dettagli del Bene"
 
-#: src/assetdialog.cpp:117 src/assetspanel.cpp:469
-#: src/import_export/qif_import_gui.cpp:214
-#: src/import_export/qif_import_gui.cpp:227
-#: src/import_export/qif_import_gui.cpp:238 src/maincurrencydialog.cpp:60
-#: src/payeedialog.cpp:67 src/reports/summarystocks.cpp:179
+#: src/assetdialog.cpp:118 src/assetspanel.cpp:73
+#: src/import_export/qif_import_gui.cpp:237
+#: src/import_export/qif_import_gui.cpp:250
+#: src/import_export/qif_import_gui.cpp:261 src/maincurrencydialog.cpp:75
+#: src/payeedialog.cpp:67 src/reports/summarystocks.cpp:172
 msgid "Name"
 msgstr "Nome"
 
-#: src/assetdialog.cpp:122
+#: src/assetdialog.cpp:123
 msgid "Enter the name of the asset"
 msgstr "Inserire il nome del Bene"
 
-#: src/assetdialog.cpp:125 src/assetspanel.cpp:484
-#: src/billsdepositsdialog.cpp:465 src/import_export/qif_import_gui.cpp:78
-#: src/import_export/univcsvdialog.cpp:71
-#: src/import_export/univcsvdialog.cpp:935 src/mmcheckingpanel.cpp:1003
-#: src/reports/cashflow.cpp:268 src/reports/summary.cpp:222
-#: src/reports/transactions.cpp:65 src/stockdialog.cpp:176
-#: src/stockdialog.cpp:280 src/stockdialog.cpp:599 src/transdialog.cpp:328
+#: src/assetdialog.cpp:126 src/assetspanel.cpp:74
+#: src/import_export/qif_import_gui.cpp:93
+#: src/import_export/univcsvdialog.cpp:76
+#: src/import_export/univcsvdialog.cpp:932 src/maincurrencydialog.cpp:238
+#: src/maincurrencydialog.cpp:263 src/mmcheckingpanel.cpp:974
+#: src/reports/cashflow.cpp:269 src/reports/summary.cpp:223
+#: src/reports/transactions.cpp:65 src/stockdialog.cpp:180
+#: src/stockdialog.cpp:284 src/stockdialog.cpp:603 src/transdialog.cpp:336
 #: src/webappdialog.cpp:79
 msgid "Date"
 msgstr "Data"
 
-#: src/assetdialog.cpp:130
+#: src/assetdialog.cpp:131
 msgid "Specify the date of purchase of asset"
 msgstr "Indicare la data di acquisto del Bene"
 
-#: src/assetdialog.cpp:132
+#: src/assetdialog.cpp:133
 msgid "Asset Type"
 msgstr "Tipo di Bene"
 
-#: src/assetdialog.cpp:138
+#: src/assetdialog.cpp:139
 msgid "Select type of asset"
 msgstr "Selezionare il tipo di bene"
 
-#: src/assetdialog.cpp:143 src/import_export/qif_import_gui.cpp:83
-#: src/reports/summarystocks.cpp:187 src/stockdialog.cpp:240
+#: src/assetdialog.cpp:144 src/import_export/qif_import_gui.cpp:98
+#: src/maincurrencydialog.cpp:245 src/maincurrencydialog.cpp:270
+#: src/reports/summarystocks.cpp:147 src/reports/summarystocks.cpp:180
+#: src/stockdialog.cpp:244
 msgid "Value"
 msgstr "Valore"
 
-#: src/assetdialog.cpp:150
+#: src/assetdialog.cpp:151
 msgid "Enter the current value of the asset"
 msgstr "Inserire il valore del bene alla data di acquisto"
 
-#: src/assetdialog.cpp:155
+#: src/assetdialog.cpp:156
 msgid "Change in Value"
 msgstr "Variazioni di Valore"
 
-#: src/assetdialog.cpp:161
+#: src/assetdialog.cpp:162
 msgid "Specify if the value of the asset changes over time"
 msgstr "Specificare se il valore del bene varia nel tempo"
 
-#: src/assetdialog.cpp:165
+#: src/assetdialog.cpp:166
 msgid "% Rate"
 msgstr "% Tasso"
 
-#: src/assetdialog.cpp:171
+#: src/assetdialog.cpp:172
 #, c-format
 msgid "Enter the rate at which the asset changes its value in % per year"
 msgstr "Inserire il tasso di variazione di valore del Bene in % per anno"
 
-#: src/assetdialog.cpp:183
+#: src/assetdialog.cpp:184
 msgid "Organize attachments of this asset"
 msgstr "Organizza gli allegati di questo bene"
 
-#: src/assetdialog.cpp:186
+#: src/assetdialog.cpp:187
 msgid "Enter notes associated with this asset"
 msgstr "Inserire delle note associate a questo bene"
 
-#: src/assetspanel.cpp:97
+#: src/assetspanel.cpp:72 src/billsdepositspanel.cpp:108
+#: src/mmcheckingpanel.cpp:973 src/stockspanel.cpp:93
+msgid "ID"
+msgstr "ID"
+
+#: src/assetspanel.cpp:75 src/billsdepositsdialog.cpp:521
+#: src/billsdepositspanel.cpp:115 src/filtertransdialog.cpp:250
+#: src/import_export/qif_import_gui.cpp:96 src/mmhomepagepanel.cpp:766
+#: src/reports/budgetingperf.cpp:130 src/reports/incexpenses.cpp:123
+#: src/reports/transactions.cpp:70 src/splitdetailsdialog.cpp:113
+#: src/transdialog.cpp:369 src/webappdialog.cpp:82
+msgid "Type"
+msgstr "Tipo"
+
+#: src/assetspanel.cpp:76
+msgid "Initial Value"
+msgstr "Valore Iniziale"
+
+#: src/assetspanel.cpp:77
+msgid "Current Value"
+msgstr "Valore Attuale"
+
+#: src/assetspanel.cpp:99
 msgid "&New Asset"
 msgstr "&Nuovo Bene"
 
-#: src/assetspanel.cpp:99
+#: src/assetspanel.cpp:101
 msgid "D&uplicate Asset"
 msgstr "D&uplica Bene"
 
-#: src/assetspanel.cpp:101
+#: src/assetspanel.cpp:103
 msgid "&Edit Asset"
 msgstr "&Modifica Bene"
 
-#: src/assetspanel.cpp:102
+#: src/assetspanel.cpp:104
 msgid "&Delete Asset"
 msgstr "&Elimina Bene"
 
-#: src/assetspanel.cpp:104 src/billsdepositspanel.cpp:482
-#: src/mmcheckingpanel.cpp:1099 src/mmframe.cpp:1120 src/payeedialog.cpp:376
-#: src/stockspanel.cpp:158
+#: src/assetspanel.cpp:106 src/billsdepositspanel.cpp:421
+#: src/mmcheckingpanel.cpp:1086 src/mmframe.cpp:1127 src/payeedialog.cpp:376
+#: src/stockspanel.cpp:147
 msgid "&Organize Attachments"
 msgstr "&Organizza gli Allegati"
 
-#: src/assetspanel.cpp:193
+#: src/assetspanel.cpp:195
 msgid "Do you really want to delete the Asset?"
 msgstr "Vuoi davvero cancellare il Bene?"
 
-#: src/assetspanel.cpp:194
+#: src/assetspanel.cpp:196
 msgid "Confirm Asset Deletion"
 msgstr "Conferma cancellazione del Bene"
 
-#: src/assetspanel.cpp:322 src/billsdepositspanel.cpp:154
-#: src/budgetingpanel.cpp:526 src/mmcheckingpanel.cpp:1245
-#: src/stockspanel.cpp:383
-msgid "Hide column"
-msgstr "Nascondi colonna"
-
-#: src/assetspanel.cpp:323 src/billsdepositspanel.cpp:155
-#: src/mmcheckingpanel.cpp:1246 src/stockspanel.cpp:384
-msgid "Order by this column"
-msgstr "Ordina per questa colonna"
-
-#: src/assetspanel.cpp:324 src/billsdepositspanel.cpp:156
-#: src/budgetingpanel.cpp:528 src/mmcheckingpanel.cpp:1247
-#: src/stockspanel.cpp:385
-msgid "Reset columns size"
-msgstr "Resetta dimensioni colonne"
-
-#: src/assetspanel.cpp:394
+#: src/assetspanel.cpp:354
 msgid ""
 "MMEX allows you to track fixed assets like cars, houses, land and others. "
 "Each asset can have its value appreciate by a certain rate per year, "
@@ -451,198 +469,176 @@ msgstr ""
 "tasso annuo, o conservare inalterato il proprio valore. Il valore totale dei "
 "beni è incluso nel valore finanziario complessivo."
 
-#: src/assetspanel.cpp:421 src/general_report_manager.cpp:658
-#: src/general_report_manager.cpp:866 src/mmframe.cpp:727 src/mmframe.cpp:1502
-#: src/mmhomepagepanel.cpp:418 src/mmhomepagepanel.cpp:787
-#: src/reports/summary.cpp:179 src/assetspanel.h:94
+#: src/assetspanel.cpp:381 src/general_report_manager.cpp:667
+#: src/general_report_manager.cpp:942 src/mmframe.cpp:729 src/mmframe.cpp:1480
+#: src/mmhomepagepanel.cpp:427 src/mmhomepagepanel.cpp:793
+#: src/reports/summary.cpp:179 src/assetspanel.h:85
 msgid "Assets"
 msgstr "Beni"
 
-#: src/assetspanel.cpp:434 src/assetspanel.cpp:707 src/assetspanel.cpp:724
-#: src/import_export/qif_export.cpp:62 src/import_export/qif_export.cpp:63
-#: src/import_export/qif_export.cpp:127 src/mmOptionViewSettings.cpp:184
-#: src/mmframe.cpp:1162
+#: src/assetspanel.cpp:394 src/assetspanel.cpp:647 src/assetspanel.cpp:664
+#: src/import_export/qif_export.cpp:63 src/import_export/qif_export.cpp:64
+#: src/import_export/qif_export.cpp:125 src/mmframe.cpp:1177
 msgid "All"
 msgstr "Tutti"
 
-#: src/assetspanel.cpp:465 src/billsdepositspanel.cpp:201
-#: src/mmcheckingpanel.cpp:1001 src/stockspanel.cpp:85
-msgid "ID"
-msgstr "ID"
-
-#: src/assetspanel.cpp:472 src/billsdepositsdialog.cpp:501
-#: src/billsdepositspanel.cpp:208 src/filtertransdialog.cpp:251
-#: src/import_export/qif_import_gui.cpp:81 src/mmhomepagepanel.cpp:760
-#: src/reports/budgetingperf.cpp:129 src/reports/incexpenses.cpp:123
-#: src/reports/transactions.cpp:70 src/splitdetailsdialog.cpp:105
-#: src/transdialog.cpp:361 src/webappdialog.cpp:82
-msgid "Type"
-msgstr "Tipo"
-
-#: src/assetspanel.cpp:476
-msgid "Initial Value"
-msgstr "Valore Iniziale"
-
-#: src/assetspanel.cpp:480
-msgid "Current Value"
-msgstr "Valore Attuale"
-
-#: src/assetspanel.cpp:505 src/billsdepositspanel.cpp:335
-#: src/mmcheckingpanel.cpp:479 src/stockspanel.cpp:536
+#: src/assetspanel.cpp:445 src/billsdepositspanel.cpp:281
+#: src/mmcheckingpanel.cpp:466 src/stockspanel.cpp:483
 msgid "&New "
 msgstr "&Nuovo "
 
-#: src/assetspanel.cpp:506
+#: src/assetspanel.cpp:446
 msgid "New Asset"
 msgstr "Nuovo Bene"
 
-#: src/assetspanel.cpp:509 src/attachmentdialog.cpp:283
-#: src/billsdepositspanel.cpp:339 src/categdialog.cpp:226
-#: src/maincurrencydialog.cpp:182 src/mmcheckingpanel.cpp:483
-#: src/payeedialog.cpp:370 src/splittransactionsdialog.cpp:167
-#: src/stockspanel.cpp:540
+#: src/assetspanel.cpp:449 src/attachmentdialog.cpp:289
+#: src/billsdepositspanel.cpp:285 src/categdialog.cpp:222
+#: src/maincurrencydialog.cpp:200 src/mmcheckingpanel.cpp:470
+#: src/payeedialog.cpp:370 src/splittransactionsdialog.cpp:159
+#: src/stockspanel.cpp:487
 msgid "&Edit "
 msgstr "&Modifica "
 
-#: src/assetspanel.cpp:510
+#: src/assetspanel.cpp:450
 msgid "Edit Asset"
 msgstr "Modifica Bene"
 
-#: src/assetspanel.cpp:514 src/billsdepositspanel.cpp:344
-#: src/budgetyeardialog.cpp:104 src/categdialog.cpp:230
-#: src/mmcheckingpanel.cpp:488 src/mmcheckingpanel.cpp:1118
-#: src/stockdialog.cpp:310 src/stockspanel.cpp:545
+#: src/assetspanel.cpp:454 src/billsdepositspanel.cpp:290
+#: src/budgetyeardialog.cpp:102 src/categdialog.cpp:226
+#: src/maincurrencydialog.cpp:288 src/mmcheckingpanel.cpp:475
+#: src/mmcheckingpanel.cpp:1105 src/stockdialog.cpp:314
+#: src/stockspanel.cpp:492
 msgid "&Delete "
 msgstr "&Elimina"
 
-#: src/assetspanel.cpp:515
+#: src/assetspanel.cpp:455
 msgid "Delete Asset"
 msgstr "Cancella il Bene"
 
-#: src/assetspanel.cpp:522 src/billsdepositspanel.cpp:362
-#: src/mmcheckingpanel.cpp:501 src/stockspanel.cpp:558
+#: src/assetspanel.cpp:462 src/billsdepositspanel.cpp:308
+#: src/mmcheckingpanel.cpp:488 src/stockspanel.cpp:505
 msgid "Open attachments"
 msgstr "Apri allegati"
 
-#: src/assetspanel.cpp:529 src/assetspanel.cpp:530 src/mmcheckingpanel.cpp:509
+#: src/assetspanel.cpp:469 src/assetspanel.cpp:470 src/mmcheckingpanel.cpp:496
 msgid "Search"
 msgstr "Ricerca"
 
-#: src/assetspanel.cpp:532
+#: src/assetspanel.cpp:472
 msgid "Enter any string to find related assets"
 msgstr "Inserire un testo per trovare i beni relativi"
 
-#: src/assetspanel.cpp:602 src/stockspanel.cpp:715 src/stockspanel.cpp:933
+#: src/assetspanel.cpp:542 src/stockspanel.cpp:668 src/stockspanel.cpp:886
 #, c-format
 msgid "Total: %s"
 msgstr "Totale: %s"
 
-#: src/assetspanel.cpp:674
+#: src/assetspanel.cpp:614
 #, c-format
 msgid "Change in Value: %s %s"
 msgstr "Variazioni di Valore: %s %s"
 
-#: src/attachmentdialog.cpp:54 src/import_export/qif_import_gui.cpp:76
-#: src/import_export/univcsvdialog.cpp:924 src/payeedialog.cpp:66
+#: src/attachmentdialog.cpp:55 src/import_export/qif_import_gui.cpp:91
+#: src/import_export/univcsvdialog.cpp:921 src/payeedialog.cpp:66
 msgid "#"
 msgstr "#"
 
-#: src/attachmentdialog.cpp:55 src/general_report_manager.cpp:405
+#: src/attachmentdialog.cpp:56 src/general_report_manager.cpp:407
 msgid "Description"
 msgstr "Descrizione"
 
-#: src/attachmentdialog.cpp:56 src/import_export/univcsvdialog.cpp:147
+#: src/attachmentdialog.cpp:57 src/import_export/univcsvdialog.cpp:150
 msgid "File"
 msgstr "File"
 
-#: src/attachmentdialog.cpp:64
+#: src/attachmentdialog.cpp:65
 msgid "Attachment folder not defined."
 msgstr "Cartella allegati non impostata."
 
-#: src/attachmentdialog.cpp:65
+#: src/attachmentdialog.cpp:66
 msgid "Please set it in Tools -> Options -> Attachments"
 msgstr "Configurala in Strumenti -> Opzioni -> Allegati"
 
-#: src/attachmentdialog.cpp:66
+#: src/attachmentdialog.cpp:67
 msgid "Attachment folder not defined"
 msgstr "Cartella allegati non impostata"
 
-#: src/attachmentdialog.cpp:70
+#: src/attachmentdialog.cpp:71
 msgid "Unable to find attachments folder:"
 msgstr "Impossibile trovare la cartella degli allegati:"
 
-#: src/attachmentdialog.cpp:73
+#: src/attachmentdialog.cpp:74
 msgid "Please verify that above path is correct"
 msgstr "Verificare che il percorso sia corretto"
 
-#: src/attachmentdialog.cpp:74
+#: src/attachmentdialog.cpp:75
 msgid "Attachments folder not found"
 msgstr "Cartella allegati non trovata"
 
-#: src/attachmentdialog.cpp:85
+#: src/attachmentdialog.cpp:86
 #, c-format
 msgid "Organize Attachments | %s %i"
 msgstr "Organizza allegati | %s %i"
 
-#: src/attachmentdialog.cpp:87
+#: src/attachmentdialog.cpp:88
 #, c-format
 msgid "Organize Attachments | New %s"
 msgstr "Organizza allegati | Nuovo %s"
 
-#: src/attachmentdialog.cpp:129 src/payeedialog.cpp:120
+#: src/attachmentdialog.cpp:127 src/payeedialog.cpp:120
 msgid "Other tools"
 msgstr "Altre opzioni"
 
-#: src/attachmentdialog.cpp:168
+#: src/attachmentdialog.cpp:166
 msgid "Import attachment:"
 msgstr "Aggiungi allegato:"
 
-#: src/attachmentdialog.cpp:178
+#: src/attachmentdialog.cpp:176
 msgid "Enter a description for the new attachment:"
 msgstr "Inserire il nome del nuovo allegato:"
 
-#: src/attachmentdialog.cpp:179
+#: src/attachmentdialog.cpp:177
 msgid "Organize Attachments: Add Attachment"
 msgstr "Organizza allegati: aggiungi allegato"
 
-#: src/attachmentdialog.cpp:215
-msgid "Modify the description for the attachment:"
-msgstr "Modifica la descrizione dell'allegato"
+#: src/attachmentdialog.cpp:218
+msgid "Enter a new description for the attachment:"
+msgstr "Inserire un nuovo nome per l'allegato:"
 
-#: src/attachmentdialog.cpp:216
+#: src/attachmentdialog.cpp:219
 msgid "Organize Attachments: Edit Attachment"
 msgstr "Organizza allegati: modifica allegato"
 
-#: src/attachmentdialog.cpp:235
+#: src/attachmentdialog.cpp:243
 msgid "Do you really want to delete this attachment?"
 msgstr "Vuoi davvero eliminare l'allegato?"
 
-#: src/attachmentdialog.cpp:236
+#: src/attachmentdialog.cpp:244
 msgid "Confirm Attachment Deletion"
 msgstr "Conferma eliminazione allegato"
 
-#: src/attachmentdialog.cpp:280 src/categdialog.cpp:222
-#: src/import_export/univcsvdialog.cpp:200 src/maincurrencydialog.cpp:179
-#: src/payeedialog.cpp:369 src/splittransactionsdialog.cpp:166
-#: src/stockdialog.cpp:312
+#: src/attachmentdialog.cpp:286 src/categdialog.cpp:218
+#: src/import_export/univcsvdialog.cpp:203 src/maincurrencydialog.cpp:197
+#: src/payeedialog.cpp:369 src/splittransactionsdialog.cpp:158
+#: src/stockdialog.cpp:316
 msgid "&Add "
 msgstr "&Aggiungi "
 
-#: src/attachmentdialog.cpp:282
+#: src/attachmentdialog.cpp:288
 msgid "&Open "
 msgstr "&Apri"
 
-#: src/attachmentdialog.cpp:285 src/import_export/univcsvdialog.cpp:204
-#: src/maincurrencydialog.cpp:186 src/payeedialog.cpp:372
-#: src/splittransactionsdialog.cpp:168
+#: src/attachmentdialog.cpp:291 src/import_export/univcsvdialog.cpp:207
+#: src/maincurrencydialog.cpp:204 src/payeedialog.cpp:372
+#: src/splittransactionsdialog.cpp:160
 msgid "&Remove "
 msgstr "&Rimuovi "
 
-#: src/attachmentdialog.cpp:336
+#: src/attachmentdialog.cpp:342
 msgid "Att."
 msgstr "All."
 
-#: src/attachmentdialog.cpp:343
+#: src/attachmentdialog.cpp:349
 msgid ""
 "This directory and its files are automatically managed by Money Manager EX "
 "software."
@@ -650,457 +646,458 @@ msgstr ""
 "Questa cartella e i suoi file sono gestiti automaticamente dal software "
 "Money Manager EX."
 
-#: src/attachmentdialog.cpp:345
+#: src/attachmentdialog.cpp:351
 msgid "Please do not remove, rename or modify manually directories and files."
 msgstr ""
 "Non rimovere, rinominare o modificare manualmente le cartelle e i file."
 
-#: src/attachmentdialog.cpp:379 src/attachmentdialog.cpp:387
+#: src/attachmentdialog.cpp:385 src/attachmentdialog.cpp:393
 msgid "Destination file already exist:"
 msgstr "File di destinazione già presente:"
 
-#: src/attachmentdialog.cpp:382
+#: src/attachmentdialog.cpp:388
 msgid "File not found in attachments. Please delete or rename it."
 msgstr "File non trovato. Eliminarlo o rinominarlo per risolvere."
 
-#: src/attachmentdialog.cpp:383 src/attachmentdialog.cpp:391
+#: src/attachmentdialog.cpp:389 src/attachmentdialog.cpp:397
 msgid "Destination file already exist"
 msgstr "File di destinazione già presente"
 
-#: src/attachmentdialog.cpp:390
+#: src/attachmentdialog.cpp:396
 msgid "File already found in attachments"
 msgstr "File già presente tra gli allegati"
 
-#: src/attachmentdialog.cpp:433
+#: src/attachmentdialog.cpp:439
 msgid "Attachment not found:"
 msgstr "Allegato non trovato:"
 
-#: src/attachmentdialog.cpp:436
+#: src/attachmentdialog.cpp:442
 msgid "Do you want to continue and delete attachment on database?"
 msgstr "Vuoi davvero continuare ed eliminare l'allegato dal database?"
 
-#: src/attachmentdialog.cpp:437
+#: src/attachmentdialog.cpp:443
 msgid "Delete attachment failed"
 msgstr "Eliminazione allegato fallita"
 
-#: src/attachmentdialog.cpp:450
+#: src/attachmentdialog.cpp:456
 msgid "Unable to open file:"
 msgstr "Impossibile aprire il file:"
 
-#: src/attachmentdialog.cpp:453
+#: src/attachmentdialog.cpp:459
 msgid "Please verify that file exists and user has rights to read it."
 msgstr "Verificare che il file esiste e l'utente ha i diritti per leggerlo"
 
-#: src/attachmentdialog.cpp:454
+#: src/attachmentdialog.cpp:460
 msgid "Open attachment failed"
 msgstr "Apertura allegato fallita"
 
-#: src/billsdepositsdialog.cpp:116
-msgid "New Repeating Transaction"
-msgstr "Nuova Operazione Ricorrente"
+#: src/billsdepositsdialog.cpp:117
+msgid "New Recurring Transaction"
+msgstr "Nuova transazione ricorrente"
+
+#: src/billsdepositsdialog.cpp:137
+msgid " Edit Recurring Transaction"
+msgstr "Modificare transazione ricorrente"
 
 #: src/billsdepositsdialog.cpp:141
-msgid " Edit Repeating Transaction"
-msgstr "Modifica Operazione Ricorrente"
+msgid " Enter Recurring Transaction"
+msgstr "Inserire transazione ricorrente"
 
-#: src/billsdepositsdialog.cpp:146
-msgid " Enter Repeating Transaction"
-msgstr "Inserisci Operazione Ricorrente"
-
-#: src/billsdepositsdialog.cpp:288
-msgid "Note: Split transactions not set"
-msgstr "Nota: Categorie suddivisa non impostata"
-
-#: src/billsdepositsdialog.cpp:288
-msgid "Reoccuring Transaction Creation"
-msgstr "Creazione Operazione Ricorrente"
-
-#: src/billsdepositsdialog.cpp:305 src/billsdepositspanel.cpp:56
-#: src/filtertransdialog.cpp:49 src/mmOptionMiscSettings.cpp:54
+#: src/billsdepositsdialog.cpp:317 src/billsdepositspanel.cpp:52
+#: src/filtertransdialog.cpp:48 src/mmOptionMiscSettings.cpp:74
 #: src/model/Model_Asset.cpp:23 src/model/Model_Billsdeposits.cpp:34
 #: src/model/Model_Budget.cpp:54 src/model/Model_Checking.cpp:34
+#: src/reports/cashflow.cpp:256
 msgid "None"
 msgstr "Nessuna"
 
-#: src/billsdepositsdialog.cpp:306 src/billsdepositspanel.cpp:57
+#: src/billsdepositsdialog.cpp:318 src/billsdepositspanel.cpp:53
 #: src/model/Model_Budget.cpp:55
 msgid "Weekly"
 msgstr "Settimanale"
 
-#: src/billsdepositsdialog.cpp:307 src/billsdepositspanel.cpp:58
+#: src/billsdepositsdialog.cpp:319 src/billsdepositspanel.cpp:54
 #: src/model/Model_Budget.cpp:56
 msgid "Bi-Weekly"
 msgstr "Quindicinale"
 
-#: src/billsdepositsdialog.cpp:308 src/billsdepositspanel.cpp:59
+#: src/billsdepositsdialog.cpp:320 src/billsdepositspanel.cpp:55
 #: src/model/Model_Budget.cpp:57
 msgid "Monthly"
 msgstr "Mensile"
 
-#: src/billsdepositsdialog.cpp:309 src/billsdepositspanel.cpp:60
+#: src/billsdepositsdialog.cpp:321 src/billsdepositspanel.cpp:56
 #: src/model/Model_Budget.cpp:58
 msgid "Bi-Monthly"
 msgstr "Bimestrale"
 
-#: src/billsdepositsdialog.cpp:310 src/billsdepositspanel.cpp:61
+#: src/billsdepositsdialog.cpp:322 src/billsdepositspanel.cpp:57
 #: src/model/Model_Budget.cpp:59
 msgid "Quarterly"
 msgstr "Trimestrale"
 
-#: src/billsdepositsdialog.cpp:311 src/billsdepositspanel.cpp:62
+#: src/billsdepositsdialog.cpp:323 src/billsdepositspanel.cpp:58
 #: src/model/Model_Budget.cpp:60
 msgid "Half-Yearly"
 msgstr "Semestrale"
 
-#: src/billsdepositsdialog.cpp:312 src/billsdepositspanel.cpp:63
+#: src/billsdepositsdialog.cpp:324 src/billsdepositspanel.cpp:59
 #: src/model/Model_Budget.cpp:61
 msgid "Yearly"
 msgstr "Annuale"
 
-#: src/billsdepositsdialog.cpp:313 src/billsdepositspanel.cpp:64
+#: src/billsdepositsdialog.cpp:325 src/billsdepositspanel.cpp:60
 msgid "Four Months"
 msgstr "Quattro Mesi"
 
-#: src/billsdepositsdialog.cpp:314 src/billsdepositspanel.cpp:65
+#: src/billsdepositsdialog.cpp:326 src/billsdepositspanel.cpp:61
 msgid "Four Weeks"
 msgstr "Quattro settimane"
 
-#: src/billsdepositsdialog.cpp:315 src/billsdepositspanel.cpp:66
+#: src/billsdepositsdialog.cpp:327 src/billsdepositspanel.cpp:62
 #: src/model/Model_Budget.cpp:62
 msgid "Daily"
 msgstr "Quotidiana"
 
-#: src/billsdepositsdialog.cpp:316 src/billsdepositspanel.cpp:67
+#: src/billsdepositsdialog.cpp:328 src/billsdepositspanel.cpp:63
 #, c-format
 msgid "In %s Days"
 msgstr "Tra %s giorni"
 
-#: src/billsdepositsdialog.cpp:317 src/billsdepositspanel.cpp:68
+#: src/billsdepositsdialog.cpp:329 src/billsdepositspanel.cpp:64
 #, c-format
 msgid "In %s Months"
 msgstr "Tra %s mesi"
 
-#: src/billsdepositsdialog.cpp:318 src/billsdepositspanel.cpp:69
+#: src/billsdepositsdialog.cpp:330 src/billsdepositspanel.cpp:65
 #, c-format
 msgid "Every %s Days"
 msgstr "Ogni %s giorni"
 
-#: src/billsdepositsdialog.cpp:319 src/billsdepositspanel.cpp:70
+#: src/billsdepositsdialog.cpp:331 src/billsdepositspanel.cpp:66
 #, c-format
 msgid "Every %s Months"
 msgstr "Ogni %s mesi"
 
-#: src/billsdepositsdialog.cpp:320 src/billsdepositspanel.cpp:71
+#: src/billsdepositsdialog.cpp:332 src/billsdepositspanel.cpp:67
 msgid "Monthly (last day)"
 msgstr "Mensile (ult. gg)"
 
-#: src/billsdepositsdialog.cpp:321 src/billsdepositspanel.cpp:72
+#: src/billsdepositsdialog.cpp:333 src/billsdepositspanel.cpp:68
 msgid "Monthly (last business day)"
 msgstr "Mensile (ult. gg lav.)"
 
-#: src/billsdepositsdialog.cpp:332 src/transdialog.cpp:306
+#: src/billsdepositsdialog.cpp:344 src/transdialog.cpp:314
 msgid "Transaction Details"
 msgstr "Dettagli Operazione"
 
-#: src/billsdepositsdialog.cpp:338 src/billsdepositspanel.cpp:202
+#: src/billsdepositsdialog.cpp:350 src/billsdepositspanel.cpp:109
 msgid "Payment Date"
 msgstr "Data pagamento"
 
-#: src/billsdepositsdialog.cpp:360
-msgid "Repeating Transaction Details"
-msgstr "Dettagli Operazione Ricorrente"
+#: src/billsdepositsdialog.cpp:372
+msgid "Recurring Transaction Details"
+msgstr "Dettagli transazione ricorrente"
 
-#: src/billsdepositsdialog.cpp:380
-msgid "Specify the date of the next bill or deposit"
+#: src/billsdepositsdialog.cpp:393
+msgid "Specify the date when this bill or deposit is due"
 msgstr "Inserire la data della prossima scadenza"
 
-#: src/billsdepositsdialog.cpp:384
+#: src/billsdepositsdialog.cpp:397
 msgid "Retard or advance the date of the 'next occurrence"
 msgstr "Ritarda o anticipa la data della Prossima scadenza"
 
-#: src/billsdepositsdialog.cpp:390 src/billsdepositspanel.cpp:203
+#: src/billsdepositsdialog.cpp:403 src/billsdepositspanel.cpp:110
 msgid "Due Date"
 msgstr "Data di scadenza"
 
-#: src/billsdepositsdialog.cpp:394 src/billsdepositsdialog.cpp:1328
+#: src/billsdepositsdialog.cpp:407 src/billsdepositsdialog.cpp:1279
 msgid "Repeats"
 msgstr "Ripetizioni"
 
-#: src/billsdepositsdialog.cpp:407
+#: src/billsdepositsdialog.cpp:420
 msgid "Next"
 msgstr "Prossima"
 
-#: src/billsdepositsdialog.cpp:409
+#: src/billsdepositsdialog.cpp:422
 msgid "Advance the Next Occurance Date with the specified values"
 msgstr "Anticipa la data della prossima scadenza secondo i valori indicati"
 
-#: src/billsdepositsdialog.cpp:417 src/billsdepositsdialog.cpp:1370
+#: src/billsdepositsdialog.cpp:430 src/billsdepositsdialog.cpp:1321
 msgid "Times Repeated"
 msgstr "Numero di ripetizioni"
 
-#: src/billsdepositsdialog.cpp:431
-msgid "Set to 'Auto Execute' on the 'Next Occurrence' date."
-msgstr "Esecuzione Automatica alla prossima scadenza"
+#: src/billsdepositsdialog.cpp:444
+msgid "Set to 'Auto Execute' on the next Pay Date."
+msgstr "Imposta 'Esecuzione Automatica' alla prossima scadenza."
 
-#: src/billsdepositsdialog.cpp:432
-msgid "Automatic Execution will require user acknowledgement."
-msgstr "L'Esecuzione Automatica richiede conferma dell'utente"
+#: src/billsdepositsdialog.cpp:445
+msgid "Set 'Auto Execute' with manual user acknowledgement."
+msgstr "'Esecuzione Automatica' con conferma manuale dell'utente."
 
-#: src/billsdepositsdialog.cpp:435
+#: src/billsdepositsdialog.cpp:448
 msgid "Set 'Auto Execute' without user acknowlegement."
 msgstr "Esecuzione Automatica senza conferma dell'utente"
 
-#: src/billsdepositsdialog.cpp:437
+#: src/billsdepositsdialog.cpp:450
 msgid "Automatic Execution will occur without user interaction"
 msgstr "L'Esecuzione Automatica non richiede l'intervento dell'utente"
 
-#: src/billsdepositsdialog.cpp:456 src/transdialog.cpp:1028
+#: src/billsdepositsdialog.cpp:470 src/transdialog.cpp:1032
 msgid "Specify the date of the transaction"
 msgstr "Specificare la data dell'operazione"
 
-#: src/billsdepositsdialog.cpp:459 src/transdialog.cpp:1029
+#: src/billsdepositsdialog.cpp:473 src/transdialog.cpp:1033
 msgid "Retard or advance the date of the transaction"
 msgstr "Ritarda o anticipa la data della operazione"
 
-#: src/billsdepositsdialog.cpp:475 src/filtertransdialog.cpp:248
-#: src/transdialog.cpp:1030
+#: src/billsdepositsdialog.cpp:478
+msgid "Reset date to the Due Date"
+msgstr "Resetta la data alla data di scadenza"
+
+#: src/billsdepositsdialog.cpp:485
+msgid "Pay Date"
+msgstr "Data pagamento"
+
+#: src/billsdepositsdialog.cpp:495 src/filtertransdialog.cpp:247
+#: src/transdialog.cpp:1034
 msgid "Specify the status for the transaction"
 msgstr "Indicare lo stato dell'operazione"
 
-#: src/billsdepositsdialog.cpp:477 src/billsdepositspanel.cpp:206
-#: src/filtertransdialog.cpp:238 src/import_export/qif_import_gui.cpp:216
-#: src/import_export/qif_import_gui.cpp:228
-#: src/import_export/qif_import_gui.cpp:239 src/mmcheckingpanel.cpp:1009
-#: src/reports/transactions.cpp:68 src/transdialog.cpp:342
+#: src/billsdepositsdialog.cpp:497 src/billsdepositspanel.cpp:113
+#: src/filtertransdialog.cpp:237 src/import_export/qif_import_gui.cpp:239
+#: src/import_export/qif_import_gui.cpp:251
+#: src/import_export/qif_import_gui.cpp:262 src/mmcheckingpanel.cpp:977
+#: src/reports/transactions.cpp:68 src/transdialog.cpp:350
 #: src/webappdialog.cpp:81
 msgid "Status"
 msgstr "Stato"
 
-#: src/billsdepositsdialog.cpp:491 src/splitdetailsdialog.cpp:117
-#: src/transdialog.cpp:1031
+#: src/billsdepositsdialog.cpp:511 src/splitdetailsdialog.cpp:125
+#: src/transdialog.cpp:1035
 msgid "Specify the type of transactions to be created."
 msgstr "Specificare il tipo di operazione da creare"
 
-#: src/billsdepositsdialog.cpp:492 src/transdialog.cpp:356
+#: src/billsdepositsdialog.cpp:512 src/transdialog.cpp:364
 msgid "&Advanced"
 msgstr "&Avanzate"
 
-#: src/billsdepositsdialog.cpp:495 src/transdialog.cpp:1035
+#: src/billsdepositsdialog.cpp:515 src/transdialog.cpp:1039
 msgid "Allows the setting of different amounts in the FROM and TO accounts."
 msgstr ""
 "Consente di impostare diversi importi nei conti di Origine e Destinazione"
 
-#: src/billsdepositsdialog.cpp:505 src/billsdepositsdialog.cpp:790
-#: src/transdialog.cpp:1019
+#: src/billsdepositsdialog.cpp:525 src/billsdepositsdialog.cpp:799
+#: src/transdialog.cpp:1023
 msgid "Specify the amount for this transaction"
 msgstr "Specificare l'importo di questa operazione"
 
-#: src/billsdepositsdialog.cpp:506
+#: src/billsdepositsdialog.cpp:526
 msgid "Specify the amount to be transfered"
 msgstr "Specificare l'importo da trasferire"
 
-#: src/billsdepositsdialog.cpp:508 src/billsdepositsdialog.cpp:993
-#: src/billsdepositspanel.cpp:209 src/budgetingpanel.cpp:298
-#: src/mmhomepagepanel.cpp:382 src/mmhomepagepanel.cpp:761
-#: src/reports/budgetcategorysummary.cpp:111 src/reports/categexp.cpp:133
-#: src/reports/incexpenses.cpp:124 src/reports/transactions.cpp:73
-#: src/splitdetailsdialog.cpp:120 src/splittransactionsdialog.cpp:131
-#: src/transdialog.cpp:379 src/webappdialog.cpp:85
+#: src/billsdepositsdialog.cpp:528 src/billsdepositspanel.cpp:116
+#: src/budgetingpanel.cpp:318 src/mmhomepagepanel.cpp:391
+#: src/mmhomepagepanel.cpp:767 src/reports/budgetcategorysummary.cpp:110
+#: src/reports/categexp.cpp:133 src/reports/incexpenses.cpp:124
+#: src/reports/transactions.cpp:73 src/splitdetailsdialog.cpp:128
+#: src/splittransactionsdialog.cpp:132 src/transdialog.cpp:387
+#: src/webappdialog.cpp:85
 msgid "Amount"
 msgstr "Importo"
 
-#: src/billsdepositsdialog.cpp:520 src/transdialog.cpp:1015
+#: src/billsdepositsdialog.cpp:540 src/transdialog.cpp:1019
 msgid "Specify the transfer amount in the To Account"
 msgstr "Specificare l'importo da trasferire al Conto Destinazione"
 
-#: src/billsdepositsdialog.cpp:532 src/billsdepositspanel.cpp:204
-#: src/filtertransdialog.cpp:176 src/import_export/qif_import_gui.cpp:77
-#: src/import_export/qif_import_gui.cpp:138
-#: src/import_export/qif_import_gui.cpp:208
-#: src/import_export/qif_import_gui.cpp:656 src/reports/transactions.cpp:66
-#: src/transdialog.cpp:214 src/transdialog.cpp:386 src/webappdialog.cpp:80
+#: src/billsdepositsdialog.cpp:552 src/billsdepositspanel.cpp:111
+#: src/filtertransdialog.cpp:175 src/import_export/qif_import_gui.cpp:92
+#: src/import_export/qif_import_gui.cpp:152
+#: src/import_export/qif_import_gui.cpp:231
+#: src/import_export/qif_import_gui.cpp:724 src/reports/transactions.cpp:66
+#: src/transdialog.cpp:222 src/transdialog.cpp:394 src/webappdialog.cpp:80
 msgid "Account"
 msgstr "Conto"
 
-#: src/billsdepositsdialog.cpp:533 src/billsdepositsdialog.cpp:663
-#: src/billsdepositsdialog.cpp:703 src/billsdepositsdialog.cpp:753
+#: src/billsdepositsdialog.cpp:553 src/billsdepositsdialog.cpp:682
+#: src/billsdepositsdialog.cpp:712 src/billsdepositsdialog.cpp:762
 msgid "Select Account"
 msgstr "Selezione Conto"
 
-#: src/billsdepositsdialog.cpp:535
-msgid "Specify the Account that will own the repeating transaction"
-msgstr "Specificare il Conto su cui sarà registrata l'operazione"
+#: src/billsdepositsdialog.cpp:555
+msgid "Specify the Account that will own the recurring transaction"
+msgstr "Specificare il Conto su cui sarà registrata l'operazione ricorrente"
 
-#: src/billsdepositsdialog.cpp:538 src/billsdepositsdialog.cpp:822
-#: src/billsdepositspanel.cpp:205 src/filtertransdialog.cpp:205
-#: src/import_export/qif_import_gui.cpp:80
-#: src/import_export/qif_import_gui.cpp:221
-#: src/import_export/univcsvdialog.cpp:72 src/mmcheckingpanel.cpp:1007
-#: src/mmhomepagepanel.cpp:382 src/reports/payee.cpp:111
-#: src/reports/transactions.cpp:67 src/transdialog.cpp:210
-#: src/transdialog.cpp:391 src/webappdialog.cpp:83
+#: src/billsdepositsdialog.cpp:558 src/billsdepositsdialog.cpp:862
+#: src/billsdepositspanel.cpp:112 src/filtertransdialog.cpp:204
+#: src/import_export/qif_import_gui.cpp:95
+#: src/import_export/qif_import_gui.cpp:244
+#: src/import_export/univcsvdialog.cpp:77 src/mmcheckingpanel.cpp:976
+#: src/mmhomepagepanel.cpp:391 src/reports/payee.cpp:111
+#: src/reports/transactions.cpp:67 src/transdialog.cpp:218
+#: src/transdialog.cpp:399 src/webappdialog.cpp:83
 msgid "Payee"
 msgstr "Beneficiario"
 
-#: src/billsdepositsdialog.cpp:540 src/billsdepositsdialog.cpp:881
+#: src/billsdepositsdialog.cpp:560 src/billsdepositsdialog.cpp:892
 msgid "Select Payee"
 msgstr "Seleziona Beneficiario"
 
-#: src/billsdepositsdialog.cpp:542
+#: src/billsdepositsdialog.cpp:562
 msgid "Specify where the transaction is going to"
 msgstr "Specificare la destinazione dell'operazione"
 
-#: src/billsdepositsdialog.cpp:550 src/transdialog.cpp:404
+#: src/billsdepositsdialog.cpp:570 src/transdialog.cpp:412
 msgid "Split"
 msgstr "Suddividi"
 
-#: src/billsdepositsdialog.cpp:553 src/transdialog.cpp:1032
+#: src/billsdepositsdialog.cpp:573 src/transdialog.cpp:1036
 msgid "Use split Categories"
 msgstr "Usa Categorie suddivise"
 
-#: src/billsdepositsdialog.cpp:559 src/billsdepositspanel.cpp:207
-#: src/budgetingpanel.cpp:295 src/filtertransdialog.cpp:216
-#: src/import_export/qif_import_gui.cpp:82
-#: src/import_export/qif_import_gui.cpp:233
-#: src/import_export/univcsvdialog.cpp:74 src/mmcheckingpanel.cpp:1011
-#: src/mmhomepagepanel.cpp:201 src/reports/budgetcategorysummary.cpp:109
-#: src/reports/budgetingperf.cpp:128 src/reports/categexp.cpp:132
+#: src/billsdepositsdialog.cpp:579 src/billsdepositspanel.cpp:114
+#: src/budgetingpanel.cpp:315 src/filtertransdialog.cpp:215
+#: src/import_export/qif_import_gui.cpp:97
+#: src/import_export/qif_import_gui.cpp:256
+#: src/import_export/univcsvdialog.cpp:79 src/mmcheckingpanel.cpp:978
+#: src/mmhomepagepanel.cpp:222 src/reports/budgetcategorysummary.cpp:109
+#: src/reports/budgetingperf.cpp:129 src/reports/categexp.cpp:132
 #: src/reports/categovertimeperf.cpp:109 src/reports/transactions.cpp:69
-#: src/splitdetailsdialog.cpp:128 src/splittransactionsdialog.cpp:130
-#: src/transdialog.cpp:414 src/webappdialog.cpp:84
+#: src/splitdetailsdialog.cpp:136 src/splittransactionsdialog.cpp:131
+#: src/transdialog.cpp:422 src/webappdialog.cpp:84
 msgid "Category"
 msgstr "Categoria"
 
-#: src/billsdepositsdialog.cpp:560 src/billsdepositsdialog.cpp:1492
-#: src/transdialog.cpp:279
+#: src/billsdepositsdialog.cpp:580 src/billsdepositsdialog.cpp:1443
+#: src/transdialog.cpp:287
 msgid "Select Category"
 msgstr "Selezione Categoria"
 
-#: src/billsdepositsdialog.cpp:570 src/transdialog.cpp:1033
+#: src/billsdepositsdialog.cpp:590 src/transdialog.cpp:1037
 msgid "Specify any associated check number or transaction number"
 msgstr "Inserire il numero di controllo o il numero dell'operazione"
 
-#: src/billsdepositsdialog.cpp:572 src/billsdepositspanel.cpp:214
-#: src/filtertransdialog.cpp:298 src/import_export/qif_import_gui.cpp:79
-#: src/import_export/univcsvdialog.cpp:76 src/mmcheckingpanel.cpp:1005
-#: src/reports/transactions.cpp:71 src/transdialog.cpp:429
+#: src/billsdepositsdialog.cpp:592 src/billsdepositspanel.cpp:121
+#: src/filtertransdialog.cpp:297 src/import_export/qif_import_gui.cpp:94
+#: src/import_export/univcsvdialog.cpp:81 src/mmcheckingpanel.cpp:975
+#: src/reports/transactions.cpp:71 src/transdialog.cpp:437
 msgid "Number"
 msgstr "Numero"
 
-#: src/billsdepositsdialog.cpp:581
-msgid "Organize attachments of this repeating transaction"
+#: src/billsdepositsdialog.cpp:601
+msgid "Organize attachments of this recurring transaction"
 msgstr "Organizza allegati per questa operazione ricorrente"
 
-#: src/billsdepositsdialog.cpp:585 src/transdialog.cpp:440
+#: src/billsdepositsdialog.cpp:605 src/transdialog.cpp:448
 msgid "Select one of the frequently used notes"
 msgstr "Selezionare una delle note usate di recente"
 
-#: src/billsdepositsdialog.cpp:595 src/transdialog.cpp:1034
+#: src/billsdepositsdialog.cpp:615 src/transdialog.cpp:1038
 msgid "Specify any text notes you want to add to this transaction."
 msgstr "Inserire una nota per questa operazione"
 
-#: src/billsdepositsdialog.cpp:662
+#: src/billsdepositsdialog.cpp:681
 msgid "Choose Bank Account or Term Account"
 msgstr "Scegli un Conto Bancario o un Conto a Termine"
 
-#: src/billsdepositsdialog.cpp:703 src/billsdepositsdialog.cpp:753
+#: src/billsdepositsdialog.cpp:712 src/billsdepositsdialog.cpp:762
 msgid "Account name"
 msgstr "Nome Conto"
 
-#: src/billsdepositsdialog.cpp:793
+#: src/billsdepositsdialog.cpp:802
 msgid "Specify which account the transfer is going to"
 msgstr "Specificare il Conto verso il quale si effettua il trasferimento"
 
-#: src/billsdepositsdialog.cpp:796
+#: src/billsdepositsdialog.cpp:805
 msgid "Specify to whom the transaction is going to or coming from "
 msgstr "Selezionare a chi va o da chi proviene il denaro dell'operazione "
 
-#: src/billsdepositsdialog.cpp:837 src/billsdepositsdialog.cpp:853
-#: src/billsdepositsdialog.cpp:867 src/transdialog.cpp:212
-#: src/transdialog.cpp:255
+#: src/billsdepositsdialog.cpp:839 src/billsdepositsdialog.cpp:850
+#: src/billsdepositsdialog.cpp:873 src/transdialog.cpp:220
+#: src/transdialog.cpp:263
 msgid "From"
 msgstr "Da"
 
-#: src/billsdepositsdialog.cpp:838 src/transdialog.cpp:1024
-msgid "Specify where the transaction is coming from"
-msgstr "Specificare l'origine dell'operazione"
-
-#: src/billsdepositsdialog.cpp:866 src/transdialog.cpp:253
+#: src/billsdepositsdialog.cpp:849 src/transdialog.cpp:261
 msgid "To"
 msgstr "A"
 
-#: src/billsdepositsdialog.cpp:868
+#: src/billsdepositsdialog.cpp:851
 msgid "Select To Account"
 msgstr "Selezionare Conto di Destinazione"
 
-#: src/billsdepositsdialog.cpp:1284
+#: src/billsdepositsdialog.cpp:874 src/transdialog.cpp:1028
+msgid "Specify where the transaction is coming from"
+msgstr "Specificare l'origine dell'operazione"
+
+#: src/billsdepositsdialog.cpp:1234
 msgid "Specify the transfer amount in the From Account"
 msgstr "Specificare l'importo da trasferire dal Conto di Origine"
 
-#: src/billsdepositsdialog.cpp:1329
+#: src/billsdepositsdialog.cpp:1280
 msgid "Activates"
 msgstr "Attiva"
 
-#: src/billsdepositsdialog.cpp:1331
+#: src/billsdepositsdialog.cpp:1282
 msgid "Period: Days"
 msgstr "Periodo: Giorni"
 
-#: src/billsdepositsdialog.cpp:1332
+#: src/billsdepositsdialog.cpp:1283
 msgid "Period: Months"
 msgstr "Periodo: Mesi"
 
-#: src/billsdepositsdialog.cpp:1340 src/billsdepositsdialog.cpp:1356
+#: src/billsdepositsdialog.cpp:1291 src/billsdepositsdialog.cpp:1307
 msgid "Specify period in Days to activate."
 msgstr "Indicare un periodo in giorni tra cui attivare la ripetizione:"
 
-#: src/billsdepositsdialog.cpp:1341 src/billsdepositsdialog.cpp:1349
+#: src/billsdepositsdialog.cpp:1292 src/billsdepositsdialog.cpp:1300
 msgid "Becomes blank when not active."
 msgstr "Diventa vuoto se non attivo"
 
-#: src/billsdepositsdialog.cpp:1348 src/billsdepositsdialog.cpp:1364
+#: src/billsdepositsdialog.cpp:1299 src/billsdepositsdialog.cpp:1315
 msgid "Specify period in Months to activate."
 msgstr "Specificare il periodo in mesi tra cui attivare la ripetizione:"
 
-#: src/billsdepositsdialog.cpp:1357 src/billsdepositsdialog.cpp:1364
+#: src/billsdepositsdialog.cpp:1308 src/billsdepositsdialog.cpp:1315
 msgid "Leave blank when not active."
 msgstr "Lasciare vuoto se non attivo"
 
-#: src/billsdepositsdialog.cpp:1371
+#: src/billsdepositsdialog.cpp:1322
 msgid "Specify the number of times this series repeats."
 msgstr "Indicare il numero di ripetizioni della serie"
 
-#: src/billsdepositsdialog.cpp:1372
+#: src/billsdepositsdialog.cpp:1323
 msgid "Leave blank if this series continues forever."
 msgstr "Lasciare il campo vuoto se la serie si ripete all'infinito"
 
-#: src/billsdepositsdialog.cpp:1466 src/transdialog.cpp:992
+#: src/billsdepositsdialog.cpp:1417 src/transdialog.cpp:996
 msgid "Specify the category for this transaction"
 msgstr "Specifica la categoria di questa operazione"
 
-#: src/billsdepositsdialog.cpp:1484 src/categdialog.cpp:113
-#: src/import_export/qif_export.cpp:119 src/mmframereport.cpp:148
-#: src/transdialog.cpp:269 src/reports/categexp.h:191
+#: src/billsdepositsdialog.cpp:1435 src/categdialog.cpp:111
+#: src/import_export/qif_export.cpp:117 src/mmframereport.cpp:153
+#: src/transdialog.cpp:277 src/reports/categexp.h:191
 msgid "Categories"
 msgstr "Categorie"
 
-#: src/billsdepositspanel.cpp:210 src/budgetingpanel.cpp:297
-#: src/reports/budgetcategorysummary.cpp:112
+#: src/billsdepositspanel.cpp:117 src/budgetingpanel.cpp:317
+#: src/reports/budgetcategorysummary.cpp:111
 msgid "Frequency"
 msgstr "Frequenza"
 
-#: src/billsdepositspanel.cpp:211
+#: src/billsdepositspanel.cpp:118
 msgid "Repetitions"
 msgstr "Ripetizioni"
 
-#: src/billsdepositspanel.cpp:212
+#: src/billsdepositspanel.cpp:119
 msgid "Autorepeat"
 msgstr "Autoripetizione"
 
-#: src/billsdepositspanel.cpp:213 src/mmhomepagepanel.cpp:382
+#: src/billsdepositspanel.cpp:120 src/mmhomepagepanel.cpp:391
 msgid "Payment"
 msgstr "Pagamento"
 
-#: src/billsdepositspanel.cpp:217
+#: src/billsdepositspanel.cpp:168
 msgid ""
 "MMEX allows regular payments to be set up as transactions. These "
 "transactions can also be regular deposits, or transfers that will occur at "
@@ -1114,7 +1111,7 @@ msgstr ""
 "prossimità della scadenza, sarà visualizzato nella Pagina Principale 14 "
 "giorni prima del termine."
 
-#: src/billsdepositspanel.cpp:218
+#: src/billsdepositspanel.cpp:169
 msgid ""
 "Tip: These transactions can be set up to activate – allowing the user to "
 "adjust any values on the due date."
@@ -1122,104 +1119,104 @@ msgstr ""
 "Suggerimento: Queste operazioni possono essere impostate come da attivare - "
 "permettendo all'utente di correggerne i valori alla scadenza."
 
-#: src/billsdepositspanel.cpp:271 src/mmframe.cpp:731
-#: src/mmhomepagepanel.cpp:424 src/billsdepositspanel.h:104
-msgid "Repeating Transactions"
+#: src/billsdepositspanel.cpp:221 src/billsdepositspanel.cpp:896
+#: src/mmframe.cpp:733 src/mmhomepagepanel.cpp:433
+msgid "Recurring Transactions"
 msgstr "Operazioni Ricorrenti"
 
-#: src/billsdepositspanel.cpp:288 src/filtertransdialog.cpp:97
-#: src/mmcheckingpanel.cpp:397
+#: src/billsdepositspanel.cpp:238 src/filtertransdialog.cpp:96
+#: src/mmcheckingpanel.cpp:384
 msgid "Transaction Filter"
 msgstr "Filtro Operazioni"
 
-#: src/billsdepositspanel.cpp:336
+#: src/billsdepositspanel.cpp:282
 msgid "New Bills & Deposit Series"
 msgstr "Nuova serie di operazioni"
 
-#: src/billsdepositspanel.cpp:340
+#: src/billsdepositspanel.cpp:286
 msgid "Edit Bills & Deposit Series"
 msgstr "Modifica la serie di operazioni"
 
-#: src/billsdepositspanel.cpp:345
+#: src/billsdepositspanel.cpp:291
 msgid "Delete Bills & Deposit Series"
 msgstr "Elimina la serie di operazioni"
 
-#: src/billsdepositspanel.cpp:349
+#: src/billsdepositspanel.cpp:295
 msgid "En&ter"
 msgstr "In&serisci"
 
-#: src/billsdepositspanel.cpp:350
+#: src/billsdepositspanel.cpp:296
 msgid "Enter Next Bills & Deposit Occurrence"
 msgstr "Inserisci la prossima scadenza della serie"
 
-#: src/billsdepositspanel.cpp:354
+#: src/billsdepositspanel.cpp:300
 msgid "&Skip"
 msgstr "&Salta"
 
-#: src/billsdepositspanel.cpp:355
+#: src/billsdepositspanel.cpp:301
 msgid "Skip Next Bills & Deposit Occurrence"
 msgstr "Ignora la prossima scadenza della serie"
 
-#: src/billsdepositspanel.cpp:474
+#: src/billsdepositspanel.cpp:413
 msgid "Enter next Occurrence..."
 msgstr "Inserisci la Scadenza successiva"
 
-#: src/billsdepositspanel.cpp:476
+#: src/billsdepositspanel.cpp:415
 msgid "Skip next Occurrence"
 msgstr "Ignora prossima Scadenza"
 
-#: src/billsdepositspanel.cpp:478
+#: src/billsdepositspanel.cpp:417
 msgid "&New Bills && Deposit Series..."
 msgstr "&Nuova Serie di Operazioni Ricorrenti"
 
-#: src/billsdepositspanel.cpp:479
+#: src/billsdepositspanel.cpp:418
 msgid "&Edit Bills && Deposit Series..."
 msgstr "&Modifica Serie Operazioni Ricorrente"
 
-#: src/billsdepositspanel.cpp:480
+#: src/billsdepositspanel.cpp:419
 msgid "&Delete Bills && Deposit Series..."
 msgstr "&Elimina Serie Operazioni Ricorrenti"
 
-#: src/billsdepositspanel.cpp:527
+#: src/billsdepositspanel.cpp:466
 msgid "Manual"
 msgstr "Manuale"
 
-#: src/billsdepositspanel.cpp:531
+#: src/billsdepositspanel.cpp:470
 msgid "Suggested"
 msgstr "Suggerita"
 
-#: src/billsdepositspanel.cpp:535
+#: src/billsdepositspanel.cpp:474
 msgid "Automated"
 msgstr "Automatica"
 
-#: src/billsdepositspanel.cpp:577 src/billsdepositspanel.cpp:643
-#: src/mmhomepagepanel.cpp:345
+#: src/billsdepositspanel.cpp:516 src/billsdepositspanel.cpp:582
+#: src/mmhomepagepanel.cpp:354
 #, c-format
 msgid "%d days remaining"
 msgstr "%d giorni rimanenti"
 
-#: src/billsdepositspanel.cpp:582 src/billsdepositspanel.cpp:589
-#: src/billsdepositspanel.cpp:596 src/billsdepositspanel.cpp:648
-#: src/billsdepositspanel.cpp:655 src/billsdepositspanel.cpp:659
+#: src/billsdepositspanel.cpp:521 src/billsdepositspanel.cpp:528
+#: src/billsdepositspanel.cpp:535 src/billsdepositspanel.cpp:587
+#: src/billsdepositspanel.cpp:594 src/billsdepositspanel.cpp:598
 msgid "Inactive"
 msgstr "Inattiva"
 
-#: src/billsdepositspanel.cpp:587 src/mmhomepagepanel.cpp:346
+#: src/billsdepositspanel.cpp:526 src/mmhomepagepanel.cpp:355
 #, c-format
 msgid "%d days delay!"
 msgstr "%d giorni di ritardo!"
 
-#: src/billsdepositspanel.cpp:594 src/billsdepositspanel.cpp:653
-#: src/mmhomepagepanel.cpp:348
+#: src/billsdepositspanel.cpp:533 src/billsdepositspanel.cpp:592
+#: src/mmhomepagepanel.cpp:357
 #, c-format
 msgid "%d days overdue!"
 msgstr "%d giorni scaduti!"
 
-#: src/billsdepositspanel.cpp:705
+#: src/billsdepositspanel.cpp:644
 msgid "Do you really want to delete the series?"
 msgstr "Vuoi davvero eliminare la serie di operazioni?"
 
-#: src/billsdepositspanel.cpp:706
+#: src/billsdepositspanel.cpp:645
 msgid "Confirm Series Deletion"
 msgstr "Conferma eliminazione Serie"
 
@@ -1227,53 +1224,53 @@ msgstr "Conferma eliminazione Serie"
 msgid "Budget Year Entry"
 msgstr "Budget Annuale"
 
-#: src/budgetentrydialog.cpp:109
+#: src/budgetentrydialog.cpp:107
 msgid "Category: "
 msgstr "Categoria: "
 
-#: src/budgetentrydialog.cpp:114
+#: src/budgetentrydialog.cpp:112
 msgid "Sub Category: "
 msgstr "Sotto-Categoria:"
 
-#: src/budgetentrydialog.cpp:121
+#: src/budgetentrydialog.cpp:119
 msgid "Estimated:"
 msgstr "Stimato:"
 
-#: src/budgetentrydialog.cpp:123
+#: src/budgetentrydialog.cpp:121
 msgid "Actual:"
 msgstr "Effettivo:"
 
-#: src/budgetentrydialog.cpp:126
+#: src/budgetentrydialog.cpp:124
 msgid "Type:"
 msgstr "Tipo:"
 
-#: src/budgetentrydialog.cpp:129
+#: src/budgetentrydialog.cpp:127
 msgid "Expense"
 msgstr "Uscita"
 
-#: src/budgetentrydialog.cpp:130 src/mmhomepagepanel.cpp:762
+#: src/budgetentrydialog.cpp:128 src/mmhomepagepanel.cpp:768
 #: src/model/Model_Category.cpp:191 src/reports/incexpenses.cpp:101
 #: src/reports/incexpenses.cpp:228
 msgid "Income"
 msgstr "Entrate"
 
-#: src/budgetentrydialog.cpp:135
+#: src/budgetentrydialog.cpp:133
 msgid "Specify whether this category is an income or an expense category"
 msgstr "Specificare se questa è una categoria di reddito o di spesa"
 
-#: src/budgetentrydialog.cpp:137
+#: src/budgetentrydialog.cpp:135
 msgid "Frequency:"
 msgstr "Frequenza:"
 
-#: src/budgetentrydialog.cpp:142
+#: src/budgetentrydialog.cpp:140
 msgid "Specify the frequency of the expense or deposit"
 msgstr "Indicare la frequenza di spese o depositi"
 
-#: src/budgetentrydialog.cpp:145
+#: src/budgetentrydialog.cpp:143
 msgid "Amount:"
 msgstr "Importo:"
 
-#: src/budgetentrydialog.cpp:150
+#: src/budgetentrydialog.cpp:148
 msgid "Enter the amount budgeted for this category."
 msgstr "Inserire l'importo di budget per questa categoria"
 
@@ -1301,57 +1298,61 @@ msgstr "Mostra Categorie di Budget di Spesa"
 msgid "View Budget Category Summary"
 msgstr "Mostra riepilogo Categorie di Budget"
 
-#: src/budgetingpanel.cpp:190 src/reports/budget.cpp:78
+#: src/budgetingpanel.cpp:187 src/reports/budget.cpp:79
 #, c-format
 msgid "Financial Year: %s - %i"
 msgstr "Esercizio finanziario: %s - %i"
 
-#: src/budgetingpanel.cpp:194 src/reports/budget.cpp:80
+#: src/budgetingpanel.cpp:191 src/reports/budget.cpp:81
 #, c-format
 msgid "Year: %s"
 msgstr "Anno: %s"
 
-#: src/budgetingpanel.cpp:199 src/reports/budget.cpp:82
+#: src/budgetingpanel.cpp:196 src/reports/budget.cpp:83
 #, c-format
 msgid "Month: %s"
 msgstr "Mese: %s"
 
-#: src/budgetingpanel.cpp:201
+#: src/budgetingpanel.cpp:198
 #, c-format
 msgid "Budget Setup for %s"
 msgstr "Imposta Budget per %s"
 
-#: src/budgetingpanel.cpp:267
+#: src/budgetingpanel.cpp:264
 msgid "Income: "
 msgstr "Entrate: "
 
-#: src/budgetingpanel.cpp:268 src/budgetingpanel.cpp:276
+#: src/budgetingpanel.cpp:265 src/budgetingpanel.cpp:273
 msgid "Estimated: "
 msgstr "Previsto: "
 
-#: src/budgetingpanel.cpp:270 src/budgetingpanel.cpp:278
+#: src/budgetingpanel.cpp:267 src/budgetingpanel.cpp:275
 msgid "Actual: "
 msgstr "Effettivo: "
 
-#: src/budgetingpanel.cpp:272 src/budgetingpanel.cpp:280
+#: src/budgetingpanel.cpp:269 src/budgetingpanel.cpp:277
 msgid "Difference: "
 msgstr "Differenza: "
 
-#: src/budgetingpanel.cpp:275
+#: src/budgetingpanel.cpp:272
 msgid "Expenses: "
 msgstr "Uscite: "
 
-#: src/budgetingpanel.cpp:296 src/reports/budgetcategorysummary.cpp:110
+#: src/budgetingpanel.cpp:314
+msgid "Icon"
+msgstr "Icona"
+
+#: src/budgetingpanel.cpp:316
 msgid "Sub Category"
 msgstr "Sotto-Categoria"
 
-#: src/budgetingpanel.cpp:299 src/reports/budgetcategorysummary.cpp:113
-#: src/reports/budgetingperf.cpp:156 src/reports/budgetingperf.cpp:209
+#: src/budgetingpanel.cpp:319 src/reports/budgetcategorysummary.cpp:112
+#: src/reports/budgetingperf.cpp:157 src/reports/budgetingperf.cpp:210
 msgid "Estimated"
 msgstr "Previsto"
 
-#: src/budgetingpanel.cpp:300 src/reports/budgetcategorysummary.cpp:114
-#: src/reports/budgetingperf.cpp:167 src/reports/budgetingperf.cpp:219
+#: src/budgetingpanel.cpp:320 src/reports/budgetcategorysummary.cpp:113
+#: src/reports/budgetingperf.cpp:168 src/reports/budgetingperf.cpp:220
 msgid "Actual"
 msgstr "Effettivo"
 
@@ -1359,27 +1360,27 @@ msgstr "Effettivo"
 msgid "Budget Editor"
 msgstr "Gestore Budget"
 
-#: src/budgetyeardialog.cpp:94
+#: src/budgetyeardialog.cpp:92
 msgid "&Add Year"
 msgstr "&Aggiungi budget annuale"
 
-#: src/budgetyeardialog.cpp:96
+#: src/budgetyeardialog.cpp:94
 msgid "Add a new budget year"
 msgstr "Inserire un nuovo budget annuale"
 
-#: src/budgetyeardialog.cpp:99
+#: src/budgetyeardialog.cpp:97
 msgid "&Add Month"
 msgstr "&Aggiungi budget mensile"
 
-#: src/budgetyeardialog.cpp:101
+#: src/budgetyeardialog.cpp:99
 msgid "Add a new budget month"
 msgstr "Inserire un nuovo budget mensile"
 
-#: src/budgetyeardialog.cpp:106
+#: src/budgetyeardialog.cpp:104
 msgid "Delete existing budget"
 msgstr "Eliminare un budget esistente"
 
-#: src/budgetyearentrydialog.cpp:41 src/budgetyearentrydialog.cpp:150
+#: src/budgetyearentrydialog.cpp:41 src/budgetyearentrydialog.cpp:149
 msgid "Budget Entry Details"
 msgstr "Dettagli del Budget"
 
@@ -1387,11 +1388,11 @@ msgstr "Dettagli del Budget"
 msgid "Budget Month Entry"
 msgstr "Inserire Budget mensile"
 
-#: src/budgetyearentrydialog.cpp:71
+#: src/budgetyearentrydialog.cpp:70
 msgid "Budget Year:"
 msgstr "Budget Anno:"
 
-#: src/budgetyearentrydialog.cpp:79
+#: src/budgetyearentrydialog.cpp:78
 msgid ""
 "Specify the required year.\n"
 "Use Spin buttons to increase or decrease the year."
@@ -1399,11 +1400,11 @@ msgstr ""
 "Specificare l'anno desiderato\n"
 "Usa i pulsanti per selezionare l'anno"
 
-#: src/budgetyearentrydialog.cpp:85
+#: src/budgetyearentrydialog.cpp:84
 msgid "Budget Month:"
 msgstr "Budget Mese:"
 
-#: src/budgetyearentrydialog.cpp:94
+#: src/budgetyearentrydialog.cpp:93
 msgid ""
 "Specify the required month.\n"
 "Use Spin buttons to increase or decrease the month."
@@ -1411,51 +1412,51 @@ msgstr ""
 "Specificare il mese desiderato\n"
 "Usa il pulsanti per scegliere il mese"
 
-#: src/budgetyearentrydialog.cpp:100
+#: src/budgetyearentrydialog.cpp:99
 msgid "Base Budget On:"
 msgstr "Utilizza Budget dell'anno:"
 
-#: src/budgetyearentrydialog.cpp:110
+#: src/budgetyearentrydialog.cpp:109
 msgid "Specify year to base budget on."
 msgstr "Indicare l'anno su cui basare il budget"
 
-#: src/budgetyearentrydialog.cpp:149
+#: src/budgetyearentrydialog.cpp:148
 msgid "Budget Year already exists"
 msgstr "Budget annuale già esistente!"
 
-#: src/categdialog.cpp:88 src/mmframe.cpp:1461 src/mmframe.cpp:1624
+#: src/categdialog.cpp:87 src/mmframe.cpp:1439 src/mmframe.cpp:1604
 msgid "Organize Categories"
 msgstr "Organizza le Categorie"
 
-#: src/categdialog.cpp:180 src/mmframe.cpp:1478
+#: src/categdialog.cpp:177 src/mmframe.cpp:1456
 msgid "Reassign all categories to another category"
 msgstr "Riassegna tutte le Categorie ad un'altra Categoria"
 
-#: src/categdialog.cpp:182
+#: src/categdialog.cpp:179
 msgid "Expand"
 msgstr "Espandere"
 
-#: src/categdialog.cpp:187 src/maincurrencydialog.cpp:147
+#: src/categdialog.cpp:184 src/maincurrencydialog.cpp:165
 msgid "Show All"
 msgstr "Mostra tutto"
 
-#: src/categdialog.cpp:189
+#: src/categdialog.cpp:186
 msgid "Show all hidden categories"
 msgstr "Mostra tutte le categorie nascoste"
 
-#: src/categdialog.cpp:217
+#: src/categdialog.cpp:213
 msgid "Enter the name of the category to add or edit here"
 msgstr "Inserire il nome della categoria da aggiungere o modificare"
 
-#: src/categdialog.cpp:224
+#: src/categdialog.cpp:220
 msgid "Add a new category"
 msgstr "Inserisce una nuova Categoria"
 
-#: src/categdialog.cpp:228
+#: src/categdialog.cpp:224
 msgid "Edit the name of an existing category"
 msgstr "Modifica il nome di una Categoria esistente"
 
-#: src/categdialog.cpp:232
+#: src/categdialog.cpp:228
 msgid ""
 "Delete an existing category. The category cannot be used by existing "
 "transactions."
@@ -1463,30 +1464,30 @@ msgstr ""
 "Elimina una Categoria esistente. La Categoria non deve essere in uso nelle "
 "operazioni inserite"
 
-#: src/categdialog.cpp:237 src/maincurrencydialog.cpp:193
+#: src/categdialog.cpp:233 src/maincurrencydialog.cpp:211
 msgid "&Select"
 msgstr "&Seleziona"
 
-#: src/categdialog.cpp:239
+#: src/categdialog.cpp:235
 msgid ""
 "Select the currently selected category as the selected category for the "
 "transaction"
 msgstr ""
 "Seleziona la Categoria attuale come Categoria assegnata alla operazione."
 
-#: src/categdialog.cpp:248
+#: src/categdialog.cpp:244
 msgid "Enter the name for the new category:"
 msgstr "Inserire il nome della nuova categoria:"
 
-#: src/categdialog.cpp:249
+#: src/categdialog.cpp:245
 msgid "Add Category"
 msgstr "Aggiungi categoria"
 
-#: src/categdialog.cpp:258 src/categdialog.cpp:479
+#: src/categdialog.cpp:254 src/categdialog.cpp:468
 msgid "Category with same name exists"
 msgstr "Categoria già esistente!"
 
-#: src/categdialog.cpp:259
+#: src/categdialog.cpp:255
 msgid ""
 "Tip: If category added now, check bottom of list.\n"
 "Category will be in sorted order next time dialog appears"
@@ -1494,21 +1495,29 @@ msgstr ""
 "Nota: La categoria appena aggiunta sarà visualizzata in fondo alla lista.\n"
 "La prossima volta sarà visualizzata in ordine alfabetico"
 
-#: src/categdialog.cpp:260 src/categdialog.cpp:285 src/categdialog.cpp:303
+#: src/categdialog.cpp:256 src/categdialog.cpp:281 src/categdialog.cpp:299
 msgid "Organise Categories: Adding Error"
 msgstr "Gestione Categorie: Errore d'inserimento"
 
-#: src/categdialog.cpp:284 src/categdialog.cpp:496
+#: src/categdialog.cpp:280 src/categdialog.cpp:485
 msgid "Sub Category with same name exists"
 msgstr "Sotto-Categoria già esistente!"
 
-#: src/categdialog.cpp:302
+#: src/categdialog.cpp:298
 msgid "Invalid Parent Category. Choose Root or Main Category node."
 msgstr ""
 "Categoria superiore non valida. Scegliere il nodo principale o una Categoria "
 "superiore."
 
-#: src/categdialog.cpp:311
+#: src/categdialog.cpp:305
+msgid "Category in use."
+msgstr "Categoria in uso."
+
+#: src/categdialog.cpp:305
+msgid "Sub-Category in use."
+msgstr "Sotto-Categoria in uso."
+
+#: src/categdialog.cpp:307
 msgid ""
 "Tip: Change all transactions using this Category to\n"
 "another Category using the relocate command:"
@@ -1516,7 +1525,7 @@ msgstr ""
 "Suggerimento: Modifica tutte le operazioni che utilizzano questa Categoria\n"
 "con un'altra Categoria utilizzando la funzione di sostituzione:"
 
-#: src/categdialog.cpp:313
+#: src/categdialog.cpp:309
 msgid ""
 "Tip: Change all transactions using this Sub-Category to\n"
 "another Sub-Category using the relocate command:"
@@ -1525,200 +1534,184 @@ msgstr ""
 "Categoria\n"
 "con un'altra Sotto-Categoria utilizzando la funzione di sostituzione:"
 
-#: src/categdialog.cpp:315
+#: src/categdialog.cpp:311
 msgid "Tools -> Relocation of -> Categories"
 msgstr "Strumenti -> Sostituzione di -> Categorie"
 
-#: src/categdialog.cpp:317
+#: src/categdialog.cpp:313
 msgid "Organise Categories: Delete Error"
 msgstr "Gestione Categorie: Errore di cancellazione"
 
-#: src/categdialog.cpp:334
-msgid "Category in use."
-msgstr "Categoria in uso."
-
-#: src/categdialog.cpp:344
-msgid "Sub-Category in use."
-msgstr "Sotto-Categoria in uso."
-
-#: src/categdialog.cpp:464
+#: src/categdialog.cpp:453
 #, c-format
 msgid "Enter a new name for %s"
 msgstr "Inserire un nuovo nome per %s"
 
-#: src/categdialog.cpp:466
+#: src/categdialog.cpp:455
 msgid "Edit Category"
 msgstr "Modifica categoria"
 
-#: src/categdialog.cpp:480 src/categdialog.cpp:497
+#: src/categdialog.cpp:469 src/categdialog.cpp:486
 msgid "Organise Categories: Editing Error"
 msgstr "Gestione Categorie: Errore di modifica"
 
-#: src/categdialog.cpp:568 src/mmframe.cpp:2675
+#: src/categdialog.cpp:559 src/mmframe.cpp:2658
 msgid "Category Relocation Completed."
 msgstr "Sostituzione categoria completata"
 
-#: src/categdialog.cpp:569 src/mmframe.cpp:2676 src/mmframe.cpp:2691
+#: src/categdialog.cpp:560 src/mmframe.cpp:2659 src/mmframe.cpp:2674
 #: src/payeedialog.cpp:320
 #, c-format
 msgid "Records have been updated in the database: %i"
 msgstr "Records aggiornati nel database: %i"
 
-#: src/categdialog.cpp:571 src/mmframe.cpp:2678
+#: src/categdialog.cpp:562 src/mmframe.cpp:2661
 msgid "Category Relocation Result"
 msgstr "Esito sostituzione categoria"
 
-#: src/categdialog.cpp:636
+#: src/categdialog.cpp:627
 msgid "Hide Selected Category"
 msgstr "Nascondi categoria selezionalta"
 
-#: src/categdialog.cpp:637
+#: src/categdialog.cpp:628
 msgid "Unhide Selected Category"
 msgstr "Mostra categoria selezionata"
 
-#: src/categdialog.cpp:639
+#: src/categdialog.cpp:630
 msgid "Clear Settings"
 msgstr "Ripristina Impostazioni"
 
-#: src/constants.cpp:83
-msgid "Version: "
-msgstr "Versione: "
+#: src/constants.cpp:84
+#, c-format
+msgid "Version: %s"
+msgstr "Versione: %s"
 
-#: src/constants.cpp:98
+#: src/constants.cpp:94
 msgid "MMEX is using the following support products"
 msgstr "MMEX utilizza i seguenti componenti"
 
-#: src/constants.cpp:177 src/mmcheckingpanel.h:269
+#: src/constants.cpp:166 src/mmcheckingpanel.h:259
 msgid "View All Transactions"
 msgstr "Mostra Tutte le operazioni"
 
-#: src/constants.cpp:178 src/mmcheckingpanel.h:270
+#: src/constants.cpp:167 src/mmcheckingpanel.h:260
 msgid "View Today"
 msgstr "Mostra Oggi"
 
-#: src/constants.cpp:179 src/mmcheckingpanel.h:271
+#: src/constants.cpp:168 src/mmcheckingpanel.h:261
 msgid "View Current Month"
 msgstr "Mostra mese corrente"
 
-#: src/constants.cpp:180 src/mmcheckingpanel.h:272
+#: src/constants.cpp:169 src/mmcheckingpanel.h:262
 msgid "View Last 30 days"
 msgstr "Mostra ultimi 30 giorni"
 
-#: src/constants.cpp:181 src/mmcheckingpanel.h:273
+#: src/constants.cpp:170 src/mmcheckingpanel.h:263
 msgid "View Last 90 days"
 msgstr "Mostra ultimi 90 giorni"
 
-#: src/constants.cpp:182 src/mmcheckingpanel.h:274
+#: src/constants.cpp:171 src/mmcheckingpanel.h:264
 msgid "View Last Month"
 msgstr "Mostra il mese scorso"
 
-#: src/constants.cpp:183 src/mmcheckingpanel.h:275
+#: src/constants.cpp:172 src/mmcheckingpanel.h:265
 msgid "View Last 3 Months"
 msgstr "Mostra ultimi 3 mesi"
 
-#: src/constants.cpp:184 src/mmcheckingpanel.h:276
+#: src/constants.cpp:173 src/mmcheckingpanel.h:266
 msgid "View Last 12 Months"
 msgstr "Mostra ultimi 12 mesi"
 
-#: src/constants.cpp:185 src/mmcheckingpanel.h:277
+#: src/constants.cpp:174 src/mmcheckingpanel.h:267
 msgid "View Current Year"
 msgstr "Mostra anno corrente"
 
-#: src/currencydialog.cpp:52
+#: src/constants.cpp:176
+msgid "ALL"
+msgstr "Tutti"
+
+#: src/constants.cpp:177 src/mmframe.cpp:1179 src/mmframe.cpp:1599
+#: src/model/Model_Account.cpp:24
+msgid "Open"
+msgstr "Aperti"
+
+#: src/constants.cpp:178 src/mmframe.cpp:1180 src/model/Model_Account.cpp:25
+msgid "Closed"
+msgstr "Chiuso"
+
+#: src/constants.cpp:179 src/mmframe.cpp:1178
+msgid "Favorites"
+msgstr "Preferiti"
+
+#: src/currencydialog.cpp:68
 msgid "Currency Manager"
 msgstr "Gestione Valute"
 
-#: src/currencydialog.cpp:74
+#: src/currencydialog.cpp:85
 msgid "Currency name"
 msgstr "Nome Valuta"
 
-#: src/currencydialog.cpp:120
-#, c-format
-msgid "%s Converted to: %s"
-msgstr "%s Convertito in: %s"
-
-#: src/currencydialog.cpp:125
-#, c-format
-msgid "%.2f Shown As: %s"
-msgstr "%.2f Visualizza come: %s"
-
-#: src/currencydialog.cpp:162
+#: src/currencydialog.cpp:161
 msgid "Currency Name"
 msgstr "Nome Valuta"
 
-#: src/currencydialog.cpp:167
+#: src/currencydialog.cpp:165
 msgid "Currency Symbol"
 msgstr "Simbolo Valuta"
 
-#: src/currencydialog.cpp:173
+#: src/currencydialog.cpp:170
 msgid "Unit Name"
 msgstr "Nome Unità"
 
-#: src/currencydialog.cpp:177
+#: src/currencydialog.cpp:174
 msgid "Cents Name"
 msgstr "Nome dei centesimi"
 
-#: src/currencydialog.cpp:181
+#: src/currencydialog.cpp:178
 msgid "Prefix Symbol"
 msgstr "Simbolo prefisso"
 
-#: src/currencydialog.cpp:185
+#: src/currencydialog.cpp:182
 msgid "Suffix Symbol"
 msgstr "Simbolo suffisso"
 
-#: src/currencydialog.cpp:189
+#: src/currencydialog.cpp:186
 msgid "Decimal Char"
 msgstr "Separatore Decimale"
 
-#: src/currencydialog.cpp:193
+#: src/currencydialog.cpp:190
 msgid "Grouping Char"
 msgstr "Separatore Migliaia"
 
-#: src/currencydialog.cpp:201
+#: src/currencydialog.cpp:198
 msgid "Scale"
 msgstr "Scala"
 
-#: src/currencydialog.cpp:206
+#: src/currencydialog.cpp:203
 msgid "Conversion to Base Rate"
 msgstr "Tasso Base di Conversione"
 
-#: src/currencydialog.cpp:211
-msgid "Other currency conversion rate. Set Base Currency to 1."
-msgstr ""
-"Tasso di conversione con altre valute. Impostare ad 1 per la Valuta Base"
-
-#: src/currencydialog.cpp:214
-msgid "Base Rate Conversion Sample:"
-msgstr "Esempio di Conversione:"
-
-#: src/currencydialog.cpp:222
+#: src/currencydialog.cpp:210
 msgid "Value Display Sample:"
 msgstr "Esempio di Visualizzazione Valore:"
 
-#: src/currencydialog.cpp:233
-msgid "&Update"
-msgstr "&Aggiorna"
-
-#: src/currencydialog.cpp:235
+#: src/currencydialog.cpp:223
 msgid "Save any changes made"
 msgstr "Salva le modifiche"
 
-#: src/currencydialog.cpp:237 src/general_report_manager.cpp:380
-#: src/stockdialog.cpp:324
+#: src/currencydialog.cpp:225 src/general_report_manager.cpp:382
+#: src/stockdialog.cpp:328
 msgid "&Close "
 msgstr "&Chiudi"
 
-#: src/currencydialog.cpp:239
+#: src/currencydialog.cpp:227
 msgid "Any changes will be lost without update"
 msgstr "Ogni modifica sarà persa senza aggiornamento"
 
-#: src/currencydialog.cpp:260
-msgid "Currency with same name exists"
-msgstr "Valuta già esistente!"
-
-#: src/currencydialog.cpp:260
-msgid "Organize Currency: Add Currency"
-msgstr "Gestione Valute: Nuova Valuta"
+#: src/currencydialog.cpp:275
+#, c-format
+msgid "%.2f Shown As: %s"
+msgstr "%.2f Visualizza come: %s"
 
 #: src/dbwrapper.cpp:70
 msgid "When database file opening:"
@@ -1751,179 +1744,178 @@ msgstr ""
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: src/dbwrapper.cpp:85 src/mmframe.cpp:1690
+#: src/dbwrapper.cpp:85 src/mmframe.cpp:1671
 msgid "Opening MMEX Database - Error"
 msgstr "Apertura del Database MMEX - Errore"
 
-#: src/filtertransdialog.cpp:50 src/mmhomepagepanel.cpp:690
+#: src/filtertransdialog.cpp:49 src/mmhomepagepanel.cpp:696
 #: src/model/Model_Billsdeposits.cpp:35 src/model/Model_Checking.cpp:35
 msgid "Reconciled"
 msgstr "Contabilizzata"
 
-#: src/filtertransdialog.cpp:51 src/model/Model_Billsdeposits.cpp:36
+#: src/filtertransdialog.cpp:50 src/model/Model_Billsdeposits.cpp:36
 #: src/model/Model_Checking.cpp:36
 msgid "Void"
 msgstr "Nulla"
 
-#: src/filtertransdialog.cpp:52 src/model/Model_Billsdeposits.cpp:37
+#: src/filtertransdialog.cpp:51 src/model/Model_Billsdeposits.cpp:37
 #: src/model/Model_Checking.cpp:37
 msgid "Follow up"
 msgstr "Da Monitorare"
 
-#: src/filtertransdialog.cpp:53 src/model/Model_Billsdeposits.cpp:38
+#: src/filtertransdialog.cpp:52 src/model/Model_Billsdeposits.cpp:38
 #: src/model/Model_Checking.cpp:38
 msgid "Duplicate"
 msgstr "Duplicata"
 
-#: src/filtertransdialog.cpp:54
+#: src/filtertransdialog.cpp:53
 msgid "Un-Reconciled"
 msgstr "Non Contabilizzata"
 
-#: src/filtertransdialog.cpp:55
+#: src/filtertransdialog.cpp:54
 msgid "All Except Reconciled"
 msgstr "Mostra tutto eccetto le contabilizzate"
 
-#: src/filtertransdialog.cpp:157
+#: src/filtertransdialog.cpp:156
 msgid " Specify "
 msgstr " Specificare "
 
-#: src/filtertransdialog.cpp:187 src/reports/mmDateRange.cpp:27
+#: src/filtertransdialog.cpp:186 src/reports/mmDateRange.cpp:27
 msgid "Date Range"
 msgstr "Selezione Periodo"
 
-#: src/filtertransdialog.cpp:229
+#: src/filtertransdialog.cpp:228
 msgid "Include Similar"
 msgstr "Includi simili"
 
-#: src/filtertransdialog.cpp:231
+#: src/filtertransdialog.cpp:230
 msgid "Include all subcategories for the selected category."
 msgstr "Include tutte le sotto-categorie della categoria selezionata"
 
-#: src/filtertransdialog.cpp:257 src/import_export/univcsvdialog.cpp:79
-#: src/mmcheckingpanel.cpp:1013 src/model/Model_Billsdeposits.cpp:27
-#: src/model/Model_Checking.cpp:27 src/splitdetailsdialog.cpp:110
-#: src/splittransactionsdialog.cpp:140
+#: src/filtertransdialog.cpp:256 src/import_export/univcsvdialog.cpp:84
+#: src/mmcheckingpanel.cpp:979 src/model/Model_Billsdeposits.cpp:27
+#: src/model/Model_Checking.cpp:27 src/splitdetailsdialog.cpp:118
 msgid "Withdrawal"
 msgstr "Prelievo"
 
-#: src/filtertransdialog.cpp:259 src/import_export/univcsvdialog.cpp:80
-#: src/mmcheckingpanel.cpp:1015 src/model/Model_Billsdeposits.cpp:28
-#: src/model/Model_Checking.cpp:28 src/splitdetailsdialog.cpp:111
-#: src/splittransactionsdialog.cpp:145
+#: src/filtertransdialog.cpp:258 src/import_export/univcsvdialog.cpp:85
+#: src/mmcheckingpanel.cpp:980 src/model/Model_Billsdeposits.cpp:28
+#: src/model/Model_Checking.cpp:28 src/splitdetailsdialog.cpp:119
 msgid "Deposit"
 msgstr "Deposito"
 
-#: src/filtertransdialog.cpp:261
+#: src/filtertransdialog.cpp:260
 msgid "Transfer To"
 msgstr "Trasferimento a"
 
-#: src/filtertransdialog.cpp:263
+#: src/filtertransdialog.cpp:262
 msgid "Transfer From"
 msgstr "Trasferimento da"
 
-#: src/filtertransdialog.cpp:276
+#: src/filtertransdialog.cpp:275
 msgid "Amount Range"
 msgstr "Range Importo:"
 
-#: src/filtertransdialog.cpp:346
+#: src/filtertransdialog.cpp:345
 msgid "&Clear "
 msgstr "&Pulisci "
 
-#: src/filtertransdialog.cpp:424 src/filtertransdialog.cpp:434
+#: src/filtertransdialog.cpp:423 src/filtertransdialog.cpp:433
 msgid "Invalid Amount Entered "
 msgstr "Inserito Importo non valido! "
 
-#: src/filtertransdialog.cpp:424 src/filtertransdialog.cpp:434
-#: src/import_export/qif_import_gui.cpp:704 src/maincurrencydialog.cpp:434
-#: src/mmframe.cpp:2793 src/splittransactionsdialog.cpp:208
-#: src/stockspanel.cpp:764 src/stockspanel.cpp:765 src/util.cpp:105
+#: src/filtertransdialog.cpp:423 src/filtertransdialog.cpp:433
+#: src/import_export/qif_import_gui.cpp:772 src/maincurrencydialog.cpp:504
+#: src/mmSimpleDialogs.cpp:153 src/mmframe.cpp:2775
+#: src/splittransactionsdialog.cpp:201 src/stockspanel.cpp:717
+#: src/stockspanel.cpp:718
 msgid "Error"
 msgstr "Errore"
 
-#: src/filtertransdialog.cpp:768
+#: src/filtertransdialog.cpp:767
 msgid "Filtering Details: "
 msgstr "Dettagli Filtro: "
 
-#: src/general_report_manager.cpp:231 src/general_report_manager.cpp:599
+#: src/general_report_manager.cpp:236 src/general_report_manager.cpp:608
 msgid "General Reports Manager"
 msgstr "Manager Resoconti"
 
-#: src/general_report_manager.cpp:276 src/mmframe.cpp:739 src/mmframe.cpp:2234
+#: src/general_report_manager.cpp:278 src/mmframe.cpp:741 src/mmframe.cpp:2215
 msgid "Reports"
 msgstr "Resoconti"
 
-#: src/general_report_manager.cpp:363 src/import_export/univcsvdialog.cpp:311
-#: src/mmframe.cpp:1157 src/mmframe.cpp:1381
+#: src/general_report_manager.cpp:365 src/import_export/univcsvdialog.cpp:314
+#: src/mmframe.cpp:1172 src/mmframe.cpp:1359
 msgid "&Import"
 msgstr "&Importa"
 
-#: src/general_report_manager.cpp:365
+#: src/general_report_manager.cpp:367
 msgid "Locate and load a report file."
 msgstr "Sfoglia e carica file resoconto"
 
-#: src/general_report_manager.cpp:367 src/import_export/univcsvdialog.cpp:318
-#: src/mmframe.cpp:1153 src/mmframe.cpp:1375
+#: src/general_report_manager.cpp:369 src/import_export/univcsvdialog.cpp:321
+#: src/mmframe.cpp:1168 src/mmframe.cpp:1353
 msgid "&Export"
 msgstr "&Esporta"
 
-#: src/general_report_manager.cpp:369
+#: src/general_report_manager.cpp:371
 msgid "Export the report to a new file."
 msgstr "Esportare il resoconto in un nuovo file"
 
-#: src/general_report_manager.cpp:372 src/stockdialog.cpp:323
+#: src/general_report_manager.cpp:374 src/stockdialog.cpp:327
 msgid "&Save "
 msgstr "&Salva"
 
-#: src/general_report_manager.cpp:374
+#: src/general_report_manager.cpp:376
 msgid "Save changes."
 msgstr "Salva le modifiche"
 
-#: src/general_report_manager.cpp:376
+#: src/general_report_manager.cpp:378
 msgid "&Run"
 msgstr "&Esegui"
 
-#: src/general_report_manager.cpp:378
+#: src/general_report_manager.cpp:380
 msgid "Run selected report."
 msgstr "Eseguire il resoconto selezionato"
 
-#: src/general_report_manager.cpp:390
+#: src/general_report_manager.cpp:392
 msgid "Output"
 msgstr "Output"
 
-#: src/general_report_manager.cpp:402
+#: src/general_report_manager.cpp:404
 msgid "SQL"
 msgstr "SQL"
 
-#: src/general_report_manager.cpp:403
+#: src/general_report_manager.cpp:405
 msgid "Lua"
 msgstr "Lua"
 
-#: src/general_report_manager.cpp:404
+#: src/general_report_manager.cpp:406
 msgid "Template"
 msgstr "Modello"
 
-#: src/general_report_manager.cpp:434
+#: src/general_report_manager.cpp:441
 msgid "&Test"
 msgstr "&Test"
 
-#: src/general_report_manager.cpp:435
+#: src/general_report_manager.cpp:442
 msgid "Create Template"
 msgstr "Salva come Modello"
 
-#: src/general_report_manager.cpp:481
+#: src/general_report_manager.cpp:488
 #, c-format
 msgid "Row(s) returned: %i  Duration: %ld ms"
 msgstr "Righe restituite: %i Durata:%ld ms"
 
-#: src/general_report_manager.cpp:504
+#: src/general_report_manager.cpp:513
 msgid "SQL Syntax Error"
 msgstr "Errore di sintassi SQL"
 
-#: src/general_report_manager.cpp:533
+#: src/general_report_manager.cpp:542
 msgid "Load report file:"
 msgstr "Carica file resoconto:"
 
-#: src/general_report_manager.cpp:598
+#: src/general_report_manager.cpp:607
 #, c-format
 msgid ""
 "Unable to open file:\n"
@@ -1934,444 +1926,476 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: src/general_report_manager.cpp:661
+#: src/general_report_manager.cpp:670
 msgid "New Empty Report"
 msgstr "Nuovo Resoconto Vuoto"
 
-#: src/general_report_manager.cpp:662
+#: src/general_report_manager.cpp:671
 msgid "New Sample Report"
 msgstr "Nuovo Resoconto da modello"
 
-#: src/general_report_manager.cpp:664
+#: src/general_report_manager.cpp:674
 msgid "Change Group"
 msgstr "Cambiare gruppo"
 
-#: src/general_report_manager.cpp:665
+#: src/general_report_manager.cpp:676
+msgid "Rename Group"
+msgstr "Rinomina Gruppo"
+
+#: src/general_report_manager.cpp:677
 msgid "UnGroup"
 msgstr "Rimovi dal gruppo"
 
-#: src/general_report_manager.cpp:666
+#: src/general_report_manager.cpp:678
 msgid "Rename Report"
 msgstr "Rinomina Resoconto"
 
-#: src/general_report_manager.cpp:668
+#: src/general_report_manager.cpp:680
 msgid "Delete Report"
 msgstr "Elimina Resoconto"
 
-#: src/general_report_manager.cpp:760
+#: src/general_report_manager.cpp:776 src/general_report_manager.cpp:921
 msgid "Enter the name for the report"
 msgstr "Inserire il nome del resoconto"
 
-#: src/general_report_manager.cpp:761 src/general_report_manager.cpp:821
-#: src/mmframe.cpp:1516 src/mmframe.cpp:1630
+#: src/general_report_manager.cpp:777 src/general_report_manager.cpp:922
+#: src/mmframe.cpp:1146 src/mmframe.cpp:1494 src/mmframe.cpp:1610
 msgid "General Report Manager"
 msgstr "Manager Resoconti"
 
-#: src/general_report_manager.cpp:779
+#: src/general_report_manager.cpp:795
 msgid "Delete the Report Title:"
 msgstr "Elimina il Resoconto:"
 
-#: src/general_report_manager.cpp:820 src/general_report_manager.cpp:845
-msgid "Enter the name for the new report group"
-msgstr "Inserire il nome del nuovo gruppo di resoconti"
+#: src/general_report_manager.cpp:824 src/general_report_manager.cpp:902
+msgid "Enter or choose name for the new report group"
+msgstr "Inserire o scegliere il nome del nuovo gruppo di resoconti"
 
-#: src/general_report_manager.cpp:846
+#: src/general_report_manager.cpp:825
+msgid "Change report group"
+msgstr "Cambiare gruppo di resoconti"
+
+#: src/general_report_manager.cpp:841
+msgid "Enter or choose name for the new group"
+msgstr "Inserire o scegliere il nome del nuovo gruppo di resoconti"
+
+#: src/general_report_manager.cpp:842
+msgid "Rename group"
+msgstr "Rinomina Gruppo"
+
+#: src/general_report_manager.cpp:903
 msgid "Add Report Group"
 msgstr "Aggiungere gruppo resoconti"
 
-#: src/general_report_manager.cpp:854
+#: src/general_report_manager.cpp:916
 #, c-format
 msgid "New Report %s"
 msgstr "Nuovo Resoconto %s"
 
-#: src/general_report_manager.cpp:860
+#: src/general_report_manager.cpp:929
+msgid "Report Name already exists"
+msgstr "Esiste già un resoconto con questo nome"
+
+#: src/general_report_manager.cpp:929 src/general_report_manager.cpp:936
 msgid "New Report"
 msgstr "Nuovo Resoconto"
 
-#: src/general_report_manager.cpp:891
+#: src/general_report_manager.cpp:967
 msgid "Choose file to Save As Report"
 msgstr "Scegliere il file da salvare come resoconto"
 
-#: src/import_export/qif_export.cpp:39 src/import_export/qif_export.cpp:218
-#: src/import_export/qif_export.cpp:303
+#: src/import_export/qif_export.cpp:39 src/import_export/qif_export.cpp:230
+#: src/import_export/qif_export.cpp:315
 msgid "QIF Export"
 msgstr "Esporta file in QIF"
 
-#: src/import_export/qif_export.cpp:96
+#: src/import_export/qif_export.cpp:94
 msgid "Parameters"
 msgstr "Parametri"
 
-#: src/import_export/qif_export.cpp:101
-#: src/import_export/qif_import_gui.cpp:180
+#: src/import_export/qif_export.cpp:99
+#: src/import_export/qif_import_gui.cpp:203
 msgid "Log"
 msgstr "Registro"
 
-#: src/import_export/qif_export.cpp:108
+#: src/import_export/qif_export.cpp:106
 msgid "QIF"
 msgstr "QIF"
 
-#: src/import_export/qif_export.cpp:108
+#: src/import_export/qif_export.cpp:106
 msgid "CSV"
 msgstr "CSV"
 
-#: src/import_export/qif_export.cpp:125 src/mmframe.cpp:2506
-#: src/mmframe.cpp:2510 src/mmframe.cpp:2529 src/mmframe.cpp:2533
+#: src/import_export/qif_export.cpp:123 src/mmframe.cpp:2489
+#: src/mmframe.cpp:2493 src/mmframe.cpp:2512 src/mmframe.cpp:2516
 msgid "Accounts"
 msgstr "Conti"
 
-#: src/import_export/qif_export.cpp:136
-#: src/import_export/qif_import_gui.cpp:158
+#: src/import_export/qif_export.cpp:134
+#: src/import_export/qif_import_gui.cpp:181
 msgid "From Date"
 msgstr "Dalla data"
 
-#: src/import_export/qif_export.cpp:145
-#: src/import_export/qif_import_gui.cpp:167
+#: src/import_export/qif_export.cpp:143
+#: src/import_export/qif_import_gui.cpp:190
 msgid "To Date"
 msgstr "Alla data"
 
 #: src/import_export/qif_export.cpp:156
+#: src/import_export/qif_import_gui.cpp:138
+#: src/mmOptionGeneralSettings.cpp:111
+msgid "Date Format"
+msgstr "Formato Data"
+
+#: src/import_export/qif_export.cpp:168
 msgid "Write to File"
 msgstr "Scrivi su file"
 
-#: src/import_export/qif_export.cpp:159
-#: src/import_export/qif_import_gui.cpp:108
-#: src/import_export/univcsvdialog.cpp:135
+#: src/import_export/qif_export.cpp:171
+#: src/import_export/qif_import_gui.cpp:122
+#: src/import_export/univcsvdialog.cpp:138
 msgid "File Name:"
 msgstr "Nome File:"
 
-#: src/import_export/qif_export.cpp:160
-#: src/import_export/qif_import_gui.cpp:109
+#: src/import_export/qif_export.cpp:172
+#: src/import_export/qif_import_gui.cpp:123
 msgid "Choose &file"
 msgstr "Scegli &file"
 
-#: src/import_export/qif_export.cpp:182
-#: src/import_export/univcsvdialog.cpp:337
+#: src/import_export/qif_export.cpp:194
+#: src/import_export/univcsvdialog.cpp:340
 msgid "Clear"
 msgstr "Pulisci"
 
-#: src/import_export/qif_export.cpp:217
+#: src/import_export/qif_export.cpp:229
 msgid "Choose Account to Export from:"
 msgstr "Selezionare il Conto da esportare:"
 
-#: src/import_export/qif_export.cpp:263
-#: src/import_export/qif_import_gui.cpp:586
+#: src/import_export/qif_export.cpp:275
+#: src/import_export/qif_import_gui.cpp:641
 msgid "QIF Files"
 msgstr "File QIF"
 
-#: src/import_export/qif_export.cpp:263
-#: src/import_export/univcsvdialog.cpp:1190
+#: src/import_export/qif_export.cpp:275
+#: src/import_export/univcsvdialog.cpp:1187
 msgid "CSV Files"
 msgstr "Files CSV"
 
-#: src/import_export/qif_export.cpp:266
+#: src/import_export/qif_export.cpp:278
 msgid "Choose QIF data file to Export"
 msgstr "Selezionare file da esportare in QIF"
 
-#: src/import_export/qif_export.cpp:267
-#: src/import_export/univcsvdialog.cpp:150
-#: src/import_export/univcsvdialog.cpp:1188
+#: src/import_export/qif_export.cpp:279
+#: src/import_export/univcsvdialog.cpp:153
+#: src/import_export/univcsvdialog.cpp:1185
 msgid "Choose CSV data file to Export"
 msgstr "Selezionare file da esportare in CSV"
 
-#: src/import_export/qif_export.cpp:283
+#: src/import_export/qif_export.cpp:295
 msgid "No Account available for export"
 msgstr "Nessun Conto disponibile da esportare!"
 
-#: src/import_export/qif_export.cpp:287
+#: src/import_export/qif_export.cpp:299
 msgid "No Accounts selected for export"
 msgstr "Nessun Conto selezionato per l'esportazione"
 
-#: src/import_export/qif_export.cpp:291
+#: src/import_export/qif_export.cpp:303
 msgid "File name is empty"
 msgstr "Il campo nome file è vuoto"
 
-#: src/import_export/qif_export.cpp:295
+#: src/import_export/qif_export.cpp:307
 msgid "To Date less than From Date"
 msgstr "'Alla Data' non può essere antecedente a 'Dalla Data'"
 
-#: src/import_export/qif_export.cpp:377
+#: src/import_export/qif_export.cpp:391
 msgid "Categories exported"
 msgstr "Categorie esportate"
 
-#: src/import_export/qif_export.cpp:385
-#: src/import_export/qif_import_gui.cpp:290
-#: src/import_export/qif_import_gui.cpp:651
+#: src/import_export/qif_export.cpp:399
+#: src/import_export/qif_import_gui.cpp:317
+#: src/import_export/qif_import_gui.cpp:719
 msgid "Please wait"
 msgstr "Attendere prego"
 
-#: src/import_export/qif_export.cpp:385
+#: src/import_export/qif_export.cpp:399
 msgid "Exporting"
 msgstr "Esportazione in corso"
 
-#: src/import_export/qif_export.cpp:406
+#: src/import_export/qif_export.cpp:419
 #, c-format
 msgid "Exporting transaction %i"
 msgstr "Esportazione operazione %i"
 
-#: src/import_export/qif_export.cpp:457
+#: src/import_export/qif_export.cpp:469
 #, c-format
 msgid "Number of transactions exported: %ld"
 msgstr "Numero di operazioni esportate:  %ld"
 
-#: src/import_export/qif_export.cpp:458 src/mmframe.cpp:1373
+#: src/import_export/qif_export.cpp:470 src/mmframe.cpp:1351
 msgid "Export to QIF"
 msgstr "Esporta in file QIF"
 
-#: src/import_export/qif_import_gui.cpp:62
-#: src/import_export/qif_import_gui.cpp:727
+#: src/import_export/qif_import_gui.cpp:77
+#: src/import_export/qif_import_gui.cpp:795
 msgid "QIF Import"
 msgstr "Importa file QIF"
 
-#: src/import_export/qif_import_gui.cpp:124 src/mmOptionGeneralSettings.cpp:89
-msgid "Date Format"
-msgstr "Formato Data"
+#: src/import_export/qif_import_gui.cpp:166
+msgid "Use account number instead of account name"
+msgstr "Utilizzare il numero di conto invece che il nome"
 
-#: src/import_export/qif_import_gui.cpp:152
+#: src/import_export/qif_import_gui.cpp:170
+msgid "Include paye field in notes"
+msgstr "Includere il campo beneficiario nelle note"
+
+#: src/import_export/qif_import_gui.cpp:175
 msgid "Filtering Details:"
 msgstr "Dettagli filtro:"
 
-#: src/import_export/qif_import_gui.cpp:189
+#: src/import_export/qif_import_gui.cpp:212
 msgid "Data"
 msgstr "Data"
 
-#: src/import_export/qif_import_gui.cpp:284
-#: src/import_export/qif_import_gui.cpp:424
-#: src/import_export/qif_import_gui.cpp:868
-#: src/import_export/univcsvdialog.cpp:493
-#: src/import_export/univcsvdialog.cpp:553
+#: src/import_export/qif_import_gui.cpp:311
+#: src/import_export/qif_import_gui.cpp:451
+#: src/import_export/qif_import_gui.cpp:454
+#: src/import_export/qif_import_gui.cpp:459
+#: src/import_export/qif_import_gui.cpp:936
+#: src/import_export/univcsvdialog.cpp:497
 #: src/import_export/univcsvdialog.cpp:557
-#: src/import_export/univcsvdialog.cpp:577
-#: src/import_export/univcsvdialog.cpp:583 src/webapp.cpp:391
+#: src/import_export/univcsvdialog.cpp:561
+#: src/import_export/univcsvdialog.cpp:581
+#: src/import_export/univcsvdialog.cpp:587 src/webapp.cpp:391
 #: src/webapp.cpp:395
 msgid "Unknown"
 msgstr "Sconosciuta"
 
-#: src/import_export/qif_import_gui.cpp:290
+#: src/import_export/qif_import_gui.cpp:317
 msgid "Scanning"
 msgstr "Scansione"
 
-#: src/import_export/qif_import_gui.cpp:308
+#: src/import_export/qif_import_gui.cpp:335
 #, c-format
 msgid "Reading line %i, %ld ms"
 msgstr "Lettura riga %i in %ld ms"
 
-#: src/import_export/qif_import_gui.cpp:314
+#: src/import_export/qif_import_gui.cpp:341
 #, c-format
 msgid "Line %i \t %s\n"
 msgstr "Riga %i  \t %s\n"
 
-#: src/import_export/qif_import_gui.cpp:370
+#: src/import_export/qif_import_gui.cpp:397
 #, c-format
 msgid "Number of lines read from QIF file: %i in %ld ms"
 msgstr "Numero di linee lette dal file QIF: %i in %ld ms"
 
-#: src/import_export/qif_import_gui.cpp:373
+#: src/import_export/qif_import_gui.cpp:400
 msgid "Press OK Button to continue"
 msgstr "Premere OK per continuare"
 
-#: src/import_export/qif_import_gui.cpp:497
-#: src/import_export/qif_import_gui.cpp:516
-#: src/import_export/qif_import_gui.cpp:533
+#: src/import_export/qif_import_gui.cpp:548
+#: src/import_export/qif_import_gui.cpp:571
+#: src/import_export/qif_import_gui.cpp:588
 msgid "OK"
 msgstr "OK"
 
-#: src/import_export/qif_import_gui.cpp:499
+#: src/import_export/qif_import_gui.cpp:550
 msgid "Warning"
 msgstr "Attenzione"
 
-#: src/import_export/qif_import_gui.cpp:502
-#: src/import_export/qif_import_gui.cpp:516
+#: src/import_export/qif_import_gui.cpp:554
+#: src/import_export/qif_import_gui.cpp:571
 msgid "Missing"
 msgstr "Mancante"
 
-#: src/import_export/qif_import_gui.cpp:587
+#: src/import_export/qif_import_gui.cpp:642
 msgid "Choose QIF data file to Import"
 msgstr "Scegliere file dati QIF da importare"
 
-#: src/import_export/qif_import_gui.cpp:644
+#: src/import_export/qif_import_gui.cpp:712
 msgid "Do you want to import all transaction ?"
 msgstr "Vuoi importare tutte le operazioni?"
 
-#: src/import_export/qif_import_gui.cpp:645
+#: src/import_export/qif_import_gui.cpp:713
 msgid "All missing account, payees and categories will be created."
 msgstr "Saranno creati tutti i conti, beneficiari e categorie mancanti."
 
-#: src/import_export/qif_import_gui.cpp:646
+#: src/import_export/qif_import_gui.cpp:714
 msgid "Confirm Import"
 msgstr "Conferma Importo"
 
-#: src/import_export/qif_import_gui.cpp:651
+#: src/import_export/qif_import_gui.cpp:719
 msgid "Importing"
 msgstr "Importazione"
 
-#: src/import_export/qif_import_gui.cpp:653
+#: src/import_export/qif_import_gui.cpp:721
 msgid "Importing Accounts"
 msgstr "Importazione Conti"
 
-#: src/import_export/qif_import_gui.cpp:660
+#: src/import_export/qif_import_gui.cpp:728
 msgid "Importing Payees"
 msgstr "Importazione Beneficiari"
 
-#: src/import_export/qif_import_gui.cpp:663
+#: src/import_export/qif_import_gui.cpp:731
 msgid "Importing Categories"
 msgstr "Importazione Categorie"
 
-#: src/import_export/qif_import_gui.cpp:678
+#: src/import_export/qif_import_gui.cpp:746
 #, c-format
 msgid "Importing transaction %i of %i"
 msgstr "Importazione operazione  %i di %i"
 
-#: src/import_export/qif_import_gui.cpp:709
+#: src/import_export/qif_import_gui.cpp:777
 msgid "Importing Transfers"
 msgstr "Importazione Trasferimenti"
 
-#: src/import_export/qif_import_gui.cpp:713
+#: src/import_export/qif_import_gui.cpp:781
 msgid "Importing Split transactions"
 msgstr "Importazione categorie suddivise"
 
-#: src/import_export/qif_import_gui.cpp:717
+#: src/import_export/qif_import_gui.cpp:785
 msgid "Import finished successfully"
 msgstr "Importazione eseguita con successo"
 
-#: src/import_export/qif_import_gui.cpp:725
-#: src/import_export/univcsvdialog.cpp:764
+#: src/import_export/qif_import_gui.cpp:793
+#: src/import_export/univcsvdialog.cpp:762
 msgid "Imported transactions discarded by user!"
 msgstr "Importazione transazioni annullata dall'utente!"
 
-#: src/import_export/qif_import_gui.cpp:917
+#: src/import_export/qif_import_gui.cpp:995
 #, c-format
 msgid "Added account: %s"
 msgstr "Aggiunto conto: %s"
 
-#: src/import_export/qif_import_gui.cpp:948
-#: src/import_export/univcsvdialog.cpp:561
+#: src/import_export/qif_import_gui.cpp:1026
+#: src/import_export/univcsvdialog.cpp:565
 #, c-format
 msgid "Added payee: %s"
 msgstr "Aggiunto Beneficiario: %s"
 
-#: src/import_export/univcsvdialog.cpp:73
+#: src/import_export/univcsvdialog.cpp:78
 msgid "Amount(+/-)"
 msgstr "Importo(+/-)"
 
-#: src/import_export/univcsvdialog.cpp:75
+#: src/import_export/univcsvdialog.cpp:80
 msgid "SubCategory"
 msgstr "Sotto-Categoria"
 
-#: src/import_export/univcsvdialog.cpp:78
+#: src/import_export/univcsvdialog.cpp:83
 msgid "Don't Care"
 msgstr "Ignora"
 
-#: src/import_export/univcsvdialog.cpp:81 src/mmcheckingpanel.cpp:1017
-#: src/mmhomepagepanel.cpp:691 src/reports/summary.cpp:135
-#: src/reports/summary.cpp:137 src/reports/summary.cpp:227
+#: src/import_export/univcsvdialog.cpp:86 src/mmcheckingpanel.cpp:981
+#: src/mmhomepagepanel.cpp:697 src/reports/summary.cpp:135
+#: src/reports/summary.cpp:137 src/reports/summary.cpp:228
 msgid "Balance"
 msgstr "Saldo"
 
-#: src/import_export/univcsvdialog.cpp:147
+#: src/import_export/univcsvdialog.cpp:150
 msgid "&Search"
 msgstr "&Cerca"
 
-#: src/import_export/univcsvdialog.cpp:150
+#: src/import_export/univcsvdialog.cpp:153
 msgid "Choose CSV data file to Import"
 msgstr "Selezionare file CSV da importare"
 
-#: src/import_export/univcsvdialog.cpp:173
+#: src/import_export/univcsvdialog.cpp:176
 msgid "Save Template"
 msgstr "Salva come Modello"
 
-#: src/import_export/univcsvdialog.cpp:177
+#: src/import_export/univcsvdialog.cpp:180
 msgid "Specify the order of fields in the CSV file"
 msgstr "Specificare l'ordine dei campi nel file CSV"
 
-#: src/import_export/univcsvdialog.cpp:208
+#: src/import_export/univcsvdialog.cpp:211
 msgid "&MMEX format"
 msgstr "Formato &MMEX"
 
-#: src/import_export/univcsvdialog.cpp:210
+#: src/import_export/univcsvdialog.cpp:213
 msgid "MMEX standard format"
 msgstr "Formato standard MMEX"
 
-#: src/import_export/univcsvdialog.cpp:226
+#: src/import_export/univcsvdialog.cpp:229
 msgid "&Up"
 msgstr "S&u"
 
-#: src/import_export/univcsvdialog.cpp:228
+#: src/import_export/univcsvdialog.cpp:231
 msgid "Move Up"
 msgstr "Sposta Su"
 
-#: src/import_export/univcsvdialog.cpp:231
+#: src/import_export/univcsvdialog.cpp:234
 msgid "&Down"
 msgstr "&Giù"
 
-#: src/import_export/univcsvdialog.cpp:233
+#: src/import_export/univcsvdialog.cpp:236
 msgid "Move &Down"
 msgstr "Sposta Giù"
 
-#: src/import_export/univcsvdialog.cpp:247
+#: src/import_export/univcsvdialog.cpp:250
 msgid "Account: "
 msgstr "Conto: "
 
-#: src/import_export/univcsvdialog.cpp:260
+#: src/import_export/univcsvdialog.cpp:263
 msgid "Date Format: "
 msgstr "Formato data: "
 
-#: src/import_export/univcsvdialog.cpp:272
+#: src/import_export/univcsvdialog.cpp:275
 msgid "Comma"
 msgstr "Virgola"
 
-#: src/import_export/univcsvdialog.cpp:272
+#: src/import_export/univcsvdialog.cpp:275
 msgid "Semicolon"
 msgstr "Punto e virgola"
 
-#: src/import_export/univcsvdialog.cpp:272
+#: src/import_export/univcsvdialog.cpp:275
 msgid "TAB"
 msgstr "Tabulazione"
 
-#: src/import_export/univcsvdialog.cpp:272
-#: src/mmOptionAttachmentSettings.cpp:166
+#: src/import_export/univcsvdialog.cpp:275
+#: src/mmOptionAttachmentSettings.cpp:185
 msgid "User Defined"
 msgstr "Altro"
 
-#: src/import_export/univcsvdialog.cpp:278 src/mmOptionMiscSettings.cpp:145
+#: src/import_export/univcsvdialog.cpp:281 src/mmOptionMiscSettings.cpp:165
 msgid "Specify the delimiter to use when importing/exporting CSV files"
 msgstr ""
 "Specificare il separatore da usare nell'importazione/esportazione dei file "
 "CSV"
 
-#: src/import_export/univcsvdialog.cpp:285
+#: src/import_export/univcsvdialog.cpp:288
 msgid "CSV Delimiter"
 msgstr "Separatore di campo CSV"
 
-#: src/import_export/univcsvdialog.cpp:295
+#: src/import_export/univcsvdialog.cpp:298
 msgid "Preview"
 msgstr "Anteprima"
 
-#: src/import_export/univcsvdialog.cpp:314
+#: src/import_export/univcsvdialog.cpp:317
 msgid "Import File"
 msgstr "Importa file"
 
-#: src/import_export/univcsvdialog.cpp:321
+#: src/import_export/univcsvdialog.cpp:324
 msgid "Export File"
 msgstr "Esporta file"
 
-#: src/import_export/univcsvdialog.cpp:598
+#: src/import_export/univcsvdialog.cpp:602
 msgid ""
 "Incorrect fields specified for CSV import! Requires at least Date and Amount."
 msgstr ""
 "Campi specificati non correttamente per l'importazione CSV! Sono richiesti "
 "almeno data e importo."
 
-#: src/import_export/univcsvdialog.cpp:599
-#: src/import_export/univcsvdialog.cpp:638
-#: src/import_export/univcsvdialog.cpp:952 src/mmframe.cpp:2079
+#: src/import_export/univcsvdialog.cpp:603
+#: src/import_export/univcsvdialog.cpp:642
+#: src/import_export/univcsvdialog.cpp:949 src/mmframe.cpp:2060
 msgid "Universal CSV Import"
 msgstr "Importa CSV generico"
 
-#: src/import_export/univcsvdialog.cpp:639
+#: src/import_export/univcsvdialog.cpp:643
 msgid "Transactions imported from CSV: "
 msgstr "Operazioni importate da file CSV: "
 
-#: src/import_export/univcsvdialog.cpp:646
+#: src/import_export/univcsvdialog.cpp:650
 #, c-format
 msgid ""
 "Transactions imported from CSV\n"
@@ -2382,8 +2406,8 @@ msgstr ""
 
 #: src/import_export/univcsvdialog.cpp:677
 #: src/import_export/univcsvdialog.cpp:679
-#: src/import_export/univcsvdialog.cpp:700
-#: src/import_export/univcsvdialog.cpp:702
+#: src/import_export/univcsvdialog.cpp:699
+#: src/import_export/univcsvdialog.cpp:701
 #, c-format
 msgid "Line: %ld"
 msgstr "Riga: %ld"
@@ -2393,241 +2417,291 @@ msgstr "Riga: %ld"
 msgid " file contains insufficient number of tokens"
 msgstr " il file contiene un numero insufficiente di valori"
 
-#: src/import_export/univcsvdialog.cpp:701
-#: src/import_export/univcsvdialog.cpp:703
+#: src/import_export/univcsvdialog.cpp:700
+#: src/import_export/univcsvdialog.cpp:702
 msgid " One of the following fields: Date, Amount, Type is missing, skipping"
 msgstr ""
 " Uno dei seguenti campi: Data, Importo, Tipo è mancante. Operazione ignorata!"
 
-#: src/import_export/univcsvdialog.cpp:728
-#: src/import_export/univcsvdialog.cpp:729
+#: src/import_export/univcsvdialog.cpp:726
+#: src/import_export/univcsvdialog.cpp:727
 #, c-format
 msgid "Line : %ld imported OK."
 msgstr "Riga : %ld importata con successo."
 
-#: src/import_export/univcsvdialog.cpp:734 src/stockdialog.cpp:595
+#: src/import_export/univcsvdialog.cpp:732 src/stockdialog.cpp:599
 #, c-format
 msgid "Total Lines : %ld"
 msgstr "Totale Righe: %ld"
 
-#: src/import_export/univcsvdialog.cpp:736 src/stockdialog.cpp:597
+#: src/import_export/univcsvdialog.cpp:734 src/stockdialog.cpp:601
 #, c-format
 msgid "Total Imported : %ld"
 msgstr "Totale Importato : %ld"
 
-#: src/import_export/univcsvdialog.cpp:738
+#: src/import_export/univcsvdialog.cpp:736
 #, c-format
 msgid "Log file written to : %s"
 msgstr "File registro scritto in : %s"
 
-#: src/import_export/univcsvdialog.cpp:741 src/stockdialog.cpp:603
+#: src/import_export/univcsvdialog.cpp:739 src/stockdialog.cpp:607
 msgid "Please confirm saving..."
 msgstr "Confermare salvataggio"
 
-#: src/import_export/univcsvdialog.cpp:743 src/stockdialog.cpp:605
+#: src/import_export/univcsvdialog.cpp:741 src/stockdialog.cpp:609
 msgid "Importing CSV"
 msgstr "Importa da file CSV"
 
-#: src/import_export/univcsvdialog.cpp:747
+#: src/import_export/univcsvdialog.cpp:745
 msgid "Imported transactions have been flagged so you can review them."
 msgstr ""
 "Le operazioni importate sono state contrassegnate in modo da poterle "
 "ricontrollare."
 
-#: src/import_export/univcsvdialog.cpp:758
-msgid "Transactions saved to database in account: "
-msgstr "Operazioni salvate nel database nel conto: "
+#: src/import_export/univcsvdialog.cpp:756
+#, c-format
+msgid "Transactions saved to database in account: %s"
+msgstr "Operazioni salvate nel database nel conto: %s"
 
-#: src/import_export/univcsvdialog.cpp:783
+#: src/import_export/univcsvdialog.cpp:781
 msgid ""
 "Incorrect fields specified for CSV export! Requires at least Date and Amount."
 msgstr ""
 "Campi specificati non correttamente per l'importazione CSV! Sono richiesti "
 "almeno data e importo."
 
-#: src/import_export/univcsvdialog.cpp:784
+#: src/import_export/univcsvdialog.cpp:782
 msgid "Universal CSV Export"
 msgstr "Esportazione Universale CSV"
 
-#: src/import_export/univcsvdialog.cpp:797
+#: src/import_export/univcsvdialog.cpp:795
 msgid "Overwrite?"
 msgstr "Sovrascrivere?"
 
-#: src/import_export/univcsvdialog.cpp:797
+#: src/import_export/univcsvdialog.cpp:795
 msgid "File exists."
 msgstr "Il file è già esistente."
 
-#: src/import_export/univcsvdialog.cpp:915
+#: src/import_export/univcsvdialog.cpp:912
 #, c-format
 msgid "Transactions exported: %ld"
 msgstr "Operazioni esportate: %ld"
 
-#: src/import_export/univcsvdialog.cpp:916 src/mmframe.cpp:1372
+#: src/import_export/univcsvdialog.cpp:913 src/mmframe.cpp:1350
 msgid "Export to CSV"
 msgstr "Esporta in file CSV"
 
-#: src/import_export/univcsvdialog.cpp:952
-#: src/import_export/univcsvdialog.cpp:1205 src/util.cpp:443
+#: src/import_export/univcsvdialog.cpp:949
+#: src/import_export/univcsvdialog.cpp:1202 src/mmSimpleDialogs.cpp:216
 msgid "Unable to open file."
 msgstr "Impossibile aprire il file"
 
-#: src/import_export/univcsvdialog.cpp:1188 src/stockdialog.cpp:511
+#: src/import_export/univcsvdialog.cpp:1185 src/stockdialog.cpp:515
 msgid "Choose CSV data file to import"
 msgstr "Selezionare file CSV da esportare"
 
-#: src/maincurrencydialog.cpp:59 src/reports/summarystocks.cpp:180
-#: src/stockdialog.cpp:184 src/stockdialog.cpp:395
+#: src/maincurrencydialog.cpp:74 src/reports/summarystocks.cpp:173
+#: src/stockdialog.cpp:188 src/stockdialog.cpp:399
 msgid "Symbol"
 msgstr "Simbolo"
 
-#: src/maincurrencydialog.cpp:61
-msgid "Base Rate"
-msgstr "Tasso Base"
+#: src/maincurrencydialog.cpp:76
+msgid "Last Rate"
+msgstr "Ultimo tasso"
 
-#: src/maincurrencydialog.cpp:65 src/maincurrencydialog.cpp:246
-#: src/maincurrencydialog.cpp:251
+#: src/maincurrencydialog.cpp:80 src/maincurrencydialog.cpp:334
+#: src/maincurrencydialog.cpp:677 src/maincurrencydialog.cpp:777
+#: src/maincurrencydialog.cpp:783
 msgid "Currency Dialog"
 msgstr "Valuta"
 
-#: src/maincurrencydialog.cpp:140
+#: src/maincurrencydialog.cpp:158
 msgid "Online update currency rate"
 msgstr "Aggiornamento online dei Tassi di Cambio"
 
-#: src/maincurrencydialog.cpp:144
+#: src/maincurrencydialog.cpp:162
 msgid "Online Update"
 msgstr "Aggiornamento Online"
 
-#: src/maincurrencydialog.cpp:149
+#: src/maincurrencydialog.cpp:167
 msgid "Show all even the unused currencies"
 msgstr "Mostra tutte le valute, anche le non usate"
 
-#: src/maincurrencydialog.cpp:245
-msgid ""
-"Attempt to delete a currency being used by an account\n"
-" or as the base currency."
-msgstr ""
-"Tentativo di eliminazione di una valuta utilizzata in un conto\n"
-" o della valuta base."
+#: src/maincurrencydialog.cpp:227
+msgid "Currency History Options"
+msgstr "Opzioni storico tassi di cambio"
 
-#: src/maincurrencydialog.cpp:250
+#: src/maincurrencydialog.cpp:252 src/stockdialog.cpp:298
+msgid "Diff."
+msgstr "Diff."
+
+#: src/maincurrencydialog.cpp:268
+msgid "Specify the date of currency value"
+msgstr "Specificare la data del tasso di cambio"
+
+#: src/maincurrencydialog.cpp:275
+msgid "Enter the currency value"
+msgstr "Inserire il tasso di cambio"
+
+#: src/maincurrencydialog.cpp:285
+msgid "Download Currency Values history"
+msgstr "Scarica storico tassi di cambio"
+
+#: src/maincurrencydialog.cpp:286
+msgid "&Add / Update "
+msgstr "&Aggiungi / Aggiorna"
+
+#: src/maincurrencydialog.cpp:287
+msgid "Add Currency Values to history"
+msgstr "Aggiungere tasso di cambio allo storico"
+
+#: src/maincurrencydialog.cpp:289
+msgid "Delete selected Currency Values"
+msgstr "Eliminare i tassi di cambio selezionati"
+
+#: src/maincurrencydialog.cpp:292
+msgid "Delete Currency Values history for unused currencies"
+msgstr "Eliminare storico tassi di cambio per le valute non utilizzate"
+
+#: src/maincurrencydialog.cpp:333
 msgid "Do you really want to delete the selected Currency?"
 msgstr "Sei sicuro di voler eliminare la Valuta selezionata?"
 
-#: src/maincurrencydialog.cpp:352
+#: src/maincurrencydialog.cpp:386
+msgid "Currency History Options: "
+msgstr "Opzioni storico tassi di cambio:"
+
+#: src/maincurrencydialog.cpp:416
 msgid "Could not find base currency symbol!"
 msgstr "Impossibile trovare il simbolo della Valuta base!"
 
-#: src/maincurrencydialog.cpp:400 src/maincurrencydialog.cpp:428
+#: src/maincurrencydialog.cpp:464 src/maincurrencydialog.cpp:496
 msgid "Currency rate updated"
 msgstr "Tassi di Cambio aggiornati"
 
-#: src/maincurrencydialog.cpp:412
+#: src/maincurrencydialog.cpp:477
 #, c-format
 msgid "%s\t: %0.4f -> %0.4f\n"
 msgstr "%s\t: %0.4f -> %0.4f\n"
 
-#: src/maincurrencydialog.cpp:421
+#: src/maincurrencydialog.cpp:488
 #, c-format
 msgid "%s\t: %s\n"
 msgstr "%s\t: %s\n"
 
-#: src/maincurrencydialog.cpp:421
+#: src/maincurrencydialog.cpp:488
 msgid "Invalid value "
 msgstr "Valore non valido "
 
-#: src/maincurrencydialog.cpp:470
+#: src/maincurrencydialog.cpp:537
 msgid "Set as Base Currency"
 msgstr "Imposta come valuta base"
 
-#: src/maincurrencydialog.cpp:471
+#: src/maincurrencydialog.cpp:538
 msgid "Online Update Currency Rate"
 msgstr "Aggiorna online i Tassi di Cambio"
 
-#: src/mmOptionAttachmentSettings.cpp:39
+#: src/maincurrencydialog.cpp:676
+msgid "Do you want to add also dates without any transaction?"
+msgstr "Aggiungere anche le date senza alcuna operazione?"
+
+#: src/maincurrencydialog.cpp:776
+msgid "Do you want to update today currency rates?"
+msgstr "Aggiornare i tassi di cambio attuali?"
+
+#: src/maincurrencydialog.cpp:782
+msgid ""
+"Do you want to update all currency history? Any custom currency rate will be "
+"deleted!"
+msgstr ""
+"Aggiornare tutto lo storico dei tassi di cambio? Ogni valore personalizzato "
+"verrà eliminato!"
+
+#: src/mmOptionAttachmentSettings.cpp:57
 msgid "Attachments Settings"
 msgstr "Impostazioni allegati"
 
-#: src/mmOptionAttachmentSettings.cpp:46
+#: src/mmOptionAttachmentSettings.cpp:64
 #, c-format
 msgid "Attachment archive folder for %s only:"
 msgstr "Cartella allegati per %s:"
 
-#: src/mmOptionAttachmentSettings.cpp:50
+#: src/mmOptionAttachmentSettings.cpp:68
 msgid "Every OS type (Win,Mac,Unix) has its attachment folder"
 msgstr ""
 "Ogni sistema operativo (Win, Mac, Unix) ha un suo percorso per gli allegati"
 
-#: src/mmOptionAttachmentSettings.cpp:66
+#: src/mmOptionAttachmentSettings.cpp:85
 msgid "Browse for folder"
 msgstr "Sfoglia una cartella"
 
-#: src/mmOptionAttachmentSettings.cpp:73
-#: src/mmOptionAttachmentSettings.cpp:213
+#: src/mmOptionAttachmentSettings.cpp:92
+#: src/mmOptionAttachmentSettings.cpp:232
 msgid "Real path:"
 msgstr "Percorso reale:"
 
-#: src/mmOptionAttachmentSettings.cpp:78
+#: src/mmOptionAttachmentSettings.cpp:97
 msgid "Legend "
 msgstr "Legenda"
 
-#: src/mmOptionAttachmentSettings.cpp:83
+#: src/mmOptionAttachmentSettings.cpp:102
 #, c-format
 msgid "%s -> User document directory"
 msgstr "%s -> Cartella documenti dell'utente"
 
-#: src/mmOptionAttachmentSettings.cpp:84
+#: src/mmOptionAttachmentSettings.cpp:103
 #, c-format
 msgid "%s -> User profile folder"
 msgstr "%s -> Cartella del profilo dell'utente"
 
-#: src/mmOptionAttachmentSettings.cpp:85
+#: src/mmOptionAttachmentSettings.cpp:104
 #, c-format
 msgid "%s -> Folder of.MMB database file"
 msgstr "%s -> Cartella del database"
 
-#: src/mmOptionAttachmentSettings.cpp:86
+#: src/mmOptionAttachmentSettings.cpp:105
 #, c-format
 msgid "%s -> MMEX Application data folder"
 msgstr "%s -> Cartella di MMEX"
 
-#: src/mmOptionAttachmentSettings.cpp:92
+#: src/mmOptionAttachmentSettings.cpp:111
 msgid "Other OS folders "
 msgstr "Cartelle per gli altri Sistemi Operativi"
 
-#: src/mmOptionAttachmentSettings.cpp:97
+#: src/mmOptionAttachmentSettings.cpp:116
 msgid "Not yet set"
 msgstr "Non ancora impostata"
 
-#: src/mmOptionAttachmentSettings.cpp:105
+#: src/mmOptionAttachmentSettings.cpp:124
 msgid "Windows folder -> "
 msgstr "Cartella Windows ->"
 
-#: src/mmOptionAttachmentSettings.cpp:113
+#: src/mmOptionAttachmentSettings.cpp:132
 msgid "Mac folder -> "
 msgstr "Cartella Mac ->"
 
-#: src/mmOptionAttachmentSettings.cpp:121
+#: src/mmOptionAttachmentSettings.cpp:140
 msgid "Unix folder -> "
 msgstr "Cartella Unix ->"
 
-#: src/mmOptionAttachmentSettings.cpp:131
+#: src/mmOptionAttachmentSettings.cpp:150
 msgid "Create and use Attachments subfolder"
 msgstr "Crea ed utilizza la sottocartella allegati"
 
-#: src/mmOptionAttachmentSettings.cpp:143
+#: src/mmOptionAttachmentSettings.cpp:162
 msgid "Delete file after import"
 msgstr "Elimina file dopo l'importazione"
 
-#: src/mmOptionAttachmentSettings.cpp:145
+#: src/mmOptionAttachmentSettings.cpp:164
 msgid "Select to delete file after import in attachments archive"
 msgstr ""
 "Selezionare per eliminare i file dopo l'importazione nell'archivio allegati"
 
-#: src/mmOptionAttachmentSettings.cpp:149
+#: src/mmOptionAttachmentSettings.cpp:168
 msgid "When remove attachment, move file instead of delete"
 msgstr "Quando l'allegato viene rimosso, spostarlo invece di eliminarlo"
 
-#: src/mmOptionAttachmentSettings.cpp:151
+#: src/mmOptionAttachmentSettings.cpp:170
 msgid ""
 "Select to don't delete file when attachment is removed, but instead move it "
 "to 'Deleted' subfolder"
@@ -2635,91 +2709,119 @@ msgstr ""
 "Selezionare per non eliminare il file quando viene rimosso l'allegato, ma "
 "invece spostarlo nella sottocartella 'Deleted'"
 
-#: src/mmOptionAttachmentSettings.cpp:158
+#: src/mmOptionAttachmentSettings.cpp:177
 msgid "System documents directory"
 msgstr "Cartella documenti di sistema"
 
-#: src/mmOptionAttachmentSettings.cpp:160
+#: src/mmOptionAttachmentSettings.cpp:179
 msgid "Application data directory"
 msgstr "Cartella dei dati applicazioni"
 
-#: src/mmOptionAttachmentSettings.cpp:162
+#: src/mmOptionAttachmentSettings.cpp:181
 msgid "Database file directory"
 msgstr "Cartella del database"
 
-#: src/mmOptionAttachmentSettings.cpp:164
+#: src/mmOptionAttachmentSettings.cpp:183
 msgid "Dropbox folder"
 msgstr "Cartella di Dropbox"
 
-#: src/mmOptionAttachmentSettings.cpp:191
+#: src/mmOptionAttachmentSettings.cpp:210
 msgid "Choose folder to set as attachments archive"
 msgstr "Impostare la cartella da utilizzare come archivio per gli allegati"
 
-#: src/mmOptionGeneralSettings.cpp:43
+#: src/mmOptionAttachmentSettings.cpp:257
+msgid "Attachments path has been changed!"
+msgstr "Il percorso della cartella allegati è cambiato!"
+
+#: src/mmOptionAttachmentSettings.cpp:259
+#: src/mmOptionAttachmentSettings.cpp:268
+msgid "Attachments folder migration"
+msgstr "Spostamento cartella allegati"
+
+#: src/mmOptionAttachmentSettings.cpp:265
+msgid "Error moving attachments folder: please move it manually!"
+msgstr ""
+"Errore nello spostamento della cartella allegati: spostarla manualmente!"
+
+#: src/mmOptionAttachmentSettings.cpp:266
+msgid "Origin"
+msgstr "Origine"
+
+#: src/mmOptionAttachmentSettings.cpp:267
+msgid "Destination"
+msgstr "Destinazione"
+
+#: src/mmOptionGeneralSettings.cpp:64
 msgid "Display Heading"
 msgstr "Intestazioni visualizzate"
 
-#: src/mmOptionGeneralSettings.cpp:48 src/wizard_newdb.cpp:137
+#: src/mmOptionGeneralSettings.cpp:69 src/wizard_newdb.cpp:137
 msgid "User Name"
 msgstr "Nome Utente"
 
-#: src/mmOptionGeneralSettings.cpp:53
+#: src/mmOptionGeneralSettings.cpp:74
 msgid "The User Name is used as a title for the database."
 msgstr "Il nome utente è usato come intestazione del database"
 
-#: src/mmOptionGeneralSettings.cpp:58
+#: src/mmOptionGeneralSettings.cpp:79
 msgid "Language"
 msgstr "Lingua"
 
-#: src/mmOptionGeneralSettings.cpp:67
+#: src/mmOptionGeneralSettings.cpp:88
 msgid "Specify the language to use"
 msgstr "Specifica la lingua da utilizzare"
 
-#: src/mmOptionGeneralSettings.cpp:77
+#: src/mmOptionGeneralSettings.cpp:98
 msgid "Base Currency"
 msgstr "Valuta Base"
 
-#: src/mmOptionGeneralSettings.cpp:79 src/wizard_newdb.cpp:108
+#: src/mmOptionGeneralSettings.cpp:100 src/wizard_newdb.cpp:108
 msgid "Set Currency"
 msgstr "Imposta Valuta"
 
-#: src/mmOptionGeneralSettings.cpp:85
+#: src/mmOptionGeneralSettings.cpp:106
 msgid "Sets the default currency for the database."
 msgstr "Impostare la valuta base per il database"
 
-#: src/mmOptionGeneralSettings.cpp:101
+#: src/mmOptionGeneralSettings.cpp:108
+msgid "Right click on currency and choose 'Set as Base Currency'"
+msgstr ""
+"Cliccare con il tasto destro sulla valuta e scegliere 'Imposta come valuta "
+"base'"
+
+#: src/mmOptionGeneralSettings.cpp:123
 msgid "Specify the date format for display"
 msgstr "Definire il formato in cui visualizzare la data"
 
-#: src/mmOptionGeneralSettings.cpp:106
+#: src/mmOptionGeneralSettings.cpp:128
 msgid "New date format sample:"
 msgstr "Anteprima nuovo formato data:"
 
-#: src/mmOptionGeneralSettings.cpp:111
+#: src/mmOptionGeneralSettings.cpp:133
 msgid "Financial Year"
 msgstr "Anno Finanziario"
 
-#: src/mmOptionGeneralSettings.cpp:118
+#: src/mmOptionGeneralSettings.cpp:140
 msgid "Start Day"
 msgstr "Giorno Iniziale"
 
-#: src/mmOptionGeneralSettings.cpp:124
+#: src/mmOptionGeneralSettings.cpp:146
 msgid "Specify Day for start of financial year"
 msgstr "Specificare il giorno d'inizio dell'anno finanziario"
 
-#: src/mmOptionGeneralSettings.cpp:128
+#: src/mmOptionGeneralSettings.cpp:150
 msgid "Start Month"
 msgstr "Mese Iniziale"
 
-#: src/mmOptionGeneralSettings.cpp:140
+#: src/mmOptionGeneralSettings.cpp:162
 msgid "Specify month for start of financial year"
 msgstr "Specificare il mese d'inizio dell'anno finanziario"
 
-#: src/mmOptionGeneralSettings.cpp:145
+#: src/mmOptionGeneralSettings.cpp:167
 msgid "Use Original Date when Pasting Transactions"
 msgstr "Usa la data originale incollando le operazioni"
 
-#: src/mmOptionGeneralSettings.cpp:147
+#: src/mmOptionGeneralSettings.cpp:169
 msgid ""
 "Select whether to use the original transaction date or current date when "
 "copying/pasting transactions"
@@ -2727,67 +2829,59 @@ msgstr ""
 "Specificare se utilizzare la data originale dell'operazione oppure la data "
 "attuale quando si copiano/incollano le transazioni"
 
-#: src/mmOptionGeneralSettings.cpp:150
+#: src/mmOptionGeneralSettings.cpp:172
 msgid "Use Transaction Sound"
 msgstr "Attiva Suono Operazione"
 
-#: src/mmOptionGeneralSettings.cpp:152
+#: src/mmOptionGeneralSettings.cpp:174
 msgid "Select whether to use sounds when entering transactions"
 msgstr "Selezionare per associare un suono all'inserimento di un'operazione"
 
-#: src/mmOptionGeneralSettings.cpp:167
-msgid "Remember to update currency rate"
-msgstr "Ricorda di aggiornare i Tassi di Cambio!"
-
-#: src/mmOptionGeneralSettings.cpp:167
-msgid "Important note"
-msgstr "Avviso Importante"
-
-#: src/mmOptionMiscSettings.cpp:34
+#: src/mmOptionMiscSettings.cpp:54
 msgid "Stock Quote Web Page"
 msgstr "Pagina web titoli azionari"
 
-#: src/mmOptionMiscSettings.cpp:43
+#: src/mmOptionMiscSettings.cpp:63
 msgid "Clear the field to Reset the value to system default."
 msgstr "Svuotare il campo per ripristinare il valore predefinito"
 
-#: src/mmOptionMiscSettings.cpp:47
+#: src/mmOptionMiscSettings.cpp:67
 msgid "New Transaction Dialog Settings"
 msgstr "Impostazioni Predefinite Nuova Operazione"
 
-#: src/mmOptionMiscSettings.cpp:55
+#: src/mmOptionMiscSettings.cpp:75
 msgid "Last Used"
 msgstr "Ultimo utilizzato"
 
-#: src/mmOptionMiscSettings.cpp:67
+#: src/mmOptionMiscSettings.cpp:87
 msgid "Last used for payee"
 msgstr "Ultima usata x beneficiario"
 
-#: src/mmOptionMiscSettings.cpp:85
+#: src/mmOptionMiscSettings.cpp:105
 msgid "Default Date:"
 msgstr "Data predefinita:"
 
-#: src/mmOptionMiscSettings.cpp:87
+#: src/mmOptionMiscSettings.cpp:107
 msgid "Default Payee:"
 msgstr "Beneficiario predefinito:"
 
-#: src/mmOptionMiscSettings.cpp:89
+#: src/mmOptionMiscSettings.cpp:109
 msgid "Default Category:"
 msgstr "Categoria predefinita:"
 
-#: src/mmOptionMiscSettings.cpp:91
+#: src/mmOptionMiscSettings.cpp:111
 msgid "Default Status:"
 msgstr "Stato predefinito:"
 
-#: src/mmOptionMiscSettings.cpp:102
+#: src/mmOptionMiscSettings.cpp:122
 msgid "Database Backup"
 msgstr "Backup Database"
 
-#: src/mmOptionMiscSettings.cpp:109
+#: src/mmOptionMiscSettings.cpp:129
 msgid "Create a new backup when MMEX Start"
 msgstr "Crea un nuovo backup all'avvio di MMEX"
 
-#: src/mmOptionMiscSettings.cpp:111
+#: src/mmOptionMiscSettings.cpp:131
 msgid ""
 "When MMEX Starts,\n"
 "creates the backup database: dbFile_start_YYYY-MM-DD.ext."
@@ -2795,11 +2889,11 @@ msgstr ""
 "All'avvio MMEX, crea un database di \n"
 "backup: dbFile_start_YYYY-MM-DD.ext"
 
-#: src/mmOptionMiscSettings.cpp:115
+#: src/mmOptionMiscSettings.cpp:135
 msgid "Backup database on exit."
 msgstr "Esegui backup del Database all'uscita"
 
-#: src/mmOptionMiscSettings.cpp:117
+#: src/mmOptionMiscSettings.cpp:137
 msgid ""
 "When MMEX shuts down and changes made to database,\n"
 "creates or updates the backup database: dbFile_update_YYYY-MM-DD.ext."
@@ -2807,439 +2901,501 @@ msgstr ""
 "Alla chiusura di MMEX in caso di modifiche al database,\n"
 "crea o aggiorna il file di backup: dbFile_update_YYYY-MM-DD.ext."
 
-#: src/mmOptionMiscSettings.cpp:124
+#: src/mmOptionMiscSettings.cpp:144
 msgid "Specify max number of backup files"
 msgstr "Determina il numero massimo di file di backup"
 
-#: src/mmOptionMiscSettings.cpp:127
+#: src/mmOptionMiscSettings.cpp:147
 msgid "Max Files"
 msgstr "Numero massimo di file"
 
-#: src/mmOptionMiscSettings.cpp:134
+#: src/mmOptionMiscSettings.cpp:154
 msgid "CSV Settings"
 msgstr "Impostazioni CSV"
 
-#: src/mmOptionMiscSettings.cpp:142
+#: src/mmOptionMiscSettings.cpp:162
 msgid "Delimiter"
 msgstr "Separatore di campo"
 
-#: src/mmOptionNetSettings.cpp:33
+#: src/mmOptionNetSettings.cpp:52
 msgid "WebApp Settings"
 msgstr "Impostazioni WebApp"
 
-#: src/mmOptionNetSettings.cpp:40
+#: src/mmOptionNetSettings.cpp:59
 msgid "Url"
 msgstr "Url"
 
-#: src/mmOptionNetSettings.cpp:44
+#: src/mmOptionNetSettings.cpp:63
 msgid "Specify the Web App URL without final slash"
 msgstr "Specificare l'URL della Web App senza slash finale"
 
-#: src/mmOptionNetSettings.cpp:47
+#: src/mmOptionNetSettings.cpp:66
 msgid "GUID"
 msgstr "GUID"
 
-#: src/mmOptionNetSettings.cpp:51
+#: src/mmOptionNetSettings.cpp:70
 msgid "Specify the Web App GUID"
 msgstr "Specificare il GUID della Web App"
 
-#: src/mmOptionNetSettings.cpp:55
+#: src/mmOptionNetSettings.cpp:74
 msgid "Proxy Settings"
 msgstr "Impostazioni Proxy"
 
-#: src/mmOptionNetSettings.cpp:63
+#: src/mmOptionNetSettings.cpp:82
 msgid "Specify the proxy IP address"
 msgstr "Specificare l'indirizzo IP del proxy"
 
-#: src/mmOptionNetSettings.cpp:69
+#: src/mmOptionNetSettings.cpp:88
 msgid "Specify proxy port number"
 msgstr "Specificare numero porta proxy"
 
-#: src/mmOptionNetSettings.cpp:72
+#: src/mmOptionNetSettings.cpp:91
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/mmOptionNetSettings.cpp:74 src/mmOptionNetSettings.cpp:98
+#: src/mmOptionNetSettings.cpp:93 src/mmOptionNetSettings.cpp:117
 msgid "Port"
 msgstr "Porta"
 
-#: src/mmOptionNetSettings.cpp:80
+#: src/mmOptionNetSettings.cpp:99
 msgid "Web Server"
 msgstr "Web Server"
 
-#: src/mmOptionNetSettings.cpp:86
+#: src/mmOptionNetSettings.cpp:105
 msgid "Enable"
 msgstr "Ablita"
 
-#: src/mmOptionNetSettings.cpp:88
+#: src/mmOptionNetSettings.cpp:107
 msgid "Enable internal web server when MMEX Starts."
 msgstr "Abilitare il web server interno quando MMEX è avviato"
 
-#: src/mmOptionNetSettings.cpp:94
+#: src/mmOptionNetSettings.cpp:113
 msgid "Specify web server port number"
 msgstr "Specificare la porta del web server"
 
-#: src/mmOptionNetSettings.cpp:104
+#: src/mmOptionNetSettings.cpp:123
 msgid "Usage statistics"
 msgstr "Statistiche d'uso"
 
-#: src/mmOptionNetSettings.cpp:110
+#: src/mmOptionNetSettings.cpp:129
 msgid "Send anonymous statistics usage data"
 msgstr "Invia statistiche anonime sull'utilizzo"
 
-#: src/mmOptionNetSettings.cpp:112
+#: src/mmOptionNetSettings.cpp:131
 msgid "Enable to help us sending anonymous data about MMEX usage."
 msgstr "Aiutaci inviando statistiche anonime sull'utilizzo di MMEX"
 
-#: src/mmOptionNetSettings.cpp:117
+#: src/mmOptionNetSettings.cpp:136
 msgid "Timeout"
 msgstr "Timeou"
 
-#: src/mmOptionNetSettings.cpp:126
+#: src/mmOptionNetSettings.cpp:145
 msgid "Specify a network communication timeout value to use."
 msgstr "Specifica un timeout di connessione da utilizzare."
 
-#: src/mmOptionNetSettings.cpp:129
+#: src/mmOptionNetSettings.cpp:148
 msgid "Seconds"
 msgstr "Secondi"
 
-#: src/mmOptionNetSettings.cpp:135
+#: src/mmOptionNetSettings.cpp:154
 msgid "Updates"
 msgstr "Aggiornamenti"
 
-#: src/mmOptionNetSettings.cpp:141
+#: src/mmOptionNetSettings.cpp:160
 msgid "Check for updates at StartUp"
 msgstr "Controlla aggiornamenti all'avvio"
 
-#: src/mmOptionNetSettings.cpp:143
+#: src/mmOptionNetSettings.cpp:162
 msgid ""
 "Enable to automatically check if new MMEX version is available at StartUp"
 msgstr ""
 "Abilita per controllare automaticamente all'avvio se sono disponibili nuove "
 "versioni di MMEX"
 
-#: src/mmOptionNetSettings.cpp:150
+#: src/mmOptionNetSettings.cpp:169
 msgid "Stable"
 msgstr "Stabile"
 
-#: src/mmOptionNetSettings.cpp:151
+#: src/mmOptionNetSettings.cpp:170
 msgid "Unstable"
 msgstr "Sviluppo"
 
-#: src/mmOptionNetSettings.cpp:155
+#: src/mmOptionNetSettings.cpp:174
 msgid "Updates source:"
 msgstr "Origine aggiornamenti:"
 
-#: src/mmOptionViewSettings.cpp:34 src/optionsdialog.cpp:130
+#: src/mmOptionViewSettings.cpp:53 src/optionsdialog.cpp:130
 msgid "View Options"
 msgstr "Visualizzazione"
 
-#: src/mmOptionViewSettings.cpp:42 src/mmframe.cpp:1165
+#: src/mmOptionViewSettings.cpp:61 src/mmframe.cpp:1181
 msgid "Accounts Visible"
 msgstr "Conti Visibili"
 
-#: src/mmOptionViewSettings.cpp:56
+#: src/mmOptionViewSettings.cpp:78
 msgid "Specify which accounts are visible"
 msgstr "Specificare quali Conti sono visibili"
 
-#: src/mmOptionViewSettings.cpp:58
+#: src/mmOptionViewSettings.cpp:80
 msgid "Transactions Visible"
 msgstr "Operazioni Visibili"
 
-#: src/mmOptionViewSettings.cpp:80
+#: src/mmOptionViewSettings.cpp:103
 msgid "Specify which transactions are visible by default"
 msgstr "Specificare le operazioni da visualizzare in maniera predefinita"
 
-#: src/mmOptionViewSettings.cpp:82
-msgid "Report Font Size"
-msgstr "Dimensione Carattere dei Resoconti"
-
-#: src/mmOptionViewSettings.cpp:85
-msgid "XSmall"
-msgstr "Molto piccolo"
-
-#: src/mmOptionViewSettings.cpp:86
-msgid "Small"
-msgstr "Piccolo"
-
-#: src/mmOptionViewSettings.cpp:87
-msgid "Normal"
-msgstr "Normale"
-
-#: src/mmOptionViewSettings.cpp:88
-msgid "Large"
-msgstr "Grande"
-
-#: src/mmOptionViewSettings.cpp:89
-msgid "XLarge"
-msgstr "Molto grande"
-
-#: src/mmOptionViewSettings.cpp:90
-msgid "XXLarge"
-msgstr "Molto più grande"
-
-#: src/mmOptionViewSettings.cpp:91
-msgid "Huge"
-msgstr "Enorme"
-
-#: src/mmOptionViewSettings.cpp:101
-msgid "Specify which font size is used on the report tables"
-msgstr "Indicare la grandezza del carattere da utilizzare per i resoconti"
-
 #: src/mmOptionViewSettings.cpp:105
+msgid "HTML scale factor"
+msgstr "Scala dimensioni HTML"
+
+#: src/mmOptionViewSettings.cpp:113
+msgid "Specify which scale factor is used for the report pages"
+msgstr ""
+"Specificare quale scala deve essere utilizzata per le pagine dei report"
+
+#: src/mmOptionViewSettings.cpp:117
 msgid "View Budgets as Financial Years"
 msgstr "Mostra Budget per Anno Finanziario"
 
-#: src/mmOptionViewSettings.cpp:111
+#: src/mmOptionViewSettings.cpp:123
 msgid "View Budgets with 'transfer' transactions"
 msgstr "Mostra i 'Trasferimenti' nei Budget"
 
-#: src/mmOptionViewSettings.cpp:117
+#: src/mmOptionViewSettings.cpp:129
 msgid "View Budgets Setup Without Budget Summaries"
 msgstr "Mostra Impostazione Budget senza Riepiloghi per Budget"
 
-#: src/mmOptionViewSettings.cpp:123
+#: src/mmOptionViewSettings.cpp:135
 msgid "View Budget Summary Report without Categories"
 msgstr "Mostra resoconti Budget senza Categorie"
 
-#: src/mmOptionViewSettings.cpp:129
+#: src/mmOptionViewSettings.cpp:141
 msgid "View Reports without Future Transactions"
 msgstr "Escludi operazioni future dai resoconti"
 
-#: src/mmOptionViewSettings.cpp:135
+#: src/mmOptionViewSettings.cpp:147
 msgid "User Colors"
 msgstr "Colori Utente"
 
-#: src/mmOptionViewSettings.cpp:141
+#: src/mmOptionViewSettings.cpp:153
 msgid "1"
 msgstr "1"
 
-#: src/mmOptionViewSettings.cpp:145
+#: src/mmOptionViewSettings.cpp:157
 msgid "2"
 msgstr "2"
 
-#: src/mmOptionViewSettings.cpp:149
+#: src/mmOptionViewSettings.cpp:161
 msgid "3"
 msgstr "3"
 
-#: src/mmOptionViewSettings.cpp:153
+#: src/mmOptionViewSettings.cpp:165
 msgid "4"
 msgstr "4"
 
-#: src/mmOptionViewSettings.cpp:157
+#: src/mmOptionViewSettings.cpp:169
 msgid "5"
 msgstr "5"
 
-#: src/mmOptionViewSettings.cpp:161
+#: src/mmOptionViewSettings.cpp:173
 msgid "6"
 msgstr "6"
 
-#: src/mmOptionViewSettings.cpp:165
+#: src/mmOptionViewSettings.cpp:177
 msgid "7"
 msgstr "7"
 
-#: src/mmOptionViewSettings.cpp:169
-msgid "Display MMEX News on home page"
-msgstr "Mostra News MMEX sull'Home Page"
+#: src/mmSimpleDialogs.cpp:152
+#, c-format
+msgid ""
+"Directory of language files does not exist:\n"
+"%s"
+msgstr ""
+"La cartella dei language file non esiste:\n"
+"%s"
 
-#: src/mmOptionViewSettings.cpp:185 src/mmframe.cpp:1163 src/mmframe.cpp:1619
-#: src/model/Model_Account.cpp:24
-msgid "Open"
-msgstr "Aperti"
+#: src/mmSimpleDialogs.cpp:200
+#, c-format
+msgid "Entry %s is invalid"
+msgstr "Inserimento %s non valido"
 
-#: src/mmOptionViewSettings.cpp:186 src/mmframe.cpp:1164
-msgid "Favorites"
-msgstr "Preferiti"
+#: src/mmSimpleDialogs.cpp:201
+msgid "Invalid Entry"
+msgstr "Inserimento non valido"
 
-#: src/mmcheckingpanel.cpp:407 src/mmcheckingpanel.cpp:553
+#: src/mmSimpleDialogs.cpp:207
+msgid "Please use this button for category selection."
+msgstr "Utilizzare questo bottone per la scelta della categoria."
+
+#: src/mmSimpleDialogs.cpp:208
+msgid ""
+"Please use this button for category selection\n"
+"or use the 'Split' checkbox for multiple categories."
+msgstr ""
+"Usare questo bottone per la selezione della categoria\n"
+"oppure usare la casella 'Suddividi' per categorie multiple"
+
+#: src/mmSimpleDialogs.cpp:209
+msgid "Invalid Category"
+msgstr "Categoria non valida"
+
+#: src/mmSimpleDialogs.cpp:216
+msgid "File name is empty."
+msgstr "Il nome del file è vuoto."
+
+#: src/mmSimpleDialogs.cpp:217
+msgid "Please select the file for this operation."
+msgstr "Specificare il file per questa operazione."
+
+#: src/mmSimpleDialogs.cpp:219
+msgid "Selection can be made by using Search button."
+msgstr "La selezione può essere fatta usando il tasto Cerca."
+
+#: src/mmSimpleDialogs.cpp:229
+msgid "Invalid Account"
+msgstr "Conto non valido"
+
+#: src/mmSimpleDialogs.cpp:232
+msgid "Please select the account for this transaction."
+msgstr "Specificare il conto per questa operazione."
+
+#: src/mmSimpleDialogs.cpp:234
+msgid "Please specify which account the transfer is going to."
+msgstr "Specificare il conto verso il quale effettuare il trasferimento"
+
+#: src/mmSimpleDialogs.cpp:236
+msgid "Selection can be made by using the dropdown button."
+msgstr "La selezione può essere fatta usando l'elenco a discesa"
+
+#: src/mmSimpleDialogs.cpp:246 src/mmcombobox.h:77
+msgid "Invalid Payee"
+msgstr "Beneficiario non valido"
+
+#: src/mmSimpleDialogs.cpp:247
+msgid ""
+"Please type in a new payee,\n"
+"or make a selection using the dropdown button."
+msgstr ""
+"Digitare il nuovo beneficiario,\n"
+"oppure sceglierlo tramite l'elenco a discesa"
+
+#: src/mmSimpleDialogs.cpp:256 src/mmSimpleDialogs.cpp:270
+msgid "Invalid Name"
+msgstr "Nome non valido"
+
+#: src/mmSimpleDialogs.cpp:259 src/mmSimpleDialogs.cpp:273
+msgid "Already exist!"
+msgstr "Già presente!"
+
+#: src/mmSimpleDialogs.cpp:261
+msgid "Please type in a non empty name."
+msgstr "Nome vuoto non valido"
+
+#: src/mmSimpleDialogs.cpp:275
+msgid "Please type in a non empty symbol."
+msgstr "Inserire un simbolo."
+
+#: src/mmcheckingpanel.cpp:394 src/mmcheckingpanel.cpp:540
 msgid "Displayed Bal: "
 msgstr "Saldo visualizzato: "
 
-#: src/mmcheckingpanel.cpp:413
+#: src/mmcheckingpanel.cpp:400
 msgid "Account Bal: "
 msgstr "Saldo Disponibile: "
 
-#: src/mmcheckingpanel.cpp:415
+#: src/mmcheckingpanel.cpp:402
 msgid "Reconciled Bal: "
 msgstr "Saldo Contabile: "
 
-#: src/mmcheckingpanel.cpp:417
+#: src/mmcheckingpanel.cpp:404
 msgid "Diff: "
 msgstr "Differenza: "
 
-#: src/mmcheckingpanel.cpp:480 src/mmframe.cpp:1634 src/transdialog.cpp:124
+#: src/mmcheckingpanel.cpp:467 src/mmframe.cpp:1614 src/transdialog.cpp:130
 msgid "New Transaction"
 msgstr "Nuova Operazione"
 
-#: src/mmcheckingpanel.cpp:484
+#: src/mmcheckingpanel.cpp:471
 msgid "Edit selected transaction"
 msgstr "Modifica operazione selezionata"
 
-#: src/mmcheckingpanel.cpp:489
+#: src/mmcheckingpanel.cpp:476
 msgid "Delete selected transaction"
 msgstr "Elimina operazione selezionata"
 
-#: src/mmcheckingpanel.cpp:493
+#: src/mmcheckingpanel.cpp:480
 msgid "D&uplicate "
 msgstr "D&uplica "
 
-#: src/mmcheckingpanel.cpp:494
+#: src/mmcheckingpanel.cpp:481
 msgid "Duplicate selected transaction"
 msgstr "Duplica operazione selezionata"
 
-#: src/mmcheckingpanel.cpp:511
+#: src/mmcheckingpanel.cpp:498
 msgid "Enter any string to find it in the nearest transaction notes"
 msgstr "Inserire una stringa da trovare nelle note operazioni"
 
-#: src/mmcheckingpanel.cpp:528
+#: src/mmcheckingpanel.cpp:515
 #, c-format
 msgid "Account View : %s"
 msgstr "Conto Visualizzato : %s"
 
-#: src/mmcheckingpanel.cpp:775
+#: src/mmcheckingpanel.cpp:762
 msgid "Select account used in transfer transactions"
 msgstr "Specificare il conto usato nelle operazioni di trasferimento"
 
-#: src/mmcheckingpanel.cpp:1074
-msgid "&New Transaction"
-msgstr "&Nuova Operazione"
+#: src/mmcheckingpanel.cpp:1058
+msgid "&New Withdrawal"
+msgstr "&Nuovo prelievo"
 
-#: src/mmcheckingpanel.cpp:1077
+#: src/mmcheckingpanel.cpp:1059
+msgid "&New Deposit"
+msgstr "&Nuovo deposito"
+
+#: src/mmcheckingpanel.cpp:1060
+msgid "&New Transfer"
+msgstr "&Nuovo trasferimento"
+
+#: src/mmcheckingpanel.cpp:1064
 msgid "&Edit Transaction"
 msgstr "&Modifica Operazione"
 
-#: src/mmcheckingpanel.cpp:1080
+#: src/mmcheckingpanel.cpp:1067
 msgid "&Copy Transaction"
 msgstr "&Copia Operazione"
 
-#: src/mmcheckingpanel.cpp:1083
+#: src/mmcheckingpanel.cpp:1070
 msgid "&Paste Transaction"
 msgstr "&Incolla Operazione"
 
-#: src/mmcheckingpanel.cpp:1086
+#: src/mmcheckingpanel.cpp:1073
 msgid "D&uplicate Transaction"
 msgstr "D&uplica Operazione"
 
-#: src/mmcheckingpanel.cpp:1089
+#: src/mmcheckingpanel.cpp:1076
 msgid "&Move Transaction"
 msgstr "&Sposta Operazione"
 
-#: src/mmcheckingpanel.cpp:1095
+#: src/mmcheckingpanel.cpp:1082
 msgid "&View Split Categories"
 msgstr "&Visualizza Categorie suddivise"
 
-#: src/mmcheckingpanel.cpp:1103
+#: src/mmcheckingpanel.cpp:1090
 msgid "Create Reoccuring T&ransaction"
 msgstr "Crea operazione ricorrente"
 
-#: src/mmcheckingpanel.cpp:1108
+#: src/mmcheckingpanel.cpp:1095
 msgid "Hide Deleted (Void)"
 msgstr "Nasconde Cancellate"
 
-#: src/mmcheckingpanel.cpp:1108
+#: src/mmcheckingpanel.cpp:1095
 msgid "Show Deleted (Void)"
 msgstr "Mostra Cancellate"
 
-#: src/mmcheckingpanel.cpp:1112
+#: src/mmcheckingpanel.cpp:1099
 msgid "&Delete Transaction"
 msgstr "&Elimina Operazione"
 
-#: src/mmcheckingpanel.cpp:1115
+#: src/mmcheckingpanel.cpp:1102
 msgid "Delete all transactions in current view"
 msgstr "Elimina tutte le operazioni nella vista attuale"
 
-#: src/mmcheckingpanel.cpp:1116
+#: src/mmcheckingpanel.cpp:1103
 msgid "Delete Viewed \"Follow Up\" Trans."
 msgstr "Elimina operazioni \"Da Monitorare\" visualizzate"
 
-#: src/mmcheckingpanel.cpp:1117
+#: src/mmcheckingpanel.cpp:1104
 msgid "Delete Viewed \"Unreconciled\" Trans."
 msgstr "Elimina operazioni visualizzate \"Da Monitorare\""
 
-#: src/mmcheckingpanel.cpp:1122
+#: src/mmcheckingpanel.cpp:1110
 msgid "Mark As &Reconciled"
 msgstr "Contrassegna come &Contabilizzata"
 
-#: src/mmcheckingpanel.cpp:1124
+#: src/mmcheckingpanel.cpp:1112
 msgid "Mark As &Unreconciled"
 msgstr "Contrassegna come &Non Contabilizzata"
 
-#: src/mmcheckingpanel.cpp:1126
+#: src/mmcheckingpanel.cpp:1114
 msgid "Mark As &Void"
 msgstr "Contrassegna come N&ulla"
 
-#: src/mmcheckingpanel.cpp:1128
+#: src/mmcheckingpanel.cpp:1116
 msgid "Mark For &Followup"
 msgstr "Contrassegna come \"Da Monitorare\""
 
-#: src/mmcheckingpanel.cpp:1130
+#: src/mmcheckingpanel.cpp:1118
 msgid "Mark As &Duplicate"
 msgstr "Contrassegna come &Duplicata"
 
-#: src/mmcheckingpanel.cpp:1135
+#: src/mmcheckingpanel.cpp:1120
+msgid "Mark"
+msgstr "Contrassegna"
+
+#: src/mmcheckingpanel.cpp:1123
 msgid "as Reconciled"
 msgstr "come Contabilizzata"
 
-#: src/mmcheckingpanel.cpp:1136
+#: src/mmcheckingpanel.cpp:1124
 msgid "as Unreconciled"
 msgstr "come Non Contabilizzata"
 
-#: src/mmcheckingpanel.cpp:1137
+#: src/mmcheckingpanel.cpp:1125
 msgid "as Void"
 msgstr "come Nulla"
 
-#: src/mmcheckingpanel.cpp:1138
+#: src/mmcheckingpanel.cpp:1126
 msgid "as needing Followup"
 msgstr "come \"Da Monitorare\""
 
-#: src/mmcheckingpanel.cpp:1139
+#: src/mmcheckingpanel.cpp:1127
 msgid "as Duplicate"
 msgstr "come Duplicata"
 
-#: src/mmcheckingpanel.cpp:1140
+#: src/mmcheckingpanel.cpp:1128
 msgid "Mark all being viewed"
 msgstr "Contrassegna tutte le visualizzate"
 
-#: src/mmcheckingpanel.cpp:1205
+#: src/mmcheckingpanel.cpp:1193
 msgid "Do you really want to delete all the transactions shown?"
 msgstr "Vuoi davvero eliminare tutte le operazioni visualizzate?"
 
-#: src/mmcheckingpanel.cpp:1206 src/mmcheckingpanel.cpp:1219
-#: src/mmcheckingpanel.cpp:1556
+#: src/mmcheckingpanel.cpp:1194 src/mmcheckingpanel.cpp:1207
+#: src/mmcheckingpanel.cpp:1492
 msgid "Confirm Transaction Deletion"
 msgstr "Conferma eliminazione Operazione"
 
-#: src/mmcheckingpanel.cpp:1215
+#: src/mmcheckingpanel.cpp:1203
 msgid "Follow Up"
 msgstr "Da Monitorare"
 
-#: src/mmcheckingpanel.cpp:1215
+#: src/mmcheckingpanel.cpp:1203
 msgid "Unreconciled"
 msgstr "Non Riconciliata"
 
-#: src/mmcheckingpanel.cpp:1218
+#: src/mmcheckingpanel.cpp:1206
 #, c-format
 msgid "Do you really want to delete all the \"%s\" transactions shown?"
 msgstr "Vuoi davvero eliminare tutte le \"%s\" operazioni visualizzate?"
 
-#: src/mmcheckingpanel.cpp:1555
+#: src/mmcheckingpanel.cpp:1491
 msgid "Do you really want to delete the selected transaction?"
 msgstr "Vuoi davvero eliminare l'operazione selezionata?"
 
-#: src/mmcheckingpanel.cpp:1664 src/stockspanel.cpp:284
+#: src/mmcheckingpanel.cpp:1612 src/stockspanel.cpp:273
 #, c-format
 msgid "Moving Transaction from %s to..."
 msgstr "Sposta operazione da %s a..."
 
-#: src/mmcheckingpanel.cpp:1667 src/stockspanel.cpp:285
+#: src/mmcheckingpanel.cpp:1615 src/stockspanel.cpp:274
 msgid "Select the destination Account "
 msgstr "Seleziona il Conto di Destinazione "
 
-#: src/mmcheckingpanel.cpp:1721
+#: src/mmcheckingpanel.cpp:1669
 msgid "Reoccuring Transaction saved."
 msgstr "Operazione Ricorrente salvata."
 
-#: src/mmex.cpp:83
+#: src/mmex.cpp:84
 msgid ""
 "Fatal error occured.\n"
 "Application will be terminated."
@@ -3247,394 +3403,394 @@ msgstr ""
 "Errore Critico.\n"
 "L'applicazione sarà chiusa."
 
-#: src/mmframe.cpp:299
+#: src/mmframe.cpp:303
 msgid "Toolbar"
 msgstr "Barra degli Strumenti"
 
-#: src/mmframe.cpp:501 src/mmframe.cpp:713
+#: src/mmframe.cpp:503 src/mmframe.cpp:715
 msgid "Bank Accounts"
 msgstr "Conti Bancari"
 
-#: src/mmframe.cpp:502 src/mmframe.cpp:720 src/reports/summary.cpp:225
+#: src/mmframe.cpp:504 src/mmframe.cpp:722 src/reports/summary.cpp:226
 msgid "Term Accounts"
 msgstr "Conti a Termine"
 
-#: src/mmframe.cpp:503 src/mmframe.cpp:723 src/mmhomepagepanel.cpp:64
-#: src/mmhomepagepanel.cpp:82 src/reports/summary.cpp:226
+#: src/mmframe.cpp:505 src/mmframe.cpp:725 src/mmhomepagepanel.cpp:86
+#: src/mmhomepagepanel.cpp:104 src/reports/summary.cpp:227
 msgid "Stocks"
 msgstr "Titoli"
 
-#: src/mmframe.cpp:544
+#: src/mmframe.cpp:546
 msgid " Auto Repeat Transactions"
 msgstr " Operazioni Ricorrenti"
 
-#: src/mmframe.cpp:690
+#: src/mmframe.cpp:692
 msgid "Navigation"
 msgstr "Pannello di Navigazione"
 
-#: src/mmframe.cpp:708
+#: src/mmframe.cpp:710
 msgid "Home Page"
 msgstr "Pagina Principale"
 
-#: src/mmframe.cpp:716 src/mmhomepagepanel.cpp:688 src/reports/summary.cpp:224
+#: src/mmframe.cpp:718 src/mmhomepagepanel.cpp:694 src/reports/summary.cpp:225
 msgid "Credit Card Accounts"
 msgstr "Conti Carta di Credito"
 
-#: src/mmframe.cpp:735 src/mmframe.cpp:1492
+#: src/mmframe.cpp:737 src/mmframe.cpp:1470
 msgid "Budget Setup"
 msgstr "Gestione Budget"
 
-#: src/mmframe.cpp:747 src/mmframe.cpp:2278
+#: src/mmframe.cpp:749 src/mmframe.cpp:2260
 msgid "Help"
 msgstr "Guida in linea"
 
-#: src/mmframe.cpp:1064
+#: src/mmframe.cpp:1070
 msgid "Do you really want to delete the account?"
 msgstr "Vuoi davvero eliminare il Conto?"
 
-#: src/mmframe.cpp:1065 src/mmframe.cpp:2541
+#: src/mmframe.cpp:1071 src/mmframe.cpp:2524
 msgid "Confirm Account Deletion"
 msgstr "Conferma eliminazione del Conto"
 
-#: src/mmframe.cpp:1085
+#: src/mmframe.cpp:1091
 msgid "MMEX has been opened without an active database."
 msgstr "MMEX è stato avviato senza un Database valido."
 
-#: src/mmframe.cpp:1086
+#: src/mmframe.cpp:1092
 msgid "MMEX: Menu Popup Error"
 msgstr "MMEX: Errore nel menù"
 
-#: src/mmframe.cpp:1112 src/mmframe.cpp:1143 src/mmframe.cpp:1441
+#: src/mmframe.cpp:1119 src/mmframe.cpp:1158 src/mmframe.cpp:1419
 msgid "&Edit Account"
 msgstr "&Modifica Conto"
 
-#: src/mmframe.cpp:1113 src/mmframe.cpp:1450
+#: src/mmframe.cpp:1120 src/mmframe.cpp:1428
 msgid "&Reallocate Account"
 msgstr "&Cambio Tipologia Conto"
 
-#: src/mmframe.cpp:1114 src/mmframe.cpp:1142 src/mmframe.cpp:1445
+#: src/mmframe.cpp:1121 src/mmframe.cpp:1157 src/mmframe.cpp:1423
 msgid "&Delete Account"
 msgstr "&Elimina Conto"
 
-#: src/mmframe.cpp:1116
+#: src/mmframe.cpp:1123
 msgid "&Launch Account Website"
 msgstr "&Apri il sito web del Conto"
 
-#: src/mmframe.cpp:1141 src/mmframe.cpp:1432
+#: src/mmframe.cpp:1156 src/mmframe.cpp:1410
 msgid "New &Account"
 msgstr "Nuovo &Conto"
 
-#: src/mmframe.cpp:1144
+#: src/mmframe.cpp:1159
 msgid "Account &List (Home)"
 msgstr "E&lenco Conti (Pagina Principale)"
 
-#: src/mmframe.cpp:1151 src/mmframe.cpp:1155 src/mmframe.cpp:1372
-#: src/mmframe.cpp:1378
+#: src/mmframe.cpp:1166 src/mmframe.cpp:1170 src/mmframe.cpp:1350
+#: src/mmframe.cpp:1356
 msgid "&CSV Files..."
 msgstr "File &CSV"
 
-#: src/mmframe.cpp:1152 src/mmframe.cpp:1156 src/mmframe.cpp:1373
-#: src/mmframe.cpp:1379
+#: src/mmframe.cpp:1167 src/mmframe.cpp:1171 src/mmframe.cpp:1351
+#: src/mmframe.cpp:1357
 msgid "&QIF Files..."
 msgstr "File &QIF"
 
-#: src/mmframe.cpp:1353
+#: src/mmframe.cpp:1331
 msgid "&New Database\tCtrl-N"
 msgstr "&Nuovo Database\tCtrl-N"
 
-#: src/mmframe.cpp:1353 src/mmframe.cpp:1618 src/wizard_newdb.cpp:155
+#: src/mmframe.cpp:1331 src/mmframe.cpp:1598 src/wizard_newdb.cpp:155
 msgid "New Database"
 msgstr "Nuovo Database"
 
-#: src/mmframe.cpp:1355
+#: src/mmframe.cpp:1333
 msgid "&Open Database\tCtrl-O"
 msgstr "&Apri Database\tCtrl-A"
 
-#: src/mmframe.cpp:1355 src/mmframe.cpp:1619
+#: src/mmframe.cpp:1333 src/mmframe.cpp:1599
 msgid "Open Database"
 msgstr "Apri Database"
 
-#: src/mmframe.cpp:1357
+#: src/mmframe.cpp:1335
 msgid "Save Database &As"
 msgstr "&Salva Database con nome\tS"
 
-#: src/mmframe.cpp:1357
+#: src/mmframe.cpp:1335
 msgid "Save Database As"
 msgstr "Salva Database con nome"
 
-#: src/mmframe.cpp:1365
+#: src/mmframe.cpp:1343
 msgid "&Recent Files..."
 msgstr "File &Recenti"
 
-#: src/mmframe.cpp:1366
+#: src/mmframe.cpp:1344
 msgid "&Clear Recent Files"
 msgstr "&Cancella cronologia file"
 
-#: src/mmframe.cpp:1374
+#: src/mmframe.cpp:1352
 msgid "&Report to HTML"
 msgstr "&Resoconto in HTML"
 
-#: src/mmframe.cpp:1374
+#: src/mmframe.cpp:1352
 msgid "Export to HTML"
 msgstr "Esporta in file HTML"
 
-#: src/mmframe.cpp:1378
+#: src/mmframe.cpp:1356
 msgid "Import from any CSV file"
 msgstr "Importa da file CSV generico"
 
-#: src/mmframe.cpp:1379
+#: src/mmframe.cpp:1357
 msgid "Import from QIF"
 msgstr "Importa da QIF"
 
-#: src/mmframe.cpp:1380
+#: src/mmframe.cpp:1358
 msgid "&WebApp..."
 msgstr "&WebApp..."
 
-#: src/mmframe.cpp:1380
+#: src/mmframe.cpp:1358
 msgid "Import from WebApp"
 msgstr "Importa da WebApp"
 
-#: src/mmframe.cpp:1386
+#: src/mmframe.cpp:1364
 msgid "&Print..."
 msgstr "&Stampa"
 
-#: src/mmframe.cpp:1386
+#: src/mmframe.cpp:1364
 msgid "Print current view"
 msgstr "Stampa vista attuale"
 
-#: src/mmframe.cpp:1392
+#: src/mmframe.cpp:1370
 msgid "E&xit\tAlt-X"
 msgstr "E&sci\tAlt-X"
 
-#: src/mmframe.cpp:1392
+#: src/mmframe.cpp:1370
 msgid "Quit this program"
 msgstr "Esce dal programma"
 
-#: src/mmframe.cpp:1399
+#: src/mmframe.cpp:1377
 msgid "&Toolbar"
 msgstr "&Barra degli Strumenti"
 
-#: src/mmframe.cpp:1399
+#: src/mmframe.cpp:1377
 msgid "Show/Hide the toolbar"
 msgstr "Mostra/Nasconde la Barra degli Strumenti"
 
-#: src/mmframe.cpp:1401
+#: src/mmframe.cpp:1379
 msgid "&Navigation"
 msgstr "Pannello di &Navigazione"
 
-#: src/mmframe.cpp:1401
+#: src/mmframe.cpp:1379
 msgid "Show/Hide the Navigation tree control"
 msgstr "Mostra/Nasconde il pannello di Navigazione"
 
-#: src/mmframe.cpp:1403
+#: src/mmframe.cpp:1381
 msgid "Budgets: As &Financial Years"
 msgstr "Budget: per Anno &Finanziario"
 
-#: src/mmframe.cpp:1403
+#: src/mmframe.cpp:1381
 msgid "Display Budgets in Financial Year Format"
 msgstr "Mostra i Budget nel formato Anno Finanziario"
 
-#: src/mmframe.cpp:1405
+#: src/mmframe.cpp:1383
 msgid "Budgets: &Include Transfers in Totals"
 msgstr "Gestione Budget: &Includi i Trasferimenti nei totali"
 
-#: src/mmframe.cpp:1405
+#: src/mmframe.cpp:1383
 msgid "Include the transfer transactions in the Budget Totals"
 msgstr "Includi i 'Trasferimenti' nei Totali del Budget"
 
-#: src/mmframe.cpp:1407
+#: src/mmframe.cpp:1385
 msgid "Budget Setup: &Without Summaries"
 msgstr "Impostazione Budget: Senza riepiloghi"
 
-#: src/mmframe.cpp:1407
+#: src/mmframe.cpp:1385
 msgid "Display the Budget Setup without category summaries"
 msgstr "Mostra l'impostazione Budget senza i riepiloghi per categoria"
 
-#: src/mmframe.cpp:1409
+#: src/mmframe.cpp:1387
 msgid "Budget Summary: Include &Categories"
 msgstr "Riepilogo Budget: Includi le &Categorie"
 
-#: src/mmframe.cpp:1409
+#: src/mmframe.cpp:1387
 msgid "Include the categories in the Budget Category Summary"
 msgstr "Include le categorie nel riepilogo Budget"
 
-#: src/mmframe.cpp:1411
+#: src/mmframe.cpp:1389
 msgid "Ignore F&uture Transactions"
 msgstr "Ignora operazioni f&uture"
 
-#: src/mmframe.cpp:1411
+#: src/mmframe.cpp:1389
 msgid "Ignore Future transactions"
 msgstr "Ignora le operazioni future"
 
-#: src/mmframe.cpp:1425
+#: src/mmframe.cpp:1403
 msgid "Toggle Fullscreen\tF11"
 msgstr "Rimuovi Fullscreen\tF11"
 
-#: src/mmframe.cpp:1425
+#: src/mmframe.cpp:1403
 msgid "Toggle Fullscreen"
 msgstr "Rimuovi Fullscreen"
 
-#: src/mmframe.cpp:1437
+#: src/mmframe.cpp:1415
 msgid "Account &List"
 msgstr "&Pagina Principale"
 
-#: src/mmframe.cpp:1437 src/mmframe.cpp:1622
+#: src/mmframe.cpp:1415 src/mmframe.cpp:1602
 msgid "Show Account List"
 msgstr "Mostra Pagina Principale"
 
-#: src/mmframe.cpp:1445
+#: src/mmframe.cpp:1423
 msgid "Delete Account from database"
 msgstr "Elimina Conto dal Database"
 
-#: src/mmframe.cpp:1450
+#: src/mmframe.cpp:1428
 msgid "Change the account type of an account."
 msgstr "Cambia il tipo di un conto."
 
-#: src/mmframe.cpp:1461
+#: src/mmframe.cpp:1439
 msgid "Organize &Categories..."
 msgstr "Gestione &Categorie"
 
-#: src/mmframe.cpp:1466
+#: src/mmframe.cpp:1444
 msgid "Organize &Payees..."
 msgstr "Gestione &Beneficiari"
 
-#: src/mmframe.cpp:1466 src/mmframe.cpp:1625 src/payeedialog.cpp:78
+#: src/mmframe.cpp:1444 src/mmframe.cpp:1605 src/payeedialog.cpp:78
 msgid "Organize Payees"
 msgstr "Organizza i Beneficiari"
 
-#: src/mmframe.cpp:1471
+#: src/mmframe.cpp:1449
 msgid "Organize Currency..."
 msgstr "&Gestione Valuta"
 
-#: src/mmframe.cpp:1471 src/mmframe.cpp:1626
+#: src/mmframe.cpp:1449 src/mmframe.cpp:1606
 msgid "Organize Currency"
 msgstr "Organizza le Valute"
 
-#: src/mmframe.cpp:1477
+#: src/mmframe.cpp:1455
 msgid "&Categories..."
 msgstr "&Categorie"
 
-#: src/mmframe.cpp:1481
+#: src/mmframe.cpp:1459
 msgid "&Payees..."
 msgstr "&Beneficiari"
 
-#: src/mmframe.cpp:1482
+#: src/mmframe.cpp:1460
 msgid "Reassign all payees to another payee"
 msgstr "Riassegna tutti i Beneficiari ad un altro Beneficiario"
 
-#: src/mmframe.cpp:1486
+#: src/mmframe.cpp:1464
 msgid "Relocation of..."
 msgstr "Sostituzione di..."
 
-#: src/mmframe.cpp:1487
+#: src/mmframe.cpp:1465
 msgid "Relocate Categories && Payees"
 msgstr "Sostituisce Categorie && Beneficiari"
 
-#: src/mmframe.cpp:1492
+#: src/mmframe.cpp:1470
 msgid "&Budget Setup"
 msgstr "Gestione &Budget"
 
-#: src/mmframe.cpp:1497
-msgid "&Repeating Transactions"
+#: src/mmframe.cpp:1475
+msgid "&Recurring Transactions"
 msgstr "Operazioni &Ricorrenti"
 
-#: src/mmframe.cpp:1497
+#: src/mmframe.cpp:1475
 msgid "Bills && Deposits"
 msgstr "Entrate && Uscite"
 
-#: src/mmframe.cpp:1502
+#: src/mmframe.cpp:1480
 msgid "&Assets"
 msgstr "&Beni"
 
-#: src/mmframe.cpp:1509
+#: src/mmframe.cpp:1487
 msgid "&Transaction Report Filter..."
 msgstr "&Filtro Resoconto Operazioni"
 
-#: src/mmframe.cpp:1509 src/mmframe.cpp:1628
+#: src/mmframe.cpp:1487 src/mmframe.cpp:1608
 msgid "Transaction Report Filter"
 msgstr "Filtro Resoconto Operazioni"
 
-#: src/mmframe.cpp:1516
+#: src/mmframe.cpp:1494
 msgid "&General Report Manager..."
 msgstr "&Manager Resoconti"
 
-#: src/mmframe.cpp:1523 src/mmframe.cpp:1632
+#: src/mmframe.cpp:1501 src/mmframe.cpp:1612
 msgid "&Options..."
 msgstr "&Opzioni"
 
-#: src/mmframe.cpp:1523 src/mmframe.cpp:1632
+#: src/mmframe.cpp:1501 src/mmframe.cpp:1612
 msgid "Show the Options Dialog"
 msgstr "Mostra la finestra Opzioni"
 
-#: src/mmframe.cpp:1531
+#: src/mmframe.cpp:1509
 msgid "Convert Encrypted &DB"
 msgstr "Converti &Database criptato"
 
-#: src/mmframe.cpp:1532
+#: src/mmframe.cpp:1510
 msgid "Convert Encrypted DB to Non-Encrypted DB"
 msgstr "Converte un DB criptato in uno non criptato"
 
-#: src/mmframe.cpp:1535
+#: src/mmframe.cpp:1513
 msgid "Change Encrypted &Password"
 msgstr "Cambio &Password"
 
-#: src/mmframe.cpp:1536
+#: src/mmframe.cpp:1514
 msgid "Change the password of an encrypted database"
 msgstr "Cambia la password di un database criptato"
 
-#: src/mmframe.cpp:1539
+#: src/mmframe.cpp:1517
 msgid "Optimize &Database"
 msgstr "Ottimizza &Database"
 
-#: src/mmframe.cpp:1540
+#: src/mmframe.cpp:1518
 msgid "Optimize database space and performance"
 msgstr "Ottimizza lo spazio e le performance del database"
 
-#: src/mmframe.cpp:1544
+#: src/mmframe.cpp:1522
 msgid "Database"
 msgstr "Database"
 
-#: src/mmframe.cpp:1545
+#: src/mmframe.cpp:1523
 msgid "Database management"
 msgstr "Gestione database"
 
-#: src/mmframe.cpp:1552 src/mmframe.cpp:1637
+#: src/mmframe.cpp:1530 src/mmframe.cpp:1617
 msgid "&Help\tF1"
 msgstr "&Guida\tF1"
 
-#: src/mmframe.cpp:1552 src/mmframe.cpp:1637
+#: src/mmframe.cpp:1530 src/mmframe.cpp:1617
 msgid "Show the Help file"
 msgstr "Visualizza il file della Guida"
 
-#: src/mmframe.cpp:1557
+#: src/mmframe.cpp:1535
 msgid "&Show App Start Dialog"
 msgstr "Vai alla &Schermata Iniziale"
 
-#: src/mmframe.cpp:1557
+#: src/mmframe.cpp:1535
 msgid "App Start Dialog"
 msgstr "Schermata Iniziale"
 
-#: src/mmframe.cpp:1564
+#: src/mmframe.cpp:1542
 msgid "Check for &Updates"
 msgstr "Controlla &Aggiornamenti"
 
-#: src/mmframe.cpp:1564
+#: src/mmframe.cpp:1542
 msgid "Check For Updates"
 msgstr "Controlla gli aggiornamenti"
 
-#: src/mmframe.cpp:1569
+#: src/mmframe.cpp:1547
 msgid "Get Android Version"
 msgstr "Versione Android"
 
-#: src/mmframe.cpp:1570
+#: src/mmframe.cpp:1548
 msgid "Run this program in your Android smart phone or tablet"
 msgstr "Esegui questo programma sul tuo smartphone o tablet Android"
 
-#: src/mmframe.cpp:1575
+#: src/mmframe.cpp:1553
 msgid "Visit MMEX Forum"
 msgstr "Visita il Forum di MMEX"
 
-#: src/mmframe.cpp:1576
+#: src/mmframe.cpp:1554
 msgid ""
 "Visit the MMEX forum. See existing user comments, or report new issues with "
 "the software."
@@ -3642,68 +3798,68 @@ msgstr ""
 "Visita il forum di MMEX. Vedrai i commenti o le segnalazioni degli utenti "
 "del software"
 
-#: src/mmframe.cpp:1581
+#: src/mmframe.cpp:1559
 msgid "Register/View Release &Notifications"
 msgstr "Registrati/Visualizza rilasci e notizie"
 
-#: src/mmframe.cpp:1582
+#: src/mmframe.cpp:1560
 msgid "Sign up to Notification Mailing List or View existing announcements."
 msgstr ""
 "Iscriviti alla Mailing list per comunicazioni o vedere gli annunci pubblicati"
 
-#: src/mmframe.cpp:1587
+#: src/mmframe.cpp:1565
 msgid "Visit us on Facebook"
 msgstr "Visitaci su Facebook"
 
-#: src/mmframe.cpp:1592 src/mmframe.cpp:1636
+#: src/mmframe.cpp:1570 src/mmframe.cpp:1616
 msgid "&About..."
 msgstr "&A proposito di"
 
-#: src/mmframe.cpp:1592 src/mmframe.cpp:1636
+#: src/mmframe.cpp:1570 src/mmframe.cpp:1616
 msgid "Show about dialog"
 msgstr "Mostra la finestra Informazioni"
 
-#: src/mmframe.cpp:1597
+#: src/mmframe.cpp:1575
 msgid "&File"
 msgstr "&File"
 
-#: src/mmframe.cpp:1598
+#: src/mmframe.cpp:1576
 msgid "&Accounts"
 msgstr "&Conti"
 
-#: src/mmframe.cpp:1599
+#: src/mmframe.cpp:1577
 msgid "&Tools"
 msgstr "&Strumenti"
 
-#: src/mmframe.cpp:1600
+#: src/mmframe.cpp:1578
 msgid "&View"
 msgstr "&Visualizza"
 
-#: src/mmframe.cpp:1601
+#: src/mmframe.cpp:1579
 msgid "&Help"
 msgstr "&Guida"
 
-#: src/mmframe.cpp:1618 src/mmframe.cpp:1634
+#: src/mmframe.cpp:1598 src/mmframe.cpp:1614
 msgid "New"
 msgstr "Nuovo"
 
-#: src/mmframe.cpp:1622
+#: src/mmframe.cpp:1602
 msgid "Account List"
 msgstr "Pagina Principale"
 
-#: src/mmframe.cpp:1624
+#: src/mmframe.cpp:1604
 msgid "Show Organize Categories Dialog"
 msgstr "Mostra la Gestione Categorie"
 
-#: src/mmframe.cpp:1625
+#: src/mmframe.cpp:1605
 msgid "Show Organize Payees Dialog"
 msgstr "Mostra la Gestione Beneficiari"
 
-#: src/mmframe.cpp:1626
+#: src/mmframe.cpp:1606
 msgid "Show Organize Currency Dialog"
 msgstr "Mostra la Gestione Valute"
 
-#: src/mmframe.cpp:1684
+#: src/mmframe.cpp:1665
 #, c-format
 msgid ""
 "Please enter password for Database\n"
@@ -3714,70 +3870,70 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/mmframe.cpp:1685 src/mmframe.cpp:1888 src/mmframe.cpp:2006
+#: src/mmframe.cpp:1666 src/mmframe.cpp:1869 src/mmframe.cpp:1987
 msgid "MMEX: Encrypted Database"
 msgstr "MMEX: Database Criptato"
 
-#: src/mmframe.cpp:1730 src/mmframe.cpp:1772
+#: src/mmframe.cpp:1711 src/mmframe.cpp:1753
 msgid " - No File opened "
 msgstr " - Nessun file aperto "
 
-#: src/mmframe.cpp:1732
+#: src/mmframe.cpp:1713
 msgid ""
 "Sorry. The Database version is too old or Database password is incorrect"
 msgstr ""
 "Spiacente. La versione del Database è troppo vecchia o la password non è "
 "corretta."
 
-#: src/mmframe.cpp:1763
+#: src/mmframe.cpp:1744
 msgid "&Next ->"
 msgstr "&Prossima ->"
 
-#: src/mmframe.cpp:1775
+#: src/mmframe.cpp:1756
 msgid "Cannot locate previously opened database.\n"
 msgstr "Impossibile trovare l'ultimo database aperto.\n"
 
-#: src/mmframe.cpp:1777
+#: src/mmframe.cpp:1758
 msgid "Password not entered for encrypted Database.\n"
 msgstr "Password non inserita per il Database criptato.\n"
 
-#: src/mmframe.cpp:1795
+#: src/mmframe.cpp:1776
 msgid "portable mode"
 msgstr "modalità <Portabile>"
 
-#: src/mmframe.cpp:1838
+#: src/mmframe.cpp:1819
 msgid "Choose database file to create"
 msgstr "Scegliere il database da creare"
 
-#: src/mmframe.cpp:1861
+#: src/mmframe.cpp:1842
 msgid "Choose database file to open"
 msgstr "Scegliere il database da aprire"
 
-#: src/mmframe.cpp:1878
+#: src/mmframe.cpp:1859
 msgid "Choose Encrypted database file to open"
 msgstr "Scegliere il database criptato da aprire"
 
-#: src/mmframe.cpp:1888
+#: src/mmframe.cpp:1869
 msgid "Enter password for database"
 msgstr "Inserire la password del database"
 
-#: src/mmframe.cpp:1893
+#: src/mmframe.cpp:1874
 msgid "Choose database file to Save As"
 msgstr "Scegliere il database da Salvare con Nome"
 
-#: src/mmframe.cpp:1915
+#: src/mmframe.cpp:1896
 msgid "Converted DB!"
 msgstr "DB Convertito!"
 
-#: src/mmframe.cpp:1915
+#: src/mmframe.cpp:1896
 msgid "MMEX message"
 msgstr "MMEX - Messaggio"
 
-#: src/mmframe.cpp:1921
+#: src/mmframe.cpp:1902
 msgid "MMEX: Encryption Password Change"
 msgstr "MMEX: Cambio password DB criptato"
 
-#: src/mmframe.cpp:1922
+#: src/mmframe.cpp:1903
 #, c-format
 msgid ""
 "New password for database\n"
@@ -3788,91 +3944,91 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/mmframe.cpp:1927
+#: src/mmframe.cpp:1908
 msgid "New password must not be empty."
 msgstr "La nuova password non deve essere vuota."
 
-#: src/mmframe.cpp:1931
+#: src/mmframe.cpp:1912
 msgid "Please confirm new password"
 msgstr "Conferma la nuova password"
 
-#: src/mmframe.cpp:1935
+#: src/mmframe.cpp:1916
 msgid "Password change completed."
 msgstr "Cambio password completato!"
 
-#: src/mmframe.cpp:1939
+#: src/mmframe.cpp:1920
 msgid "Confirm password failed."
 msgstr "La password di conferma non coincide."
 
-#: src/mmframe.cpp:1948
+#: src/mmframe.cpp:1929
 msgid "Make sure you have a backup of DB before optimize it"
 msgstr "Assicurati di avre un backup del DB prima di ottimizzarlo"
 
-#: src/mmframe.cpp:1948
+#: src/mmframe.cpp:1929
 msgid "Do you want to proceed?"
 msgstr "Vuoi procedere?"
 
-#: src/mmframe.cpp:1949 src/mmframe.cpp:1956
+#: src/mmframe.cpp:1930 src/mmframe.cpp:1937
 msgid "DB Optimization"
 msgstr "Ottimizzazione DB"
 
-#: src/mmframe.cpp:1955
+#: src/mmframe.cpp:1936
 msgid "Database Optimization Completed!"
 msgstr "Ottimizzazione Database completata!"
 
-#: src/mmframe.cpp:1955
+#: src/mmframe.cpp:1936
 msgid "Size before"
 msgstr "Dimensione precedente"
 
-#: src/mmframe.cpp:1955
+#: src/mmframe.cpp:1936
 msgid "Size after"
 msgstr "Dimensione attuale"
 
-#: src/mmframe.cpp:1972 src/mmframe.cpp:1993
+#: src/mmframe.cpp:1953 src/mmframe.cpp:1974
 msgid "Save database file as"
 msgstr "Salva il database con un determinato nome"
 
-#: src/mmframe.cpp:1993
+#: src/mmframe.cpp:1974
 msgid "Can't copy file to itself"
 msgstr "Impossibile copiare il file su sè stesso!"
 
-#: src/mmframe.cpp:2006
+#: src/mmframe.cpp:1987
 msgid "Enter password for new database"
 msgstr "Inserire la password per il nuovo database"
 
-#: src/mmframe.cpp:2079
+#: src/mmframe.cpp:2060
 msgid "No account available to import"
 msgstr "Nessun Conto disponibile da importare"
 
-#: src/mmframe.cpp:2268
+#: src/mmframe.cpp:2250
 msgid "MMEX Options have been updated."
 msgstr "Le impostazioni di MMEX sono state aggiornate"
 
-#: src/mmframe.cpp:2269 src/optionsdialog.cpp:55
+#: src/mmframe.cpp:2251 src/optionsdialog.cpp:55
 msgid "MMEX Options"
 msgstr "Opzioni MMEX"
 
-#: src/mmframe.cpp:2362
+#: src/mmframe.cpp:2344
 msgid "Choose HTML file to Export"
 msgstr "Scegliere il file HTML in cui esportare"
 
-#: src/mmframe.cpp:2506
+#: src/mmframe.cpp:2489
 msgid "No account available to edit!"
 msgstr "Nessun Conto da modificare!"
 
-#: src/mmframe.cpp:2510
+#: src/mmframe.cpp:2493
 msgid "Choose Account to Edit"
 msgstr "Scegliere il Conto da modificare"
 
-#: src/mmframe.cpp:2529
+#: src/mmframe.cpp:2512
 msgid "No account available to delete!"
 msgstr "Nessun Conto da eliminare!"
 
-#: src/mmframe.cpp:2533
+#: src/mmframe.cpp:2516
 msgid "Choose Account to Delete"
 msgstr "Scegliere il Conto da eliminare"
 
-#: src/mmframe.cpp:2538
+#: src/mmframe.cpp:2521
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -3881,197 +4037,197 @@ msgstr ""
 "Sicuro di voler cancellare il\n"
 " %s conto: %s ?"
 
-#: src/mmframe.cpp:2559
+#: src/mmframe.cpp:2542
 msgid "No account available to reallocate!"
 msgstr "Nessun conto disponibile da cambiare!"
 
-#: src/mmframe.cpp:2559 src/mmframe.cpp:2571 src/mmframe.cpp:2584
+#: src/mmframe.cpp:2542 src/mmframe.cpp:2554 src/mmframe.cpp:2567
 msgid "Account Reallocation"
 msgstr "Cambio tipo di conto"
 
-#: src/mmframe.cpp:2571
+#: src/mmframe.cpp:2554
 msgid "Choose account to reallocate account type"
 msgstr "Scegliere il Conto da cambiare di tipologia"
 
-#: src/mmframe.cpp:2584
+#: src/mmframe.cpp:2567
 #, c-format
 msgid "Choose the new type for account: %s"
 msgstr "Scegliere il nuovo tipo per il conto: %s"
 
-#: src/mmframe.cpp:2690 src/payeedialog.cpp:319
+#: src/mmframe.cpp:2673 src/payeedialog.cpp:319
 msgid "Payee Relocation Completed."
 msgstr "Sostituzione beneficiario completata"
 
-#: src/mmframe.cpp:2694 src/payeedialog.cpp:323
+#: src/mmframe.cpp:2677 src/payeedialog.cpp:323
 msgid "Payee Relocation Result"
 msgstr "Esito sostituzione beneficiario"
 
-#: src/mmframe.cpp:2793
+#: src/mmframe.cpp:2775
 #, c-format
 msgid "File %s not found"
 msgstr "File %s non trovato"
 
-#: src/mmframereport.cpp:82
+#: src/mmframereport.cpp:84
 msgid "mmGeneralGroupReport"
 msgstr "mmGeneralGroupReport"
 
-#: src/mmframereport.cpp:122 src/reports/myusage.cpp:134
+#: src/mmframereport.cpp:125 src/reports/myusage.cpp:133
 msgid "My Usage"
 msgstr "Utilizzo"
 
-#: src/mmframereport.cpp:126
+#: src/mmframereport.cpp:129
 msgid "Monthly Summary of Accounts"
 msgstr "Saldo mensile dei Conti"
 
-#: src/mmframereport.cpp:134 src/reports/categexp.h:57
+#: src/mmframereport.cpp:138 src/reports/categexp.h:57
 msgid "Where the Money Goes"
 msgstr "Dove va il denaro"
 
-#: src/mmframereport.cpp:141 src/reports/categexp.h:124
+#: src/mmframereport.cpp:145 src/reports/categexp.h:124
 msgid "Where the Money Comes From"
 msgstr "Da dove arriva il denaro"
 
-#: src/mmframereport.cpp:155
+#: src/mmframereport.cpp:161
 msgid "Payees"
 msgstr "Beneficiari"
 
-#: src/mmframereport.cpp:162 src/reports/incexpenses.cpp:27
+#: src/mmframereport.cpp:168 src/reports/incexpenses.cpp:27
 #: src/reports/incexpenses.cpp:148
 msgid "Income vs Expenses"
 msgstr "Entrate / Uscite"
 
-#: src/mmframereport.cpp:166 src/mmframereport.cpp:245
-#: src/mmframereport.cpp:430 src/mmframereport.cpp:514
-#: src/mmframereport.cpp:601 src/mmframereport.cpp:684
+#: src/mmframereport.cpp:174 src/mmframereport.cpp:259
+#: src/mmframereport.cpp:469 src/mmframereport.cpp:554
+#: src/mmframereport.cpp:641 src/mmframereport.cpp:726
 msgid "Last Calendar Month"
 msgstr "Mese scorso"
 
-#: src/mmframereport.cpp:174 src/mmframereport.cpp:253
-#: src/mmframereport.cpp:438 src/mmframereport.cpp:522
-#: src/mmframereport.cpp:609 src/mmframereport.cpp:692
+#: src/mmframereport.cpp:182 src/mmframereport.cpp:267
+#: src/mmframereport.cpp:477 src/mmframereport.cpp:562
+#: src/mmframereport.cpp:649 src/mmframereport.cpp:734
 #: src/reports/categexp.cpp:202 src/reports/categexp.cpp:266
 #: src/reports/categexp.cpp:331 src/reports/mmDateRange.cpp:90
 #: src/reports/payee.h:66
 msgid "Current Month to Date"
 msgstr "Mese in corso alla data"
 
-#: src/mmframereport.cpp:182 src/mmframereport.cpp:261
-#: src/mmframereport.cpp:446 src/mmframereport.cpp:530
-#: src/mmframereport.cpp:617 src/mmframereport.cpp:700
+#: src/mmframereport.cpp:190 src/mmframereport.cpp:275
+#: src/mmframereport.cpp:485 src/mmframereport.cpp:570
+#: src/mmframereport.cpp:657 src/mmframereport.cpp:742
 #: src/reports/categexp.cpp:196 src/reports/categexp.cpp:260
 #: src/reports/categexp.cpp:325 src/reports/mmDateRange.cpp:74
 #: src/reports/payee.h:58
 msgid "Current Month"
 msgstr "Mese corrente"
 
-#: src/mmframereport.cpp:188 src/mmframereport.cpp:267
-#: src/mmframereport.cpp:378 src/mmframereport.cpp:453
-#: src/mmframereport.cpp:537 src/mmframereport.cpp:623
-#: src/mmframereport.cpp:707 src/reports/categexp.cpp:214
+#: src/mmframereport.cpp:197 src/mmframereport.cpp:282
+#: src/mmframereport.cpp:412 src/mmframereport.cpp:492
+#: src/mmframereport.cpp:577 src/mmframereport.cpp:664
+#: src/mmframereport.cpp:749 src/reports/categexp.cpp:214
 #: src/reports/categexp.cpp:278 src/reports/categexp.cpp:342
 #: src/reports/mmDateRange.cpp:108 src/reports/payee.h:82
 msgid "Last 30 Days"
 msgstr "Ultimi 30 giorni"
 
-#: src/mmframereport.cpp:193 src/mmframereport.cpp:272
-#: src/mmframereport.cpp:386 src/mmframereport.cpp:458
-#: src/mmframereport.cpp:543 src/mmframereport.cpp:628
-#: src/mmframereport.cpp:713 src/reports/categexp.cpp:220
+#: src/mmframereport.cpp:203 src/mmframereport.cpp:288
+#: src/mmframereport.cpp:422 src/mmframereport.cpp:498
+#: src/mmframereport.cpp:583 src/mmframereport.cpp:670
+#: src/mmframereport.cpp:755 src/reports/categexp.cpp:220
 #: src/reports/categexp.cpp:284 src/reports/categexp.cpp:347
 #: src/reports/mmDateRange.cpp:162 src/reports/payee.h:90
 msgid "Last Year"
 msgstr "Anno scorso"
 
-#: src/mmframereport.cpp:200 src/mmframereport.cpp:279
-#: src/mmframereport.cpp:466 src/mmframereport.cpp:551
-#: src/mmframereport.cpp:636 src/mmframereport.cpp:721
+#: src/mmframereport.cpp:211 src/mmframereport.cpp:296
+#: src/mmframereport.cpp:506 src/mmframereport.cpp:591
+#: src/mmframereport.cpp:678 src/mmframereport.cpp:763
 #: src/reports/categexp.cpp:231 src/reports/categexp.cpp:296
 #: src/reports/categexp.cpp:359 src/reports/mmDateRange.cpp:154
 #: src/reports/payee.h:106
 msgid "Current Year to Date"
 msgstr "Anno in corso alla data"
 
-#: src/mmframereport.cpp:207 src/mmframereport.cpp:286
-#: src/mmframereport.cpp:390 src/mmframereport.cpp:474
-#: src/mmframereport.cpp:559 src/mmframereport.cpp:644
-#: src/mmframereport.cpp:729 src/reports/categexp.cpp:225
+#: src/mmframereport.cpp:219 src/mmframereport.cpp:304
+#: src/mmframereport.cpp:427 src/mmframereport.cpp:514
+#: src/mmframereport.cpp:599 src/mmframereport.cpp:686
+#: src/mmframereport.cpp:771 src/reports/categexp.cpp:225
 #: src/reports/categexp.cpp:290 src/reports/categexp.cpp:353
 #: src/reports/mmDateRange.cpp:146 src/reports/payee.h:98
 msgid "Current Year"
 msgstr "Anno in corso"
 
-#: src/mmframereport.cpp:216 src/mmframereport.cpp:295
-#: src/mmframereport.cpp:485 src/mmframereport.cpp:570
-#: src/mmframereport.cpp:653 src/mmframereport.cpp:738
+#: src/mmframereport.cpp:228 src/mmframereport.cpp:313
+#: src/mmframereport.cpp:525 src/mmframereport.cpp:610
+#: src/mmframereport.cpp:695 src/mmframereport.cpp:780
 #: src/reports/categexp.cpp:237 src/reports/categexp.cpp:302
 #: src/reports/categexp.cpp:365 src/reports/mmDateRange.cpp:202
 #: src/reports/payee.h:114
 msgid "Last Financial Year"
 msgstr "Ultimo Anno Finanziario"
 
-#: src/mmframereport.cpp:224 src/mmframereport.cpp:303
-#: src/mmframereport.cpp:493 src/mmframereport.cpp:578
-#: src/mmframereport.cpp:661 src/mmframereport.cpp:746
+#: src/mmframereport.cpp:236 src/mmframereport.cpp:321
+#: src/mmframereport.cpp:533 src/mmframereport.cpp:618
+#: src/mmframereport.cpp:703 src/mmframereport.cpp:788
 #: src/reports/categexp.cpp:249 src/reports/categexp.cpp:314
 #: src/reports/categexp.cpp:377 src/reports/mmDateRange.cpp:192
 #: src/reports/payee.h:130
 msgid "Current Financial Year to Date"
 msgstr "Anno Finanziario in corso"
 
-#: src/mmframereport.cpp:232 src/mmframereport.cpp:311
-#: src/mmframereport.cpp:501 src/mmframereport.cpp:586
-#: src/mmframereport.cpp:669 src/mmframereport.cpp:754
+#: src/mmframereport.cpp:244 src/mmframereport.cpp:329
+#: src/mmframereport.cpp:541 src/mmframereport.cpp:626
+#: src/mmframereport.cpp:711 src/mmframereport.cpp:796
 #: src/reports/categexp.cpp:243 src/reports/categexp.cpp:308
 #: src/reports/categexp.cpp:371 src/reports/mmDateRange.cpp:182
 #: src/reports/payee.h:122
 msgid "Current Financial Year"
 msgstr "Anno Finanziario in corso"
 
-#: src/mmframereport.cpp:241
+#: src/mmframereport.cpp:254
 msgid "Income vs Expenses - Specific Accounts"
 msgstr "Entrate / Uscite - Conti specifici"
 
-#: src/mmframereport.cpp:327
+#: src/mmframereport.cpp:346
 msgid "Budget Performance"
 msgstr "Risultati Budget"
 
-#: src/mmframereport.cpp:330
+#: src/mmframereport.cpp:350
 msgid "Budget Category Summary"
 msgstr "Riepilogo Budget Categorie"
 
-#: src/mmframereport.cpp:352 src/reports/cashflow.cpp:33
+#: src/mmframereport.cpp:375 src/reports/cashflow.cpp:33
 msgid "Cash Flow"
 msgstr "Flusso di Cassa"
 
-#: src/mmframereport.cpp:355
+#: src/mmframereport.cpp:379
 msgid "Cash Flow - With Bank Accounts"
 msgstr "Flusso di Cassa - Conti Bancari"
 
-#: src/mmframereport.cpp:358
+#: src/mmframereport.cpp:384
 msgid "Cash Flow - With Term Accounts"
 msgstr "Flusso di Cassa - Conti a Termine"
 
-#: src/mmframereport.cpp:361
+#: src/mmframereport.cpp:389
 msgid "Cash Flow - Specific Accounts"
 msgstr "Flusso di Cassa - Conti Specifici"
 
-#: src/mmframereport.cpp:364
+#: src/mmframereport.cpp:394
 msgid "Daily Cash Flow - Specific Accounts"
 msgstr "Cash Flow quotidiano - Conti Specifici"
 
-#: src/mmframereport.cpp:369
+#: src/mmframereport.cpp:401
 msgid "Transaction Report"
 msgstr "Resoconto Operazioni"
 
-#: src/mmframereport.cpp:374
+#: src/mmframereport.cpp:407
 msgid "Stocks Report"
 msgstr "Report azioni"
 
-#: src/mmframereport.cpp:382 src/reports/mmDateRange.cpp:230
+#: src/mmframereport.cpp:417 src/reports/mmDateRange.cpp:230
 msgid "Last 365 Days"
 msgstr "Ultimi 365 giorni"
 
-#: src/mmframereport.cpp:394
+#: src/mmframereport.cpp:432
 msgid "All Time"
 msgstr "Nel tempo"
 
@@ -4087,86 +4243,98 @@ msgstr "&Avanti"
 msgid " Help"
 msgstr " Guida"
 
-#: src/mmhomepagepanel.cpp:82 src/reports/summarystocks.cpp:186
-#: src/stockspanel.cpp:92
+#: src/mmhomepagepanel.cpp:104 src/reports/summarystocks.cpp:146
+#: src/reports/summarystocks.cpp:179 src/stockspanel.cpp:100
 msgid "Gain/Loss"
 msgstr "Guadagno/Perdita"
 
-#: src/mmhomepagepanel.cpp:83 src/reports/cashflow.cpp:269
+#: src/mmhomepagepanel.cpp:105 src/reports/cashflow.cpp:270
 #: src/reports/categexp.cpp:134 src/reports/categovertimeperf.cpp:140
 msgid "Total"
 msgstr "Totale"
 
-#: src/mmhomepagepanel.cpp:106 src/mmhomepagepanel.cpp:724
+#: src/mmhomepagepanel.cpp:128 src/mmhomepagepanel.cpp:730
 #: src/reports/incexpenses.cpp:259 src/reports/payee.cpp:136
-#: src/reports/summarystocks.cpp:136 src/splittransactionsdialog.cpp:136
+#: src/reports/summarystocks.cpp:131 src/splittransactionsdialog.cpp:137
 msgid "Total:"
 msgstr "Totale:"
 
-#: src/mmhomepagepanel.cpp:174
+#: src/mmhomepagepanel.cpp:196
 #, c-format
 msgid "Top Withdrawals: %s"
 msgstr "Principali uscite: %s"
 
-#: src/mmhomepagepanel.cpp:201
+#: src/mmhomepagepanel.cpp:222
 msgid "Summary"
 msgstr "Saldo"
 
-#: src/mmhomepagepanel.cpp:590
+#: src/mmhomepagepanel.cpp:596
 msgid "Upcoming Transactions"
 msgstr "Operazioni Imminenti"
 
-#: src/mmhomepagepanel.cpp:688 src/reports/summary.cpp:223
+#: src/mmhomepagepanel.cpp:694 src/reports/summary.cpp:224
 msgid "Bank Account"
 msgstr "Conti Bancari"
 
-#: src/mmhomepagepanel.cpp:688
+#: src/mmhomepagepanel.cpp:694
 msgid "Term Account"
 msgstr "Conti a Termine"
 
-#: src/mmhomepagepanel.cpp:759 src/reports/incexpenses.cpp:29
+#: src/mmhomepagepanel.cpp:765 src/reports/incexpenses.cpp:29
 #: src/reports/incexpenses.cpp:152
 #, c-format
 msgid "Income vs Expenses: %s"
 msgstr "Entrate / Uscite: %s"
 
-#: src/mmhomepagepanel.cpp:764 src/reports/categovertimeperf.cpp:139
+#: src/mmhomepagepanel.cpp:770 src/reports/categovertimeperf.cpp:139
 #: src/reports/incexpenses.cpp:105 src/reports/incexpenses.cpp:229
 #: src/reports/payee.cpp:113
 msgid "Expenses"
 msgstr "Uscite"
 
-#: src/mmhomepagepanel.cpp:766 src/reports/incexpenses.cpp:131
+#: src/mmhomepagepanel.cpp:772 src/reports/incexpenses.cpp:131
 msgid "Difference:"
 msgstr "Differenza:"
 
-#: src/mmhomepagepanel.cpp:768
+#: src/mmhomepagepanel.cpp:774
 msgid "Income/Expenses"
 msgstr "Entrate / Uscite"
 
-#: src/mmhomepagepanel.cpp:799
+#: src/mmhomepagepanel.cpp:805
 msgid "Transaction Statistics"
 msgstr "Statistiche Operazioni"
 
-#: src/mmhomepagepanel.cpp:802
+#: src/mmhomepagepanel.cpp:808
 msgid "Follow Up On Transactions: "
 msgstr "Operazioni \"Da Monitorare\": "
 
-#: src/mmhomepagepanel.cpp:804
+#: src/mmhomepagepanel.cpp:810
 msgid "Total Transactions: "
 msgstr "Totale Operazioni: "
 
-#: src/mmhomepagepanel.cpp:817 src/reports/summarystocks.cpp:156
+#: src/mmhomepagepanel.cpp:823 src/reports/summarystocks.cpp:141
 msgid "Grand Total:"
 msgstr "Totale Generale:"
+
+#: src/mmpanelbase.cpp:130
+msgid "Hide/Show Columns"
+msgstr "Mostra/Nascondi colonne"
+
+#: src/mmpanelbase.cpp:131
+msgid "Hide this column"
+msgstr "Nascondi colonna"
+
+#: src/mmpanelbase.cpp:133
+msgid "Order by this column"
+msgstr "Ordina per questa colonna"
+
+#: src/mmpanelbase.cpp:134
+msgid "Reset columns"
+msgstr "Resetta dimensioni colonne"
 
 #: src/mmreportspanel.cpp:191
 msgid "REPORTS"
 msgstr "RESOCONTI"
-
-#: src/model/Model_Account.cpp:25
-msgid "Closed"
-msgstr "Chiuso"
 
 #: src/model/Model_Account.cpp:30
 msgid "Checking"
@@ -4184,7 +4352,7 @@ msgstr "Investimento"
 msgid "Credit Card"
 msgstr "Carta di Credito"
 
-#: src/model/Model_Account.cpp:109
+#: src/model/Model_Account.cpp:120
 msgid "Account Error"
 msgstr "Errore Conto"
 
@@ -4425,7 +4593,7 @@ msgstr "Altre Entrate"
 msgid "Other Expenses"
 msgstr "Altre Uscite"
 
-#: src/model/Model_Currency.cpp:107 src/wizard_newdb.cpp:155
+#: src/model/Model_Currency.cpp:111 src/wizard_newdb.cpp:155
 msgid "Base Currency Not Set"
 msgstr "Valuta Base non impostata"
 
@@ -4433,7 +4601,7 @@ msgstr "Valuta Base non impostata"
 msgid "Payee Error"
 msgstr "Errore Beneficiario"
 
-#: src/model/Model_Report.cpp:98
+#: src/model/Model_Report.cpp:113
 #, c-format
 msgid ""
 "The SQL script:\n"
@@ -4460,7 +4628,7 @@ msgstr "Rete"
 msgid "&Apply"
 msgstr "&Applica"
 
-#: src/optionsdialog.cpp:176
+#: src/optionsdialog.cpp:188
 #, c-format
 msgid "%s page has been saved."
 msgstr "La pagina '%s' è stata salvata."
@@ -4563,12 +4731,12 @@ msgstr "Records in operazioni suddivise: %i"
 
 #: src/relocatecategorydialog.cpp:188
 #, c-format
-msgid "Records found in repeating transactions: %i"
+msgid "Records found in recurring transactions: %i"
 msgstr "Record trovati nelle operazioni ricorrenti: %i"
 
 #: src/relocatecategorydialog.cpp:189
 #, c-format
-msgid "Records found in repeating split transactions: %i"
+msgid "Records found in recurring split transactions: %i"
 msgstr "Record trovati in operazioni ricorrenti suddivise: %i"
 
 #: src/relocatecategorydialog.cpp:190
@@ -4633,66 +4801,67 @@ msgstr "Riepilogo Categoria Budget per %s"
 msgid "( Estimated Vs Actual )"
 msgstr "(Previsto / Effettivo)"
 
-#: src/reports/budgetcategorysummary.cpp:195
+#: src/reports/budgetcategorysummary.cpp:190
 msgid "Estimated Income:"
 msgstr "Entrate Previste:"
 
-#: src/reports/budgetcategorysummary.cpp:197
+#: src/reports/budgetcategorysummary.cpp:192
 msgid "Actual Income:"
 msgstr "Entrate Attuali:"
 
-#: src/reports/budgetcategorysummary.cpp:199
+#: src/reports/budgetcategorysummary.cpp:194
 msgid "Difference Income:"
 msgstr "Saldo Entrate:"
 
-#: src/reports/budgetcategorysummary.cpp:204
+#: src/reports/budgetcategorysummary.cpp:199
 msgid "Estimated Expenses:"
 msgstr "Uscite Previste:"
 
-#: src/reports/budgetcategorysummary.cpp:206
+#: src/reports/budgetcategorysummary.cpp:201
 msgid "Actual Expenses:"
 msgstr "Uscite Attuali:"
 
-#: src/reports/budgetcategorysummary.cpp:208
+#: src/reports/budgetcategorysummary.cpp:203
 msgid "Difference Expenses:"
 msgstr "Saldo Uscite:"
 
-#: src/reports/budgetingperf.cpp:122
-msgid "Budget Performance for "
-msgstr "Risultati Budget "
+#: src/reports/budgetingperf.cpp:123
+#, c-format
+msgid "Budget Performance for %s"
+msgstr "Risultati Budget per %s"
 
-#: src/reports/budgetingperf.cpp:137 src/reports/categovertimeperf.cpp:116
+#: src/reports/budgetingperf.cpp:138 src/reports/categovertimeperf.cpp:116
 msgid "Overall"
 msgstr "Totale"
 
-#: src/reports/budgetingperf.cpp:138
+#: src/reports/budgetingperf.cpp:139
 msgid "%"
 msgstr "%"
 
-#: src/reports/cashflow.cpp:226
+#: src/reports/cashflow.cpp:237
 #, c-format
 msgid "Cash Flow Forecast for %i Years Ahead"
 msgstr "Previsione del Flusso di Cassa per i prossimi %d anni"
 
-#: src/reports/cashflow.cpp:228 src/reports/incexpenses.cpp:46
-#: src/reports/incexpenses.cpp:164
-msgid "Accounts: "
-msgstr "Conti: "
-
-#: src/reports/cashflow.cpp:232 src/reports/incexpenses.cpp:49
+#: src/reports/cashflow.cpp:248 src/reports/incexpenses.cpp:49
 #: src/reports/incexpenses.cpp:167
 msgid "All Accounts"
 msgstr "Tutti i Conti"
 
-#: src/reports/cashflow.cpp:234
+#: src/reports/cashflow.cpp:250
 msgid "All Bank Accounts"
 msgstr "Tutti i Conti Bancari"
 
-#: src/reports/cashflow.cpp:236
+#: src/reports/cashflow.cpp:252
 msgid "All Term Accounts"
 msgstr "Tutti i Conti a Termine"
 
-#: src/reports/cashflow.cpp:270 src/reports/incexpenses.cpp:230
+#: src/reports/cashflow.cpp:257
+#, c-format
+msgid "Accounts: %s"
+msgstr "Conti: %s"
+
+#: src/reports/cashflow.cpp:271 src/reports/incexpenses.cpp:230
 #: src/reports/payee.cpp:114
 msgid "Difference"
 msgstr "Differenza"
@@ -4755,19 +4924,23 @@ msgstr "Entate/Uscite per Categoria: %s"
 msgid "Incomes"
 msgstr "Entrate"
 
-#: src/reports/htmlbuilder.cpp:116
+#: src/reports/htmlbuilder.cpp:112
 #, c-format
 msgid "Today's Date: %s"
 msgstr "Oggi: %s"
 
-#: src/reports/htmlbuilder.cpp:302
+#: src/reports/htmlbuilder.cpp:305
 #, c-format
 msgid "From %s till %s"
 msgstr "Da %s a %s"
 
-#: src/reports/htmlbuilder.cpp:308 src/reports/mmDateRange.cpp:208
+#: src/reports/htmlbuilder.cpp:311 src/reports/mmDateRange.cpp:208
 msgid "Over Time"
 msgstr "Nel tempo"
+
+#: src/reports/incexpenses.cpp:46 src/reports/incexpenses.cpp:164
+msgid "Accounts: "
+msgstr "Conti: "
 
 #: src/reports/incexpenses.cpp:128
 msgid "Income:"
@@ -4833,45 +5006,45 @@ msgstr "Totale Titoli:"
 msgid "Total Balance on all Accounts"
 msgstr "Saldo Totale (Tutti i conti)"
 
-#: src/reports/summary.cpp:215
+#: src/reports/summary.cpp:216
 #, c-format
 msgid "Account Balance - %s"
 msgstr "Saldo Disponibile - %s"
 
-#: src/reports/summary.cpp:215
+#: src/reports/summary.cpp:216
 msgid "Monthly Report"
 msgstr "Report mensile"
 
-#: src/reports/summary.cpp:215
+#: src/reports/summary.cpp:216
 msgid "Yearly Report"
 msgstr "Report annuale"
 
-#: src/reports/summarystocks.cpp:95
+#: src/reports/summarystocks.cpp:96
 msgid "Summary of Stocks"
 msgstr "Saldo dei Titoli"
 
-#: src/reports/summarystocks.cpp:181 src/stockspanel.cpp:86
+#: src/reports/summarystocks.cpp:174 src/stockspanel.cpp:94
 msgid "Purchase Date"
 msgstr "Data di Acquisto"
 
-#: src/reports/summarystocks.cpp:182
+#: src/reports/summarystocks.cpp:175
 msgid "Quantity"
 msgstr "Quantità"
 
-#: src/reports/summarystocks.cpp:183 src/stockdialog.cpp:205
+#: src/reports/summarystocks.cpp:176 src/stockdialog.cpp:209
 msgid "Purchase Price"
 msgstr "Prezzo di Acquisto"
 
-#: src/reports/summarystocks.cpp:184 src/stockdialog.cpp:216
+#: src/reports/summarystocks.cpp:177 src/stockdialog.cpp:220
 msgid "Current Price"
 msgstr "Prezzo Attuale"
 
-#: src/reports/summarystocks.cpp:185 src/stockdialog.cpp:231
-#: src/stockspanel.cpp:96
+#: src/reports/summarystocks.cpp:178 src/stockdialog.cpp:235
+#: src/stockspanel.cpp:104
 msgid "Commission"
 msgstr "Commissioni"
 
-#: src/reports/summarystocks.cpp:196
+#: src/reports/summarystocks.cpp:190
 msgid "Stocks Performance Charts"
 msgstr "Risultati andamento azioni"
 
@@ -4888,170 +5061,166 @@ msgstr "Lista operazioni del conto: %s"
 msgid "Total Amount: "
 msgstr "Totale Complessivo: "
 
-#: src/splitdetailsdialog.cpp:66
+#: src/splitdetailsdialog.cpp:72
 msgid "Split Detail Dialog"
 msgstr "Operazione suddivisa"
 
-#: src/splitdetailsdialog.cpp:95
+#: src/splitdetailsdialog.cpp:103
 msgid "Split Transaction Details"
 msgstr "Dettagli Operazione suddivisa"
 
-#: src/splittransactionsdialog.cpp:68
+#: src/splittransactionsdialog.cpp:72
 msgid "Split Transaction Dialog"
 msgstr "Gestione Operazione suddivisa"
 
-#: src/splittransactionsdialog.cpp:122
+#: src/splittransactionsdialog.cpp:123
 msgid " Split Category Details"
 msgstr " Dettagli Operazione suddivisa"
 
-#: src/splittransactionsdialog.cpp:208
+#: src/splittransactionsdialog.cpp:201
 msgid "Invalid Total Amount"
 msgstr "Totale Complessivo non valido "
 
-#: src/stockdialog.cpp:128 src/stockspanel.cpp:541
+#: src/stockdialog.cpp:132 src/stockspanel.cpp:488
 msgid "Edit Stock Investment"
 msgstr "Modifica Investimento in Titoli"
 
-#: src/stockdialog.cpp:128 src/stockspanel.cpp:537
+#: src/stockdialog.cpp:132 src/stockspanel.cpp:484
 msgid "New Stock Investment"
 msgstr "Nuovo Investimento in Titoli"
 
-#: src/stockdialog.cpp:159
+#: src/stockdialog.cpp:163
 msgid "Stock Investment Details"
 msgstr "Dettagli Investimento in Titoli"
 
-#: src/stockdialog.cpp:169
+#: src/stockdialog.cpp:173
 msgid "Stock Name"
 msgstr "Nome del Titolo"
 
-#: src/stockdialog.cpp:173
+#: src/stockdialog.cpp:177
 msgid "Enter the stock company name"
 msgstr "Inserire il nome della società emittente il Titolo"
 
-#: src/stockdialog.cpp:181
+#: src/stockdialog.cpp:185
 msgid "Specify the purchase date of the stock investment"
 msgstr "Indicare la data di acquisto del titolo"
 
-#: src/stockdialog.cpp:191
+#: src/stockdialog.cpp:195
 msgid "Enter the stock symbol. (Optional) Include exchange. eg: IBM.BE"
 msgstr ""
 "Inserire il simbolo del Titolo, incluso (facoltativo) il suffisso di cambio. "
 "es: IBM.MI"
 
-#: src/stockdialog.cpp:194 src/stockspanel.cpp:89
+#: src/stockdialog.cpp:198 src/stockspanel.cpp:97
 msgid "Number of Shares"
 msgstr "Numero di Azioni"
 
-#: src/stockdialog.cpp:200
+#: src/stockdialog.cpp:204
 msgid "Enter number of shares held"
 msgstr "Inserire il numero di azioni possedute"
 
-#: src/stockdialog.cpp:211
+#: src/stockdialog.cpp:215
 msgid "Enter purchase price for each stock"
 msgstr "Inserire il prezzo di acquisto per ciascun titolo"
 
-#: src/stockdialog.cpp:220
+#: src/stockdialog.cpp:224
 msgid "Enter current stock price"
 msgstr "Inserire il prezzo attuale del titolo"
 
-#: src/stockdialog.cpp:225 src/stockspanel.cpp:95
+#: src/stockdialog.cpp:229
 msgid "Price Date"
 msgstr "Data Valore"
 
-#: src/stockdialog.cpp:229
+#: src/stockdialog.cpp:233
 msgid "Specify the stock price date"
 msgstr "Indicare la data di acquisto delle azioni"
 
-#: src/stockdialog.cpp:235
+#: src/stockdialog.cpp:239
 msgid "Enter any commission paid"
 msgstr "Inserire i costi di commissione"
 
-#: src/stockdialog.cpp:250
+#: src/stockdialog.cpp:254
 msgid "Organize attachments of this stock"
 msgstr "Organizza allegati di questo titolo"
 
-#: src/stockdialog.cpp:253
+#: src/stockdialog.cpp:257
 msgid "Display the web page for the specified Stock symbol"
 msgstr "Visualizza la pagina web per il titolo del simbolo specificato"
 
-#: src/stockdialog.cpp:260
+#: src/stockdialog.cpp:264
 msgid "Enter notes associated with this investment"
 msgstr "Inserire le note per questo investimento"
 
-#: src/stockdialog.cpp:268
+#: src/stockdialog.cpp:272
 msgid "Stock History Options"
 msgstr "Opzioni storico azioni"
 
-#: src/stockdialog.cpp:275
+#: src/stockdialog.cpp:279
 msgid "Stock Price History"
 msgstr "Valore storico azioni"
 
-#: src/stockdialog.cpp:287 src/stockdialog.cpp:599
+#: src/stockdialog.cpp:291 src/stockdialog.cpp:603
 msgid "Price"
 msgstr "Valore"
 
-#: src/stockdialog.cpp:294
-msgid "Diff."
-msgstr "Diff."
-
-#: src/stockdialog.cpp:306
+#: src/stockdialog.cpp:310
 msgid "Download Stock Price history"
 msgstr "Scarica valore storico azioni"
 
-#: src/stockdialog.cpp:309
+#: src/stockdialog.cpp:313
 msgid "Import Stock Price history (CSV Format)"
 msgstr "Importa valore storico azioni (Formato CSV)"
 
-#: src/stockdialog.cpp:311
+#: src/stockdialog.cpp:315
 msgid "Delete selected Stock Price"
 msgstr "Elimina il valore selezionato"
 
-#: src/stockdialog.cpp:313
+#: src/stockdialog.cpp:317
 msgid "Add Stock Price to history"
 msgstr "Aggiungi valore azione allo storico"
 
-#: src/stockdialog.cpp:389
+#: src/stockdialog.cpp:393
 msgid "Held At"
 msgstr "Tenuto presso"
 
-#: src/stockdialog.cpp:524
+#: src/stockdialog.cpp:528
 msgid "Stock History CSV Import"
 msgstr "Importazione CSV valore azioni"
 
-#: src/stockdialog.cpp:525 src/stockdialog.cpp:540
+#: src/stockdialog.cpp:529 src/stockdialog.cpp:544
 msgid "Quotes imported from CSV: "
 msgstr "Valori importati da file CSV: "
 
-#: src/stockdialog.cpp:644
+#: src/stockdialog.cpp:650
 msgid "Days"
 msgstr "Giorni"
 
-#: src/stockdialog.cpp:645
+#: src/stockdialog.cpp:651
 msgid "Weeks"
 msgstr "Settimane"
 
-#: src/stockdialog.cpp:646
+#: src/stockdialog.cpp:652
 msgid "Months"
 msgstr "Mesi"
 
-#: src/stockdialog.cpp:648
+#: src/stockdialog.cpp:654
 msgid "Specify type frequency of stock history"
 msgstr "Indicare la frequenza del valore azioni"
 
-#: src/stockdialog.cpp:649 src/stockdialog.cpp:661
+#: src/stockdialog.cpp:655 src/stockdialog.cpp:667
 msgid "Stock History Update"
 msgstr "Aggiornamento storico azioni"
 
-#: src/stockdialog.cpp:660
+#: src/stockdialog.cpp:666
 msgid "Specify how many stock history prices download from purchase date"
 msgstr "Specifica quanti valori scaricare dalla data d'acquisto"
 
-#: src/stockdialog.cpp:661
+#: src/stockdialog.cpp:667
 #, c-format
 msgid "Number of %s:"
 msgstr "Numero di %s:"
 
-#: src/stockdialog.cpp:682
+#: src/stockdialog.cpp:688
 msgid ""
 "End date is in the future\n"
 "Quotes will be updated until today"
@@ -5059,20 +5228,20 @@ msgstr ""
 "La data finale è nel futuro\n"
 "I valori verranno aggiornati fino ad oggi"
 
-#: src/stockdialog.cpp:683 src/stockdialog.cpp:710
+#: src/stockdialog.cpp:689 src/stockdialog.cpp:716
 msgid "Stock History Error"
 msgstr "Errore valore azioni"
 
-#: src/stockdialog.cpp:709
+#: src/stockdialog.cpp:715
 msgid "Stock history not found!"
 msgstr "Storico azioni non trovato!"
 
-#: src/stockspanel.cpp:38
+#: src/stockspanel.cpp:39
 msgid "Using MMEX it is possible to track stocks/mutual funds investments."
 msgstr ""
 "Utilizzando MMEX è possibile seguire investimenti in titolo e fondi comuni."
 
-#: src/stockspanel.cpp:39
+#: src/stockspanel.cpp:40
 msgid ""
 "To create new stocks entry the Symbol, Number of shares and Purchase prise "
 "should be entered."
@@ -5080,153 +5249,157 @@ msgstr ""
 "Per creare nuovi titoli devono essere inseriti il simbolo, il numero di "
 "azioni e il prezzo d'acquisto."
 
-#: src/stockspanel.cpp:40
+#: src/stockspanel.cpp:41
 msgid "Sample of UK (HSBC HLDG) share: HSBA.L"
 msgstr "Esempio di azione UK (HSBC HLDG): HSBA.L"
 
-#: src/stockspanel.cpp:41
+#: src/stockspanel.cpp:42
 msgid "If the Stock Name field is empty it will be filed when prices updated"
 msgstr ""
 "Se il nome del titolo è vuoto verrà completato con l'aggiornamento del valore"
 
-#: src/stockspanel.cpp:87
+#: src/stockspanel.cpp:95
 msgid "Share Name"
 msgstr "Nome Azione"
 
-#: src/stockspanel.cpp:88
+#: src/stockspanel.cpp:96
 msgid "Share Symbol"
 msgstr "Simbolo azione"
 
-#: src/stockspanel.cpp:90
+#: src/stockspanel.cpp:98
 msgid "Unit Price"
 msgstr "Prezzo unit."
 
-#: src/stockspanel.cpp:91
-msgid "Total Value"
-msgstr "Valore Totale"
+#: src/stockspanel.cpp:99
+msgid "Total Price"
+msgstr "Prezzo Totale"
 
-#: src/stockspanel.cpp:93
-msgid "Curr. unit price"
+#: src/stockspanel.cpp:101
+msgid "Curr. unit value"
 msgstr "Prezzo Attuale unit."
 
-#: src/stockspanel.cpp:94
+#: src/stockspanel.cpp:102
 msgid "Curr. total value"
 msgstr "Valore attuale totale"
 
-#: src/stockspanel.cpp:153
+#: src/stockspanel.cpp:103
+msgid "Value Date"
+msgstr "Data valore"
+
+#: src/stockspanel.cpp:142
 msgid "&New Stock Investment"
 msgstr "&Nuovo Investimento in Titoli"
 
-#: src/stockspanel.cpp:155
+#: src/stockspanel.cpp:144
 msgid "&Edit Stock Investment"
 msgstr "&Modifica Investimento in Titoli"
 
-#: src/stockspanel.cpp:156
+#: src/stockspanel.cpp:145
 msgid "&Delete Stock Investment"
 msgstr "&Elimina Investimento in Titoli"
 
-#: src/stockspanel.cpp:264
+#: src/stockspanel.cpp:253
 msgid "Do you really want to delete the stock investment?"
 msgstr "Vuoi davvero cancellare questo investimento azionario?"
 
-#: src/stockspanel.cpp:265
+#: src/stockspanel.cpp:254
 msgid "Confirm Stock Investment Deletion"
 msgstr "Conferma eliminazione Investimento Azionario"
 
-#: src/stockspanel.cpp:546
+#: src/stockspanel.cpp:493
 msgid "Delete Stock Investment"
 msgstr "Elimina Investimento in Titoli"
 
-#: src/stockspanel.cpp:550
+#: src/stockspanel.cpp:497
 msgid "&Move"
 msgstr "Sposta"
 
-#: src/stockspanel.cpp:551
+#: src/stockspanel.cpp:498
 msgid "Move selected transaction to another account"
 msgstr "Sposta l'operazione selezionata ad un altro conto"
 
-#: src/stockspanel.cpp:564
+#: src/stockspanel.cpp:511
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: src/stockspanel.cpp:565
+#: src/stockspanel.cpp:512
 msgid "Refresh Stock Prices from Yahoo"
 msgstr "Aggiorna le quotazioni dei Titoli da Yahoo"
 
-#: src/stockspanel.cpp:672
+#: src/stockspanel.cpp:625
 #, c-format
 msgid "Stock Investments: %s"
 msgstr "Investimenti: %s"
 
-#: src/stockspanel.cpp:714
+#: src/stockspanel.cpp:667
 #, c-format
 msgid "Total Shares: %s"
 msgstr "Totale Azioni: %s"
 
-#: src/stockspanel.cpp:716
+#: src/stockspanel.cpp:669
 #, c-format
 msgid "Invested: %s"
 msgstr "Investito: %s"
 
-#: src/stockspanel.cpp:717
+#: src/stockspanel.cpp:670
 #, c-format
 msgid "Gain: %s"
 msgstr "Guadagno: %s"
 
-#: src/stockspanel.cpp:717
+#: src/stockspanel.cpp:670
 #, c-format
 msgid "Loss: %s"
 msgstr "Perdita: %s"
 
-#: src/stockspanel.cpp:754
+#: src/stockspanel.cpp:707
 msgid "Stock prices successfully updated"
 msgstr "Quotazioni azioni aggiornate correttamente"
 
-#: src/stockspanel.cpp:756 src/stockspanel.cpp:967
+#: src/stockspanel.cpp:709 src/stockspanel.cpp:920
 #, c-format
 msgid "Last updated %s"
 msgstr "Ultimo aggiornamento %s"
 
-#: src/stockspanel.cpp:774
+#: src/stockspanel.cpp:727
 msgid "Nothing to update"
 msgstr "Nulla da aggiornare"
 
-#: src/stockspanel.cpp:801
+#: src/stockspanel.cpp:754
 msgid "Connecting..."
 msgstr "Connessione in corso..."
 
-#: src/stockspanel.cpp:845
+#: src/stockspanel.cpp:798
 #, c-format
 msgid "%s\t -> %s\n"
 msgstr "%s\t -> %s\n"
 
-#: src/stockspanel.cpp:875
+#: src/stockspanel.cpp:828
 #, c-format
 msgid "%s on %s"
 msgstr "%s su %s"
 
-#: src/stockspanel.cpp:932
+#: src/stockspanel.cpp:885
 #, c-format
 msgid "Symbol: %s"
 msgstr "Simbolo: %s"
 
-#: src/transdialog.cpp:123
+#: src/transdialog.cpp:129
 msgid "Duplicate Transaction"
 msgstr "Duplica operazione"
 
-#: src/transdialog.cpp:124
+#: src/transdialog.cpp:130
 msgid "Edit Transaction"
 msgstr "Modifica Operazione"
 
-#: src/transdialog.cpp:427
+#: src/transdialog.cpp:435
 msgid "Populate Transaction #"
 msgstr "Numerazione progressiva della operazione #"
 
-#: src/transdialog.cpp:448
+#: src/transdialog.cpp:456
 msgid "Organize attachments of this transaction"
 msgstr "Organizza allegati di questa transazione"
 
-#: src/transdialog.cpp:526
+#: src/transdialog.cpp:534
 #, c-format
 msgid ""
 "Do you want to add new payee: \n"
@@ -5235,263 +5408,181 @@ msgstr ""
 "Vuoi aggiungere il nuovo Beneficiario: \n"
 "%s?"
 
-#: src/transdialog.cpp:527
+#: src/transdialog.cpp:535
 msgid "Confirm to add new payee"
 msgstr "Conferma per aggiunta nuovo benefeciario"
 
-#: src/transdialog.cpp:1010
+#: src/transdialog.cpp:1014
 msgid "Specify account the money is taken from"
 msgstr "Specificare il Conto dal quale si effettua il trasferimento"
 
-#: src/transdialog.cpp:1011
+#: src/transdialog.cpp:1015
 msgid "Specify account the money is moved to"
 msgstr "Specificare il Conto verso il quale si effettua il trasferimento"
 
-#: src/transdialog.cpp:1012
+#: src/transdialog.cpp:1016
 msgid "Specify the transfer amount in the From Account."
 msgstr "Specificare l'importo da trasferire dal Conto Origine"
 
-#: src/transdialog.cpp:1020
+#: src/transdialog.cpp:1024
 msgid "Specify account for the transaction"
 msgstr "Specificare il conto per questa operazione"
 
-#: src/transdialog.cpp:1022
+#: src/transdialog.cpp:1026
 msgid "Specify to whom the transaction is going to"
 msgstr "Specificare la destinazione della operazione"
 
-#: src/util.cpp:104
-#, c-format
-msgid ""
-"Directory of language files does not exist:\n"
-"%s"
-msgstr ""
-"La cartella dei language file non esiste:\n"
-"%s"
-
-#: src/util.cpp:210
+#: src/util.cpp:117
 msgid "Syntax error in the URL string"
 msgstr "Errore di sintassi nella stringa URL"
 
-#: src/util.cpp:211
+#: src/util.cpp:118
 msgid "Found no protocol which can get this URL"
 msgstr "Nessun protocollo trovato per questo URL"
 
-#: src/util.cpp:212
+#: src/util.cpp:119
 msgid "A host name is required for this protocol"
 msgstr "Richiesto un nome host per questo protocollo"
 
-#: src/util.cpp:213
+#: src/util.cpp:120
 msgid "A path is required for this protocol"
 msgstr "Richiesto un percorso per questo protocollo"
 
-#: src/util.cpp:214
+#: src/util.cpp:121
 msgid "Connection error"
 msgstr "Errore di connessione"
 
-#: src/util.cpp:215 src/webapp.cpp:189
+#: src/util.cpp:122 src/webapp.cpp:189
 msgid "An error occurred during negotiation"
 msgstr "Si è verificato un errore durante la negoziazione"
 
-#: src/util.cpp:216
+#: src/util.cpp:123
 msgid "Cannot get data from WWW!"
 msgstr "Impossibile ricevere dati dal WWW!"
 
-#: src/util.cpp:217 src/webapp.cpp:196
+#: src/util.cpp:124 src/webapp.cpp:196
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
-#: src/util.cpp:390
+#: src/util.cpp:351
 msgid "January"
 msgstr "Gennaio"
 
-#: src/util.cpp:390
+#: src/util.cpp:351
 msgid "February"
 msgstr "Febbraio"
 
-#: src/util.cpp:390
+#: src/util.cpp:351
 msgid "March"
 msgstr "Marzo"
 
-#: src/util.cpp:391
+#: src/util.cpp:352
 msgid "April"
 msgstr "Aprile"
 
-#: src/util.cpp:391
-msgid "May "
-msgstr "Maggio "
-
-#: src/util.cpp:391
-msgid "June"
-msgstr "Giugno"
-
-#: src/util.cpp:392
-msgid "July"
-msgstr "Luglio"
-
-#: src/util.cpp:392
-msgid "August"
-msgstr "Agosto"
-
-#: src/util.cpp:392
-msgid "September"
-msgstr "Settembre"
-
-#: src/util.cpp:393
-msgid "October"
-msgstr "Ottobre"
-
-#: src/util.cpp:393
-msgid "November"
-msgstr "Novembre"
-
-#: src/util.cpp:393
-msgid "December"
-msgstr "Dicembre"
-
-#: src/util.cpp:398
-msgid "Jan"
-msgstr "Gen"
-
-#: src/util.cpp:398
-msgid "Feb"
-msgstr "Feb"
-
-#: src/util.cpp:398
-msgid "Mar"
-msgstr "Mar"
-
-#: src/util.cpp:399
-msgid "Apr"
-msgstr "Apr"
-
-#: src/util.cpp:399
+#: src/util.cpp:352 src/util.cpp:360
 msgid "May"
 msgstr "Mag"
 
-#: src/util.cpp:399
+#: src/util.cpp:352
+msgid "June"
+msgstr "Giugno"
+
+#: src/util.cpp:353
+msgid "July"
+msgstr "Luglio"
+
+#: src/util.cpp:353
+msgid "August"
+msgstr "Agosto"
+
+#: src/util.cpp:353
+msgid "September"
+msgstr "Settembre"
+
+#: src/util.cpp:354
+msgid "October"
+msgstr "Ottobre"
+
+#: src/util.cpp:354
+msgid "November"
+msgstr "Novembre"
+
+#: src/util.cpp:354
+msgid "December"
+msgstr "Dicembre"
+
+#: src/util.cpp:359
+msgid "Jan"
+msgstr "Gen"
+
+#: src/util.cpp:359
+msgid "Feb"
+msgstr "Feb"
+
+#: src/util.cpp:359
+msgid "Mar"
+msgstr "Mar"
+
+#: src/util.cpp:360
+msgid "Apr"
+msgstr "Apr"
+
+#: src/util.cpp:360
 msgid "Jun"
 msgstr "Giu"
 
-#: src/util.cpp:400
+#: src/util.cpp:361
 msgid "Jul"
 msgstr "Lug"
 
-#: src/util.cpp:400
+#: src/util.cpp:361
 msgid "Aug"
 msgstr "Ago"
 
-#: src/util.cpp:400
+#: src/util.cpp:361
 msgid "Sep"
 msgstr "Set"
 
-#: src/util.cpp:401
+#: src/util.cpp:362
 msgid "Oct"
 msgstr "Ott"
 
-#: src/util.cpp:401
+#: src/util.cpp:362
 msgid "Nov"
 msgstr "Nov"
 
-#: src/util.cpp:401
+#: src/util.cpp:362
 msgid "Dec"
 msgstr "Dic"
 
-#: src/util.cpp:406
+#: src/util.cpp:367
 msgid "Sunday"
 msgstr "Domenica"
 
-#: src/util.cpp:406
+#: src/util.cpp:367
 msgid "Monday"
 msgstr "Lunedì"
 
-#: src/util.cpp:406
+#: src/util.cpp:367
 msgid "Tuesday"
 msgstr "Martedì"
 
-#: src/util.cpp:407
+#: src/util.cpp:368
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: src/util.cpp:407
+#: src/util.cpp:368
 msgid "Thursday"
 msgstr "Giovedì"
 
-#: src/util.cpp:407
+#: src/util.cpp:368
 msgid "Friday"
 msgstr "Venerdì"
 
-#: src/util.cpp:408
+#: src/util.cpp:369
 msgid "Saturday"
 msgstr "Sabato"
-
-#: src/util.cpp:428
-#, c-format
-msgid "Entry %s is invalid"
-msgstr "Inserimento %s non valido"
-
-#: src/util.cpp:429
-msgid "Invalid Entry"
-msgstr "Inserimento non valido"
-
-#: src/util.cpp:434
-msgid "Invalid Category"
-msgstr "Categoria non valida"
-
-#: src/util.cpp:435
-msgid ""
-"Please use this button for category selection\n"
-"or use the 'Split' checkbox for multiple categories."
-msgstr ""
-"Usare questo bottone per la selezione della categoria\n"
-"oppure usare la casella 'Suddividi' per categorie multiple"
-
-#: src/util.cpp:443
-msgid "File name is empty."
-msgstr "Il nome del file è vuoto."
-
-#: src/util.cpp:444
-msgid "Please select the file for this operation."
-msgstr "Specificare il file per questa operazione."
-
-#: src/util.cpp:446
-msgid "Selection can be made by using Search button."
-msgstr "La selezione può essere fatta usando il tasto Cerca."
-
-#: src/util.cpp:456
-msgid "Invalid Account"
-msgstr "Conto non valido"
-
-#: src/util.cpp:459
-msgid "Please select the account for this transaction."
-msgstr "Specificare il conto per questa operazione."
-
-#: src/util.cpp:461
-msgid "Please specify which account the transfer is going to."
-msgstr "Specificare il conto verso il quale effettuare il trasferimento"
-
-#: src/util.cpp:463
-msgid "Selection can be made by using the dropdown button."
-msgstr "La selezione può essere fatta usando l'elenco a discesa"
-
-#: src/util.cpp:473 src/mmcombobox.h:77
-msgid "Invalid Payee"
-msgstr "Beneficiario non valido"
-
-#: src/util.cpp:474
-msgid ""
-"Please type in a new payee,\n"
-"or make a selection using the dropdown button."
-msgstr ""
-"Digitare il nuovo beneficiario,\n"
-"oppure sceglierlo tramite l'elenco a discesa"
-
-#: src/util.cpp:483
-msgid "Invalid Name"
-msgstr "Nome non valido"
-
-#: src/util.cpp:484
-msgid "Please type in a non empty name."
-msgstr "Nome vuoto non valido"
 
 #: src/webapp.cpp:115
 msgid "Wrong WebApp GUID:"
@@ -6006,15 +6097,19 @@ msgstr ""
 "Digitare un beneficiario esistente,\n"
 "oppure sceglierlo tramite l'elenco a discesa."
 
-#: src/mmtextctrl.h:89
+#: src/mmtextctrl.h:90
 msgid "Invalid Amount."
 msgstr "Importo non valido:"
 
-#: src/mmtextctrl.h:90
+#: src/mmtextctrl.h:91
 msgid "Please enter a positive or calculated value."
 msgstr "Inserire un valore positivo oppure un'operazione"
 
-#: src/mmtextctrl.h:92
+#: src/mmtextctrl.h:91
+msgid "Please enter a calculated value."
+msgstr "Inserire un valore positivo oppure un'operazione."
+
+#: src/mmtextctrl.h:93
 msgid ""
 "Tip: For calculations, enter expressions like (2+2)*(2+2)\n"
 "Calculations will be evaluated and the result used as the entry."
@@ -6034,6 +6129,149 @@ msgstr "Resoconto Beneficiari"
 #, c-format
 msgid "Payee Report - %s"
 msgstr "Resoconto Beneficiario - %s"
+
+#~ msgid "Hide column"
+#~ msgstr "Nascondi colonna"
+
+#~ msgid "Reset columns size"
+#~ msgstr "Resetta dimensioni colonne"
+
+#~ msgid "Modify the description for the attachment:"
+#~ msgstr "Modifica la descrizione dell'allegato"
+
+#~ msgid "New Repeating Transaction"
+#~ msgstr "Nuova Operazione Ricorrente"
+
+#~ msgid " Edit Repeating Transaction"
+#~ msgstr "Modifica Operazione Ricorrente"
+
+#~ msgid " Enter Repeating Transaction"
+#~ msgstr "Inserisci Operazione Ricorrente"
+
+#~ msgid "Note: Split transactions not set"
+#~ msgstr "Nota: Categorie suddivisa non impostata"
+
+#~ msgid "Reoccuring Transaction Creation"
+#~ msgstr "Creazione Operazione Ricorrente"
+
+#~ msgid "Repeating Transaction Details"
+#~ msgstr "Dettagli Operazione Ricorrente"
+
+#~ msgid "Specify the date of the next bill or deposit"
+#~ msgstr "Inserire la data della prossima scadenza"
+
+#~ msgid "Set to 'Auto Execute' on the 'Next Occurrence' date."
+#~ msgstr "Esecuzione Automatica alla prossima scadenza"
+
+#~ msgid "Automatic Execution will require user acknowledgement."
+#~ msgstr "L'Esecuzione Automatica richiede conferma dell'utente"
+
+#~ msgid "Specify the Account that will own the repeating transaction"
+#~ msgstr "Specificare il Conto su cui sarà registrata l'operazione"
+
+#~ msgid "Organize attachments of this repeating transaction"
+#~ msgstr "Organizza allegati per questa operazione ricorrente"
+
+#~ msgid "Repeating Transactions"
+#~ msgstr "Operazioni Ricorrenti"
+
+#~ msgid "Version: "
+#~ msgstr "Versione: "
+
+#~ msgid "%s Converted to: %s"
+#~ msgstr "%s Convertito in: %s"
+
+#~ msgid "Other currency conversion rate. Set Base Currency to 1."
+#~ msgstr ""
+#~ "Tasso di conversione con altre valute. Impostare ad 1 per la Valuta Base"
+
+#~ msgid "Base Rate Conversion Sample:"
+#~ msgstr "Esempio di Conversione:"
+
+#~ msgid "&Update"
+#~ msgstr "&Aggiorna"
+
+#~ msgid "Currency with same name exists"
+#~ msgstr "Valuta già esistente!"
+
+#~ msgid "Organize Currency: Add Currency"
+#~ msgstr "Gestione Valute: Nuova Valuta"
+
+#~ msgid "Enter the name for the new report group"
+#~ msgstr "Inserire il nome del nuovo gruppo di resoconti"
+
+#~ msgid "Transactions saved to database in account: "
+#~ msgstr "Operazioni salvate nel database nel conto: "
+
+#~ msgid "Base Rate"
+#~ msgstr "Tasso Base"
+
+#~ msgid ""
+#~ "Attempt to delete a currency being used by an account\n"
+#~ " or as the base currency."
+#~ msgstr ""
+#~ "Tentativo di eliminazione di una valuta utilizzata in un conto\n"
+#~ " o della valuta base."
+
+#~ msgid "Remember to update currency rate"
+#~ msgstr "Ricorda di aggiornare i Tassi di Cambio!"
+
+#~ msgid "Important note"
+#~ msgstr "Avviso Importante"
+
+#~ msgid "Report Font Size"
+#~ msgstr "Dimensione Carattere dei Resoconti"
+
+#~ msgid "XSmall"
+#~ msgstr "Molto piccolo"
+
+#~ msgid "Small"
+#~ msgstr "Piccolo"
+
+#~ msgid "Normal"
+#~ msgstr "Normale"
+
+#~ msgid "Large"
+#~ msgstr "Grande"
+
+#~ msgid "XLarge"
+#~ msgstr "Molto grande"
+
+#~ msgid "XXLarge"
+#~ msgstr "Molto più grande"
+
+#~ msgid "Huge"
+#~ msgstr "Enorme"
+
+#~ msgid "Specify which font size is used on the report tables"
+#~ msgstr "Indicare la grandezza del carattere da utilizzare per i resoconti"
+
+#~ msgid "Display MMEX News on home page"
+#~ msgstr "Mostra News MMEX sull'Home Page"
+
+#~ msgid "&New Transaction"
+#~ msgstr "&Nuova Operazione"
+
+#~ msgid "&Repeating Transactions"
+#~ msgstr "Operazioni &Ricorrenti"
+
+#~ msgid "Records found in repeating transactions: %i"
+#~ msgstr "Record trovati nelle operazioni ricorrenti: %i"
+
+#~ msgid "Records found in repeating split transactions: %i"
+#~ msgstr "Record trovati in operazioni ricorrenti suddivise: %i"
+
+#~ msgid "Budget Performance for "
+#~ msgstr "Risultati Budget "
+
+#~ msgid "Total Value"
+#~ msgstr "Valore Totale"
+
+#~ msgid "Curr. unit price"
+#~ msgstr "Prezzo Attuale unit."
+
+#~ msgid "May "
+#~ msgstr "Maggio "
 
 #~ msgid "Calendar"
 #~ msgstr "Calendario"

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -140,6 +140,8 @@ const wxString mmex::weblink::Twitter = "https://twitter.com/MoneyManagerEx";
 const wxString mmex::weblink::Facebook = "http://www.facebook.com/pages/Money-Manager-Ex/242286559144586";
 const wxString mmex::weblink::YahooQuotes = "http://download.finance.yahoo.com/d/quotes.csv?s=%s&f=sl1c4n&e=.csv";
 const wxString mmex::weblink::YahooQuotesHistory = "http://ichart.finance.yahoo.com/table.csv?s=";
+const wxString mmex::weblink::BceCurrencyHistory = "http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml";
+//const wxString mmex::weblink::BceCurrencyHistory = "http://192.168.6.1/eurofxref-hist.xml"; // used for debug
 const wxString mmex::weblink::GooglePlay = "https://play.google.com/store/apps/details?id=com.money.manager.ex";
 
 // Will display the stock page when using Looks up the current value

--- a/src/constants.h
+++ b/src/constants.h
@@ -77,6 +77,7 @@ namespace weblink
     extern const wxString Facebook;
     extern const wxString YahooQuotes;
     extern const wxString YahooQuotesHistory;
+    extern const wxString BceCurrencyHistory;
     extern const wxString DefStockUrl;
     extern const wxString GooglePlay;
 } // namespace weblink

--- a/src/currencydialog.h
+++ b/src/currencydialog.h
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
+ Copyright (C) 2015 Gabriele-V
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@ class mmTextCtrl;
 enum
 {
     ID_DIALOG_CURRENCY = wxID_HIGHEST + 400,
+    ID_DIALOG_CURRENCY_RATE,
 };
 
 class mmCurrencyDialog : public wxDialog
@@ -52,14 +54,14 @@ private:
 
     void OnOk(wxCommandEvent& event);
     void OnCancel(wxCommandEvent& event);
+    void OnTextChanged(wxCommandEvent& event);
     void OnTextEntered(wxCommandEvent& event);
 
     Model_Currency::Data* m_currency;
     double convRate_;
-    int scale_;
+    int m_scale;
 
     mmTextCtrl* m_currencyName;
-    wxStaticText* baseRateSample_;
     wxStaticText* sampleText_;
     mmTextCtrl* m_currencySymbol;
     mmTextCtrl* baseConvRate_;
@@ -70,7 +72,6 @@ private:
     wxTextCtrl* unitTx_;
     wxTextCtrl* centTx_;
     wxTextCtrl* scaleTx_;
-    wxTextCtrl* baseConv_;
 
 };
 

--- a/src/maincurrencydialog.h
+++ b/src/maincurrencydialog.h
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
+ Copyright (C) 2015 Gabriele-V
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -20,11 +21,20 @@
 #define MM_EX_MAINCURRENCY_DIALOG_H_
 
 #include "defs.h"
-#include <wx/dataview.h>
 #include <map>
+#include <vector>
+#include <wx/dataview.h>
 
 class wxDatePickerCtrl;
 class mmTextCtrl;
+
+struct CurrencyHistoryRate
+{
+    wxString BaseCurrency;
+    wxDateTime Date;
+    wxString Currency;
+    double Rate;
+};
 
 class mmMainCurrencyDialog: public wxDialog
 {
@@ -51,6 +61,7 @@ private:
         HISTORY_ADD,
         HISTORY_DELETE,
         HISTORY_UPDATE,
+        HISTORY_DELUNUSED,
         MENU_ITEM1,
         MENU_ITEM2
     };
@@ -72,7 +83,6 @@ private:
     void OnCancel(wxCommandEvent& event);
     void OnListItemActivated(wxDataViewEvent& event);
     void OnListItemSelected(wxDataViewEvent& event);
-    void OnValueChanged(wxDataViewEvent& event);
     void fillControls();
     void OnShowHiddenChbClick(wxCommandEvent& event);
 
@@ -80,18 +90,19 @@ private:
     void OnHistoryAdd(wxCommandEvent& event);
     void OnHistoryDelete(wxCommandEvent& event);
     void OnHistoryUpdate(wxCommandEvent& event);
+    void OnHistoryDeleteUnused(wxCommandEvent& event);
     void OnHistorySelected(wxListEvent& event);
     void OnHistoryDeselected(wxListEvent& event);
 
     void OnOnlineUpdateCurRate(wxCommandEvent& event);
-    bool onlineUpdateCurRate(int curr_id = -1);
+    bool onlineUpdateCurRate(int curr_id = -1, bool hide = true);
     void OnItemRightClick(wxDataViewEvent& event);
     void OnMenuSelected(wxCommandEvent& event);
+    bool SetBaseCurrency(int& baseCurrencyID);
 
     wxDataViewListCtrl* currencyListBox_;
     std::map<int, wxString> ColName_;
     bool bEnableSelect_;
-    double curr_rate_;
     wxButton* itemButtonEdit_;
     wxButton* itemButtonDelete_;
     wxCheckBox* cbShowAll_;
@@ -99,9 +110,15 @@ private:
     wxDatePickerCtrl* valueDatePicker_;
     mmTextCtrl* valueTextBox_;
     wxStaticBox* historyStaticBox_;
+    wxButton* historyButtonAdd_;
+    wxButton* historyButtonDelete_;
 
     int currencyID_;
     int selectedIndex_;
+
+    std::vector<CurrencyHistoryRate> _BceCurrencyHistoryRatesList;
+    bool HistoryDownloadBce();
+    bool ConvertHistoryRates(const std::vector<CurrencyHistoryRate>& Bce, std::vector<CurrencyHistoryRate>& ConvertedRate, const wxString& BaseCurrencySymbol);
 };
 
 #endif // MM_EX_MAINCURRENCY_DIALOG_H_

--- a/src/mmOptionGeneralSettings.cpp
+++ b/src/mmOptionGeneralSettings.cpp
@@ -105,6 +105,7 @@ void mmOptionGeneralSettings::Create()
         , currName, wxDefaultPosition, wxDefaultSize);
     baseCurrencyButton->SetToolTip(_("Sets the default currency for the database."));
     currencyStaticBoxSizer->Add(baseCurrencyButton, g_flags);
+    currencyStaticBoxSizer->Add(new wxStaticText(this, wxID_STATIC, _("Right click on currency and choose 'Set as Base Currency'")), g_flags);
 
     // Date Format Settings
     wxStaticBox* dateFormatStaticBox = new wxStaticBox(this, wxID_STATIC, _("Date Format"));
@@ -185,8 +186,8 @@ void mmOptionGeneralSettings::OnCurrency(wxCommandEvent& /*event*/)
         bn->SetLabelText(currency->CURRENCYNAME);
         m_currency_id = currencyID;
 
-        wxMessageDialog msgDlg(this, _("Remember to update currency rate"), _("Important note"));
-        msgDlg.ShowModal();
+        //wxMessageDialog msgDlg(this, _("Remember to update currency rate"), _("Important note"));
+        //msgDlg.ShowModal();
     }
 }
 
@@ -239,7 +240,7 @@ void mmOptionGeneralSettings::SaveSettings()
     Model_Setting::instance().Set(LANGUAGE_PARAMETER, languageButton->GetLabel().Lower());
     mmDialogs::mmSelectLanguage(this->m_app, this, false);
 
-    Model_Infotable::instance().SetBaseCurrency(m_currency_id);
+    //Model_Infotable::instance().SetBaseCurrency(m_currency_id); Handled only inside MainCurrencyDialog to better manage CurrencyHistory changes
     Model_Infotable::instance().Set("DATEFORMAT", m_date_format);
     SaveFinancialYearStart();
 

--- a/src/model/Model_Currency.h
+++ b/src/model/Model_Currency.h
@@ -22,6 +22,7 @@
 #include "Model.h"
 #include "db/DB_Table_Currencyformats_V1.h"
 #include "Model_Infotable.h" // detect base currency setting BASECURRENCYID
+#include <map>
 #include <tuple>
 
 class Model_Currency : public Model<DB_Table_CURRENCYFORMATS_V1>
@@ -56,8 +57,6 @@ public:
 
     /** Return the Data record of the base currency.*/
     static Data* GetBaseCurrency();
-    /** Set the ID of the Data record as the base currency.*/
-    static void SetBaseCurrency(Data* r);
 
     /** Return the currency Data record for the given symbol */
     Model_Currency::Data* GetCurrencyRecord(const wxString& currency_symbol);
@@ -67,6 +66,8 @@ public:
     * Delete also all currency history
     */
     bool remove(int id);
+
+    static std::map<wxDateTime,int> DateUsed(int CurrencyID);
 
     /** Add prefix and suffix characters to string value */
     static wxString toCurrency(double value, const Data* currency = GetBaseCurrency(), int precision = -1);

--- a/src/model/Model_CurrencyHistory.cpp
+++ b/src/model/Model_CurrencyHistory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************
-Copyright (C) 2013,2014 Guan Lisheng (guanlisheng@gmail.com)
+Copyright (C) 2015 Gabriele-V
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ********************************************************/
 
 #include "Model_CurrencyHistory.h"
+#include "Model_Currency.h"
 
 Model_CurrencyHistory::Model_CurrencyHistory()
 : Model<DB_Table_CURRENCYHISTORY_V1>()
@@ -79,4 +80,21 @@ int Model_CurrencyHistory::addUpdate(const int& currencyID, const wxDate& date, 
     currHist->CURRVALUE = price;
     currHist->CURRUPDTYPE = type;
     return save(currHist);
+}
+
+
+/** Return the last attachment number linked to a specific object */
+double Model_CurrencyHistory::LastRate(const int& currencyID)
+{
+    Model_CurrencyHistory::Data_Set histData = Model_CurrencyHistory::instance().find(Model_CurrencyHistory::CURRENCYID(currencyID));
+    
+    std::stable_sort(histData.begin(), histData.end(), SorterByCURRDATE());
+
+    if (!histData.empty())
+        return histData.back().CURRVALUE;
+    else
+    {
+        Model_Currency::Data* Currency = Model_Currency::instance().get(currencyID);
+        return Currency->BASECONVRATE;
+    }
 }

--- a/src/model/Model_CurrencyHistory.h
+++ b/src/model/Model_CurrencyHistory.h
@@ -1,5 +1,5 @@
 /*******************************************************
-Copyright (C) 2013,2014 Guan Lisheng (guanlisheng@gmail.com)
+Copyright (C) 2015 Gabriele-V
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -52,10 +52,12 @@ public:
     static wxDate CURRDATE(const Data& hist);
 
     static DB_Table_CURRENCYHISTORY_V1::CURRDATE CURRDATE(const wxDate& date, OP op = EQUAL);
-    /**
-    Adds or updates an element in currency history
-    */
+    
+    /** Adds or updates an element in currency history */
     int addUpdate(const int& currencyID, const wxDate& date, double price, UPDTYPE type);
+
+    /** Return the last rate for a specific currency */
+    static double LastRate(const int& currencyID);
 };
 
 #endif // 

--- a/src/model/Model_Infotable.cpp
+++ b/src/model/Model_Infotable.cpp
@@ -159,19 +159,9 @@ int Model_Infotable::GetBaseCurrencyId()
     return this->GetIntInfo("BASECURRENCYID", -1);
 }
 
-wxString Model_Infotable::GetBaseCurrencyName()
-{
-    return this->GetStringInfo("BASECURRENCYNAME", "United States dollar");
-}
-
 void Model_Infotable::SetBaseCurrency(int currency_id)
 {
     Model_Infotable::instance().Set("BASECURRENCYID", currency_id);
-}
-
-void Model_Infotable::SetBaseCurrency(const wxString& currency_name)
-{
-    Model_Infotable::instance().Set("BASECURRENCYNAME", currency_name);
 }
 
 /* Returns true if key setting found */

--- a/src/model/Model_Infotable.h
+++ b/src/model/Model_Infotable.h
@@ -59,9 +59,7 @@ public:
     const wxColour GetColourSetting(const wxString& key, const wxColour& default_value = wxColour(255, 255, 255));
 
     int GetBaseCurrencyId();
-    wxString GetBaseCurrencyName();
     void SetBaseCurrency(int currency_id);
-    void SetBaseCurrency(const wxString& currency_name);
 
     /* Returns true if key setting found */
     bool KeyExists(const wxString& key);

--- a/src/wizard_newdb.cpp
+++ b/src/wizard_newdb.cpp
@@ -172,8 +172,8 @@ void mmNewDatabaseWizardPage::OnCurrency(wxCommandEvent& /*event*/)
         if (currency)
         {
             itemButtonCurrency_->SetLabelText(currency->CURRENCYNAME);
-            Model_Currency::instance().SetBaseCurrency(currency);
             currencyID_ = currency->CURRENCYID;
+            Model_Infotable::instance().SetBaseCurrency(currencyID_);
         }
     }
 }


### PR DESCRIPTION
Unfortunately there isn't any free service to download currency history, so I've implemented download from BCE (European Central Bank) website, but it's a quite big XML (4MB) from 1999 until today so a bit slow to download & parse.

I've implemented a sort of cache that won't re-download the file until stay in Currency Dialog, but first time executed it will take some time. Do you think we need to add a warning that could take some time to execute? On my i5 Notebook it's quite fast (about 6 sec) but I don't know on slowest machines..


Now remains open only step 3: implement values in total and amount logics.