### PR TITLE
feat(CurrencyHistory): converted IncExpenses

### DIFF
--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -116,7 +116,7 @@ void mmMainCurrencyDialog::fillControls()
         data.push_back(wxVariant(baseCurrencyID == currencyID));
         data.push_back(wxVariant(currency.CURRENCY_SYMBOL));
         data.push_back(wxVariant(currency.CURRENCYNAME));
-        data.push_back(wxVariant(wxString()<<Model_CurrencyHistory::LastRate(currencyID)));
+        data.push_back(wxVariant(wxString()<<Model_CurrencyHistory::getLastRate(currencyID)));
         currencyListBox_->AppendItem(data, (wxUIntPtr)currencyID);
         if (selectedIndex_ == currencyListBox_->GetItemCount() - 1)
         {
@@ -611,6 +611,7 @@ void mmMainCurrencyDialog::OnHistoryAdd(wxCommandEvent& /*event*/)
         return;
     Model_CurrencyHistory::instance().addUpdate(currencyID_, valueDatePicker_->GetValue(), dPrice, Model_CurrencyHistory::MANUAL);
 
+    fillControls();
     ShowCurrencyHistory();
 }
 
@@ -630,6 +631,8 @@ void mmMainCurrencyDialog::OnHistoryDelete(wxCommandEvent& /*event*/)
         Model_CurrencyHistory::instance().remove((int)valueListBox_->GetItemData(item));
     }
     Model_CurrencyHistory::instance().ReleaseSavepoint();
+
+    fillControls();
     ShowCurrencyHistory();
 }
 
@@ -698,7 +701,10 @@ void mmMainCurrencyDialog::OnHistoryUpdate(wxCommandEvent& /*event*/)
     Model_CurrencyHistory::instance().ReleaseSavepoint();
 
     if (Found)
+    {
+        fillControls();
         ShowCurrencyHistory();
+    }
     else
         mmErrorDialogs::MessageError(this,
             wxString::Format("Unable to download history for symbol %S. History rates not available!", CurrentCurrency->CURRENCY_SYMBOL.Upper()),
@@ -729,6 +735,8 @@ void mmMainCurrencyDialog::OnHistoryDeleteUnused(wxCommandEvent& /*event*/)
         }
     }
     Model_CurrencyHistory::instance().ReleaseSavepoint();
+
+    fillControls();
     ShowCurrencyHistory();
 }
 
@@ -827,6 +835,7 @@ bool mmMainCurrencyDialog::SetBaseCurrency(int& baseCurrencyID)
     }
     Model_CurrencyHistory::instance().ReleaseSavepoint();
 
+    fillControls();
     ShowCurrencyHistory();
     return true;
 }

--- a/src/model/Model_CurrencyHistory.cpp
+++ b/src/model/Model_CurrencyHistory.cpp
@@ -82,12 +82,47 @@ int Model_CurrencyHistory::addUpdate(const int& currencyID, const wxDate& date, 
     return save(currHist);
 }
 
+/** Return the rate for a specific currency in a specific day*/
+double Model_CurrencyHistory::getDayRate(const int& currencyID, const wxString& DateISO)
+{
+    if (currencyID == Model_Currency::GetBaseCurrency()->CURRENCYID)
+        return 1;
+    
+    wxDateTime Date;
+    Date.ParseDate(DateISO);
+    Model_CurrencyHistory::Data_Set Data = Model_CurrencyHistory::instance().find(Model_CurrencyHistory::CURRENCYID(currencyID),Model_CurrencyHistory::CURRDATE(Date));
+
+    if (!Data.empty())
+        return Data.back().CURRVALUE;
+    else
+    {
+        //int Rate = 0, DaysTMP = 999, Days = 999;
+        //Model_CurrencyHistory::Data_Set histData = Model_CurrencyHistory::instance().find(Model_CurrencyHistory::CURRENCYID(currencyID));
+        //for (auto& hist : histData)
+        //{
+        //    DaysTMP = abs((Date - Model_CurrencyHistory::CURRDATE(hist)).GetDays());
+        //    if (DaysTMP < Days)
+        //    {
+        //        Days = DaysTMP;
+        //        Rate = hist.CURRVALUE;
+        //    }
+        //}
+        //if (Rate != 0)
+        //    return Rate;
+        //else
+        //{
+        //    Model_Currency::Data* Currency = Model_Currency::instance().get(currencyID);
+        //    return Currency->BASECONVRATE;
+        //}
+        Model_Currency::Data* Currency = Model_Currency::instance().get(currencyID);
+        return Currency->BASECONVRATE;
+    }
+}
 
 /** Return the last attachment number linked to a specific object */
-double Model_CurrencyHistory::LastRate(const int& currencyID)
+double Model_CurrencyHistory::getLastRate(const int& currencyID)
 {
     Model_CurrencyHistory::Data_Set histData = Model_CurrencyHistory::instance().find(Model_CurrencyHistory::CURRENCYID(currencyID));
-    
     std::stable_sort(histData.begin(), histData.end(), SorterByCURRDATE());
 
     if (!histData.empty())

--- a/src/model/Model_CurrencyHistory.h
+++ b/src/model/Model_CurrencyHistory.h
@@ -56,8 +56,11 @@ public:
     /** Adds or updates an element in currency history */
     int addUpdate(const int& currencyID, const wxDate& date, double price, UPDTYPE type);
 
+    /** Return the rate for a specific currency in a specific day*/
+    static double getDayRate(const int& currencyID, const wxString& DateISO);
+
     /** Return the last rate for a specific currency */
-    static double LastRate(const int& currencyID);
+    static double getLastRate(const int& currencyID);
 };
 
 #endif // 

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -20,8 +20,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "htmlbuilder.h"
 #include "util.h"
-#include "model/Model_Checking.h"
+
 #include "model/Model_Account.h"
+#include "model/Model_Checking.h"
+#include "model/Model_CurrencyHistory.h"
+
 
 mmReportIncomeExpenses::mmReportIncomeExpenses(mmDateRange* date_range)
     : mmPrintableBaseSpecificAccounts(_("Income vs Expenses"))
@@ -85,7 +88,7 @@ wxString mmReportIncomeExpenses::getHTMLText()
             if (wxNOT_FOUND == accountArray_->Index(account->ACCOUNTNAME)) continue;
         }
         double convRate = 1;
-        if (account) convRate = Model_Account::currency(account)->BASECONVRATE;
+        if (account) convRate = Model_CurrencyHistory::getDayRate(Model_Account::currency(account)->CURRENCYID,transaction.TRANSDATE);
 
         if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT)
             income_expenses_pair.first += transaction.TRANSAMOUNT * convRate;
@@ -202,7 +205,8 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
         {
             if (wxNOT_FOUND == accountArray_->Index(account->ACCOUNTNAME)) continue;
         }
-        double convRate = (account ? Model_Account::currency(account)->BASECONVRATE : 1);
+        double convRate = 1;
+        if (account) convRate = Model_CurrencyHistory::getDayRate(Model_Account::currency(account)->CURRENCYID, transaction.TRANSDATE);
 
         int idx = (Model_Checking::TRANSDATE(transaction).GetYear() * 100
             + (int) Model_Checking::TRANSDATE(transaction).GetMonth());


### PR DESCRIPTION
I've converted IncExpenses with new CurrencyHistory.
Please test and, if working fine, I'll update also other reports.

We should think about a way to obtain nearest currency value if not present for a specific date.
I've tried with the commented code in Model_CurrencyHistory.cpp but it's quite slow so I preferred to use BASECONVRATE for now.