### PR TITLE
fix(CMake): set correct location of mmex.exe for Windows Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
             BUNDLE DESTINATION .)
 ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     INSTALL(PROGRAMS
-            "${CMAKE_SOURCE_DIR}/bin/${PROJECT_TARGET_BIN}.exe"
+            "${CMAKE_SOURCE_DIR}/bin/Release/${PROJECT_TARGET_BIN}.exe"
             DESTINATION "${INSTALL_BIN_DIR}")
 
     # Besides normal installable version, for windows the portable version needs additionally files


### PR DESCRIPTION
This allows the Install project in MSVC IDE to work correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1296)
<!-- Reviewable:end -->
