### PR TITLE
Fix errors and add detailed messages in mmUnivCSVDialog

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2242,7 +2242,7 @@ void mmGUIFrame::OnImportUniversalCSV(wxCommandEvent& /*event*/)
 {
     if (Model_Account::instance().all().empty())
     {
-        wxMessageBox(_("No account available to import"), _("Universal CSV Import"), wxOK | wxICON_WARNING);
+        wxMessageBox(_("No account available to import to"), _("Universal CSV Import"), wxOK | wxICON_WARNING);
         return;
     }
 
@@ -2261,7 +2261,7 @@ void mmGUIFrame::OnImportXML(wxCommandEvent& /*event*/)
 {
     if (Model_Account::instance().all().empty())
     {
-        wxMessageBox(_("No account available to import"), _("Universal CSV Import"), wxOK | wxICON_WARNING);
+        wxMessageBox(_("No account available to import to"), _("Universal CSV Import"), wxOK | wxICON_WARNING);
         return;
     }
 


### PR DESCRIPTION
Add details to diagnostic messages (for user and log).
Fix wrong total lines number displayed.
Update progress meter to show real values.
Change all counters to the same type (long).
Select summary pop-up icon and buttons depending on import result.
Commented out messages never displayed to user.

This should help users to diagnose problems with CSV imports (like #1277).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1291)
<!-- Reviewable:end -->
