### PR TITLE
fix(appveyor): skip CMake patches already applied in AppVeyor env

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,7 +95,7 @@ install:
 - clcache -s
 # Patch CMake
 - for /d %%d in ("%ProgramFiles(x86)%\CMake\share\cmake-*") do (
-    type util\F*.cmake-*.patch 2>nul | patch -Nf -d "%%d\Modules" )
+    type util\FindwxWidgets.cmake-SupportMSVC1911.patch 2>nul | patch -Nf -d "%%d\Modules" )
 # wxWidgets, try to download pre-compiled version first
 - if %wxShared%==1 (
     curl -fsL --fail-early


### PR DESCRIPTION
My CMake patches where included in upstream CMake 3.10 version
used in latest AppVeyor environment.
They are still usable for users using older CMake version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1425)
<!-- Reviewable:end -->
