### PR TITLE
fix(cashflow): don't crash on an account without transactions

### DIFF
--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -70,8 +70,10 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
             if (wxNOT_FOUND == accountArray_->Index(account.ACCOUNTNAME)) continue;
         }
 
-        // Use account first transaction date for initial balance
         const auto transactions = Model_Account::transaction(account);
+        if (transactions.empty()) continue;
+        
+        // Use account first transaction date for initial balance
         const double convRate = Model_CurrencyHistory::getDayRate(account.CURRENCYID, transactions[0].TRANSDATE);
         tInitialBalance += account.INITIALBAL * convRate;
 


### PR DESCRIPTION
This fixes bug from #1644

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1781)
<!-- Reviewable:end -->
