### PR TITLE
currency: guard against nullptr in dialog

### DIFF
--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -392,7 +392,8 @@ void mmMainCurrencyDialog::OnListItemSelected(wxDataViewEvent& event)
             currName = currency->CURRENCYNAME;
             itemButtonEdit_->Enable();
         }
-		m_button_download_history->Enable(currency->CURRENCYID != Model_Currency::GetBaseCurrency()->CURRENCYID);
+        auto baseCurrency = Model_Currency::GetBaseCurrency();
+        m_button_download_history->Enable(baseCurrency == nullptr || currency->CURRENCYID != baseCurrency->CURRENCYID);
     }
 
     if (!bEnableSelect_)    // prevent user deleting currencies when editing accounts.


### PR DESCRIPTION
Prevent null dereference when starting a new database

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1450)
<!-- Reviewable:end -->
