### PR TITLE
Enhancement: change exit hotkey to Ctrl-Q on Linux

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1492,13 +1492,7 @@ void mmGUIFrame::createMenu()
     menu_file->Append(menuItemPrint);
 
     menu_file->AppendSeparator();
-#ifdef __LINUX__
-    wxMenuItem* menuItemQuit = new wxMenuItem(menu_file, wxID_EXIT,
-        _("E&xit\tCtrl-Q"), _("Quit this program"));
-#else
-    wxMenuItem* menuItemQuit = new wxMenuItem(menu_file, wxID_EXIT,
-        _("E&xit\tAlt-X"), _("Quit this program"));
-#endif
+    wxMenuItem* menuItemQuit = new wxMenuItem(menu_file, wxID_EXIT);
     menuItemQuit->SetBitmap(mmBitmap(png::EXIT));
     menu_file->Append(menuItemQuit);
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1492,9 +1492,13 @@ void mmGUIFrame::createMenu()
     menu_file->Append(menuItemPrint);
 
     menu_file->AppendSeparator();
-
+#ifdef __LINUX__
+    wxMenuItem* menuItemQuit = new wxMenuItem(menu_file, wxID_EXIT,
+        _("E&xit\tCtrl-Q"), _("Quit this program"));
+#else
     wxMenuItem* menuItemQuit = new wxMenuItem(menu_file, wxID_EXIT,
         _("E&xit\tAlt-X"), _("Quit this program"));
+#endif
     menuItemQuit->SetBitmap(mmBitmap(png::EXIT));
     menu_file->Append(menuItemQuit);
 


### PR DESCRIPTION
All GNU/Linux software I know (except maybe for EagleCAD) use Ctrl-Q as "Exit" hotkey. Having Alt-X in mmex renders the function keyless for anyone who's used to typical key combination

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1765)
<!-- Reviewable:end -->
