### PR TITLE
fix(#516): stop nav tree items from disappearing, minimize news checks

### DIFF
--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -824,11 +824,15 @@ const wxString mmHomePagePanel::displayGrandTotals(double& tBalance)
 /* Website News*/
 const wxString mmHomePagePanel::displayWebsiteNews()
 {
-    wxString output = wxEmptyString;
+    static wxString output = wxEmptyString;
 
     if (!Model_Setting::instance().DisplayInternetNews())
+        output = wxEmptyString; // in case user changed setting
         return output;
 
+    if (output != wxEmptyString) // function has run before and returned a successful news html
+        return output;
+    
     std::vector<WebsiteNews> WebsiteNewsList;
     if (!mmHomePagePanel::getNewsRSS(WebsiteNewsList))
         return output;


### PR DESCRIPTION
Changed displayWebsiteNews output to be static so it retains it value on subsequent calls. Only check if it is wxEmptyString (the first time or if pref changed). 
