### PR TITLE
fix(BaseCurrency.Option.Setting): prevent system failure

### DIFF
--- a/src/currencydialog.cpp
+++ b/src/currencydialog.cpp
@@ -117,7 +117,7 @@ void mmCurrencyDialog::fillControls()
         m_scale = log10(m_currency->SCALE);
         const wxString& scale_value = wxString::Format("%i", m_scale);
         scaleTx_->ChangeValue(scale_value);
-        bool baseCurrency = (Model_Infotable::instance().GetBaseCurrencyId() == m_currency->CURRENCYID);
+        bool baseCurrency = (Option::instance().BaseCurrency() == m_currency->CURRENCYID);
         baseConvRate_->SetValue((baseCurrency ? 1.00 : m_currency->BASECONVRATE), SCALE);
         baseConvRate_->Enable(!baseCurrency);
         m_currencySymbol->ChangeValue(m_currency->CURRENCY_SYMBOL);
@@ -238,15 +238,18 @@ void mmCurrencyDialog::OnOk(wxCommandEvent& /*event*/)
 void mmCurrencyDialog::OnTextChanged(wxCommandEvent& event)
 {  
     int scale = wxAtoi(scaleTx_->GetValue());
-    m_currency->PFX_SYMBOL = pfxTx_->GetValue();
-    m_currency->SFX_SYMBOL = sfxTx_->GetValue();
-    m_currency->DECIMAL_POINT = decTx_->GetValue();
-    m_currency->GROUP_SEPARATOR = grpTx_->GetValue();
-    m_currency->UNIT_NAME = unitTx_->GetValue();
-    m_currency->CENT_NAME = centTx_->GetValue();
-    m_currency->SCALE = static_cast<int>(pow(10, scale));
-    m_currency->CURRENCY_SYMBOL = m_currencySymbol->GetValue().Trim();
-    m_currency->CURRENCYNAME = m_currencyName->GetValue();
+    if (m_currency)
+    {
+        m_currency->PFX_SYMBOL = pfxTx_->GetValue();
+        m_currency->SFX_SYMBOL = sfxTx_->GetValue();
+        m_currency->DECIMAL_POINT = decTx_->GetValue();
+        m_currency->GROUP_SEPARATOR = grpTx_->GetValue();
+        m_currency->UNIT_NAME = unitTx_->GetValue();
+        m_currency->CENT_NAME = centTx_->GetValue();
+        m_currency->SCALE = static_cast<int>(pow(10, scale));
+        m_currency->CURRENCY_SYMBOL = m_currencySymbol->GetValue().Trim();
+        m_currency->CURRENCYNAME = m_currencyName->GetValue();
+    }
 
     wxString dispAmount = "";
     double base_amount = 123456.78;

--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -74,7 +74,7 @@ mmMainCurrencyDialog::mmMainCurrencyDialog(
     ColName_[CURR_NAME]   = _("Name");
     ColName_[BASE_RATE]   = _("Last Rate");
 
-    currencyID_ = currencyID == -1 ? Model_Infotable::instance().GetBaseCurrencyId() : currencyID;
+    currencyID_ = currencyID == -1 ? Option::instance().BaseCurrency() : currencyID;
     long style = wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX;
     Create(parent, wxID_ANY, _("Currency Dialog"), wxDefaultPosition, wxDefaultSize, style);
 }
@@ -100,7 +100,7 @@ bool mmMainCurrencyDialog::Create(wxWindow* parent
 void mmMainCurrencyDialog::fillControls()
 {
     currencyListBox_->DeleteAllItems();
-    int baseCurrencyID = Model_Infotable::instance().GetBaseCurrencyId();
+    int baseCurrencyID = Option::instance().BaseCurrency();
 
     cbShowAll_->SetValue(Model_Infotable::instance().GetBoolInfo("SHOW_HIDDEN_CURRENCIES", true));
 
@@ -374,7 +374,7 @@ void mmMainCurrencyDialog::OnListItemSelected(wxDataViewEvent& event)
     }
     if (!bEnableSelect_)    // prevent user deleting currencies when editing accounts.
     {
-        int baseCurrencyID = Model_Infotable::instance().GetBaseCurrencyId();
+        int baseCurrencyID = Option::instance().BaseCurrency();
         Model_Currency::Data* currency = Model_Currency::instance().get(currencyID_);
         if (currency)
         {
@@ -538,7 +538,7 @@ void mmMainCurrencyDialog::OnItemRightClick(wxDataViewEvent& event)
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_ITEM1, _("Set as Base Currency")));
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_ITEM2, _("Online Update Currency Rate")));
     
-    int baseCurrencyID = Model_Infotable::instance().GetBaseCurrencyId();
+    int baseCurrencyID = Option::instance().BaseCurrency();
     if (baseCurrencyID == currencyID_)
         mainMenu->Enable(MENU_ITEM1, false);
 
