### PR TITLE
fix(Multiple.Instance): prevent 2nd instance crash

### DIFF
--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -206,6 +206,16 @@ bool OnInitImpl(mmGUIApp* app)
 //----------------------------------------------------------------------------
 bool mmGUIApp::OnInit()
 {
+    m_checker = new wxSingleInstanceChecker;
+    if (m_checker->IsAnotherRunning())
+    {
+        wxMessageBox(_(
+            "MMEX is already running...\n\n"
+            "Multiple instances are no longer supported."), _("MMEX Instance Check"));
+        delete m_checker;
+        return false;
+    }
+
     bool ok = false;
 
     try
@@ -239,5 +249,6 @@ int mmGUIApp::OnExit()
     //Delete mmex temp folder for current user
     wxFileName::Rmdir(mmex::getTempFolder(), wxPATH_RMDIR_RECURSIVE);
 
+    delete m_checker;
     return 0;
 }

--- a/src/mmex.h
+++ b/src/mmex.h
@@ -22,6 +22,7 @@
 //----------------------------------------------------------------------------
 #include <wx/app.h>
 #include <wx/debugrpt.h>
+#include <wx/snglinst.h>
 
 //----------------------------------------------------------------------------
 class mmGUIFrame;
@@ -47,6 +48,7 @@ private:
     int OnExit();
     void OnFatalException(); // called when a crash occurs in this application
     void HandleEvent(wxEvtHandler *handler, wxEventFunction func, wxEvent& event) const;
+    wxSingleInstanceChecker* m_checker;
 
 public:
     virtual int FilterEvent(wxEvent& event);


### PR DESCRIPTION
Best to stop another instance rather than having MMEX crash.
Stop gap measure until problem with mongoose initialisation fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/830)
<!-- Reviewable:end -->
