### PR TITLE
fix(IE): revert #606 with minor changes

### DIFF
--- a/resources/home_page.htt
+++ b/resources/home_page.htt
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8" />
     <meta http - equiv="Content-Type" content="text/html" />
-	<meta http-equiv="X-UA-Compatible" content="IE=10,9">
     <title>Home Page</title>
     <script src="ChartNew.js"></script>
     <script src="sorttable.js"></script>

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -54,7 +54,6 @@ R"(<!DOCTYPE html>
 <head>
     <meta charset="UTF-8" />
     <meta http - equiv = "Content-Type" content = "text/html" />
-    <meta http-equiv="X-UA-Compatible" content="IE=10,9">
     <title><TMPL_VAR REPORTNAME></title>
     <script src = "sorttable.js"></script>
     <link href="master.css" rel="stylesheet">
@@ -130,7 +129,6 @@ R"(<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta http - equiv = "Content-Type" content = "text/html">
-    <meta http-equiv="X-UA-Compatible" content="IE=10,9">
     <title><TMPL_VAR REPORTNAME></title>
     <script src = "ChartNew.js"></script>
     <script src = "sorttable.js"></script>

--- a/src/mmframereport.cpp
+++ b/src/mmframereport.cpp
@@ -43,7 +43,6 @@ const char *group_report_template = R"(
 <head>
     <meta charset="UTF-8" />
     <meta http - equiv = "Content-Type" content = "text/html" />
-    <meta http-equiv="X-UA-Compatible" content="IE=10,9">
     <title><TMPL_VAR REPORTNAME></title>
     <script src = "ChartNew.js"></script>
     <script src = "sorttable.js"></script>

--- a/src/model/Model_Report.cpp
+++ b/src/model/Model_Report.cpp
@@ -294,11 +294,15 @@ void Model_Report::prepareTempFolder()
 bool Model_Report::WindowsUpdateRegistry()
 {
 #if defined (__WXMSW__)
+    // https://msdn.microsoft.com/en-us/library/ee330730(v=vs.85).aspx
     wxRegKey Key(wxRegKey::HKCU, "Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION");
-    if (Key.Exists())
-        Key.DeleteValue("mmex.exe");
+    if (Key.Create(true) && Key.SetValue("mmex.exe", 11001))
+        return true;
+    else
+        return false;
+#else
+    return true;
 #endif
-     return true;
 }
 
 void Model_Report::outputReportFile(const wxString& str)

--- a/src/model/Model_Report.cpp
+++ b/src/model/Model_Report.cpp
@@ -297,7 +297,7 @@ bool Model_Report::WindowsUpdateRegistry()
     // https://msdn.microsoft.com/en-us/library/ee330730(v=vs.85).aspx
     // https://kevinragsdale.net/windows-10-and-the-web-browser-control/
     wxRegKey Key(wxRegKey::HKCU, "Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION");
-    if (Key.Create(true) && Key.SetValue("mmex.exe", 11001))
+    if (Key.Create(true) && Key.SetValue(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetFullName(), 11001))
         return true;
     else
         return false;

--- a/src/model/Model_Report.cpp
+++ b/src/model/Model_Report.cpp
@@ -295,6 +295,7 @@ bool Model_Report::WindowsUpdateRegistry()
 {
 #if defined (__WXMSW__)
     // https://msdn.microsoft.com/en-us/library/ee330730(v=vs.85).aspx
+    // https://kevinragsdale.net/windows-10-and-the-web-browser-control/
     wxRegKey Key(wxRegKey::HKCU, "Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION");
     if (Key.Create(true) && Key.SetValue("mmex.exe", 11001))
         return true;

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -42,7 +42,6 @@ static const wxString END = R"(
 static const char HTML[] = R"(<!DOCTYPE html>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta http-equiv="X-UA-Compatible" content="IE=10,9">
 <title>%s - Report</title>
 <link href = 'master.css' rel = 'stylesheet' />
 <script src = 'ChartNew.js'></script>

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -30,7 +30,6 @@ const char *usage_template = R"(
 <head>
     <meta charset="UTF-8" />
     <meta http - equiv = "Content-Type" content = "text/html" />
-    <meta http-equiv="X-UA-Compatible" content="IE=10,9">
     <title><TMPL_VAR REPORTNAME></title>
     <script src = "ChartNew.js"></script>
     <script src = "sorttable.js"></script>


### PR DESCRIPTION
See https://msdn.microsoft.com/en-us/library/ee330730(v=vs.85).aspx and https://kevinragsdale.net/windows-10-and-the-web-browser-control/

I've noticed that on my system also Avira Antivirus add a keys and sets to 11001.

Tested and working fine with VS2015 too.

PS: I've replaced fixed "mmex.exe" with EXE name so it will works fine with renamed EXE too