### PR TITLE
fix(checkUpdates): workaround for GitHub API rate limit exceeded error

### DIFF
--- a/src/wizard_update.cpp
+++ b/src/wizard_update.cpp
@@ -344,12 +344,14 @@ void mmUpdate::checkUpdates(const bool bSilent, wxFrame *frame)
 
     Document json_releases;
     ParseResult res = json_releases.Parse(resp.c_str());
-    if (!res)
+    if (!res || !json_releases.IsArray())
     {
         if (!bSilent)
         {
             const wxString& msgStr = _("Unable to check for updates!")
-                + "\n\n" + _("Error: ") + GetParseError_En(res.Code());
+                + "\n\n" + _("Error: ")
+                + ((!res) ? GetParseError_En(res.Code())
+                          : json_releases.GetString());
             wxMessageBox(msgStr, _("MMEX Update Check"));
         }
         return;


### PR DESCRIPTION
There will be error response returned from GitHub Releases API:
> HTTP/1.1 403 Forbidden
> Date: Tue, 20 Aug 2013 14:50:41 GMT
> Status: 403 Forbidden
> X-RateLimit-Limit: 60
> X-RateLimit-Remaining: 0
> X-RateLimit-Reset: 1377013266
> {
>    "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
>    "documentation_url": "https://developer.github.com/v3/#rate-limiting"
> }

if user check for MMEX updates more then 60 requests per hour. This brakes current implementation expecting array of releases in JSON response.

It will be detected and handled now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1840)
<!-- Reviewable:end -->
