### PR TITLE
feat(Import.XML): import XML files in excel format

### DIFF
--- a/build/msw-vc-2015/mmex_mmex.vcxproj
+++ b/build/msw-vc-2015/mmex_mmex.vcxproj
@@ -266,6 +266,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\dbcheck.cpp" />
+    <ClCompile Include="..\..\src\import_export\parsers.cpp" />
     <ClCompile Include="..\..\src\mmOptionAttachmentSettings.cpp" />
     <ClCompile Include="..\..\src\mmOptionBaseSettings.cpp" />
     <ClCompile Include="..\..\src\mmOptionGeneralSettings.cpp" />
@@ -390,6 +391,7 @@
     <ClInclude Include="..\..\src\db\DB_Table_Stock_V1.h" />
     <ClInclude Include="..\..\src\db\DB_Table_Subcategory_V1.h" />
     <ClInclude Include="..\..\src\db\DB_Table_Usage_V1.h" />
+    <ClInclude Include="..\..\src\import_export\parsers.h" />
     <ClInclude Include="..\..\src\mmOptionAttachmentSettings.h" />
     <ClInclude Include="..\..\src\mmOptionBaseSettings.h" />
     <ClInclude Include="..\..\src\mmOptionGeneralSettings.h" />

--- a/build/msw-vc-2015/mmex_mmex.vcxproj.filters
+++ b/build/msw-vc-2015/mmex_mmex.vcxproj.filters
@@ -348,6 +348,9 @@
     <ClCompile Include="..\..\src\dbcheck.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\import_export\parsers.cpp">
