### PR TITLE
feat(bug.report): new pre-filled bug report template for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,23 @@
+> Please follow these tasks before submitting new bug:
+> 1. Use Help->Check for Updates in MMEX to get latest version - your problem can be fixed already.
+> 2. Search https://github.com/moneymanagerex/moneymanagerex/issues?q=is:issue
+> for similar problem - update existing issue instead of creating new one.
+> 3. Use Help->Report a Bug in MMEX if possible - it will include details important for dev team.
+> 4. Put some descriptive name for your issue in the Title field above.
+> 5. Replace this text (marked with >) with detailed description of your problem.
+> Read https://www.chiark.greenend.org.uk/~sgtatham/bugs.html for useful tips.
+> 6. Include steps to reproduce your issue, attach screenshots where appropriate.
+> 7. Mark (put x inside brackets: [x]) correct answers below.
 
-make sure these boxed are checked before submitting your issue - thank you!
-- Check OS
-  - [ ] Windows
-  - [ ] Mac OSX
-  - [ ] Linux 
--  Check MMEX version
-  - [ ] 1.3.x
-  - [ ] 1.2.x
-  - [ ] 1.1 or older
+Your OS:
+- [ ] Windows
+- [ ] Mac OSX
+- [ ] Linux 
+- [ ] Android -> please report bugs to moneymanagerex/android-money-manager-ex repo!
+
+MMEX version:
+- [ ] 1.4.x
+- [ ] 1.3.x
+- [ ] 1.2.x
+- [ ] 1.1 or older
+- [ ] development version (git master branch)

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -100,20 +100,15 @@ const wxString mmex::getProgramDescription()
 #endif
 
         << "\n" << _("MMEX is using the following support products:") << "\n"
-        << L" \u2b25 " << wxVERSION_STRING << "\n"
-        << L" \u2b25 SQLite " << wxSQLite3Database::GetVersion() << "\n"
-        << L" \u2b25 " << wxSQLITE3_VERSION_STRING << "\n"
+        << L" \u2b25 " << wxVERSION_STRING
+        << wxString::Format(" (%s %d.%d)\n",
+            wxPlatformInfo::Get().GetPortIdName(),
+            wxPlatformInfo::Get().GetToolkitMajorVersion(),
+            wxPlatformInfo::Get().GetToolkitMinorVersion())
+        << L" \u2b25 " << wxSQLITE3_VERSION_STRING
+        << " (SQLite " << wxSQLite3Database::GetVersion() << ")\n"
         << L" \u2b25 Mongoose " << MG_VERSION << "\n"
         << L" \u2b25 " << LUA_RELEASE << "\n\n"
-
-        << _("Running on:") << "\n"
-#ifdef __LINUX__
-        << L" \u2b25 " << wxGetLinuxDistributionInfo().Description
-        << " \"" << wxGetLinuxDistributionInfo().CodeName << "\"\n"
-#endif
-        << L" \u2b25 " << wxGetOsDescription() << "\n"
-        << L" \u2b25 " << wxLocale::GetLanguageName(wxLocale::GetSystemLanguage())
-        << " " << wxLocale::GetSystemEncodingName() << _(" locale") << "\n\n"
 
         << wxString::Format(_("Build on %s %s with:"), __DATE__, __TIME__) << "\n"
 #if defined(_MSC_VER)
@@ -129,6 +124,23 @@ const wxString mmex::getProgramDescription()
 #ifdef MAKE_VERSION
         << L" \u2b25 GNU Make " MAKE_VERSION << "\n"
 #endif
+
+        << "\n" << _("Running on:") << "\n"
+#ifdef __LINUX__
+        << L" \u2b25 " << wxGetLinuxDistributionInfo().Description
+        << " \"" << wxGetLinuxDistributionInfo().CodeName << "\"\n"
+#endif
+        << L" \u2b25 " << wxGetOsDescription()
+        << " " << wxPlatformInfo::Get().GetEndiannessName() << "\n"
+        << L" \u2b25 " << wxPlatformInfo::Get().GetDesktopEnvironment()
+        << " " << wxLocale::GetLanguageName(wxLocale::GetSystemLanguage())
+        << " " << wxLocale::GetSystemEncodingName() 
+        << wxString::Format(L"\n \u2b25 %ix%ix%ibit %ix%ippi\n",
+            wxGetDisplaySize().GetX(),
+            wxGetDisplaySize().GetY(),
+            wxDisplayDepth(),
+            wxGetDisplayPPI().GetX(),
+            wxGetDisplayPPI().GetY())
     ;
     description.RemoveLast();
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -100,34 +100,34 @@ const wxString mmex::getProgramDescription()
 #endif
 
         << "\n" << _("MMEX is using the following support products:") << "\n"
