### PR TITLE
Withdrawals not imported from CSV

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -805,8 +805,8 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& /*event*/)
             Model_Checking::instance().save(pTransaction);
 
             countImported++;
-            log << wxString::Format(_("Line : %ld imported OK."), lineNum+1) << endl;
-            *log_field_ << wxString::Format(_("Line : %ld imported OK."), lineNum+1) << "\n";
+            log << wxString::Format(_("Line: %ld imported OK."), lineNum+1) << endl;
+            *log_field_ << wxString::Format(_("Line: %ld imported OK."), lineNum+1) << "\n";
         }
 
         delete pParser;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -20,6 +20,7 @@ Copyright (C) 2015 Yosef
  ********************************************************/
 
 #include "univcsvdialog.h"
+
 #include "images_list.h"
 #include "constants.h"
 #include "mmSimpleDialogs.h"
@@ -1394,6 +1395,9 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         case UNIV_CSV_DEPOSIT:
             if (token.IsEmpty())
                 return;
+            // do nothing if an amount has already been stored by a previous call
+            if (holder.Amount != 0.0)
+                break;
             if (!Model_Currency::fromString(token, holder.Amount, Model_Account::currency(Model_Account::instance().get(fromAccountID_))))
                 return;
             holder.Amount = fabs(holder.Amount);
@@ -1403,6 +1407,9 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         case UNIV_CSV_WITHDRAWAL:
             if (token.IsEmpty())
                 return;
+            // do nothing if an amount has already been stored by a previous call
+            if (holder.Amount != 0.0)
+                break;
             if (!Model_Currency::fromString(token, holder.Amount, Model_Account::currency(Model_Account::instance().get(fromAccountID_))))
                 return;
             holder.Amount = fabs(holder.Amount);


### PR DESCRIPTION
Hi MMX team

Very attracted by MMEX for its very customisable reporting, I found my first bug when importing my first CSV file with custom format:  only the Deposit lines are taken into account, Withdraw lines are discarded with error message ".

Could you please have a look? Thanks!

### Version used 

* MMEX 1.2.7
* Mac OSX 10.11.3

### Steps to reproduce

1. Create a fresh new database
* Single account with GBP currency
* Create a CSV file with the following two lines (minimal example, anything bigger will exhibit the same problem):

        2016-06-29,PaymentOut,10.0,0.0
        2016-06-30,PaymentIn,0.0,10.0
* Import with `Date Format` set to `YYYY-MM-DD` and the following fields list:
a. Date
b. Payee
c. Withdrawal
d. Deposit
* Click `Import`.

### Expected result

* Two new lines in the account:
1. one for the PaymentOut with a Withdrawal of 10.0
2. one for the PaymentIn with a Deposit of 10.0

### Actual result

* Only one line in the account:
1. PaymentIn with a Deposit of 10.0

### Log
* Logfile says:

```text
Line: 1 One of the following fields: Date, Amount, Type is missing, skipping
Line : 2 imported OK.
```

* Screenshot after import:
<img width="1017" alt="screen shot 2016-10-23 at 12 26 18" src="https://cloud.githubusercontent.com/assets/660037/19625863/56485e06-991c-11e6-90a2-dbdea407aa51.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/934)
<!-- Reviewable:end -->
