### PR TITLE
fix(travis): don't build openSUSE Tumbleweed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - OS=fedora DIST=24
   - OS=fedora DIST=25
   - OS=fedora DIST=26
-  - OS=opensuse
+  # - OS=opensuse # see issue #1331 on GitHub
   - OS=opensuse DIST=42.2
   - OS=opensuse DIST=42.3
   - OS=archlinux

--- a/dockers/opensuse/Dockerfile
+++ b/dockers/opensuse/Dockerfile
@@ -2,6 +2,6 @@ FROM opensuse:tumbleweed
 MAINTAINER developers@moneymanagerex.org
 RUN zypper refresh && zypper install -y --no-recommends \
       cmake gettext-tools gcc-c++ git make rpm-build lsb-release \
-      wxWidgets-3_0-devel \
+      wxWidgets-devel \
       automake libtool \
  && zypper clean --all


### PR DESCRIPTION
openSUSE Tumbleweed doesn't have wx webview (no webkitgtk support)
See issue #1331 on GitHub

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1356)
<!-- Reviewable:end -->