-        << L" \u2022 " << wxVERSION_STRING << "\n"
-        << L" \u2022 SQLite " << wxSQLite3Database::GetVersion() << "\n"
-        << L" \u2022 " << wxSQLITE3_VERSION_STRING << "\n"
-        << L" \u2022 Mongoose " << MG_VERSION << "\n"
-        << L" \u2022 " << LUA_RELEASE << "\n\n"
+        << L" \u2b25 " << wxVERSION_STRING << "\n"
+        << L" \u2b25 SQLite " << wxSQLite3Database::GetVersion() << "\n"
+        << L" \u2b25 " << wxSQLITE3_VERSION_STRING << "\n"
+        << L" \u2b25 Mongoose " << MG_VERSION << "\n"
+        << L" \u2b25 " << LUA_RELEASE << "\n\n"
 
         << _("Running on:") << "\n"
 #ifdef __LINUX__
-        << L" \u2022 " << wxGetLinuxDistributionInfo().Description
+        << L" \u2b25 " << wxGetLinuxDistributionInfo().Description
         << " \"" << wxGetLinuxDistributionInfo().CodeName << "\"\n"
 #endif
-        << L" \u2022 " << wxGetOsDescription() << "\n"
-        << L" \u2022 " << wxLocale::GetLanguageName(wxLocale::GetSystemLanguage())
+        << L" \u2b25 " << wxGetOsDescription() << "\n"
+        << L" \u2b25 " << wxLocale::GetLanguageName(wxLocale::GetSystemLanguage())
         << " " << wxLocale::GetSystemEncodingName() << _(" locale") << "\n\n"
 
         << wxString::Format(_("Build on %s %s with:"), __DATE__, __TIME__) << "\n"
 #if defined(_MSC_VER)
-        << L" \u2022 Microsoft Visual Studio " << _MSC_VER << "\n"
+        << L" \u2b25 Microsoft Visual Studio " << _MSC_VER << "\n"
 #elif defined(__clang__)
-        << L" \u2022 Clang/LLVM " << __VERSION__ << "\n"
+        << L" \u2b25 Clang/LLVM " << __VERSION__ << "\n"
 #elif (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
-        << L" \u2022 GNU GCC/G++ " << __VERSION__ << "\n"
+        << L" \u2b25 GNU GCC/G++ " << __VERSION__ << "\n"
 #endif
 #ifdef CMAKE_VERSION
-        << L" \u2022 CMake " CMAKE_VERSION << "\n"
+        << L" \u2b25 CMake " CMAKE_VERSION << "\n"
 #endif
 #ifdef MAKE_VERSION
-        << L" \u2022 GNU Make " MAKE_VERSION << "\n"
+        << L" \u2b25 GNU Make " MAKE_VERSION << "\n"
 #endif
     ;
     description.RemoveLast();
@@ -162,7 +162,7 @@ const wxString mmex::weblink::Wiki = "http://wiki.moneymanagerex.org";
 const wxString mmex::weblink::GitHub = "https://github.com/moneymanagerex/moneymanagerex";
 const wxString mmex::weblink::YouTube = "http://www.youtube.com/user/moneymanagerex";
 const wxString mmex::weblink::Slack = "http://slack.moneymanagerex.org/";
-const wxString mmex::weblink::BugReport = "http://bugreport.moneymanagerex.org";
+const wxString mmex::weblink::BugReport = "https://github.com/moneymanagerex/moneymanagerex/issues";
 const wxString mmex::weblink::Donate = "https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=moneymanagerex%40gmail%2ecom&lc=US&item_name=MoneyManagerEx&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest";
 const wxString mmex::weblink::SquareCashGuan = "https://cash.me/$guanlisheng/1";
 const wxString mmex::weblink::Twitter = "https://twitter.com/MoneyManagerEx";

