### PR TITLE
feat(#1292): new option - Budget Offset (days)

### DIFF
--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -188,6 +188,12 @@ wxString mmBudgetingPanel::GetPanelTitle() const
     {
         yearStr = wxString::Format(_("Month: %s"), yearStr);
     }
+
+    if (Option::instance().BudgetDaysOffset() != 0)
+    {
+        yearStr = wxString::Format(_("%s    Start Date of: %s"), yearStr, mmGetDateForDisplay(m_budget_offset_date));
+    }
+
     return wxString::Format(_("Budget Setup for %s"), yearStr);
 }
 
@@ -391,7 +397,13 @@ void mmBudgetingPanel::initVirtualListControl()
         budgetDetails.AdjustYearValues(day, month, dtBegin);
         budgetDetails.AdjustDateForEndFinancialYear(dtEnd);
     }
+
+    // Readjust dates by the Budget Offset Option
+    Option::instance().BudgetDateOffset(dtBegin);
+    m_budget_offset_date = dtBegin.FormatISODate();
+    Option::instance().BudgetDateOffset(dtEnd);
     mmSpecifiedRange date_range(dtBegin, dtEnd);
+
     //Get statistics
     Model_Budget::instance().getBudgetEntry(budgetYearID_, budgetPeriod_, budgetAmt_);
     Model_Category::instance().getCategoryStats(categoryStats_

--- a/src/budgetingpanel.h
+++ b/src/budgetingpanel.h
@@ -102,6 +102,8 @@ private:
     budgetingListCtrl* listCtrlBudget_;
     wxString currentView_;
     int budgetYearID_;
+    wxString m_budget_offset_date;
+
     wxImageList* m_imageList;
     wxStaticText* budgetReportHeading_;
     wxStaticText* income_estimated_;

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
+ Copyright (C) 2016 - 2017 Stefano Giorgio [stef145g]
  Copyright (C) 2017 James Higley
 
  This program is free software; you can redistribute it and/or modify
@@ -148,6 +149,7 @@ void Option::LoadOptions(bool include_infotable)
         m_userNameString = Model_Infotable::instance().GetStringInfo("USERNAME", "");
         m_financialYearStartDayString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_DAY", "1");
         m_financialYearStartMonthString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_MONTH", "7");
+        m_budget_days_offset = Model_Infotable::instance().GetIntInfo("BUDGET_DAYS_OFFSET", 0);
         m_sharePrecision = Model_Infotable::instance().GetIntInfo("SHARE_PRECISION", 4);
         m_baseCurrency = Model_Infotable::instance().GetIntInfo("BASECURRENCYID", -1);
         // Ensure that base currency is set for the database.
@@ -180,7 +182,13 @@ void Option::LoadOptions(bool include_infotable)
     m_transDateDefault = Model_Setting::instance().GetIntSetting("TRANSACTION_DATE_DEFAULT", 0);
     m_usageStatistics = Model_Setting::instance().GetBoolSetting(INIDB_SEND_USAGE_STATS, true);
 
-    m_html_font_size = Model_Setting::instance().GetIntSetting("HTMLSCALE", 100);
+    // Windows problem on high res screens Ref Issue #478
+    int default_font_size = 100;
+#ifdef _WINDOWS
+    default_font_size = 116;
+#endif
+
+    m_html_font_size = Model_Setting::instance().GetIntSetting("HTMLSCALE", default_font_size);
     m_ico_size = 16;
     if (m_html_font_size >= 300)
     {
@@ -345,7 +353,6 @@ bool Option::IgnoreFutureTransactions()
     return m_ignoreFutureTransactions;
 }
 
-
 void Option::TransPayeeSelection(int value)
 {
     Model_Setting::instance().Set("TRANSACTION_PAYEE_NONE", value);
@@ -356,7 +363,6 @@ int Option::TransPayeeSelection()
 {
     return m_transPayeeSelection;
 }
-
 
 void Option::TransCategorySelection(int value)
 {
@@ -422,6 +428,23 @@ void Option::HtmlFontSize(int value)
 int Option::HtmlFontSize()
 {
     return m_html_font_size;
+}
+
+void Option::BudgetDaysOffset(int value)
+{
+    Model_Infotable::instance().Set("BUDGET_DAYS_OFFSET", value);
+    m_budget_days_offset = value;
+}
+
+int Option::BudgetDaysOffset()
+{
+    return m_budget_days_offset;
+}
+
+void Option::BudgetDateOffset(wxDateTime& date)
+{
+    if (m_budget_days_offset != 0)
+        date.Add(wxDateSpan::Days(m_budget_days_offset));
 }
 
 void Option::IconSize(int value)

--- a/src/option.h
+++ b/src/option.h
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
+ Copyright (C) 2016 - 2017 Stefano Giorgio [stef145g]
  Copyright (C) 2017 James Higley
 
  This program is free software; you can redistribute it and/or modify
@@ -108,6 +109,12 @@ public:
     void HtmlFontSize(int value);
     int HtmlFontSize();
 
+    // Allows a year or financial year to start before or after the 1st of the month.
+    void BudgetDaysOffset(int value);
+    int BudgetDaysOffset();
+    /**Re-adjust date by the date offset value*/
+    void BudgetDateOffset(wxDateTime& date);
+
     void IconSize(int value);
     int IconSize();
 
@@ -146,7 +153,7 @@ private:
 
     int m_html_font_size;
     int m_ico_size;
-
+    int m_budget_days_offset;
     int m_hideReport;
     wxArrayPtrVoid m_reports;
 

--- a/src/optionsettingsview.cpp
+++ b/src/optionsettingsview.cpp
@@ -116,35 +116,59 @@ void OptionSettingsView::Create()
     m_scale_factor->SetToolTip(_("Specify which scale factor is used for the report pages"));
     view_sizer1->Add(m_scale_factor, g_flagsH);
 
-    // Budget options
-    m_budget_financial_years = new wxCheckBox(this, wxID_STATIC, _("View Budgets as Financial Years")
+    // Budget Options
+    wxStaticBox* budgetStaticBox = new wxStaticBox(this, wxID_STATIC, _("Budget Options"));
+    SetBoldFont(budgetStaticBox);
+
+    wxStaticBoxSizer* budgetSizer = new wxStaticBoxSizer(budgetStaticBox, wxVERTICAL);
+    viewsPanelSizer->Add(budgetSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
+
+    m_budget_financial_years = new wxCheckBox(this, wxID_STATIC, _("View as Financial Years")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_budget_financial_years->SetValue(Option::instance().BudgetFinancialYears());
-    viewsPanelSizer->Add(m_budget_financial_years, g_flagsV);
+    budgetSizer->Add(m_budget_financial_years, g_flagsV);
 
     m_budget_include_transfers = new wxCheckBox(this, wxID_STATIC
-        , _("View Budgets with 'transfer' transactions")
+        , _("View with 'transfer' transactions")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_budget_include_transfers->SetValue(Option::instance().BudgetIncludeTransfers());
-    viewsPanelSizer->Add(m_budget_include_transfers, g_flagsV);
+    budgetSizer->Add(m_budget_include_transfers, g_flagsV);
 
     m_budget_setup_without_summary = new wxCheckBox(this, wxID_STATIC
-        , _("View Budgets Setup Without Budget Summaries")
+        , _("View Setup Without Budget Summaries")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_budget_setup_without_summary->SetValue(Option::instance().BudgetSetupWithoutSummaries());
-    viewsPanelSizer->Add(m_budget_setup_without_summary, g_flagsV);
+    budgetSizer->Add(m_budget_setup_without_summary, g_flagsV);
 
     m_budget_summary_without_category = new wxCheckBox(this, wxID_STATIC
-        , _("View Budget Category Report with Summaries")
+        , _("View Category Report with Summaries")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_budget_summary_without_category->SetValue(Option::instance().BudgetReportWithSummaries());
-    viewsPanelSizer->Add(m_budget_summary_without_category, g_flagsV);
+    budgetSizer->Add(m_budget_summary_without_category, g_flagsV);
 
+    // Allows a year or financial year to start before or after the 1st of the month.
+    wxBoxSizer* budget_offset_sizer = new wxBoxSizer(wxHORIZONTAL);
+    budgetSizer->Add(budget_offset_sizer);
+
+    budget_offset_sizer->Add(new wxStaticText(this, wxID_STATIC, _("Budget Offset (days):")), g_flagsH);
+    
+    m_budget_days_offset = new wxSpinCtrl(this, wxID_ANY
+        , wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, -30, +30);
+    m_budget_days_offset->SetToolTip(_("Advance or retard the start date from the 1st of the month or year by the number of days"));
+    m_budget_days_offset->SetValue(Option::instance().BudgetDaysOffset());
+    budget_offset_sizer->Add(m_budget_days_offset, g_flagsH);
+
+    // Report Options
+    wxStaticBox* reportStaticBox = new wxStaticBox(this, wxID_STATIC, _("Report Options"));
+    SetBoldFont(reportStaticBox);
+
+    wxStaticBoxSizer* reportSizer = new wxStaticBoxSizer(reportStaticBox, wxVERTICAL);
+    viewsPanelSizer->Add(reportSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
     m_ignore_future_transactions = new wxCheckBox(this, wxID_STATIC
-        , _("View Reports without Future Transactions")
+        , _("View without Future Transactions")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_ignore_future_transactions->SetValue(Option::instance().IgnoreFutureTransactions());
-    viewsPanelSizer->Add(m_ignore_future_transactions, g_flagsV);
+    reportSizer->Add(m_ignore_future_transactions, g_flagsV);
 
     // Colours settings
     wxStaticBox* userColourSettingStBox = new wxStaticBox(this, wxID_ANY, _("User Colors"));
@@ -225,6 +249,7 @@ void OptionSettingsView::SaveSettings()
     Option::instance().BudgetIncludeTransfers(m_budget_include_transfers->GetValue());
     Option::instance().BudgetSetupWithoutSummaries(m_budget_setup_without_summary->GetValue());
     Option::instance().BudgetReportWithSummaries(m_budget_summary_without_category->GetValue());
+    Option::instance().BudgetDaysOffset(m_budget_days_offset->GetValue());
     Option::instance().IgnoreFutureTransactions(m_ignore_future_transactions->GetValue());
 
     mmColors::userDefColor1 = m_UDFCB1->GetForegroundColour();

--- a/src/optionsettingsview.h
+++ b/src/optionsettingsview.h
@@ -62,6 +62,7 @@ private:
     wxCheckBox* m_budget_include_transfers;
     wxCheckBox* m_budget_setup_without_summary;
     wxCheckBox* m_budget_summary_without_category;
+    wxSpinCtrl* m_budget_days_offset;
     wxCheckBox* m_ignore_future_transactions;
 
     enum

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -97,6 +97,9 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     else
         yearEnd.Add(wxDateSpan::Year()).Subtract(wxDateSpan::Day());
 
+    // Readjust dates by the Budget Offset Option
+    Option::instance().BudgetDateOffset(yearBegin);
+    Option::instance().BudgetDateOffset(yearEnd);
     mmSpecifiedRange date_range(yearBegin, yearEnd);
 
     bool evaluateTransfer = false;

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -115,6 +115,9 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     wxDateTime yearEnd = yearBegin;
     yearEnd.Add(wxDateSpan::Year()).Subtract(wxDateSpan::Day());
 
+    // Readjust dates by the Budget Offset Option
+    Option::instance().BudgetDateOffset(yearBegin);
+    Option::instance().BudgetDateOffset(yearEnd);
     mmSpecifiedRange date_range(yearBegin, yearEnd);
 
     bool evaluateTransfer = false;


### PR DESCRIPTION
This option advances or retards the start date from the 1st of the
month or year for a budget by the budget offset in days.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1355)
<!-- Reviewable:end -->