+      <Filter>Source Files\import_export</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\aboutdialog.h">
@@ -736,6 +739,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\dbcheck.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\import_export\parsers.h">
+      <Filter>Source Files\import_export</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/import_export/parsers.cpp
+++ b/src/import_export/parsers.cpp
@@ -1,0 +1,161 @@
+/*******************************************************
+Copyright (C) 2015 Yosef
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+********************************************************/
+
+#include "parsers.h"
+#include "mmSimpleDialogs.h"
+#include "util.h"
+#include <wx/xml/xml.h>
+#include <wx/filename.h>
+
+// ---------------------------- CSV Parser --------------------------------
+ImportParserCSV::ImportParserCSV(wxWindow *pParentWindow, wxConvAuto encoding, wxString delimiter):
+    TableBasedParser(pParentWindow), encoding_(encoding), delimiter_(delimiter)
+{
+}
+
+bool ImportParserCSV::Open(wxString fileName)
+{
+    return false;
+}
+
+bool ImportParserCSV::Parse(wxString fileName, unsigned int itemsInLine)
+{
+    // Make sure file exists
+    if (fileName.IsEmpty() || !wxFileName::FileExists(fileName))
+    {
+        mmErrorDialogs::InvalidFile(pParentWindow_);
+        return false;
+    }
+
+    // Open file
+    wxTextFile txtFile(fileName);
+    if (!txtFile.Open(encoding_))
+    {
+        mmErrorDialogs::MessageError(pParentWindow_, _("Unable to open file."), _("Universal CSV Import"));
+        return false;
+    }
+
+    // Parse rows
+    wxString line;
+    int row = 0;
+    for (line = txtFile.GetFirstLine(); !txtFile.Eof(); line = txtFile.GetNextLine())
+    {
+        csv2tab_separated_values(line, delimiter_);
+        wxStringTokenizer tkz(line, "\t", wxTOKEN_RET_EMPTY_ALL);
+        itemsTable_.push_back(std::vector<wxString>());
+
+        // Tokens in row
+        while (tkz.HasMoreTokens())
+        {
+            if (itemsTable_[row].size() >= itemsInLine)
+                break;
+
+            wxString token = tkz.GetNextToken();
+            itemsTable_[row].push_back(token);
+        }
+
+        ++row;
+    }
+
+    txtFile.Close();
+    return true;
+}
+
+// ---------------------------- XML Parser --------------------------------
+ImportParserXML::ImportParserXML(wxWindow *pParentWindow, wxString encoding):
+    TableBasedParser(pParentWindow), encoding_(encoding)
+{
+}
+
+bool ImportParserXML::Open(wxString fileName)
+{
+    return false;
+}
+
+bool ImportParserXML::Parse(wxString fileName, unsigned int itemsInLine)
+{
+    // Make sure file exists
+    if (fileName.IsEmpty() || !wxFileName::FileExists(fileName))
+    {
+        mmErrorDialogs::InvalidFile(pParentWindow_);
+        return false;
+    }
+
+    // Open file
+    wxXmlDocument xmlFile;
+    if (!xmlFile.Load(fileName, encoding_))
+    {
+        mmErrorDialogs::MessageError(pParentWindow_, _("File is not in Excel XML Spreadsheet 2003 format."), _("Parsing error"));
+        return false;
+    }
+
+    // Workbook
+    wxXmlNode *workbookElement = xmlFile.GetRoot();
+    if (workbookElement->GetName() != _("Workbook") || workbookElement->GetAttribute("xmlns") != _("urn:schemas-microsoft-com:office:spreadsheet"))
+    {
+        mmErrorDialogs::MessageError(pParentWindow_, _("File is not in Excel XML Spreadsheet 2003 format."), _("Parsing error"));
+        return false;
+    }
+
+    // Worksheet
+    // TODO: Allow the user to choose the worksheet. This just uses the first.
+    wxXmlNode *worksheetElement = workbookElement->GetChildren();
+    for (; worksheetElement && worksheetElement->GetName() != _("Worksheet"); worksheetElement = worksheetElement->GetNext())
+    {
+    };
+
+    if (!worksheetElement)
+    {
+        mmErrorDialogs::MessageError(pParentWindow_, _("Could not find Worksheet."), _("Parsing error"));
+        return false;
+    }
+
+    // Table
+    wxXmlNode *tableElement = worksheetElement->GetChildren();
+    if (tableElement->GetName() != _("Table"))
+    {
+        mmErrorDialogs::MessageError(pParentWindow_, _("Could not find Table."), _("Parsing error"));
+        return false;
+    }
+    
+    // Rows
+    int row = 0;
+    for (wxXmlNode *rowElement = tableElement->GetChildren(); rowElement; rowElement = rowElement->GetNext())
+    {
+        if (rowElement->GetName() != _("Row"))
+            continue;
+
+        itemsTable_.push_back(std::vector<wxString>());
+
+        // Cells in row
+        for (wxXmlNode *cellElement = rowElement->GetChildren(); cellElement; cellElement = cellElement->GetNext())
+        {
+            if (cellElement->GetName() != _("Cell"))
+                continue;
+
+            if (itemsTable_[row].size() >= itemsInLine)
+                break;
+
+            wxXmlNode *dataElement = cellElement->GetChildren();
+            wxString content = dataElement->GetNodeContent();
+            itemsTable_[row].push_back(content);
+        }
+        row++;
+    }
+    return true;
+}

