### PR TITLE
fix(#1553): update BUILD.md after #1547

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -92,6 +92,8 @@ __All following commands must be run from this command prompt!__
 
        cd "%DevEnvDir%CommonExtensions\Microsoft\CMake\CMake\share\cmake-3.8\Modules"
        for %p in (c:\projects\mmex\util\*.cmake-*.patch) do git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn %p
+       cd Compiler
+       git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn c:\projects\mmex\util\MSVC-C.cmake.patch
 
    See previous step for instructions if git command is not recognized.
 


### PR DESCRIPTION
There is CMake patch for MSVC compiler included in #1547 from upstream
CMake 3.12.0 release and build instructions should be updated as stated in #1553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1554)
<!-- Reviewable:end -->
