### PR TITLE
fix(cashflow): fix SEGFAULT in cashflow report

### DIFF
--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -121,9 +121,6 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
         if (!isAccountFound && !isToAccountFound)
             continue; // skip account
 
-        const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(entry.ACCOUNTID)->CURRENCYID, entry.TRANSDATE);
-        const double toConvRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(entry.TOACCOUNTID)->CURRENCYID, entry.TRANSDATE);
-
         // Process all possible recurring transactions for this BD
         while (1)
         {
@@ -133,6 +130,7 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
             mmRepeatForecast rf;
             rf.date = nextOccurDate;
             rf.amount = 0.0;
+            const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(entry.ACCOUNTID)->CURRENCYID, rf.date);
 
             switch (Model_Billsdeposits::type(entry))
             {
@@ -146,7 +144,10 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
                 if (isAccountFound)
                     rf.amount -= amt * convRate;
                 if (isToAccountFound)
+                {
+                    const double toConvRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(entry.TOACCOUNTID)->CURRENCYID, rf.date);
                     rf.amount += toAmt * toConvRate;
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
Cash flow report crashes if recurring transaction different then transfer is defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1682)
<!-- Reviewable:end -->
