### PR TITLE
fix(compile): remove deprecated std::auto_ptr

### DIFF
--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -574,7 +574,7 @@ bool mmGeneralReportManager::openZipFile(const wxString &reportFileName
         wxTextFile reportFile(reportFileName);
         if (reportFile.Open())
         {
-            std::auto_ptr<wxZipEntry> entry;
+            std::unique_ptr<wxZipEntry> entry;
             wxFFileInputStream in(reportFileName);
             wxZipInputStream zip(in);
             while (entry.reset(zip.GetNextEntry()), entry.get() != nullptr)


### PR DESCRIPTION
This removes following compile warning:
```
/moneymanagerex/src/general_report_manager.cpp: In member function 'bool mmGeneralReportManager::openZipFile(const wxString&, wxString&, wxString&, wxString&, wxString&, wxString&)':
/moneymanagerex/src/general_report_manager.cpp:577:18: warning: 'template<class> class std::auto_ptr' is deprecated [-Wdeprecated-declarations]
             std::auto_ptr<wxZipEntry> entry;
                  ^~~~~~~~
In file included from /usr/include/c++/6/bits/locale_conv.h:41:0,
                 from /usr/include/c++/6/locale:43,
                 from /usr/include/c++/6/iomanip:43,
                 from /moneymanagerex/3rd/cajun/json/writer.inl:16,
                 from /moneymanagerex/3rd/cajun/json/writer.h:62,
                 from /moneymanagerex/src/db/DB_Table.h:31,
                 from /moneymanagerex/src/model/Model.h:35,
                 from /moneymanagerex/src/model/Model_Report.h:22,
                 from /moneymanagerex/src/reports/reportbase.h:27,
                 from /moneymanagerex/src/util.h:23,
                 from /moneymanagerex/src/mmpanelbase.h:22,
                 from /moneymanagerex/src/general_report_manager.h:27,
                 from /moneymanagerex/src/general_report_manager.cpp:20:
/usr/include/c++/6/bits/unique_ptr.h:49:28: note: declared here
   template<typename> class auto_ptr;
                            ^~~~~~~~
```
For details see https://isocpp.org/files/papers/N4190.txt
[Tested](https://github.com/slodki/moneymanagerex/releases/tag/test-auto_ptr) on linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1201)
<!-- Reviewable:end -->
