### PR TITLE
fix(docker): use lua5.2 for Ubuntu Jessie

### DIFF
--- a/dockers/debian.jessie.x86/Dockerfile
+++ b/dockers/debian.jessie.x86/Dockerfile
@@ -4,6 +4,6 @@ RUN dpkg --add-architecture i386 && apt-get update && \
     apt-get install -y --no-install-recommends \
       cmake build-essential g++-multilib gettext git pkg-config lsb-release file \
       libwxgtk3.0-dev:i386 libwxgtk-webview3.0-dev:i386 \
-      libwxsqlite3-3.0-dev:i386 liblua5.3-dev:i386 libcurl4-openssl-dev:i386 \
+      libwxsqlite3-3.0-dev:i386 liblua5.2-dev:i386 libcurl4-openssl-dev:i386 \
       automake libtool ccache && \
     apt-get clean

--- a/dockers/debian.jessie/Dockerfile
+++ b/dockers/debian.jessie/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       cmake build-essential gettext git pkg-config lsb-release file \
       libwebkitgtk-dev libwxgtk3.0-dev libwxgtk-webview3.0-dev \
-      libwxsqlite3-3.0-dev liblua5.3-dev libcurl4-openssl-dev \
+      libwxsqlite3-3.0-dev liblua5.2-dev libcurl4-openssl-dev \
       automake libtool ccache && \
     apt-get clean


### PR DESCRIPTION
This is fix for #1511. lua5.3 is available only from backports in Jessie

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1518)
<!-- Reviewable:end -->
