### PR TITLE
fix(#1495): ignore locale setting and force C number formatting where…

### DIFF
--- a/src/currencydialog.cpp
+++ b/src/currencydialog.cpp
@@ -320,7 +320,7 @@ void mmCurrencyDialog::OnTextChanged(wxCommandEvent& event)
     wxString dispAmount = "";
     double base_amount = 123456.78;
 
-    dispAmount = wxString::Format(_("%.2f Shown As: %s"), base_amount
+    dispAmount = wxString::Format(_("%s Shown As: %s"), wxString::FromCDouble(base_amount, 2)
         , Model_Currency::toCurrency(base_amount, m_currency));
     m_sample_text->SetLabelText(dispAmount);
 }

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -46,9 +46,9 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
         const auto curr_to = Model_Currency::instance().get(acc_to->CURRENCYID);
 
         categ = "[" + (reverce ? full_tran.ACCOUNTNAME : full_tran.TOACCOUNTNAME) + "]";
-        payee = wxString::Format("%.2f %s %s -> %.2f %s %s"
-            , full_tran.TRANSAMOUNT, curr_in->CURRENCY_SYMBOL, acc_in->ACCOUNTNAME
-            , full_tran.TOTRANSAMOUNT, curr_to->CURRENCY_SYMBOL, acc_to->ACCOUNTNAME);
+        payee = wxString::Format("%s %s %s -> %s %s %s"
+            , wxString::FromCDouble(full_tran.TRANSAMOUNT, 2), curr_in->CURRENCY_SYMBOL, acc_in->ACCOUNTNAME
+            , wxString::FromCDouble(full_tran.TOTRANSAMOUNT, 2), curr_to->CURRENCY_SYMBOL, acc_to->ACCOUNTNAME);
         //Transaction number used to make transaction unique
         // to proper merge transfer records
         if (transNum.IsEmpty() && notes.IsEmpty())
@@ -59,8 +59,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
     buffer << "C" << (full_tran.STATUS == "R" ? "R" : "") << "\n";
     double value = Model_Checking::balance(full_tran
         , (reverce ? full_tran.TOACCOUNTID : full_tran.ACCOUNTID));
-    int style = wxNumberFormatter::Style_None;
-    const wxString& s = wxNumberFormatter::ToString(value, 2, style);
+    const wxString& s = wxString::FromCDouble(value, 2);
     buffer << "T" << s << "\n";
     if (!payee.empty())
         buffer << "P" << payee << "\n";
@@ -80,7 +79,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
         double valueSplit = split_entry.SPLITTRANSAMOUNT;
         if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL)
             valueSplit = -valueSplit;
-        const wxString split_amount = wxNumberFormatter::ToString(valueSplit, 2, style);
+        const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
         const wxString split_categ = Model_Category::full_name(split_entry.CATEGID, split_entry.SUBCATEGID);
         buffer << "S" << split_categ << "\n"
             << "$" << split_amount << "\n";

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -810,9 +810,9 @@ const wxString mmHomePagePanel::displayIncomeVsExpenses()
     json_writer.Key("9");
     json_writer.String(_("Income/Expenses").c_str());
     json_writer.Key("10");
-    json_writer.String(wxString::Format("%.2f", tIncome).c_str());
+    json_writer.String(wxString::FromCDouble(tIncome, 2).c_str());
     json_writer.Key("11");
-    json_writer.String(wxString::Format("%.2f", tExpenses).c_str());
+    json_writer.String(wxString::FromCDouble(tExpenses, 2).c_str());
     json_writer.Key("12");
     json_writer.Int(steps);
     json_writer.Key("13");

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -60,8 +60,8 @@ wxString mmReportForecast::getHTMLText()
     {
         row_t r;
         r(L"DATE") = kv.first;
-        r(L"WITHDRAWAL") = wxString::Format("%f", kv.second.first);
-        r(L"DEPOSIT") = wxString::Format("%f", kv.second.second);
+        r(L"WITHDRAWAL") = wxString::FromCDouble(kv.second.first, 6);
+        r(L"DEPOSIT") = wxString::FromCDouble(kv.second.second, 6);
 
         contents += r;
     }

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -452,11 +452,11 @@ void mmHTMLBuilder::addRadarChart(std::vector<ValueTrio>& actData, std::vector<V
     for (const auto& entry : actData)
     {
         labels += wxString::Format("'%s',", entry.label);
-        actValues += wxString::Format("%.2f,", entry.amount);
+        actValues += wxString::FromCDouble(entry.amount, 2) + ",";
     }
     for (const auto& entry : estData)
     {
-        estValues += wxString::Format("%.2f,", entry.amount);
+        estValues += wxString::FromCDouble(entry.amount, 2) + ",";
     }
 
     wxString datasets = wxString::Format(data_item, _("Actual"), getColor(8), getColor(8), getColor(8), actValues);
@@ -469,7 +469,7 @@ void mmHTMLBuilder::addPieChart(std::vector<ValueTrio>& valueList, const wxStrin
 {
     static const wxString data_item =
         "{\n"
-        "value : %.2f,\n"
+        "value : %s,\n"
         "color : '%s',\n"
         "title : '%s',\n"
         "},\n";
@@ -492,7 +492,7 @@ void mmHTMLBuilder::addPieChart(std::vector<ValueTrio>& valueList, const wxStrin
         label.Replace("'", " ");
 
         data += wxString::Format(data_item
-            , fabs(entry.amount), entry.color
+            , wxString::FromCDouble(fabs(entry.amount), 2), entry.color
             , label );
     }
     this->addText(wxString::Format("<canvas id='%s' width ='%i' height='%i' style='min-width: %dpx; min-height: %dpx'></canvas>\n", id, x, y, x, y));
@@ -531,7 +531,7 @@ void mmHTMLBuilder::addBarChart(const wxString &labels, const std::vector<ValueT
     wxString values = "";
     for (const auto& entry : data)
     {
-        values += wxString::Format(data_item, entry.color, entry.color, wxString::Format("%.2f", entry.amount), entry.label);
+        values += wxString::Format(data_item, entry.color, entry.color, wxString::FromCDouble(entry.amount, 2), entry.label);
         scaleStepWidth = std::max(entry.amount, scaleStepWidth);
     }
     scaleStepWidth = ceil(scaleStepWidth / steps);
@@ -581,7 +581,7 @@ void mmHTMLBuilder::addLineChart(const std::vector<ValueTrio>& data, const wxStr
     for (const auto& entry : data)
     {
         labels += wxString::Format("'%s',", entry.label);
-        values += wxString::Format("%.2f,", entry.amount);
+        values += wxString::FromCDouble(entry.amount, 2) + ",";
     }
 
     wxString datasets = wxString::Format(data_item, "LineChart", getColor(index), getColor(index), getColor(index), values);

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -977,7 +977,7 @@ void mmTransDialog::OnAutoTransNum(wxCommandEvent& /*event*/)
     }
 
     next_number++;
-    textNumber_->SetValue(wxNumberFormatter::ToString(next_number, 0, wxNumberFormatter::Style_None));
+    textNumber_->SetValue(wxString::FromDouble(next_number, 0));
 }
 
 void mmTransDialog::OnAdvanceChecked(wxCommandEvent& /*event*/)


### PR DESCRIPTION
… required

Format/printf "%f" and "%'f" use current locale LC_NUMBER settings.
We must ignore locale settings when exporting data to JavaScript, QIF etc.
This fixes broken from ff8e448 charts in MMEX reports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1509)
<!-- Reviewable:end -->
