### PR TITLE
fix(issue.559): additional mac fix

### DIFF
--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -226,7 +226,7 @@ const wxString mmex::getTempFolder()
 {
     const wxString path = mmex::isPortableMode() ? mmex::GetUserDir(false).GetPath() : wxStandardPaths::Get().GetTempDir();
     const wxString folder = mmex::isPortableMode() ? "tmp"
-        : wxString::Format("%s_%s_tmp", mmex::GetAppName(), ::wxGetUserName());
+        : wxString::Format("%s_%s_tmp", mmex::GetAppName(), ::wxGetUserId());
     wxLogDebug(wxString::Format("%s%s%s%s", path, wxString(wxFILE_SEP_PATH), folder, wxString(wxFILE_SEP_PATH)));
     return wxString::Format("%s%s%s%s", path, wxString(wxFILE_SEP_PATH), folder, wxString(wxFILE_SEP_PATH));
 }


### PR DESCRIPTION
Fixes an issue where the homepage will not display if wxGetUserName() returns a string with special characters (') on Mac.