### PR TITLE
fix(appveyor): AppVeyor environment upgrade

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -103,10 +103,6 @@ install:
 - copy clcache\clcache-%clcVer%\clcache.exe clcache\clcache-%clcVer%\cl.exe
 - if exist %APPVEYOR_BUILD_FOLDER%\clcache\clcache-%clcVer%\cl.exe set "PATH=%APPVEYOR_BUILD_FOLDER%\clcache\clcache-%clcVer%;%PATH%"
 - clcache -s
-# Patch CMake
-- for /d %%d in ("%ProgramFiles(x86)%\CMake\share\cmake-*") do (
-    type util\FindwxWidgets.cmake-SupportMSVC1911.patch 2>nul | patch -Nf -d "%%d\Modules"
-  )
 # wxWidgets, try to download pre-compiled version first
 - if %wxShared%==1 (
     curl -fsL --fail-early


### PR DESCRIPTION
AppVeyor uses latest CMake 3.12.1 now: https://www.appveyor.com/updates/2018/08/29/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1790)
<!-- Reviewable:end -->
