### PR TITLE
Remove compiler warnings for VC2013

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,9 +14,21 @@ else()
     add_compile_options("-Wall" "-Wextra" "-Wno-unknown-pragmas")
 endif()
 
-# use UTF-8 for /source-charset and /execution-charset
-add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+if(MSVC)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(/utf-8 MSVC_UFT8_CXX_FLAG)
+    if(MSVC_UFT8_CXX_FLAG)
+        # use UTF-8 for /source-charset and /execution-charset
+        add_compile_options(/utf-8)
+    else()
+        # use old pragma execution_character_set
+        file(GENERATE
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/msvc_build_header_$<CONFIG>.h
+            CONTENT "#pragma execution_character_set(\"utf-8\")"
+        )
+        add_compile_options(/FI"${CMAKE_CURRENT_BINARY_DIR}/msvc_build_header_$<CONFIG>.h")
+    endif()
+endif()
 
 # Pass version numbers to the sources
 configure_file(versions.h.in versions.h @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,6 +298,10 @@ add_executable(${MMEX_EXE} WIN32 MACOSX_BUNDLE
     "${MACOSX_APP_ICON_FILE}"
     "${MMEX_RC}")
 
+if(MSVC AND MSVC_VERSION LESS 1800)
+    message(SEND_ERROR "MSVC version too old. Please use VS2013 (12.0) or later for required C++11 features.")
+endif()
+
 if(";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_std_11;")
     target_compile_features(${MMEX_EXE} PUBLIC cxx_std_11)
 elseif(";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_range_for;"


### PR DESCRIPTION
`#pragma execution_character_set("utf-8")` is added in-the-fly to all MMEX sources when compiled with VS2013. VS2015 and later uses `/utf-8` compiler option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2113)
<!-- Reviewable:end -->
