### PR TITLE
Use GitHub Releases API for update checking

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -36,11 +36,11 @@ const wxString mmex::version::generateProgramVersion(int vMajor, int vMinor, int
     if (vAlpha >= 0 || vBeta >= 0 || vRC >= 0)
     {
         if (vAlpha >= 0)
-            suffix = vAlpha < 1 ? "-Alpha" : wxString::Format("-Alpha.%i", vAlpha);
+            suffix += "-alpha" + (vAlpha > 0 ? wxString::Format(".%i", vAlpha) : "");
         if (Beta >= 0)
-            suffix = vBeta < 1 ? "-Beta" : wxString::Format("-Beta.%i", vBeta);
+            suffix += "-beta" + (vBeta < 1 ? wxString::Format(".%i", vBeta) : "");
         if (vRC >= 0)
-            suffix = vRC < 1 ? "-RC" : wxString::Format("-RC.%i", vRC);
+            suffix = "-rc" + (vRC < 1 ? wxString::Format(".%i", vRC) : "");
     }
     return wxString::Format("%i.%i.%i%s", vMajor, vMinor, vPatch, suffix);
 }
@@ -185,10 +185,7 @@ const wxString mmex::weblink::addReferralToURL(const wxString& BaseURL, const wx
 }
 
 const wxString mmex::weblink::WebSite = mmex::weblink::addReferralToURL("http://www.moneymanagerex.org", "Website");
-const wxString mmex::weblink::Update = wxString::Format("http://www.moneymanagerex.org/version.php?Version=%s", mmex::version::string);
-const wxString mmex::weblink::UpdateLinks = wxString::Format("http://www.moneymanagerex.org/version.php?Version=%s&Links=true", mmex::version::string);
-const wxString mmex::weblink::Changelog = wxString::Format("http://www.moneymanagerex.org/version.php?Version=%s&ChangeLog=", mmex::version::string);
-const wxString mmex::weblink::Download = mmex::weblink::addReferralToURL("http://www.moneymanagerex.org/download", "Download");
+const wxString mmex::weblink::Releases = "https://api.github.com/repos/moneymanagerex/moneymanagerex/releases";
 const wxString mmex::weblink::News = mmex::weblink::addReferralToURL("http://www.moneymanagerex.org/news", "News");
 const wxString mmex::weblink::NewsRSS = "http://www.moneymanagerex.org/news?format=feed";
 const wxString mmex::weblink::Forum = mmex::weblink::addReferralToURL("http://forum.moneymanagerex.org", "Forum");