--- a/src/import_export/parsers.h
+++ b/src/import_export/parsers.h
@@ -1,0 +1,103 @@
+/*******************************************************
+Copyright (C) 2015 Yosef
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+********************************************************/
+
+#ifndef MM_PARSERS_H_
+#define MM_PARSERS_H_
+
+#include <wx/string.h>
+#include <wx/window.h>
+#include <wx/convauto.h>
+#include <vector>
+
+// Generic interface for importing data from a file.
+// Get functions should be called after Parse() was called.
+class IImportParser
+{
+public:
+    virtual bool Open(wxString fileName) = 0;
+    virtual bool Parse(wxString fileName, unsigned int itemsInLine) = 0;
+    
+    // Gets the number of lines that can be parsed.
+    // Depending on type of file there may be lines that are not transactions.
+    virtual unsigned int GetLinesCount() const = 0;
+
+    // Gets the number of items in the specified line.
+    virtual unsigned int GetItemsCount(unsigned int line) const = 0;
+
+    // Gets the item or wxEmptyString if there is none.
+    virtual wxString GetItem(unsigned int line, unsigned int itemInLine) const = 0;
+    virtual ~IImportParser() {}
+};
+
+// A base class for a parser that reads the file in to a string table in memory.
+class TableBasedParser : public IImportParser
+{
+public:
+    TableBasedParser(wxWindow *pParentWindow) : pParentWindow_(pParentWindow) {}
+    virtual unsigned int GetLinesCount() const
+    {
+        return itemsTable_.size();
+    }
+    virtual unsigned int GetItemsCount(unsigned int line) const
+    {
+        if (line >= GetLinesCount())
+            return 0;
+        return itemsTable_[line].size();
+    }
+    virtual wxString GetItem(unsigned int line, unsigned int itemInLine) const
+    {
+        if (line >= GetLinesCount() || itemInLine >= itemsTable_[line].size())
+            return wxEmptyString;
+        return itemsTable_[line][itemInLine];
+    }
+    virtual ~TableBasedParser()
+    {
+        for (auto line : itemsTable_)
+            line.clear();
+        itemsTable_.clear();
+    }
+protected:
+    wxWindow *pParentWindow_;
+    typedef std::vector<wxString> RowItemsT;
+    std::vector<RowItemsT> itemsTable_;
+};
+
+// CSV parser
+class ImportParserCSV : public TableBasedParser
+{
+public:
+    ImportParserCSV(wxWindow *pParentWindow, wxConvAuto encoding, wxString delimiter);
+    virtual bool Open(wxString fileName);
+    virtual bool Parse(wxString fileName, unsigned int itemsInLine);
+protected:
+    wxConvAuto encoding_;
+    wxString delimiter_;
+};
+
+// XML parser
+class ImportParserXML : public TableBasedParser
+{
+public:
+    ImportParserXML(wxWindow *pParentWindow, wxString encoding);
+    virtual bool Open(wxString fileName);
+    virtual bool Parse(wxString fileName, unsigned int itemsInLine);
+protected:
+    wxString encoding_;
+};
+
+#endif // MM_PARSERS_H_

--- a/src/import_export/univcsvdialog.h
+++ b/src/import_export/univcsvdialog.h
@@ -27,7 +27,7 @@
 
 #define ID_MYDIALOG8 10040
 #define SYMBOL_UNIVCSVDIALOG_STYLE wxCAPTION|wxRESIZE_BORDER|wxSYSTEM_MENU|wxCLOSE_BOX
-#define SYMBOL_UNIVCSVDIALOG_TITLE _("Universal CSV Dialog")
+#define SYMBOL_UNIVCSVDIALOG_TITLE _("Import Dialog")
 #define SYMBOL_UNIVCSVDIALOG_IDNAME ID_MYDIALOG8
 #define SYMBOL_UNIVCSVDIALOG_SIZE wxSize(400, 300)
 #define SYMBOL_UNIVCSVDIALOG_POSITION wxDefaultPosition
@@ -60,15 +60,24 @@
 #define wxFIXED_MINSIZE 0
 #endif
 
