### PR TITLE
#1180 Split transaction Status for Transfers

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -725,7 +725,7 @@ bool mmFilterTransactionsDialog::checkAll(const Model_Checking::Full_Data &tran,
         ok = false;
     else if (getCategoryCheckBox() && !checkCategory<Model_Checking>(tran))
         ok = false;
-    else if (getStatusCheckBox() && !compareStatus(tran.STATUS))
+    else if (getStatusCheckBox() && !compareStatus(tran.STATUSFD))
         ok = false;
     else if (getTypeCheckBox() && !allowType(tran.TRANSCODE, accountID == tran.ACCOUNTID)) 
         ok = false;

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -420,7 +420,7 @@ void mmQIFExportDialog::mmExportQIF()
                 break; // abort processing
 
             wxString trx_str;
-            Model_Checking::Full_Data full_tran(transaction, splits);
+            Model_Checking::Full_Data full_tran(0, transaction, splits);
 
             int accID = transaction.ACCOUNTID;
             bool reverce = false;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -920,7 +920,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& /*event*/)
 
         pTxFile->AddNewLine();
 
-        Model_Checking::Full_Data tran(pBankTransaction, split);
+        Model_Checking::Full_Data tran(0, pBankTransaction, split);
 
         double value = Model_Checking::balance(pBankTransaction, fromAccountID);
         account_balance += value;
@@ -1080,7 +1080,7 @@ void mmUnivCSVDialog::update_preview()
                 if (Model_Checking::status(pBankTransaction) == Model_Checking::VOID_)
                     continue;
 
-                Model_Checking::Full_Data tran(pBankTransaction, split);
+                Model_Checking::Full_Data tran(0, pBankTransaction, split);
 
                 double value = Model_Checking::balance(pBankTransaction, fromAccountID);
                 account_balance += value;

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -1,5 +1,6 @@
 /*******************************************************
- Copyright (C) 2013,2014 Guan Lisheng (guanlisheng@gmail.com)
+ Copyright (C) 2013-2016 Guan Lisheng (guanlisheng@gmail.com)
+ Copyright (C) 2013-2017 Stefano Giorgio [stef145g]
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -16,8 +17,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-#ifndef MODEL_CHECKING_H
-#define MODEL_CHECKING_H
+#pragma once
 
 #include "Model.h"
 #include "db/DB_Table_Checkingaccount_V1.h"
@@ -40,15 +40,16 @@ public:
     struct Full_Data: public Data
     {
         Full_Data();
-        explicit Full_Data(const Data& r);
-        Full_Data(const Data& r
+        explicit Full_Data(int account_id, const Data& r);
+        Full_Data(int account_id, const Data& r
             , const std::map<int /*trans id*/
                 , Model_Splittransaction::Data_Set /*split trans*/ > & splits);
-
         ~Full_Data();
         wxString ACCOUNTNAME, TOACCOUNTNAME;
         wxString PAYEENAME;
         wxString CATEGNAME;
+        //Modified Status for a Transfer transaction.
+        wxString STATUSFD;
         double AMOUNT;
         double BALANCE;
         Model_Splittransaction::Data_Set m_splits;
@@ -59,6 +60,9 @@ public:
 
         wxString info() const;
         const wxString to_json();
+
+    private:
+        void Initialise(int account_id, const Data& r);
     };
     typedef std::vector<Full_Data> Full_Data_Set;
 
@@ -164,4 +168,18 @@ public:
     static const bool foreignTransactionAsTransfer(const Data& data);
 };
 
