### PR TITLE
feat(sqlite): add Application ID to sqlite database header

### DIFF
--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -48,8 +48,7 @@ int dbUpgrade::GetCurrentVersion(wxSQLite3Database * db)
 {
     try
     {
-        wxSQLite3Statement stmt = db->PrepareStatement("PRAGMA user_version");
-        wxSQLite3ResultSet rs = stmt.ExecuteQuery();
+        wxSQLite3ResultSet rs = db->ExecuteQuery("PRAGMA user_version;");
         int ver = FixVersionStatus(db, rs.GetInt(0));
 
         return ver;
@@ -82,8 +81,7 @@ bool dbUpgrade::UpgradeToVersion(wxSQLite3Database * db, int version)
     {
         try
         {
-            wxSQLite3Statement stmt = db->PrepareStatement(query);
-            stmt.ExecuteUpdate();
+            db->ExecuteUpdate(query);
         }
         catch (const wxSQLite3Exception& e)
         {
@@ -105,8 +103,7 @@ bool dbUpgrade::InitializeVersion(wxSQLite3Database* db, int version)
 {
     try
     {
-        wxSQLite3Statement stmt = db->PrepareStatement(wxString::Format("PRAGMA user_version = %i", version));
-        stmt.ExecuteUpdate();
+        db->ExecuteUpdate(wxString::Format("PRAGMA user_version = %i;", version));
         db->ExecuteUpdate("PRAGMA application_id = 0x4d4d4558;");
         return true;
     }
@@ -302,8 +299,7 @@ void dbUpgrade::SqlFileDebug(wxSQLite3Database* db)
         {
             try
             {
-                wxSQLite3Statement stmt = db->PrepareStatement(txtLine);
-                stmt.ExecuteUpdate();
+                db->ExecuteUpdate(txtLine);
             }
             catch (const wxSQLite3Exception& e)
             {

--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -107,6 +107,7 @@ bool dbUpgrade::InitializeVersion(wxSQLite3Database* db, int version)
     {
         wxSQLite3Statement stmt = db->PrepareStatement(wxString::Format("PRAGMA user_version = %i", version));
         stmt.ExecuteUpdate();
+        db->ExecuteUpdate("PRAGMA application_id = 0x4d4d4558;");
         return true;
     }
     catch (const wxSQLite3Exception& /*e*/)

--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -48,9 +48,7 @@ int dbUpgrade::GetCurrentVersion(wxSQLite3Database * db)
 {
     try
     {
-        wxSQLite3ResultSet rs = db->ExecuteQuery("PRAGMA user_version;");
-        int ver = FixVersionStatus(db, rs.GetInt(0));
-
+        int ver = FixVersionStatus(db, db->ExecuteScalar("PRAGMA user_version;"));
         return ver;
     }
     catch (const wxSQLite3Exception& /*e*/)

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -1060,16 +1060,14 @@ void mmGeneralReportManager::getSqlTableInfo(std::vector<std::pair<wxString, wxA
     sqlTableInfo.clear();
 
     // Get a list of the database tables
-    wxSQLite3Statement stmtTables = this->m_db->PrepareStatement(sqlTables);
-    wxSQLite3ResultSet qTables = stmtTables.ExecuteQuery();
+    wxSQLite3ResultSet qTables = this->m_db->ExecuteQuery(sqlTables);
     while (qTables.NextRow())
     {
         const wxString table_name = qTables.GetAsString(1);
 
         // Get a list of the table columns
         const wxString& sql = wxString::Format(sqlColumns, table_name);
-        wxSQLite3Statement stmtColumns = this->m_db->PrepareStatement(sql);
-        wxSQLite3ResultSet qColumns = stmtColumns.ExecuteQuery();
+        wxSQLite3ResultSet qColumns = this->m_db->ExecuteQuery(sql);
         wxArrayString column_names;
         while (qColumns.NextRow())
             column_names.push_back(qColumns.GetAsString(1));


### PR DESCRIPTION
This will add `MMEX` application ID (=1296909656) to a newly created or updated sqlite database file header as described in #1206.

```
$ hexdump -C test.mmb | head
00000000  53 51 4c 69 74 65 20 66  6f 72 6d 61 74 20 33 00  |SQLite format 3.|
00000010  10 00 01 01 00 40 20 20  00 00 00 5a 00 00 00 40  |.....@  ...Z...@|
00000020  00 00 00 00 00 00 00 00  00 00 00 2e 00 00 00 04  |................|
00000030  00 00 00 00 00 00 00 00  00 00 00 01 00 00 00 07  |................|
00000040  00 00 00 00 4d 4d 45 58  00 00 00 00 00 00 00 00  |....MMEX........|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 5a  |...............Z|
00000060  00 2d fd 71 05 00 00 00  02 0f f6 00 00 00 00 35  |.-.q...........5|
00000070  0f fb 0f f6 0c e5 0b b1  0b 5a 0a 4c 0b 1b 09 d8  |.........Z.L....|
00000080  07 4d 09 9b 06 ce 05 f7  06 9d 05 99 03 bf 03 2b  |.M.............+|
00000090  02 a0 02 5b 02 16 02 16  00 00 00 00 00 00 00 00  |...[............|

$ file test.mmb
test.mmb: SQLite 3.x database, application id 1296909656, user version 7, last written using SQLite version 3014001
```

dbUpgrade::InitializeVersion was reused as existing method to set header value.

Also calls to ExecuteQuery, ExecuteUpdate are simplified where precompiled wxSQLite3Statement object is not necessary. There is no need to use precompiled statements if we not use
parameter binding nor examine query before executing it.

It builds without errors and [works](https://github.com/slodki/moneymanagerex/releases/tag/test-1206) as expected (tested on linux).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1211)
<!-- Reviewable:end -->
