### PR TITLE
feat(encryption): autodetect encrypted databases

### DIFF
--- a/src/mmTips.h
+++ b/src/mmTips.h
@@ -23,7 +23,7 @@ static const wxString TIPS [] =
     wxTRANSLATE("Recommendation: If upgrading to a new version of MMEX, make sure you backup your .mmb database file before doing so."),
     wxTRANSLATE("Recommendation: Use copy (Ctrl+C) and paste (Ctrl+V) for frequently used transactions."),
     wxTRANSLATE("Tip: Remember to make backups of your .mmb."),
-    wxTRANSLATE("Tip: The .mmb file is not encrypted. That means anyone else having the proper know how can actually open the file and read the contents. So make sure that if you are storing any sensitive financial information it is properly guarded."),
+    wxTRANSLATE("Tip: The not encrypted .mmb file is insecure. That means anyone else having the proper know how can actually open the file and read the contents. So make sure that if you are storing any sensitive financial information it is properly guarded."),
     wxTRANSLATE("Tip: To mark a transaction as reconciled, just select the transaction and hit the 'r' or 'R' key. To mark a transaction as unreconciled, just select the transaction and hit the 'u' or 'U' key."),
     wxTRANSLATE("Tip: To mark a transaction as requiring followup, just select the transaction and hit the 'f' or 'F' key."),
     wxTRANSLATE("Tip: MMEX supports printing of all reports that can be viewed. The print options are available under the menu, File->Print."),

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -120,9 +120,9 @@ private:
     void resetNavTreeControl();
     void cleanupNavTreeControl(wxTreeItemId& item);
     wxSizer* cleanupHomePanel(bool new_sizer = true);
-    bool openFile(const wxString& fileName, bool openingNew, const wxString &password = wxEmptyString);
+    bool openFile(const wxString& fileName, const bool openingNew, const bool encrypt, const wxString &password = wxEmptyString);
+    bool createDataStore(const wxString& fileName, const bool openingNew, const bool encrypt, const wxString &passwd);
     void InitializeModelTables();
-    bool createDataStore(const wxString& fileName, const wxString &passwd, bool openingNew);
     void createMenu();
     void CreateToolBar();
     void createReportsPage(mmPrintableBase* rb, bool cleanup);
@@ -157,8 +157,8 @@ private:
 
     void OnNew(wxCommandEvent& event);
     void OnOpen(wxCommandEvent& event);
-    void OnConvertEncryptedDB(wxCommandEvent& event);
-    void OnChangeEncryptPassword(wxCommandEvent& event);
+    void OnSetPassword(wxCommandEvent& event);
+    void OnRemovePassword(wxCommandEvent& event);
     void OnVacuumDB(wxCommandEvent& event);
     void OnDebugDB(wxCommandEvent& event);
     void OnSaveAs(wxCommandEvent& event);
@@ -247,7 +247,7 @@ private:
     void OnHideShowReport(wxCommandEvent& event);
 
     /** Sets the database to the new database selected by the user */
-    void SetDatabaseFile(const wxString& dbFileName, bool newDatabase = false, const wxString& password = wxEmptyString);
+    void SetDatabaseFile(const wxString& dbFileName, bool newDatabase = false, bool eencrypt = false, const wxString& password = wxEmptyString);
     
     // Required to prevent memory leaks.
     CommitCallbackHook* m_commit_callback_hook;
@@ -311,8 +311,8 @@ private:
         MENU_VIEW_HIDE_SHARE_ACCOUNTS,
         MENU_CATEGORY_RELOCATION,
         MENU_PAYEE_RELOCATION,
-        MENU_CONVERT_ENC_DB,
-        MENU_CHANGE_ENCRYPT_PASSWORD,
+        MENU_SET_PASSWORD,
+        MENU_REMOVE_PASSWORD,
         MENU_DB_VACUUM,
         MENU_DB_DEBUG,
         MENU_ONLINE_UPD_CURRENCY_RATE,

--- a/src/optionsettingsattachment.cpp
+++ b/src/optionsettingsattachment.cpp
@@ -101,7 +101,7 @@ void OptionSettingsAttachment::Create()
 
     wxString legend = ATTACHMENTS_FOLDER_DOCUMENTS + " -> " + _("User documents directory");
     legend += "\n" + ATTACHMENTS_FOLDER_USERPROFILE + " -> " + _("User profile folder");
-    legend += "\n" + ATTACHMENTS_FOLDER_DATABASE + " -> " + _("Folder of.MMB database file");
+    legend += "\n" + ATTACHMENTS_FOLDER_DATABASE + " -> " + _("Folder of .mmb database file");
     legend += "\n" + ATTACHMENTS_FOLDER_APPDATA + " -> " + _("MMEX Application data folder");
     wxStaticText* legendStaticText = new wxStaticText(this, wxID_STATIC, legend);
     attachmentStaticBoxSizerLegend->Add(legendStaticText);


### PR DESCRIPTION
Use .mmb extension for both encrypted and unencrypted db files
Allow encrypt/decrypt database on-the-fly without need to open/close file and extension change
Autodetect if password is required for file to open

![mmex11](https://user-images.githubusercontent.com/3155552/39016926-278e3ea2-4422-11e8-9793-b3fbb98af333.png)

File->New and File->Save As allow to select between encrypted or not file
but creates .mmb files in both cases
File->Open displays .mmb and .emb in one view and ask for password when required
Tools->Database->Set Password encrypts current database or change password if encrypted already
Tools->Database->Remove Password decrypts current database file

![mmex10](https://user-images.githubusercontent.com/3155552/39016920-232783b4-4422-11e8-95be-408542580369.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1573)
<!-- Reviewable:end -->
