### PR TITLE
feat(docker): add support for new Linux Mint releases to fix #1409

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ env:
   - OS=archlinux
   - OS=el DIST=7 # DIST=6 doesn't provide webview in wxGTK3
   - OS=linuxmint DIST=serena
+  - OS=linuxmint DIST=sonya
+  # - OS=linuxmint DIST=sylvia # Docker Hub image not avaiable
   - OS=slackware DIST=14.2 # DIST=14.1 has cmake 2.x
 
 matrix:
@@ -67,6 +69,8 @@ matrix:
   - env: OS=opensuse DIST=42.3
   - env: OS=archlinux
   - env: OS=linuxmint DIST=serena
+  - env: OS=linuxmint DIST=sonya
+  - env: OS=linuxmint DIST=sylvia
   - env: OS=osx DIST=10.10
   - env: OS=osx DIST=10.11
   - env: OS=macos DIST=10.12

--- a/dockers/linuxmint.sonya/Dockerfile
+++ b/dockers/linuxmint.sonya/Dockerfile
@@ -1,0 +1,8 @@
+FROM vcatechnology/linux-mint:18.2
+MAINTAINER developers@moneymanagerex.org
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      cmake build-essential gettext git lsb-release \
+      libwebkitgtk-dev libwxgtk3.0-dev libwxgtk-webview3.0-dev \
+      automake libtool ccache && \
+    apt-get clean

--- a/dockers/linuxmint.sylvia/Dockerfile
+++ b/dockers/linuxmint.sylvia/Dockerfile
@@ -1,0 +1,8 @@
+FROM vcatechnology/linux-mint:18.3
+MAINTAINER developers@moneymanagerex.org
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      cmake build-essential gettext git lsb-release \
+      libwebkitgtk-dev libwxgtk3.0-dev libwxgtk-webview3.0-dev \
+      automake libtool ccache && \
+    apt-get clean


### PR DESCRIPTION
Mint 18.3 is prepared but not build because Docker Hub image is not available so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1416)
<!-- Reviewable:end -->
