### PR TITLE
style(lang_menu): use pure UTF-8 for flag icons

### DIFF
--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Money Manager Ex-Benutzerhandbuch</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Money Manager Ex User Manual</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/es/index.html
+++ b/docs/es/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Manual de usuario de Money Manager Ex</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Manuel de l’utilisateur de Money Manager Ex</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/hu/index.html
+++ b/docs/hu/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Money Manager Ex felhasználói kézikönyv</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/it/index.html
+++ b/docs/it/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Manuale Utente di Money Manager Ex</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/js/lang_menu.js
+++ b/docs/js/lang_menu.js
@@ -6,14 +6,14 @@
 
 function generateLangMenu(nav) {
     var list = [
-        { id: "en", flag: "gb", lang: "English"   },
-        { id: "de", flag: "de", lang: "German"    },
-        { id: "fr", flag: "fr", lang: "French"    },
-        { id: "hu", flag: "hu", lang: "Hungarian" },
-        { id: "it", flag: "it", lang: "Italian"   },
-        { id: "pl", flag: "pl", lang: "Polish"    },
-        { id: "ru", flag: "ru", lang: "Russian"   },
-        { id: "es", flag: "es", lang: "Spanish"   }
+        { id: "en", flag: "🇬🇧", lang: "English"   },
+        { id: "de", flag: "🇩🇪", lang: "German"    },
+        { id: "fr", flag: "🇫🇷", lang: "French"    },
+        { id: "hu", flag: "🇭🇺", lang: "Hungarian" },
+        { id: "it", flag: "🇮🇹", lang: "Italian"   },
+        { id: "pl", flag: "🇵🇱", lang: "Polish"    },
+        { id: "ru", flag: "🇷🇺", lang: "Russian"   },
+        { id: "es", flag: "🇪🇸", lang: "Spanish"   }
     ];
     var docLang = document.getElementsByTagName("html")[0].lang;
     nav = nav.appendChild(document.createElement("small"));
@@ -25,9 +25,10 @@ function generateLangMenu(nav) {
         } else
             a = nav;
         var f = document.createElement("span");
-        f.setAttribute("class", "flag-icon flag-icon-" + d.flag);
+        f.setAttribute("class", "flag-icon");
+        f.appendChild(document.createTextNode(d.flag));
         a.appendChild(f);
-        a.appendChild(document.createTextNode(" " + d.lang));
+        a.appendChild(document.createTextNode(d.lang));
         if (d.id !== docLang)
             nav.appendChild(a);
         nav.appendChild(document.createTextNode(" "));

--- a/docs/manual.css
+++ b/docs/manual.css
@@ -27,6 +27,11 @@ table {
 th, td { padding: 3px 10px; }
 
 .shadow { box-shadow: 8px 8px 10px #aaa; }
+#language-menu .flag-icon {
+    font-size: 1.3em;
+    margin-right: 0.3ex;
+    margin-left: 0.5ex;
+}
 
 /* Back to top button */
 #back-to-top:hover { text-decoration: none; }
@@ -131,6 +136,7 @@ aside.sticky {
     -webkit-box-shadow: 5px 5px 7px rgba(33,33,33,.7);
     /* Opera */
     box-shadow: 5px 5px 7px rgba(33,33,33,.7);
+    transform: rotate(var(--rotation-angle));
     -ms-transform: rotate(var(--rotation-angle));
     -webkit-transform: rotate(var(--rotation-angle));
     -o-transform: rotate(var(--rotation-angle));

--- a/docs/pl/index.html
+++ b/docs/pl/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Podręcznik użytkownika Money Manager Ex</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Руководство пользователя Money Manager Ex</title>
     <link href="../manual.css" rel="stylesheet" type="text/css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet" type="text/css">
     <script src="../js/toc.js"></script>
     <script src="../js/lang_menu.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>


### PR DESCRIPTION
Removes external `flag-icon.min.css` from user manual pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2095)
<!-- Reviewable:end -->
