### PR TITLE
feat(import.csv.dialog): implement LISTBOX_DCLICK

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1281,18 +1281,10 @@ void mmUnivCSVDialog::OnBrowse(wxCommandEvent& /*event*/)
 
 void mmUnivCSVDialog::OnListBox(wxCommandEvent& event)
 {
-    int sel = event.GetSelection();
-    const wxString& object = event.GetString();
-    //TODO: Add/Remove item if double clicked
     if (m_oject_in_focus == ID_LISTBOX_CANDICATE)
-    {
-        wxLogDebug("Selected Left Control item: %i %s", sel, object);
-    }
+        OnAdd(event);
     else if (m_oject_in_focus == ID_LISTBOX)
-    {
-        wxLogDebug("Selected Right Control item: %i %s", sel, object);
-    }
-
+        OnRemove(event);
 }
 
 void mmUnivCSVDialog::OnDelimiterChange(wxCommandEvent& event)


### PR DESCRIPTION
Implemented add/remove item if double clicked on fields list in CSV import/export dialog. No need to select list element and then click on Add or Remove button!

[Tested](https://github.com/slodki/moneymanagerex/releases/tag/test-dblclk-import) on linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1202)
<!-- Reviewable:end -->
