### PR TITLE
 fix(#659): ignore preceding currency symbol when parsing amounts

### DIFF
--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -175,8 +175,9 @@ wxString Model_Currency::toString(double value, const Data* currency, int precis
 
 const wxString Model_Currency::fromString2Default(const wxString &s, const Data* currency)
 {
-    wxString str = s;
-    str.Trim();
+    // Remove any characters before the number stars. Useful especially for removing currency symbols.
+    wxString str = s.Mid(s.find_first_of("-0123456789"));
+
     str.Replace(" ", "");
     if (currency)
     {


### PR DESCRIPTION
Instead of Trim() that ignores only white spaces, ignore all chars up to the first number or '-' char.
This will not handle the case of a trailing currency symbol (I'm not personalty aware there is such a thing)