+class IImportParser;
+
 class mmUnivCSVDialog: public wxDialog
 {
     wxDECLARE_DYNAMIC_CLASS(mmUnivCSVDialog);
     wxDECLARE_EVENT_TABLE();
 
 public:
+    enum EDialogType
+    {
+        DIALOG_TYPE_IMPORT_CSV,
+        DIALOG_TYPE_EXPORT_CSV,
+        DIALOG_TYPE_IMPORT_XML,
+    };
+
     /// Constructors
     mmUnivCSVDialog();
-    mmUnivCSVDialog(wxWindow* parent, bool is_importer = true,
+    mmUnivCSVDialog(wxWindow* parent, EDialogType dialogType,
                     wxWindowID id = SYMBOL_UNIVCSVDIALOG_IDNAME,
                     const wxString& caption = SYMBOL_UNIVCSVDIALOG_TITLE,
                     const wxPoint& pos = SYMBOL_UNIVCSVDIALOG_POSITION,
@@ -86,7 +95,19 @@ public:
 
     bool IsImporter() const
     {
-        return is_importer_;
+        return dialogType_ == DIALOG_TYPE_IMPORT_CSV || dialogType_ == DIALOG_TYPE_IMPORT_XML;
+    }
+    bool IsXML() const
+    {
+        return dialogType_ == DIALOG_TYPE_IMPORT_XML;
+    }
+    bool IsCSV() const
+    {
+        return !IsXML();
+    }
+    wxString GetSettingsPrfix() const
+    {
+        return IsXML() ? "XML_SETTINGS_" : "CSV_SETTINGS_";
     }
 
 private:
@@ -120,7 +141,7 @@ private:
         wxString Number;
         wxString Notes;
     };
-    bool is_importer_;
+    EDialogType dialogType_;
     wxString delimit_;
 
     std::vector<int> csvFieldOrder_;
@@ -196,5 +217,6 @@ private:
     void OnSettingsSelected(wxCommandEvent& event);
     wxString GetStoredSettings(int id);
     void SetSettings(const wxString &data);
+    IImportParser *CreateParser();
 };
 #endif

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -117,6 +117,7 @@ EVT_MENU(MENU_EXPORT_CSV, mmGUIFrame::OnExportToCSV)
 EVT_MENU(MENU_EXPORT_QIF, mmGUIFrame::OnExportToQIF)
 EVT_MENU(MENU_IMPORT_QIF, mmGUIFrame::OnImportQIF)
 EVT_MENU(MENU_IMPORT_UNIVCSV, mmGUIFrame::OnImportUniversalCSV)
+EVT_MENU(MENU_IMPORT_XML, mmGUIFrame::OnImportXML)
 EVT_MENU(MENU_IMPORT_WEBAPP, mmGUIFrame::OnImportWebApp)
 EVT_MENU(wxID_EXIT, mmGUIFrame::OnQuit)
 EVT_MENU(MENU_NEWACCT, mmGUIFrame::OnNewAccount)
@@ -186,6 +187,7 @@ EVT_MENU(MENU_TREEPOPUP_ACCOUNT_EXPORT2CSV, mmGUIFrame::OnExportToCSV)
 EVT_MENU(MENU_TREEPOPUP_ACCOUNT_EXPORT2QIF, mmGUIFrame::OnExportToQIF)
 //EVT_MENU(MENU_TREEPOPUP_ACCOUNT_IMPORTQIF, mmGUIFrame::OnImportQIF)
 EVT_MENU(MENU_TREEPOPUP_ACCOUNT_IMPORTUNIVCSV, mmGUIFrame::OnImportUniversalCSV)
+EVT_MENU(MENU_TREEPOPUP_ACCOUNT_IMPORTXML, mmGUIFrame::OnImportXML)
 EVT_MENU_RANGE(MENU_TREEPOPUP_ACCOUNT_VIEWALL, MENU_TREEPOPUP_ACCOUNT_VIEWCLOSED, mmGUIFrame::OnViewAccountsTemporaryChange)
 
 /*Automatic processing of repeat transactions*/
@@ -1131,6 +1133,7 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
                 menu.AppendSubMenu(exportTo, _("&Export"));
                 wxMenu *importFrom = new wxMenu;
                 importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTUNIVCSV, _("&CSV Files..."));
+                importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTXML, _("&XML Files..."), _("Import from XML (Excel format)"));
                 importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTQIF, _("&QIF Files..."));
                 menu.AppendSubMenu(importFrom, _("&Import"));
                 menu.AppendSeparator();
@@ -1317,6 +1320,7 @@ void mmGUIFrame::createMenu()
 
     wxMenu* importMenu = new wxMenu;
     importMenu->Append(MENU_IMPORT_UNIVCSV, _("&CSV Files..."), _("Import from any CSV file"));
+    importMenu->Append(MENU_IMPORT_XML, _("&XML Files..."), _("Import from XML (Excel format)"));
     importMenu->Append(MENU_IMPORT_QIF, _("&QIF Files..."), _("Import from QIF"));
     importMenu->Append(MENU_IMPORT_WEBAPP, _("&WebApp..."), _("Import from WebApp"));
     menu_file->Append(MENU_IMPORT, _("&Import"), importMenu);
@@ -2017,7 +2021,7 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
 
 void mmGUIFrame::OnExportToCSV(wxCommandEvent& /*event*/)
 {
-    mmUnivCSVDialog(this, false).ShowModal();
+    mmUnivCSVDialog(this, mmUnivCSVDialog::DIALOG_TYPE_EXPORT_CSV).ShowModal();
 }
 //----------------------------------------------------------------------------
 