-#endif // 
+class TransactionStatus
+{
+private:
+    int m_account_b;
+    wxString m_status_a;
+    wxString m_status_b;
+
+public:
+    TransactionStatus();
+    TransactionStatus(const DB_Table_CHECKINGACCOUNT_V1::Data& data);
+    void InitStatus(const DB_Table_CHECKINGACCOUNT_V1::Data& data);
+    void InitStatus(const DB_Table_CHECKINGACCOUNT_V1::Data* data);
+    void SetStatus(const wxString& status, int account_id, DB_Table_CHECKINGACCOUNT_V1::Data& data);
+    wxString Status(int account_id);
+};

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -176,7 +176,7 @@ void mmReportTransactions::Run(mmFilterTransactionsDialog* dlg)
     const auto splits = Model_Splittransaction::instance().get_all();
     for (const auto& tran : Model_Checking::instance().all()) //TODO: find should be faster
     {
-        Model_Checking::Full_Data full_tran(tran, splits);
+        Model_Checking::Full_Data full_tran(m_refAccountID, tran, splits);
         if (!dlg->checkAll(full_tran, m_refAccountID)) continue;
         full_tran.PAYEENAME = full_tran.real_payee_name(m_refAccountID);
         if (full_tran.has_split()) 

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -1,7 +1,7 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
- Copyright (C) 2011 Stefano Giorgio
  Copyright (C) 2011-2017 Nikolay Akimov
+ Copyright (C) 2011-2017 Stefano Giorgio [stef145g]
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -76,6 +76,7 @@ mmTransDialog::mmTransDialog(wxWindow* parent
     , m_advanced(false)
     , m_current_balance(current_balance)
     , m_duplicate(duplicate)
+    , m_account_id(account_id)
     , skip_account_init_(false)
     , skip_payee_init_(false)
     , skip_status_init_(false)
@@ -162,7 +163,8 @@ void mmTransDialog::dataToControls()
 
     if (!skip_status_init_) //Status
     {
-        choiceStatus_->SetSelection(Model_Checking::status(m_trx_data.STATUS));
+        m_status.InitStatus(m_trx_data);
+        choiceStatus_->SetSelection(Model_Checking::status(m_status.Status(m_account_id)));
         skip_status_init_ = true;
     }
 
@@ -1085,7 +1087,10 @@ void mmTransDialog::OnOk(wxCommandEvent& event)
     m_trx_data.TRANSACTIONNUMBER = textNumber_->GetValue();
     m_trx_data.TRANSDATE = dpc_->GetValue().FormatISODate();
     wxStringClientData* status_obj = (wxStringClientData*) choiceStatus_->GetClientObject(choiceStatus_->GetSelection());
-    if (status_obj) m_trx_data.STATUS = Model_Checking::toShortStatus(status_obj->GetData());
+    if (status_obj)
+    {
+        m_status.SetStatus(Model_Checking::toShortStatus(status_obj->GetData()), m_account_id, m_trx_data);
+    }
 
     if (!validateData()) return;
 
@@ -1118,7 +1123,7 @@ void mmTransDialog::OnOk(wxCommandEvent& event)
     }
 
     const Model_Checking::Data& tran(*r);
-    Model_Checking::Full_Data trx(tran);
+    Model_Checking::Full_Data trx(m_account_id, tran);
     wxLogDebug("%s", trx.to_json());
     EndModal(wxID_OK);
 }

--- a/src/transdialog.h
+++ b/src/transdialog.h
@@ -1,6 +1,7 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
- Copyright (C) 2011 Nikolay & Stefano Giorgio
+ Copyright (C) 2011-2017 Nikolay
+ Copyright (C) 2011-2017 Stefano Giorgio [stef145g]
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -124,6 +125,8 @@ private:
     double m_current_balance;
 
     int object_in_focus_;
+    int m_account_id;
+    TransactionStatus m_status;
 
     DB_Table_CHECKINGACCOUNT_V1::Data m_trx_data;
     std::vector<Split> local_splits;


### PR DESCRIPTION
This sets the status of a transfer as a 2 character token instead of one.
The database status is recorded as NN for both sides being unreconciled but is viewed as normal in Account View.
When the A side is reconciled and B side as Follow-up the database shows RF.
Viewing the transactions, the A side will show the status as R and viewing the B side will show as F

On changeover, both sides of a transaction will assume the current status for both sides until it is modified by the update. Reverting back and remodifying the transaction will restore to original.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1208)
<!-- Reviewable:end -->
