### PR TITLE
clean(mmCalc): remove useless check_syntax()

### DIFF
--- a/src/mmCalculator.cpp
+++ b/src/mmCalculator.cpp
@@ -18,44 +18,29 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "mmCalculator.h"
 #include "LuaGlue/LuaGlue.h"
+#include <wx/log.h>
 
 mmCalculator::mmCalculator()
 {
     output_ = 0;
 }
 
+const double mmCalculator::get_result()
+{
+    return output_;
+}
+
 const bool mmCalculator::is_ok(const wxString& input)
 {
-    bool ok = check_syntax(input);
     LuaGlue state;
     state.open().glue();
     std::string lua_f = "function calc() return " + input.ToStdString() + "; end";
     if(!state.doString(lua_f))
     {
-        printf("err: %s\n", state.lastError().c_str());
+        wxLogDebug("lua calc() err: %s", state.lastError().c_str());
         return false;
     }
 
     this->output_ = state.invokeFunction<double>("calc");
-    return ok;
-}
-
-const bool mmCalculator::check_syntax(const wxString& input) const
-{
-    wxString temp = input;
-    int a = temp.Replace("(", "(");
-    int b = temp.Replace(")", ")");
-    bool ok = (a == b);
-    if (ok && a > 0)
-    {
-        for (size_t i = 0; i < input.Len(); i++)
-        {
-            if (input[i] == '(') a += i;
-            else if (input[i] == ')') b += i;
-            if (i > 0 && input[i] == '(') ok = (ok && (wxString("(+-*/").Contains(input[i-1])));
-            if (i < input.Len()-1 && input[i] == ')') ok = (ok && wxString(")+-*/").Contains(input[i+1]));
-        }
-        ok = (a < b);
-    }
-    return ok;
+    return true;
 }

--- a/src/mmCalculator.h
+++ b/src/mmCalculator.h
@@ -26,13 +26,10 @@ class mmCalculator
 public:
     mmCalculator();
     const virtual bool is_ok(const wxString& input);
-    const virtual double get_result() {return output_;}
-
-protected:
+    const virtual double get_result();
 
 private:
     double output_;
-    const virtual bool check_syntax(const wxString& input) const;
 };
 
 #endif 


### PR DESCRIPTION
See results below:
```
20:41:38: Debug: check_syntax: input = "434", res = 1
20:42:12: Debug: check_syntax: input = "))(((34656345)", res = 1
20:45:38: Debug: check_syntax: input = "*56)+((5647562-)", res = 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1599)
<!-- Reviewable:end -->
