### PR TITLE
fix(#1256): disable toolbar icons when no database

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -649,6 +649,9 @@ void mmGUIFrame::menuEnableItems(bool enable)
     toolBar_->EnableTool(MENU_ORGCATEGS, enable);
     toolBar_->EnableTool(MENU_CURRENCY, enable);
     toolBar_->EnableTool(wxID_VIEW_LIST, enable);
+    toolBar_->EnableTool(MENU_TRANSACTIONREPORT, enable);
+    toolBar_->EnableTool(wxID_PREFERENCES, enable);
+    toolBar_->EnableTool(wxID_NEW, enable);
     toolBar_->EnableTool(wxID_PRINT, enable);
 }
 //----------------------------------------------------------------------------
@@ -2536,13 +2539,13 @@ void mmGUIFrame::OnReportBug(wxCommandEvent& /*event*/)
     std::vector<std::pair<wxString, wxString>> fixes = {
         { "\n\n", "<br>" }, { "\n", " " }, { "  ", " " },
         { "^Version", "\n<hr><small><b>Version</b>" },
-        { "Database version supported:", "\u2b25 db" },
-        { "Git commit:", "\u2b25 git" },
+        { "Database version supported:", L"\u2b25 db" },
+        { "Git commit:", L"\u2b25 git" },
         { "Git branch: ", "" },
-        { "MMEX is using the following support products: \u2b25", "<b>Libs</b>:" },
+        { L"MMEX is using the following support products: \u2b25", "<b>Libs</b>:" },
         { "<br>Build on", "<br><b>Build</b>:" },
         { " with:", "" },
-        { "Running on: \u2b25", "<b>OS</b>:" },
+        { L"Running on: \u2b25", "<b>OS</b>:" },
         { "(.)$", "\\1</small>" }
     };
     wxRegEx re;

--- a/src/optionsettingsview.cpp
+++ b/src/optionsettingsview.cpp
@@ -153,31 +153,31 @@ void OptionSettingsView::Create()
     viewsPanelSizer->Add(userColourSettingStBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
 
     int size_x = 55;
-    m_UDFCB1 = new wxButton(this, wxID_HIGHEST + 11, _("1")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB1 = new wxButton(this, wxID_HIGHEST + 11, _("1") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB1->SetForegroundColour(mmColors::userDefColor1);
     userColourSettingStBoxSizer->Add(m_UDFCB1, g_flagsH);
 
-    m_UDFCB2 = new wxButton(this, wxID_HIGHEST + 22, _("2")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB2 = new wxButton(this, wxID_HIGHEST + 22, _("2") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB2->SetForegroundColour(mmColors::userDefColor2);
     userColourSettingStBoxSizer->Add(m_UDFCB2, g_flagsH);
 
-    m_UDFCB3 = new wxButton(this, wxID_HIGHEST + 33, _("3")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB3 = new wxButton(this, wxID_HIGHEST + 33, _("3") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB3->SetForegroundColour(mmColors::userDefColor3);
     userColourSettingStBoxSizer->Add(m_UDFCB3, g_flagsH);
 
-    m_UDFCB4 = new wxButton(this, wxID_HIGHEST + 44, _("4")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB4 = new wxButton(this, wxID_HIGHEST + 44, _("4") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB4->SetForegroundColour(mmColors::userDefColor4);
     userColourSettingStBoxSizer->Add(m_UDFCB4, g_flagsH);
 
-    m_UDFCB5 = new wxButton(this, wxID_HIGHEST + 55, _("5")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB5 = new wxButton(this, wxID_HIGHEST + 55, _("5") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB5->SetForegroundColour(mmColors::userDefColor5);
     userColourSettingStBoxSizer->Add(m_UDFCB5, g_flagsH);
 
-    m_UDFCB6 = new wxButton(this, wxID_HIGHEST + 66, _("6")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB6 = new wxButton(this, wxID_HIGHEST + 66, _("6") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB6->SetForegroundColour(mmColors::userDefColor6);
     userColourSettingStBoxSizer->Add(m_UDFCB6, g_flagsH);
 
-    m_UDFCB7 = new wxButton(this, wxID_HIGHEST + 77, _("7")+"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
+    m_UDFCB7 = new wxButton(this, wxID_HIGHEST + 77, _("7") + L"  \u2588\u2588", wxDefaultPosition, wxSize(size_x, -1), 0);
     m_UDFCB7->SetForegroundColour(mmColors::userDefColor7);
     userColourSettingStBoxSizer->Add(m_UDFCB7, g_flagsH);
 


### PR DESCRIPTION
Also correct compile warnings for Unicode characters \u2b25 \u2588

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1263)
<!-- Reviewable:end -->