@@ -2059,7 +2063,7 @@ void mmGUIFrame::OnImportUniversalCSV(wxCommandEvent& /*event*/)
         return;
     }
 
-    mmUnivCSVDialog univCSVDialog(this);
+    mmUnivCSVDialog univCSVDialog(this, mmUnivCSVDialog::DIALOG_TYPE_IMPORT_CSV);
     univCSVDialog.ShowModal();
     if (univCSVDialog.ImportCompletedSuccessfully())
     {
@@ -2068,6 +2072,26 @@ void mmGUIFrame::OnImportUniversalCSV(wxCommandEvent& /*event*/)
         if (account) setAccountNavTreeSection(account->ACCOUNTNAME);
     }
 }
+//----------------------------------------------------------------------------
+
+void mmGUIFrame::OnImportXML(wxCommandEvent& /*event*/)
+{
+    if (Model_Account::instance().all().empty())
+    {
+        wxMessageBox(_("No account available to import"), _("Universal CSV Import"), wxOK | wxICON_WARNING);
+        return;
+    }
+
+    mmUnivCSVDialog univCSVDialog(this, mmUnivCSVDialog::DIALOG_TYPE_IMPORT_XML);
+    univCSVDialog.ShowModal();
+    if (univCSVDialog.ImportCompletedSuccessfully())
+    {
+        Model_Account::Data* account = Model_Account::instance().get(univCSVDialog.ImportedAccountID());
+        createCheckingAccountPage(univCSVDialog.ImportedAccountID());
+        if (account) setAccountNavTreeSection(account->ACCOUNTNAME);
+    }
+}
+
 //----------------------------------------------------------------------------
 
 void mmGUIFrame::OnImportWebApp(wxCommandEvent& /*event*/)

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -170,6 +170,7 @@ private:
     void OnExportToHtml(wxCommandEvent& event);
     void OnImportQFX(wxCommandEvent& event);
     void OnImportUniversalCSV(wxCommandEvent& event);
+    void OnImportXML(wxCommandEvent& event);
     void OnImportQIF(wxCommandEvent& event);
     void OnImportWebApp(wxCommandEvent& event);
     void OnPrintPage(wxCommandEvent& WXUNUSED(event));
@@ -276,6 +277,7 @@ private:
         MENU_GOOGLEPLAY,
         MENU_IMPORT,
         MENU_IMPORT_UNIVCSV,
+        MENU_IMPORT_XML,
         MENU_IMPORT_WEBAPP,
         MENU_REPORTISSUES,
         MENU_ANNOUNCEMENTMAILING,
@@ -323,6 +325,7 @@ private:
         MENU_TREEPOPUP_ACCOUNT_IMPORTCSV,
         MENU_TREEPOPUP_ACCOUNT_IMPORTQIF,
         MENU_TREEPOPUP_ACCOUNT_IMPORTUNIVCSV,
+        MENU_TREEPOPUP_ACCOUNT_IMPORTXML,
         MENU_TREEPOPUP_ACCOUNT_VIEWALL,
         MENU_TREEPOPUP_ACCOUNT_VIEWFAVORITE,
         MENU_TREEPOPUP_ACCOUNT_VIEWOPEN,


### PR DESCRIPTION
Can now import transactions for a file saved by excel in XML format (Save as->Other formats-> XML Spreadsheet 2003).

* I debated between creating a new dialog or adding it to the CSV dialog. I chose to use the CSV dialog and simply cut out the parser sections. This actually removes duplicate code that was used for both preview and import.
* Only import is currently supported, not export.
* Data is imported from first spreadsheet in workbook.
* The concept of printing a few lines of the source file to an edit box to allow the user to choose fields doesn't work with XML. Instead of having the fields list determine the number of columns, the parser determines the number of columns. Any column that does not have a corresponding field we be set to "Don't care". This will now be the case for CSV as well.
* Templates for CSV and XML are separate.
* Only field value are extracted from XML. It can be considered in the future to parse field formatting as well.
* Everything else is same as CSV is today.  