### PR TITLE
fix(#1942 comment): disable select button in organising categories dialog

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2394,7 +2394,7 @@ void mmGUIFrame::refreshPanelData()
 
 void mmGUIFrame::OnOrgCategories(wxCommandEvent& WXUNUSED(event))
 {
-    mmCategDialog dlg(this, -1, false);
+    mmCategDialog dlg(this, -1, -1, true, false);
     dlg.ShowModal();
     if (dlg.getRefreshRequested())
     {


### PR DESCRIPTION
Fixes the issue mentioned in [this comment](https://github.com/moneymanagerex/moneymanagerex/issues/1942#issuecomment-459982369) on #1942. I noticed this behaviour while investigating the other issue and meant to investigate and fix it too. Seems to have broken in a refactor in 2c475bf6, I have checked all other uses of this constructor and they were all either dealt with in the refactor or added later so I believe this was the only break as a result of the change in parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/1977)
<!-- Reviewable:end -->
