### PR TITLE
fix(strings): Fix extra spaces in strings (#757)

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -130,11 +130,11 @@ bool mmBDDialog::Create(wxWindow* parent, wxWindowID id, const wxString& caption
         dataToControls();
         if (!m_enter_occur)
         {
-            SetDialogHeader(_(" Edit Recurring Transaction"));
+            SetDialogHeader(_("Edit Recurring Transaction"));
         }
         else
         {
-            SetDialogHeader(_(" Enter Recurring Transaction"));
+            SetDialogHeader(_("Enter Recurring Transaction"));
             transaction_type_->Disable();
             m_date_due->Disable();
             m_calendar_ctrl->Disable();

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -153,7 +153,7 @@ void mmFilterTransactionsDialog::CreateControls()
     wxBoxSizer* itemBoxSizer3 = new wxBoxSizer(wxVERTICAL);
     itemBoxSizer2->Add(itemBoxSizer3, g_flagsExpand);
 
-    wxStaticBox* static_box_sizer = new wxStaticBox(this, wxID_ANY, _("Specify "));
+    wxStaticBox* static_box_sizer = new wxStaticBox(this, wxID_ANY, _("Specify"));
     wxStaticBoxSizer* itemStaticBoxSizer4 = new wxStaticBoxSizer(static_box_sizer, wxVERTICAL);
     itemBoxSizer3->Add(itemStaticBoxSizer4, 1, wxGROW|wxALL, 10);
 

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -153,7 +153,7 @@ void mmFilterTransactionsDialog::CreateControls()
     wxBoxSizer* itemBoxSizer3 = new wxBoxSizer(wxVERTICAL);
     itemBoxSizer2->Add(itemBoxSizer3, g_flagsExpand);
 
-    wxStaticBox* static_box_sizer = new wxStaticBox(this, wxID_ANY, _(" Specify "));
+    wxStaticBox* static_box_sizer = new wxStaticBox(this, wxID_ANY, _("Specify "));
     wxStaticBoxSizer* itemStaticBoxSizer4 = new wxStaticBoxSizer(static_box_sizer, wxVERTICAL);
     itemBoxSizer3->Add(itemStaticBoxSizer4, 1, wxGROW|wxALL, 10);
 

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -784,9 +784,9 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& /*event*/)
             {
                 // TODO: print a more specific error.
                 log << wxString::Format(_("Line: %ld"), lineNum+1)
-                    << _(" One of the following fields: Date, Amount, Type is missing, skipping") << endl;
+                    << _("One of the following fields: Date, Amount, Type is missing, skipping") << endl;
                 *log_field_ << wxString::Format(_("Line: %ld"), lineNum+1)
-                    << _(" One of the following fields: Date, Amount, Type is missing, skipping") << "\n";
+                    << _("One of the following fields: Date, Amount, Type is missing, skipping") << "\n";
 
                 continue;
             }

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -514,7 +514,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
             {
                 continueExecution = true;
                 mmBDDialog repeatTransactionsDlg(this, q1.BDID, false, true);
-                repeatTransactionsDlg.SetDialogHeader(_(" Auto Repeat Transactions"));
+                repeatTransactionsDlg.SetDialogHeader(_("Auto Repeat Transactions"));
                 if (repeatTransactionsDlg.ShowModal() == wxID_OK)
                 {
                     refreshPanelData();
@@ -1721,7 +1721,7 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const wxString& pwd, 
         // Mantained only for really old compatibility reason and replaced by dbupgrade.cpp
         if (!Model_Infotable::instance().checkDBVersion())
         {
-            wxString note = mmex::getProgramName() + _(" - No File opened ");
+            wxString note = mmex::getProgramName() + " - " + _("No File opened");
             this->SetTitle(note);
             wxMessageBox(_("Sorry. The Database version is too old or Database password is incorrect")
                 , dialogErrorMessageHeading
@@ -1764,7 +1764,7 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const wxString& pwd, 
     }
     else // open of existing database failed
     {
-        wxString note = mmex::getProgramName() + _(" - No File opened ");
+        wxString note = mmex::getProgramName() + " - " + _("No File opened");
         this->SetTitle(note);
 
         wxString msgStr = _("Cannot locate previously opened database.\n");

--- a/src/mmhelppanel.cpp
+++ b/src/mmhelppanel.cpp
@@ -63,7 +63,7 @@ void mmHelpPanel::CreateControls()
     wxButton* buttonBack     = new wxButton(itemPanel3, wxID_BACKWARD, _("&Back"));
     wxButton* buttonFordward = new wxButton(itemPanel3, wxID_FORWARD, _("&Forward") );
 
-    wxString helpHeader = mmex::getProgramName() + _(" Help");
+    wxString helpHeader = mmex::getProgramName() + _("Help");
     wxStaticText* itemStaticText9 = new wxStaticText(itemPanel3, wxID_ANY
         , helpHeader);
     itemStaticText9->SetFont(this->GetFont().Larger().Bold());

--- a/src/mmhelppanel.cpp
+++ b/src/mmhelppanel.cpp
@@ -63,7 +63,7 @@ void mmHelpPanel::CreateControls()
     wxButton* buttonBack     = new wxButton(itemPanel3, wxID_BACKWARD, _("&Back"));
     wxButton* buttonFordward = new wxButton(itemPanel3, wxID_FORWARD, _("&Forward") );
 
-    wxString helpHeader = mmex::getProgramName() + _("Help");
+    wxString helpHeader = mmex::getProgramName() + " " + _("Help");
     wxStaticText* itemStaticText9 = new wxStaticText(itemPanel3, wxID_ANY
         , helpHeader);
     itemStaticText9->SetFont(this->GetFont().Larger().Bold());

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -35,7 +35,7 @@ wxString mmPrintableBase::local_title() const
     if (!m_date_range) 
         return m_local_title; 
     else 
-        return m_local_title + _(" - ") + m_date_range->local_title();
+        return m_local_title + " - " + m_date_range->local_title();
 }
 
 mmGeneralReport::mmGeneralReport(const Model_Report::Data* report)

--- a/src/splittransactionsdialog.cpp
+++ b/src/splittransactionsdialog.cpp
@@ -120,7 +120,7 @@ void SplitTransactionDialog::CreateControls()
     wxBoxSizer* dialogMainSizerV = new wxBoxSizer(wxVERTICAL);
     this->SetSizer(dialogMainSizerV);
 
-    wxStaticText* headingText = new wxStaticText(this, wxID_STATIC, _(" Split Category Details"));
+    wxStaticText* headingText = new wxStaticText(this, wxID_STATIC, _("Split Category Details"));
     dialogMainSizerV->Add(headingText, g_flags);
 
     wxBoxSizer* listCtrlSizer = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
make sure your code would work on both windows, linux and osx

The final string in the issue is caused by all of the wxTRANSLATE calls in src/db/DB_Table_Currencyformats_V1.h

