### PR TITLE
fix(cmake): complete support for Visual Studio 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 *.swp
 *.d
 
+# Visual Studio Cache Folder
+/.vs

--- a/BUILD.md
+++ b/BUILD.md
@@ -60,7 +60,7 @@ Simply clone [official Git repository] with submodules using:
 
 You can select MMEX version by adding `-b v1.4.0` parameter.
 
-#### 4. Compile
+#### 4. Option 1: Compile with NMake
 
 Generate build enviroment for [NMake] tool using [CMake]:
 
@@ -77,15 +77,12 @@ Then start build process with:
 
 Replace `x86` with `x64` for 64-bits arch.
 
-#### 5. Build Package
+#### 4. Option 2: Load MMEX Project into Visual Studio GUI with Native CMake support **(ONLY VISUAL STUDIO 2017)**
 
-For building installable package, you need to have [NSIS] installed.
-Then you can create it using:
+Simply open Visual Studio, then File > Open > Folder > Choose c:\projects\mmex
+Wait for cache generation, then click on CMake > Build All
 
-    cd c:\projects\mmex\build
-    cpack .
-
-#### Loading MMEX Project into Visual Studio GUI
+#### 4. Option 3: Generate MMEX Project for Visual Studio GUI
 
 If you are interested in producing *Visual Studio project file*, you can run
 following command:
@@ -100,7 +97,15 @@ or for 64-bits build:
 
 .vcproj file will be generated ready to be load into Visual Studio.
 
-You can also try native [CMake support in Visual Studio 2017].
+
+
+#### 5. Build Package
+
+For building installable package, you need to have [NSIS] installed.
+Then you can create it using:
+
+    cd c:\projects\mmex\build
+    cpack .
 
 
 macOS with Homebrew
