### PR TITLE
fix(#1008): dublicate status for the same trx

### DIFF
--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -877,10 +877,6 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& /*event*/)
             if (!Model_Checking::is_transfer(trx))
                 continue;
 
-            const auto data_å = Model_Checking::instance().find(
-                //Model_Checking::ACCOUNTID(trx->TOACCOUNTID)
-                Model_Checking::TRANSCODE(Model_Checking::TRANSFER)
-            );
             const auto data = Model_Checking::instance().find(
                 Model_Checking::TRANSDATE(trx->TRANSDATE)
                 , Model_Checking::ACCOUNTID(trx->ACCOUNTID)

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -108,6 +108,11 @@ DB_Table_CHECKINGACCOUNT_V1::TRANSDATE Model_Checking::TRANSDATE(const wxDate& d
     return DB_Table_CHECKINGACCOUNT_V1::TRANSDATE(date.FormatISODate(), op);
 }
 
+DB_Table_CHECKINGACCOUNT_V1::TRANSDATE Model_Checking::TRANSDATE(const wxString& date, OP op)
+{
+    return DB_Table_CHECKINGACCOUNT_V1::TRANSDATE(date, op);
+}
+
 DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ENUM status, OP op)
 {
     return DB_Table_CHECKINGACCOUNT_V1::STATUS(toShortStatus(all_status()[status]), op);

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -128,6 +128,7 @@ public:
 
 public:
     static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxDate& date, OP op = EQUAL);
+    static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxString& date, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::STATUS STATUS(STATUS_ENUM status, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::TRANSCODE TRANSCODE(TYPE type, OP op = EQUAL);
 


### PR DESCRIPTION
Mark as "Duplicate" the same transactions if present as 'Transfer' in QIF file for another account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1010)
<!-- Reviewable:end -->