--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -233,7 +233,7 @@ void dbUpgrade::SqlFileDebug(wxSQLite3Database* db)
     {
         wxString txtLine, txtLog = "";
 
-        txtLog << wxString::Format("Current DB file version: %i", dbUpgrade::GetCurrentVersion(db)) + wxTextFile::GetEOL();
+        txtLog << wxString::Format("Current db file version: %i", dbUpgrade::GetCurrentVersion(db)) + wxTextFile::GetEOL();
         txtLog << mmex::getProgramDescription() + wxTextFile::GetEOL();
 
         for (txtLine = txtFile.GetNextLine(); !txtFile.Eof(); txtLine = txtFile.GetNextLine())

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2504,7 +2504,38 @@ void mmGUIFrame::OnSimpleURLOpen(wxCommandEvent& event)
 
 void mmGUIFrame::OnReportBug(wxCommandEvent& /*event*/)
 {
-    wxLaunchDefaultBrowser(mmex::weblink::BugReport);
+    std::vector<wxString> texts = {
+        _("Please follow these tasks before submitting new bug:"),
+        _("1. Use Help->Check for Updates in MMEX to get latest version - your problem can be fixed already."),
+        _("2. Search https://github.com/moneymanagerex/moneymanagerex/issues?q=is:issue for similar problem - update existing issue instead of creating new one."),
+        _("3. Put some descriptive name for your issue in the Title field above."),
+        _("4. Replace this text (marked with >) with detailed description of your problem."),
+        _("Read https://www.chiark.greenend.org.uk/~sgtatham/bugs.html for useful tips."),
+        _("5. Include steps to reproduce your issue, attach screenshots where appropriate."),
+        _("6. Please do not remove information attached below this text.")
+    };
+    std::vector<std::array<std::string, 2>> fixes = {
+        { "\n\n", "<br>" }, { "\n", " " }, { "  ", " " },
+        { "^Version", "\n<hr><small><b>Version</b>" },
+        { "Database version supported:", "\u2b25 db" },
+        { "Git commit:", "\u2b25 git" },
+        { "Git branch: ", "" },
+        { "MMEX is using the following support products: \u2b25", "<b>Libs</b>:" },
+        { "Running on: \u2b25", "<b>OS</b>:" },
+        { "locale<br>Build on", "<br><b>Build</b>:" },
+        { " with:", "" },
+        { "(.)$", "\\1</small>" }
+    };
+    wxRegEx re;
+    wxString diag = mmex::getProgramDescription();
+    for (auto const& fix: fixes)
+        if (re.Compile(fix[0], wxRE_EXTENDED)) re.Replace(&diag,fix[1]);
+    wxString api = "/new?body=";
+    for (auto const& text: texts)
+        api << "> " << text << "\n";
+    api << diag;
+    wxURI req = mmex::weblink::BugReport + api;
+    wxLaunchDefaultBrowser(req.BuildURI());
 }
 
 //----------------------------------------------------------------------------

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2514,7 +2514,7 @@ void mmGUIFrame::OnReportBug(wxCommandEvent& /*event*/)
         _("5. Include steps to reproduce your issue, attach screenshots where appropriate."),
         _("6. Please do not remove information attached below this text.")
     };
-    std::vector<std::array<std::string, 2>> fixes = {
+    std::vector<std::pair<wxString, wxString>> fixes = {
         { "\n\n", "<br>" }, { "\n", " " }, { "  ", " " },
         { "^Version", "\n<hr><small><b>Version</b>" },
         { "Database version supported:", "\u2b25 db" },
@@ -2528,10 +2528,10 @@ void mmGUIFrame::OnReportBug(wxCommandEvent& /*event*/)
     };
     wxRegEx re;
     wxString diag = mmex::getProgramDescription();
-    for (auto const& fix: fixes)
-        if (re.Compile(fix[0], wxRE_EXTENDED)) re.Replace(&diag,fix[1]);
+    for (const auto& kv: fixes)
+        if (re.Compile(kv.first, wxRE_EXTENDED)) re.Replace(&diag, kv.second);
     wxString api = "/new?body=";
-    for (auto const& text: texts)
+    for (const auto& text: texts)
         api << "> " << text << "\n";
     api << diag;
     wxURI req = mmex::weblink::BugReport + api;

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2521,9 +2521,9 @@ void mmGUIFrame::OnReportBug(wxCommandEvent& /*event*/)
         { "Git commit:", "\u2b25 git" },
         { "Git branch: ", "" },
         { "MMEX is using the following support products: \u2b25", "<b>Libs</b>:" },
-        { "Running on: \u2b25", "<b>OS</b>:" },
-        { "locale<br>Build on", "<br><b>Build</b>:" },
+        { "<br>Build on", "<br><b>Build</b>:" },
         { " with:", "" },
+        { "Running on: \u2b25", "<b>OS</b>:" },
         { "(.)$", "\\1</small>" }
     };
     wxRegEx re;


### PR DESCRIPTION
Pre-fill bug report template for Help->Report a Bug.
Update GitHub ISSUE_TEMPLATE.md.

When user use `Help`->`Report a Bug` menu command following page will be opened:
![mmex-newbug-1](https://user-images.githubusercontent.com/3155552/27994656-898d06be-64c2-11e7-89c8-6009a606d50b.png)

Rendered as:
![mmex-newbug-2](https://user-images.githubusercontent.com/3155552/27994659-938b9f22-64c2-11e7-8ddc-baccf81c5fb2.png)

Similar changes are introduced to issues created directly from GitHub website:
![mmex-newbug-3](https://user-images.githubusercontent.com/3155552/27994672-9e89962c-64c2-11e7-9cc4-35ade9204a55.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1225)
<!-- Reviewable:end -->