@@ -232,7 +237,7 @@ Same as for [macOS](#3-compile-and-create-package)
     https://wxwidgets.org/
 [NSIS]:
     http://nsis.sourceforge.net/Download
-[CMake support in Visual Studio 2017]:
-    https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/
 [Homebrew]:
     https://brew.sh
+[GnuWin Make]:
+    http://gnuwin32.sourceforge.net/downlinks/make.php

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ ENDIF()
 IF(GIT_BRANCH)
   ADD_DEFINITIONS(-DGIT_BRANCH="${GIT_BRANCH}")
 ENDIF()
-ADD_DEFINITIONS(-DCMAKE_VERSION="${CMAKE_VERSION}" -DMAKE_VERSION="$(MAKE_VERSION)")
+ADD_DEFINITIONS(-DCMAKE_VERSION="${CMAKE_VERSION}" -DMAKE_VERSION="${MAKE_VERSION}")
 
 # Passing CMake variables (specificaly current version numbers) to files
 # Header file
@@ -200,7 +200,11 @@ ELSE()
 ENDIF()
 
 INCLUDE(${wxWidgets_USE_FILE})
-SET(wxWidgets_USE_DEBUG false)
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    SET(wxWidgets_USE_DEBUG true)
+ELSE()
+    SET(wxWidgets_USE_DEBUG false)
+ENDIF()
 
 MESSAGE(STATUS "Base Directory =  ${CMAKE_SOURCE_DIR}")
 
@@ -274,21 +278,42 @@ IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     SET_TARGET_PROPERTIES(${PROJECT_TARGET_BIN} PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/resources/Info.plist")
 ENDIF()
 
+# Fixes for Visual Studio 2017 immediate build\execution\debug directly opening CMake folder without project
+# Initialize IS_VS_2017CMAKE to 0, it will be override by Visual Studio cmake with -D command line parameter
+SET(IS_VS_2017CMAKE 0 CACHE BOOL "Executed from VS2017 IDE")
+IF(IS_VS_2017CMAKE EQUAL 1)
+    SET(CONFIGURATION_NAME "${TARGET_ARCH}-${CMAKE_BUILD_TYPE}")
+    SET(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}/bin")
+    SET(LIBRARY_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}/bin/lib")
+    SET(INSTALL_BIN_DIR "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}/bin")
+    SET(INSTALL_DOC_DIR "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}")
+    SET(INSTALL_RES_DIR "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}/res")
+    SET(INSTALL_MO_DIR "${CMAKE_SOURCE_DIR}/bin/${CONFIGURATION_NAME}/po/en")
+    ADD_CUSTOM_COMMAND(
+        TARGET ${PROJECT_TARGET_BIN} POST_BUILD
+        COMMAND cmake -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        COMMENT "Copying files to output directory" VERBATIM
+    )
+ENDIF()
 # Finally set ups for multiplatform INSTALL
 # Binary
 IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     INSTALL(PROGRAMS
-            "${CMAKE_SOURCE_DIR}/bin/${PROJECT_TARGET_BIN}"
+            "${EXECUTABLE_OUTPUT_PATH}/${PROJECT_TARGET_BIN}"
             DESTINATION "${INSTALL_BIN_DIR}")
 ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     INSTALL(TARGETS
             "${PROJECT_TARGET_BIN}"
             BUNDLE DESTINATION .)
 ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    INSTALL(PROGRAMS
-            "${CMAKE_SOURCE_DIR}/bin/${PROJECT_TARGET_BIN}.exe"
-            DESTINATION "${INSTALL_BIN_DIR}")
-
+    # For VS2017 with cmake mmex.exe it's already in the right place
+    IF(NOT IS_VS_2017CMAKE EQUAL 1)
+        INSTALL(PROGRAMS
+                "${EXECUTABLE_OUTPUT_PATH}/${PROJECT_TARGET_BIN}.exe"
+                DESTINATION "${INSTALL_BIN_DIR}")
+    ENDIF()
+    
     # Besides normal installable version, for windows the portable version needs additionally files
     FILE(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mmexini.db3" "")
     INSTALL(FILES
@@ -296,8 +321,18 @@ ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Windows")
             DESTINATION "${INSTALL_DOC_DIR}")
 
     IF(MSVC)
-        FILE(TO_CMAKE_PATH "$ENV{VCINSTALLDIR}redist" REDISTDIR)
-        SET(REDISTDIR "${REDISTDIR}/${TARGET_ARCH}/Microsoft.VC140.CRT")
+        FILE(TO_CMAKE_PATH "$ENV{VCINSTALLDIR}redist" BASEREDISTDIR)
+        SET(REDISTDIR "${BASEREDISTDIR}/${TARGET_ARCH}/Microsoft.VC140.CRT")
+        IF(NOT EXISTS REDISTDIR)
+            # Visual Studio 2017 with VC 14.1 has changed redist path
+            SET(REDISTDIR "${BASEREDISTDIR}/MSVC")
+            FILE(GLOB REDISTSUBDIRS RELATIVE ${REDISTDIR} ${REDISTDIR}/*)
+            FOREACH(REDISTSUBDIR ${REDISTSUBDIRS})
+                IF(IS_DIRECTORY ${REDISTDIR}/${REDISTSUBDIR})
+                    SET(REDISTDIR "${REDISTDIR}/${REDISTSUBDIR}/${TARGET_ARCH}/Microsoft.VC141.CRT")
+                ENDIF()
+            ENDFOREACH()
+        ENDIF()
         SET(VCRUNTIME
             "${REDISTDIR}/msvcp140.dll"
             "${REDISTDIR}/vcruntime140.dll"
@@ -309,7 +344,6 @@ ELSEIF(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         ENDFOREACH(f)
         INSTALL(FILES ${VCRUNTIME} DESTINATION "${INSTALL_BIN_DIR}" OPTIONAL)
     ENDIF(MSVC)
-
 ENDIF()
 
 # Help Files

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,69 @@
+{
+    // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+    "configurations": [
+        {
+        "name": "x86-Debug",
+        "generator": "Ninja",
+        "configurationType" : "Debug",
+        "inheritEnvironments": [ "msvc_x86" ],
+        "buildRoot":  "${workspaceRoot}\\build\\${name}",
+        "cmakeCommandArgs":  "",
+        "buildCommandArgs": "-v",
+        "ctestCommandArgs":  "",
+	    "variables": [
+			{
+				"name": "IS_VS_2017CMAKE",
+				"value": 1
+			}
+		]
+        },
+        {
+        "name": "x86-Release",
+        "generator": "Ninja",
+        "configurationType" : "Release",
+        "inheritEnvironments": [ "msvc_x86" ],
+        "buildRoot":  "${workspaceRoot}\\build\\${name}",
+        "cmakeCommandArgs":  "",
+        "buildCommandArgs": "-v",
+        "ctestCommandArgs":  "",
+		"variables": [
+			{
+				"name": "IS_VS_2017CMAKE",
+				"value": 1
+			}
+		]
+        },
+        {
+        "name": "x64-Debug",
+        "generator": "Ninja",
+        "configurationType" : "Debug",
+        "inheritEnvironments": [ "msvc_x64" ],
+        "buildRoot":  "${workspaceRoot}\\build\\${name}",
+        "cmakeCommandArgs":  "",
+        "buildCommandArgs": "-v",
+        "ctestCommandArgs":  "",
+	    "variables": [
+			{
+				"name": "IS_VS_2017CMAKE",
+				"value": 1
+			}
+		]
+        },
+        {
+        "name": "x64-Release",
+        "generator": "Ninja",
+        "configurationType" : "Release",
+		"inheritEnvironments": [ "msvc_x64" ],
+        "buildRoot":  "${workspaceRoot}\\build\\${name}",
+        "cmakeCommandArgs":  "",
+        "buildCommandArgs": "-v",
+        "ctestCommandArgs":  "",
+		"variables": [
+			{
+				"name": "IS_VS_2017CMAKE",
+				"value": 1
+			}
+		]
+        }
+    ]
+}

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -7,12 +7,19 @@ FIND_PACKAGE(Gettext REQUIRED)
 ADD_CUSTOM_TARGET(Translations ALL)
 FILE(GLOB POFiles "${CMAKE_CURRENT_SOURCE_DIR}/*.po")
 
+IF(IS_VS_2017CMAKE EQUAL 1)
+    SET(INSTALL_MO_DIR "${CMAKE_SOURCE_DIR}/bin/${TARGET_ARCH}-${CMAKE_BUILD_TYPE}/po/en")
+ENDIF()
+
 FOREACH(POFile ${POFiles})
     GET_FILENAME_COMPONENT(CurrentFile ${POFile} NAME_WE)
     SET(MOFile "${CMAKE_CURRENT_BINARY_DIR}/${CurrentFile}.mo")
 
     ADD_CUSTOM_COMMAND(TARGET Translations
-            COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${MOFile} ${POFile}
+            # Should be COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${MOFile} ${POFile}
+            # but MOFile full path has been removed because VS2017 Ninja appends all commands in a unique command that exceeds max lenght
+            # Anyway an error will be triggered if folder is different because install command below is based ${MOFile} and is not optional
+            COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o "${CurrentFile}.mo" ${POFile}
             DEPENDS ${POFile})
     INSTALL(FILES ${MOFile} DESTINATION ${INSTALL_MO_DIR})
 ENDFOREACH()


### PR DESCRIPTION
With this changes, in Visual Studio 2017 it's possible to directly open\build\debug MMEX without need to generate vcproj files.

cpack it's not working (I think because of changed folder structure) but it can be fixed later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1299)
<!-- Reviewable:end -->
