### PR TITLE
fix(webapp.#935): use libcurl to send POST data so that HTTPS can be suppo…

### DIFF
--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -871,7 +871,7 @@ bool mmMainCurrencyDialog::GetOnlineHistory(std::map<wxDateTime, double> &histor
         , "5y", "1d"); //TODO: ask range and interval
 
     wxString json_data;
-    auto err_code = site_content(URL, json_data);
+    auto err_code = http_get_data(URL, json_data);
     if (err_code != CURLE_OK)
     {
         msg = json_data;

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -178,6 +178,9 @@ bool OnInitImpl(mmGUIApp* app)
     Model_Report::prepareTempFolder();
     Model_Report::WindowsUpdateRegistry();
 
+    /* Initialize CURL */
+    curl_global_init(CURL_GLOBAL_ALL);
+
     /* Initialize Image Handlers */
     wxInitAllImageHandlers();
 
@@ -288,6 +291,9 @@ int mmGUIApp::OnExit()
     if (m_setting_db) delete m_setting_db;
 
     Mongoose_Service::instance().stop();
+
+    /* CURL Cleanup */
+    curl_global_cleanup();
 
     //Delete mmex temp folder for current user
     wxFileName::Rmdir(mmex::getTempFolder(), wxPATH_RMDIR_RECURSIVE);

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -726,7 +726,7 @@ void mmStockDialog::OnHistoryDownloadButton(wxCommandEvent& /*event*/)
 		, m_stock->SYMBOL, range, interval);
 
     wxString json_data, sOutput;
-    auto err_code = site_content(URL, json_data);
+    auto err_code = http_get_data(URL, json_data);
     if (err_code != CURLE_OK)
     {
         if (sOutput == wxEmptyString) sOutput = _("Stock history not found!"); //TODO: ?

--- a/src/util.h
+++ b/src/util.h
@@ -151,8 +151,9 @@ bool get_crypto_currency_prices(std::vector<wxString>& symbols, double& usd_rate
     , wxString& output);
 
 const bool getNewsRSS(std::vector<WebsiteNews>& WebsiteNewsList);
-CURLcode site_content(const wxString& site, wxString& output);
-bool download_file(const wxString& site, const wxString& path);
+CURLcode http_get_data(const wxString& site, wxString& output);
+CURLcode http_post_data(const wxString& site, const wxString& data, const wxString& contentType, wxString& output);
+CURLcode http_download_file(const wxString& site, const wxString& path);
 const wxString getURL(const wxString& file);
 
 const wxString mmPlatformType();

--- a/src/wizard_update.cpp
+++ b/src/wizard_update.cpp
@@ -140,7 +140,7 @@ mmUpdateWizardPage2::mmUpdateWizardPage2(mmUpdateWizard* parent)
     : wxWizardPageSimple(parent)
 {
     wxString json_links, installer_type;
-    site_content(mmex::weblink::UpdateLinks, json_links);
+    http_get_data(mmex::weblink::UpdateLinks, json_links);
 
     Document json_doc;
     if (json_doc.Parse(json_links.c_str()).HasParseError())
@@ -328,7 +328,7 @@ struct Version
 void mmUpdate::checkUpdates(const bool bSilent, wxFrame *frame)
 {
     wxString resp;
-    CURLcode err_code = site_content(mmex::weblink::Releases, resp);
+    CURLcode err_code = http_get_data(mmex::weblink::Releases, resp);
     if (err_code != CURLE_OK)
     {
         if (!bSilent)


### PR DESCRIPTION
Remove the code that silently replaces `https://` with `http://`
Use libcurl (which supports SSL natively) to send the POST data

This finally resolves #935, which was closed some time ago despite not being fully fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1755)
<!-- Reviewable:end -->
