### PR TITLE
fix(#1347): use %zu from C99

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -61,7 +61,7 @@ static void handle_sql(struct mg_connection* nc, struct http_message* hm)
 
     mg_printf(nc, "HTTP/1.1 200 OK\r\n"
                 "Content-Type: application/json; charset=utf-8\r\n"
-                "Content-Length: %lu\r\n\r\n%ls", str.length(), str.c_str());
+                "Content-Length: %zu\r\n\r\n%ls", str.length(), str.c_str());
 }
 
 static void ev_handler(struct mg_connection *nc, int ev, void *ev_data) 


### PR DESCRIPTION
Using %zu is portable way to print size_t
This will fix #1347 compile warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1350)
<!-- Reviewable:end -->
