### PR TITLE
fix(docker): update ubuntu zesty repos after EOL

### DIFF
--- a/dockers/ubuntu.zesty.x86/Dockerfile
+++ b/dockers/ubuntu.zesty.x86/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:zesty
 MAINTAINER developers@moneymanagerex.org
-RUN dpkg --add-architecture i386 && apt-get update && \
+RUN sed -i -re 's/(([a-z]{2}\.)?archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    dpkg --add-architecture i386 && apt-get update && \
     apt-get install -y --no-install-recommends \
       cmake build-essential g++-multilib gettext git pkg-config lsb-release \
       libwxgtk3.0-dev:i386 libwxgtk-webview3.0-dev:i386 \

--- a/dockers/ubuntu.zesty/Dockerfile
+++ b/dockers/ubuntu.zesty/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:zesty
 MAINTAINER developers@moneymanagerex.org
-RUN apt-get update && \
+RUN sed -i -re 's/(([a-z]{2}\.)?archive|security)\.ubuntu\.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       cmake build-essential gettext git pkg-config lsb-release \
       libwxgtk3.0-dev libwxgtk-webview3.0-dev \


### PR DESCRIPTION
Ubuntu moved zesty repos to old-releases as no longer maintained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1428)
<!-- Reviewable:end -->