--- a/src/constants.h
+++ b/src/constants.h
@@ -74,10 +74,7 @@ namespace weblink
 {
     const wxString addReferralToURL(const wxString& BaseURL, const wxString& CampSource);
     extern const wxString WebSite;
-    extern const wxString Update;
-    extern const wxString UpdateLinks;
-    extern const wxString Changelog;
-    extern const wxString Download;
+    extern const wxString Releases;
     extern const wxString News;
     extern const wxString NewsRSS;
     extern const wxString Forum;

--- a/src/optionsettingsnet.cpp
+++ b/src/optionsettingsnet.cpp
@@ -29,7 +29,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 wxBEGIN_EVENT_TABLE(OptionSettingsNet, wxPanel)
     EVT_TEXT(ID_DIALOG_OPTIONS_TEXTCTRL_PROXY, OptionSettingsNet::OnProxyChanged)
     EVT_CHECKBOX(ID_DIALOG_OPTIONS_ENABLE_WEBSERVER, OptionSettingsNet::OnEnableWebserverChanged)
-    EVT_CHECKBOX(ID_DIALOG_OPTIONS_UPDATES_CHECK, OptionSettingsNet::OnUpdateCheckChanged)
     EVT_BUTTON(ID_DIALOG_OPTIONS_BUTTON_WEBAPP_TEST, OptionSettingsNet::OnWebAppTest)
 wxEND_EVENT_TABLE()
 /*******************************************************/
@@ -169,13 +168,13 @@ void OptionSettingsNet::Create()
     timeoutStaticBoxSizer->Add(flex_sizer5, g_flagsV);
 
     //Updates check
-    wxStaticBox* updateStaticBox = new wxStaticBox(this, wxID_STATIC, _("Updates"));
+    wxStaticBox* updateStaticBox = new wxStaticBox(this, wxID_STATIC, _("Check for Updates"));
     SetBoldFont(updateStaticBox);
     wxStaticBoxSizer* updateStaticBoxSizer = new wxStaticBoxSizer(updateStaticBox, wxVERTICAL);
     networkPanelSizer->Add(updateStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
 
     m_check_update = new wxCheckBox(this, ID_DIALOG_OPTIONS_UPDATES_CHECK
-        , _("Check for updates at StartUp"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+        , _("Check at StartUp"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_check_update->SetValue(GetIniDatabaseCheckboxValue("UPDATECHECK", true));
     m_check_update->SetToolTip(_("Enable to automatically check if new MMEX version is available at StartUp"));
 
@@ -185,17 +184,17 @@ void OptionSettingsNet::Create()
     m_update_source = new wxChoice(this, wxID_ANY
         , wxDefaultPosition, wxSize(150, -1), UpdatesType_);
     m_update_source->SetSelection(Model_Setting::instance().GetIntSetting("UPDATESOURCE", 0));
-    m_update_source->SetToolTip(_("Updates source"));
+    m_update_source->SetToolTip(_("Select updates source channel"));
 
-    wxFlexGridSizer* UpdateSourceStaticBoxSizerGrid = new wxFlexGridSizer(0, 2, 0, 0);
-    UpdateSourceStaticBoxSizerGrid->Add(m_check_update, g_flagsH);
+    wxFlexGridSizer* UpdateSourceStaticBoxSizerGrid = new wxFlexGridSizer(0, 3, 0, 0);
+    UpdateSourceStaticBoxSizerGrid->Add(new wxStaticText(this, wxID_STATIC, _("Select preferred version:")), g_flagsH);
     UpdateSourceStaticBoxSizerGrid->Add(m_update_source, g_flagsH);
+    UpdateSourceStaticBoxSizerGrid->Add(m_check_update, g_flagsH);
     updateStaticBoxSizer->Add(UpdateSourceStaticBoxSizerGrid, wxSizerFlags(g_flagsExpand).Proportion(0));
 
     wxCommandEvent evt;
     OptionSettingsNet::OnProxyChanged(evt);
     OptionSettingsNet::OnEnableWebserverChanged(evt);
-    OptionSettingsNet::OnUpdateCheckChanged(evt);
     SetSizer(networkPanelSizer);
 }
 
@@ -207,11 +206,6 @@ void OptionSettingsNet::OnProxyChanged(wxCommandEvent& event)
 void OptionSettingsNet::OnEnableWebserverChanged(wxCommandEvent& event)
 {
     m_webserver_port->Enable(m_webserver_checkbox->GetValue());
-}
-
-void OptionSettingsNet::OnUpdateCheckChanged(wxCommandEvent& event)
-{
-    m_update_source->Enable(m_check_update->GetValue());
 }
 
 void OptionSettingsNet::OnWebAppTest(wxCommandEvent& /*event*/)

--- a/src/optionsettingsnet.h
+++ b/src/optionsettingsnet.h
@@ -45,7 +45,6 @@ private:
     void Create();
 
     void OnProxyChanged(wxCommandEvent& event);
-    void OnUpdateCheckChanged(wxCommandEvent& event);
     void OnEnableWebserverChanged(wxCommandEvent& event);
 
     void OnWebAppTest(wxCommandEvent& event);

--- a/src/wizard_update.h
+++ b/src/wizard_update.h
@@ -40,6 +40,7 @@ public:
 private:
     wxWizardPageSimple* page1;
     void PageChanged(wxWizardEvent& /*event*/);
+    void LinkClicked(wxHtmlLinkEvent& /*event*/);
 
     wxDECLARE_EVENT_TABLE();
 };

--- a/src/wizard_update.h
+++ b/src/wizard_update.h
@@ -19,6 +19,7 @@
 
 #include <wx/wizard.h>
 #include <wx/frame.h>
+#include "rapidjson/document.h"
 #include "option.h"
 
 class mmUpdate
@@ -26,17 +27,15 @@ class mmUpdate
 public:
     static void checkUpdates(const bool bSilent, wxFrame *frame);
 
-private:
-    static const bool IsUpdateAvailable(const bool bSilent, wxString& new_version);
 };
 
 class mmUpdateWizard : public wxWizard
 {
 public:
-    mmUpdateWizard(wxFrame *frame, const wxString& new_version);
+    mmUpdateWizard(wxFrame *frame, const rapidjson::Value& new_version);
     void RunIt(bool modal);
 
-    wxString m_new_version;
+    const rapidjson::Value& m_new_version;
 
 private:
     wxWizardPageSimple* page1;


### PR DESCRIPTION
This implements #1278
Manually prepare update records for website is no longer required.
Latest release description from GitHub is presented to user.

![mmex2](https://user-images.githubusercontent.com/3155552/39692704-e59fd28a-51e1-11e8-8474-1f36bc6fa353.png)

![mmex1](https://user-images.githubusercontent.com/3155552/39692698-e12ce4b8-51e1-11e8-818d-af06753fb91a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1640)
<!-- Reviewable:end -->