@@ -562,7 +562,7 @@ void mmMainCurrencyDialog::ShowCurrencyHistory()
 {
     valueListBox_->DeleteAllItems();
 
-    int baseCurrencyID = Model_Infotable::instance().GetBaseCurrencyId();
+    int baseCurrencyID = Option::instance().BaseCurrency();
     if (currencyID_ <= 0 || currencyID_ == baseCurrencyID)
     {
         historyButtonAdd_->Disable();
@@ -763,11 +763,11 @@ void mmMainCurrencyDialog::OnHistoryDeselected(wxListEvent& event)
 
 bool mmMainCurrencyDialog::SetBaseCurrency(int& baseCurrencyID)
 {
-    int baseCurrencyOLD = Model_Infotable::instance().GetBaseCurrencyId();
+    int baseCurrencyOLD = Option::instance().BaseCurrency();
     if (baseCurrencyID == baseCurrencyOLD)
         return true;
 
-    Model_Infotable::instance().SetBaseCurrency(baseCurrencyID);
+    Option::instance().BaseCurrency(baseCurrencyID);
 
     Model_Currency::Data* BaseCurrency = Model_Currency::instance().get(baseCurrencyID);
     BaseCurrency->BASECONVRATE = 1;

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -102,7 +102,7 @@ mmCheckingPanel::mmCheckingPanel(wxWindow *parent, mmGUIFrame *frame, int accoun
     , transFilterDlg_(0)
     , m_frame(frame)
 {
-    m_basecurrecyID = Model_Infotable::instance().GetBaseCurrencyId();
+    m_basecurrecyID = Option::instance().BaseCurrency();
     long style = wxTAB_TRAVERSAL | wxNO_BORDER;
     Create(parent, mmID_CHECKING, wxDefaultPosition, wxDefaultSize, style);
 }

--- a/src/mmtextctrl.h
+++ b/src/mmtextctrl.h
@@ -65,8 +65,9 @@ public:
         mmCalculator calc;
         int precision = alt_precision >= 0 ? alt_precision : log10(currency_->SCALE);
         const wxString str = Model_Currency::fromString2Default(this->GetValue(), currency_);
-        if (calc.is_ok(str)) {
-            this->SetValue(Model_Currency::toString(calc.get_result(), currency_, precision));
+        if (calc.is_ok(str))
+        {
+            this->ChangeValue(Model_Currency::toString(calc.get_result(), currency_, precision));
             this->SetInsertionPoint(this->GetValue().Len());
             return true;
         }

--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -21,6 +21,7 @@
 #include "Model_Account.h"
 #include "Model_Checking.h"
 #include "Model_Stock.h"
+#include "option.h"
 #include <wx/numformatter.h>
 
 Model_Currency::Model_Currency()
@@ -71,7 +72,7 @@ wxArrayString Model_Currency::all_currency_symbols()
 // Getter
 Model_Currency::Data* Model_Currency::GetBaseCurrency()
 {
-    int currency_id = Model_Infotable::instance().GetBaseCurrencyId();
+    int currency_id = Option::instance().BaseCurrency();
     Model_Currency::Data *currency = Model_Currency::instance().get(currency_id);
     return currency;
 }

--- a/src/model/Model_Infotable.cpp
+++ b/src/model/Model_Infotable.cpp
@@ -154,16 +154,6 @@ const wxColour Model_Infotable::GetColourSetting(const wxString& key, const wxCo
     return default_value;
 }
 
-int Model_Infotable::GetBaseCurrencyId()
-{
-    return this->GetIntInfo("BASECURRENCYID", -1);
-}
-
-void Model_Infotable::SetBaseCurrency(int currency_id)
-{
-    Model_Infotable::instance().Set("BASECURRENCYID", currency_id);
-}
-
 /* Returns true if key setting found */
 bool Model_Infotable::KeyExists(const wxString& key)
 {

--- a/src/model/Model_Infotable.h
+++ b/src/model/Model_Infotable.h
@@ -58,9 +58,6 @@ public:
     wxString GetStringInfo(const wxString& key, const wxString& default_value);
     const wxColour GetColourSetting(const wxString& key, const wxColour& default_value = wxColour(255, 255, 255));
 
-    int GetBaseCurrencyId();
-    void SetBaseCurrency(int currency_id);
-
     /* Returns true if key setting found */
     bool KeyExists(const wxString& key);
     /* Check database at minimum revision*/

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -58,6 +58,7 @@ void Option::LoadOptions(bool include_infotable)
         m_userNameString = Model_Infotable::instance().GetStringInfo("USERNAME", "");
         m_financialYearStartDayString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_DAY", "1");
         m_financialYearStartMonthString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_MONTH", "7");
+        m_baseCurrency = Model_Infotable::instance().GetIntInfo("BASECURRENCYID", -1);
     }
 
     m_language = Model_Setting::instance().GetStringSetting(LANGUAGE_PARAMETER, "english");
@@ -151,6 +152,17 @@ void Option::FinancialYearStartMonth(const wxString& setting)
 {
     m_financialYearStartMonthString = setting;
     Model_Infotable::instance().Set("FINANCIAL_YEAR_START_MONTH", setting);
+}
+
+void Option::BaseCurrency(int base_currency_id)
+{
+    m_baseCurrency = base_currency_id;
+    Model_Infotable::instance().Set("BASECURRENCYID", base_currency_id);
+}
+
+int Option::BaseCurrency()
+{
+    return m_baseCurrency;
 }
 
 void Option::DatabaseUpdated(bool value)

--- a/src/option.h
+++ b/src/option.h
@@ -53,6 +53,11 @@ public:
     void FinancialYearStartMonth(const wxString& setting);
     wxString FinancialYearStartMonth();
 
+    // set the base currency ID
+    void BaseCurrency(int base_currency_id);
+    // returns the base currency ID
+    int BaseCurrency();
+
     // set and save the option: m_databaseUpdated
     void DatabaseUpdated(bool value);
     bool DatabaseUpdated();
@@ -99,6 +104,7 @@ private:
     wxString m_userNameString;
     wxString m_financialYearStartDayString;
     wxString m_financialYearStartMonthString;
+    int m_baseCurrency;
 
     bool m_databaseUpdated;
     bool m_budgetFinancialYears;            //INIDB_BUDGET_FINANCIAL_YEARS

--- a/src/optionsettingsgeneral.cpp
+++ b/src/optionsettingsgeneral.cpp
@@ -45,7 +45,7 @@ OptionSettingsGeneral::OptionSettingsGeneral(wxWindow *parent, mmGUIApp* app
 {
     wxPanel::Create(parent, id, pos, size, style, name);
     m_app = app;
-    m_currency_id = Model_Infotable::instance().GetBaseCurrencyId();
+    m_currency_id = Option::instance().BaseCurrency();
     m_date_format = Option::instance().DateFormat();
 
     Create();
@@ -103,9 +103,9 @@ void OptionSettingsGeneral::Create()
         currName = currency->CURRENCYNAME;
     wxButton* baseCurrencyButton = new wxButton(this, ID_DIALOG_OPTIONS_BUTTON_CURRENCY
         , currName, wxDefaultPosition, wxDefaultSize);
-    baseCurrencyButton->SetToolTip(_("Sets the default currency for the database."));
+    baseCurrencyButton->SetToolTip(_("Sets the database default Currency using the 'Currency Dialog'"));
     currencyStaticBoxSizer->Add(baseCurrencyButton, g_flagsH);
-    currencyStaticBoxSizer->Add(new wxStaticText(this, wxID_STATIC, _("Right click on currency and choose 'Set as Base Currency'")), g_flagsH);
+    currencyStaticBoxSizer->Add(new wxStaticText(this, wxID_STATIC, _("Right click and select 'Set as Base Currency' in 'Currency Dialog'")), g_flagsH);
 
     // Date Format Settings
     wxStaticBox* dateFormatStaticBox = new wxStaticBox(this, wxID_STATIC, _("Date Format"));
@@ -177,10 +177,11 @@ void OptionSettingsGeneral::Create()
 
 void OptionSettingsGeneral::OnCurrency(wxCommandEvent& /*event*/)
 {
-    int currencyID = Model_Infotable::instance().GetBaseCurrencyId();
+    int currencyID = Option::instance().BaseCurrency();
 
     if (mmMainCurrencyDialog::Execute(this, currencyID) && currencyID != -1)
     {
+        currencyID = Option::instance().BaseCurrency();
         Model_Currency::Data* currency = Model_Currency::instance().get(currencyID);
         wxButton* bn = (wxButton*) FindWindow(ID_DIALOG_OPTIONS_BUTTON_CURRENCY);
         bn->SetLabelText(currency->CURRENCYNAME);

--- a/src/wizard_newaccount.cpp
+++ b/src/wizard_newaccount.cpp
@@ -149,7 +149,7 @@ mmAddAccountTypePage::mmAddAccountTypePage(mmAddAccountWizard *parent)
 
 bool mmAddAccountTypePage::TransferDataFromWindow()
 {
-    int currencyID = Model_Infotable::instance().GetBaseCurrencyId();
+    int currencyID = Option::instance().BaseCurrency();
     if (currencyID == -1)
     {
         wxString errorMsg;

--- a/src/wizard_newdb.cpp
+++ b/src/wizard_newdb.cpp
@@ -171,7 +171,7 @@ bool mmNewDatabaseWizardPage::TransferDataFromWindow()
 
 void mmNewDatabaseWizardPage::OnCurrency(wxCommandEvent& /*event*/)
 {
-    currencyID_ = Model_Infotable::instance().GetBaseCurrencyId();
+    currencyID_ = Option::instance().BaseCurrency();
 
     if (mmMainCurrencyDialog::Execute(this, currencyID_) && currencyID_ != -1)
     {
@@ -180,7 +180,7 @@ void mmNewDatabaseWizardPage::OnCurrency(wxCommandEvent& /*event*/)
         {
             itemButtonCurrency_->SetLabelText(currency->CURRENCYNAME);
             currencyID_ = currency->CURRENCYID;
-            Model_Infotable::instance().SetBaseCurrency(currencyID_);
+            Option::instance().BaseCurrency(currencyID_);
         }
     }
 }


### PR DESCRIPTION
make sure your code would work on both windows, linux and osx

- prevent event generation in middle of calculation
- set Base Currency in Option.h
- Clarification in Option dialog for Base Currency settings
- Updated Database submodule.