### PR TITLE
clean(#1391): fix function names in PR#1391

### DIFF
--- a/src/maincurrencydialog.h
+++ b/src/maincurrencydialog.h
@@ -24,7 +24,6 @@
 #include <map>
 #include <vector>
 #include <wx/dataview.h>
-#include "constants.h"
 
 class wxDatePickerCtrl;
 class mmTextCtrl;
@@ -122,7 +121,9 @@ private:
     bool m_static_dialog;
 
     std::vector<CurrencyHistoryRate> _BceCurrencyHistoryRatesList;
-    bool HistoryDownloadBce(const wxString& url = mmex::weblink::BceCurrencyHistory);
+    bool HistoryDownloadBce();
+    bool CurrentDownloadBce();
+    bool ParseDownloadedBce(wxString &XmlContent);
     bool ConvertHistoryRates(const std::vector<CurrencyHistoryRate>& Bce, std::vector<CurrencyHistoryRate>& ConvertedRate, const wxString& BaseCurrencySymbol);
 };
 


### PR DESCRIPTION
We shouldn't use *History...* function name while downloading current values...
@lexa2 #1391
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1394)
<!-- Reviewable:end -->

  