### PR TITLE
fix(Export.XML): existing file bug and thousand separator bug

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -880,17 +880,19 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& /*event*/)
         return mmErrorDialogs::InvalidFile(m_text_ctrl_);
 
     wxFileName out_file(fileName);
-    if (out_file.Exists()) {
-        if (wxMessageBox(_("Overwrite?"), _("File exists."), wxYES_NO | wxICON_WARNING) != wxYES)
-            return;
-    }
-    if (!wxRemoveFile(fileName))
+    if (out_file.Exists()) 
     {
-        return mmErrorDialogs::MessageWarning( this,
-            _("Failed to delete existing file. File may be locked by another program."),
-            _("Destination file error"));
+        if (wxMessageBox(_("Overwrite existing file?"), _("File exists"), wxYES_NO | wxICON_WARNING) != wxYES)
+            return;
+ 
+        if (!wxRemoveFile(fileName))
+        {
+            return mmErrorDialogs::MessageWarning(this,
+                _("Failed to delete existing file. File may be locked by another program."),
+                _("Destination file error"));
+        }
     }
-
+ 
     const wxString& acctName = m_choice_account_->GetStringSelection();
     Model_Account::Data* from_account = Model_Account::instance().get(acctName);
 
@@ -932,8 +934,8 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& /*event*/)
         double value = Model_Checking::balance(pBankTransaction, fromAccountID);
         account_balance += value;
 
-        const wxString& amount = Model_Currency::toString(value, currency);
-        const wxString& amount_abs = Model_Currency::toString(fabs(value), currency);
+        const wxString& amount = Model_Currency::toStringNoFormatting(value, currency);
+        const wxString& amount_abs = Model_Currency::toStringNoFormatting(fabs(value), currency);
 
         Model_Category::Data* category = Model_Category::instance().get(pBankTransaction.CATEGID);
         Model_Subcategory::Data* sub_category = Model_Subcategory::instance().get(pBankTransaction.SUBCATEGID);

--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -192,6 +192,15 @@ wxString Model_Currency::os_group_separator()
     return sys_thousand_separator;
 }
 
+wxString Model_Currency::toStringNoFormatting(double value, const Data* currency, int precision)
+{
+    precision = (precision >= 0 ? precision : (currency ? log10(currency->SCALE) : 2));
+    int style = wxNumberFormatter::Style_None;
+    wxString s = wxNumberFormatter::ToString(value, precision, style);
+    if (s == "-0.00") s = "0.00";
+    else if (s == "-0.0") s = "0.0";
+    return s;
+}
 wxString Model_Currency::toString(double value, const Data* currency, int precision)
 {
     precision = (precision >= 0 ? precision : (currency ? log10(currency->SCALE) : 2));

--- a/src/model/Model_Currency.h
+++ b/src/model/Model_Currency.h
@@ -73,6 +73,8 @@ public:
     static wxString toCurrency(double value, const Data* currency = GetBaseCurrency(), int precision = -1);
  
     static wxString os_group_separator();
+    /** convert value to a string with required precision. Currency is used only for percision */
+    static wxString toStringNoFormatting(double value, const Data* currency = GetBaseCurrency(), int precision = -1);
     /** convert value to a currency formatted string with required precision */
     static wxString toString(double value, const Data* currency = GetBaseCurrency(), int precision = -1);
     /** Reset currency string like 1.234,56 to standard number format like 1234.56 */


### PR DESCRIPTION
- Don't try to delete the export file if it didn't exist.
- Export raw numbers with no formatting except precision.
   so that they can be easily parsed by external programs (e.g. Excel)