### PR TITLE
Replace C old-style casts with C++ casting operators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,14 +117,14 @@ install: |-
   case $TRAVIS_OS_NAME in
     linux)
       DOCKER=moneymanagerex/mmex_build_env:$OS${DIST:+.$DIST}${ARCH:+.$ARCH}
-      ccache -s || true
+      ccache -cs || true
       docker pull ${DOCKER}
       docker build dockers/$OS${DIST:+.$DIST}${ARCH:+.$ARCH} --cache-from ${DOCKER} -t ${DOCKER}
       ;;
     osx)
       export MACOSX_DEPLOYMENT_TARGET=$DIST
       brew update && brew bundle --verbose --file=util/Brewfile
-      ccache -s && export PATH="/usr/local/opt/ccache/libexec:$PATH"
+      ccache -cs && export PATH="/usr/local/opt/ccache/libexec:$PATH"
       cd $HOME
       curl -fsSL -O https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.2/wxWidgets-3.1.2.tar.bz2
       tar xzf wxWidgets-*.tar.bz2
@@ -169,7 +169,7 @@ notifications: # set notification options
     on_failure: always
 
 after_success:
-- ccache -s || true
+- ccache -cs || true
 # Rename mac packages
 - if [ $TRAVIS_OS_NAME = osx ]; then
     for p in *.dmg; do mv -v $p ${p%Darwin.*}$OS.dmg; done; fi

--- a/dockers/opensuse.42.1/Dockerfile
+++ b/dockers/opensuse.42.1/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="developers@moneymanagerex.org"
 RUN zypper install -y --no-recommends \
       ccache \
       cmake \
-      gcc-c++ \
+      gcc5-c++ \
       gettext-tools \
       git \
       libcurl-devel \
@@ -11,6 +11,8 @@ RUN zypper install -y --no-recommends \
       make \
       rpm-build \
       wxWidgets-3_0-devel \
- && zypper clean --all
+ && zypper clean --all \
+ && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-5 50 \
+ && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-5 50
 
 ENV MMEX_INST_CMD zypper --no-refresh --no-gpg-checks install -y ./mmex-*.rpm

--- a/dockers/opensuse.42.2/Dockerfile
+++ b/dockers/opensuse.42.2/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="developers@moneymanagerex.org"
 RUN zypper install -y --no-recommends \
       ccache \
       cmake \
-      gcc-c++ \
+      gcc6-c++ \
       gettext-tools \
       git \
       libcurl-devel \
@@ -12,6 +12,8 @@ RUN zypper install -y --no-recommends \
       make \
       rpm-build \
       wxWidgets-3_0-devel \
- && zypper clean --all
+ && zypper clean --all \
+ && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 50 \
+ && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-6 50
 
 ENV MMEX_INST_CMD zypper --no-refresh --no-gpg-checks install -y ./mmex-*.rpm

--- a/dockers/opensuse.42.3/Dockerfile
+++ b/dockers/opensuse.42.3/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="developers@moneymanagerex.org"
 RUN zypper install -y --no-recommends \
       ccache \
       cmake \
-      gcc-c++ \
+      gcc8-c++ \
       gettext-tools \
       git \
       libcurl-devel \
@@ -11,6 +11,8 @@ RUN zypper install -y --no-recommends \
       make \
       rpm-build \
       wxWidgets-3_0-devel \
- && zypper clean --all
+ && zypper clean --all \
+ && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 50 \
+ && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 50
 
 ENV MMEX_INST_CMD zypper --no-refresh --no-gpg-checks install -y ./mmex-*.rpm

--- a/dockers/ubuntu.disco.armhf/Dockerfile
+++ b/dockers/ubuntu.disco.armhf/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:disco
 LABEL maintainer="developers@moneymanagerex.org"
 RUN dpkg --add-architecture armhf \
- && sed -ri 's#deb( http://([a-z]{2}\.)?archive|security)#deb [arch=i386,amd64]\1#' /etc/apt/sources.list \
+ && sed -ri 's#deb( http://([a-z]{2}\.)?(archive|security))#deb [arch=i386,amd64]\1#' /etc/apt/sources.list \
  && echo 'deb [arch=armhf] http://ports.ubuntu.com/ disco main universe' >> /etc/apt/sources.list \
  && apt-get update && apt-get install -y --no-install-recommends \
       ccache \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@ if(NOT m_hasParent)
 endif()
 unset(m_hasParent)
 
+include(CheckCXXCompilerFlag)
+
 # enable warnings while compile sources in src
 if(MSVC)
     string(REGEX REPLACE "(^| )[/-](w|W[0-4])( |$)" " " CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
@@ -11,11 +13,23 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 else()
-    add_compile_options("-Wall" "-Wextra" "-Wno-unknown-pragmas")
+    check_cxx_compiler_flag(-Wduplicated-cond Wduplicated-cond)
+    check_cxx_compiler_flag(-Wduplicated-branches Wduplicated-branches)
+    check_cxx_compiler_flag(-Wnull-dereference Wnull-dereference)
+    check_cxx_compiler_flag(-Wlogical-op Wlogical-op)
+    add_compile_options(-Wall -Wextra -Wno-unknown-pragmas -Wformat=2
+        $<$<BOOL:${Wduplicated-cond}>:-Wduplicated-cond>
+        $<$<BOOL:${Wduplicated-branches}>:-Wduplicated-branches>
+        $<$<BOOL:${Wnull-dereference}>:-Wnull-dereference>
+        $<$<BOOL:${Wlogical-op}>:-Wlogical-op>)
+    if(NOT (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6))
+        check_cxx_compiler_flag(-Wuseless-cast Wuseless-cast)
+        add_compile_options(-Werror=old-style-cast
+            $<$<BOOL:${Wuseless-cast}>:-Werror=useless-cast>)
+    endif()
 endif()
 
 if(MSVC)
-    include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag(/utf-8 MSVC_UFT8_CXX_FLAG)
     if(MSVC_UFT8_CXX_FLAG)
         # use UTF-8 for /source-charset and /execution-charset
@@ -322,7 +336,6 @@ elseif(";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_range_for;"
     target_compile_features(${MMEX_EXE} PUBLIC
         cxx_range_for cxx_nullptr cxx_variadic_templates)
 else()
-    include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=gnu++11" COMPILER_SUPPORTS_GXX11)
     CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
     CHECK_CXX_COMPILER_FLAG("-std=gnu++0x" COMPILER_SUPPORTS_GXX0X)

--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -123,33 +123,33 @@ void mmNewAcctDialog::fillControls()
 
     m_textAccountName->SetValue(m_account->ACCOUNTNAME);
 
-    wxTextCtrl* textCtrl = (wxTextCtrl*)FindWindow(ID_ACCTNUMBER);
+    wxTextCtrl* textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_ACCTNUMBER));
     textCtrl->SetValue(m_account->ACCOUNTNUM);
 
-    textCtrl = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_HELDAT);
+    textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_HELDAT));
     textCtrl->SetValue(m_account->HELDAT);
 
-    textCtrl = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_WEBSITE);
+    textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_WEBSITE));
     textCtrl->SetValue(m_account->WEBSITE);
 
-    textCtrl = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_CONTACT);
+    textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_CONTACT));
     textCtrl->SetValue(m_account->CONTACTINFO);
 
-    textCtrl = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_NOTES);
+    textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_NOTES));
     textCtrl->SetValue(m_account->NOTES);
 
-    wxChoice* itemAcctType = (wxChoice*)FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTTYPE);
+    wxChoice* itemAcctType = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTTYPE));
     itemAcctType->SetStringSelection(wxGetTranslation(m_account->ACCOUNTTYPE));
     itemAcctType->Enable(false);
 
-    wxChoice* choice = (wxChoice*)FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS);
+    wxChoice* choice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS));
     choice->SetSelection(Model_Account::status(m_account));
 
-    wxCheckBox* itemCheckBox = (wxCheckBox*)FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT);
+    wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT));
     itemCheckBox->SetValue(Model_Account::FAVORITEACCT(m_account));
 
     Model_Account::currency(m_account);
-    wxButton* bn = (wxButton*)FindWindow(ID_DIALOG_NEWACCT_BUTTON_CURRENCY);
+    wxButton* bn = static_cast<wxButton*>(FindWindow(ID_DIALOG_NEWACCT_BUTTON_CURRENCY));
     bn->SetLabelText(wxGetTranslation(Model_Account::currency(m_account)->CURRENCYNAME));
     m_currencyID = m_account->CURRENCYID;
 
@@ -251,7 +251,7 @@ void mmNewAcctDialog::CreateControls()
     notes_tab->SetSizer(notes_sizer);
 
     m_notesCtrl = new wxTextCtrl(notes_tab, ID_DIALOG_NEWACCT_TEXTCTRL_NOTES, ""
-        , wxDefaultPosition, wxSize(-1, wxSize(favoriteAccCheckBox->GetSize()).GetHeight() * 5), wxTE_MULTILINE);
+        , wxDefaultPosition, wxSize(-1, favoriteAccCheckBox->GetSize().GetHeight() * 5), wxTE_MULTILINE);
     notes_sizer->Add(m_notesCtrl, g_flagsExpand);
     //
 
@@ -408,7 +408,7 @@ void mmNewAcctDialog::OnCurrency(wxCommandEvent& WXUNUSED(event))
     if (mmMainCurrencyDialog::Execute(this, m_currencyID))
     {
         Model_Currency::Data* currency = Model_Currency::instance().get(m_currencyID);
-        wxButton* bn = (wxButton*)FindWindow(ID_DIALOG_NEWACCT_BUTTON_CURRENCY);
+        wxButton* bn = static_cast<wxButton*>(FindWindow(ID_DIALOG_NEWACCT_BUTTON_CURRENCY));
         bn->SetLabelText(wxGetTranslation(currency->CURRENCYNAME));
 
         double init_balance;
@@ -450,15 +450,15 @@ void mmNewAcctDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
     if (!this->m_account) this->m_account = Model_Account::instance().create();
 
-    wxTextCtrl* textCtrlAcctNumber = (wxTextCtrl*)FindWindow(ID_ACCTNUMBER);
-    wxTextCtrl* textCtrlHeldAt = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_HELDAT);
-    wxTextCtrl* textCtrlWebsite = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_WEBSITE);
-    wxTextCtrl* textCtrlContact = (wxTextCtrl*)FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_CONTACT);
+    wxTextCtrl* textCtrlAcctNumber = static_cast<wxTextCtrl*>(FindWindow(ID_ACCTNUMBER));
+    wxTextCtrl* textCtrlHeldAt = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_HELDAT));
+    wxTextCtrl* textCtrlWebsite = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_WEBSITE));
+    wxTextCtrl* textCtrlContact = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_CONTACT));
 
-    wxChoice* choice = (wxChoice*)FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS);
+    wxChoice* choice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS));
     m_account->STATUS = Model_Account::all_status()[choice->GetSelection()];
 
-    wxCheckBox* itemCheckBox = (wxCheckBox*)FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT);
+    wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT));
     m_account->FAVORITEACCT = itemCheckBox->IsChecked() ? "TRUE" : "FALSE";
 
     m_account->ACCOUNTNAME = acctName;
@@ -535,7 +535,7 @@ void mmNewAcctDialog::OnChangeFocus(wxChildFocusEvent& event)
     int oject_in_focus = 0;
     if ( w ) oject_in_focus = w->GetId();
 
-    wxTextCtrl* textCtrl = (wxTextCtrl*) FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_ACCESSINFO);
+    wxTextCtrl* textCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_ACCESSINFO));
     if (oject_in_focus == ID_DIALOG_NEWACCT_TEXTCTRL_ACCESSINFO)
     {
         if (!m_accessinfo_infocus)

--- a/src/appstartdialog.cpp
+++ b/src/appstartdialog.cpp
@@ -76,7 +76,7 @@ mmAppStartDialog::~mmAppStartDialog()
     }
     catch (...)
     {
-        wxASSERT(false);
+        wxFAIL_MSG("cannot save SHOWBEGINAPP setting");
     }
 }
 
@@ -162,8 +162,8 @@ void mmAppStartDialog::SetCloseButtonToExit()
 
 void mmAppStartDialog::OnButtonAppstartHelpClick( wxCommandEvent& WXUNUSED(event) )
 {
-    int helpFileIndex_ = mmex::HTML_INDEX;
-    wxFileName helpIndexFile(mmex::getPathDoc((mmex::EDocFile)helpFileIndex_));
+    mmex::EDocFile helpFileIndex_ = mmex::HTML_INDEX;
+    wxFileName helpIndexFile(mmex::getPathDoc(helpFileIndex_));
     wxString url = "file://";
 
     const auto lang_code = Option::instance().getLanguageISO6391();
@@ -177,7 +177,7 @@ void mmAppStartDialog::OnButtonAppstartHelpClick( wxCommandEvent& WXUNUSED(event
     }
     else // load the default help file
     {
-        url << (mmex::getPathDoc((mmex::EDocFile)helpFileIndex_));
+        url << mmex::getPathDoc(helpFileIndex_);
     }
     wxLaunchDefaultBrowser(url);
 }

--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -255,7 +255,7 @@ void mmAssetDialog::CreateControls()
     bAttachments_->SetToolTip(_("Organize attachments of this asset"));
 
     m_notes = new mmTextCtrl(this, IDC_NOTES, wxGetEmptyString()
-        , wxDefaultPosition, wxSize(-1, wxSize(m_dpc->GetSize()).GetHeight() * 5), wxTE_MULTILINE);
+        , wxDefaultPosition, wxSize(-1, m_dpc->GetSize().GetHeight() * 5), wxTE_MULTILINE);
     m_notes->SetToolTip(_("Enter notes associated with this asset"));
     details_frame_sizer->Add(m_notes, 0, wxGROW | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 
@@ -357,7 +357,7 @@ void mmAssetDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     }
 
     wxString asset_type = "";
-    wxStringClientData* type_obj = (wxStringClientData *)m_assetType->GetClientObject(m_assetType->GetSelection());
+    wxStringClientData* type_obj = static_cast<wxStringClientData *>(m_assetType->GetClientObject(m_assetType->GetSelection()));
     if (type_obj) asset_type = type_obj->GetData();
 
     bool is_new = !m_asset;
@@ -395,19 +395,19 @@ void mmAssetDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         if (g_err == UserTransactionPanel::GUI_ERROR::ACCOUNT)
         {
-            mmErrorDialogs::InvalidAccount((wxWindow*)m_transaction_panel->m_account, false, mmErrorDialogs::MESSAGE_POPUP_BOX);
+            mmErrorDialogs::InvalidAccount(m_transaction_panel->m_account, false, mmErrorDialogs::MESSAGE_POPUP_BOX);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::PAYEE)
         {
-            mmErrorDialogs::InvalidPayee((wxWindow*)m_transaction_panel->m_payee, mmErrorDialogs::MESSAGE_POPUP_BOX);
+            mmErrorDialogs::InvalidPayee(m_transaction_panel->m_payee, mmErrorDialogs::MESSAGE_POPUP_BOX);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::CATEGORY)
         {
-            mmErrorDialogs::InvalidCategory((wxWindow*)m_transaction_panel->m_category, true);
+            mmErrorDialogs::InvalidCategory(m_transaction_panel->m_category, true);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::ENTRY)
         {
-            mmErrorDialogs::InvalidAmount((wxWindow*)m_transaction_panel->m_entered_amount);
+            mmErrorDialogs::InvalidAmount(m_transaction_panel->m_entered_amount);
         }
 
         return;

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -164,7 +164,7 @@ void mmAssetsListCtrl::OnListKeyDown(wxListEvent& event)
 
 void mmAssetsListCtrl::OnNewAsset(wxCommandEvent& WXUNUSED(event))
 {
-    mmAssetDialog dlg(this, m_panel->getAssetPanelFrame(), (Model_Asset::Data*)nullptr);
+    mmAssetDialog dlg(this, m_panel->getAssetPanelFrame(), nullptr, false);
     if (dlg.ShowModal() == wxID_OK)
     {
         doRefreshItems(dlg.getAssetData()->ASSETID);
@@ -176,9 +176,9 @@ void mmAssetsListCtrl::doRefreshItems(int trx_id)
 {
     int selectedIndex = initVirtualListControl(trx_id, m_selected_col, m_asc);
 
-    long cnt = static_cast<long>(m_panel->getAssetDataSet().size());
+    size_t cnt = m_panel->getAssetDataSet().size();
 
-    if (selectedIndex >= cnt || selectedIndex < 0)
+    if (selectedIndex < 0 || static_cast<size_t>(selectedIndex) >= cnt)
         selectedIndex = m_asc ? cnt - 1 : 0;
 
     if (cnt>0)
@@ -658,8 +658,8 @@ const wxString mmAssetsPanel::getItem(long item, long column) const
 
 void mmAssetsPanel::updateExtraAssetData(int selIndex)
 {
-    wxStaticText* st = (wxStaticText*)FindWindow(IDC_PANEL_ASSET_STATIC_DETAILS);
-    wxStaticText* stm = (wxStaticText*)FindWindow(IDC_PANEL_ASSET_STATIC_DETAILS_MINI);
+    wxStaticText* st = static_cast<wxStaticText*>(FindWindow(IDC_PANEL_ASSET_STATIC_DETAILS));
+    wxStaticText* stm = static_cast<wxStaticText*>(FindWindow(IDC_PANEL_ASSET_STATIC_DETAILS_MINI));
     if (selIndex > -1)
     {
         const Model_Asset::Data& asset = this->m_assets[selIndex];

--- a/src/attachmentdialog.cpp
+++ b/src/attachmentdialog.cpp
@@ -134,7 +134,7 @@ void mmAttachmentDialog::fillControls()
     attachmentListBox_->DeleteAllItems();
 
     Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(m_RefType, m_RefId);
-    if (attachments.size() == 0) return;
+    if (attachments.empty()) return;
 
     int firstInTheListAttachentID = -1;
     for (const auto &entry : attachments)
@@ -144,7 +144,7 @@ void mmAttachmentDialog::fillControls()
         if (debug_) data.push_back(wxVariant(wxString::Format("%i", entry.ATTACHMENTID)));
         data.push_back(wxVariant(entry.DESCRIPTION));
         data.push_back(wxVariant(entry.REFTYPE + m_PathSep + entry.FILENAME));
-        attachmentListBox_->AppendItem(data, (wxUIntPtr)entry.ATTACHMENTID);
+        attachmentListBox_->AppendItem(data, static_cast<wxUIntPtr>(entry.ATTACHMENTID));
     }
 
     m_attachment_id = firstInTheListAttachentID;
@@ -156,7 +156,7 @@ void mmAttachmentDialog::OnListItemSelected(wxDataViewEvent& event)
     int selected_index = attachmentListBox_->ItemToRow(item);
 
     if (selected_index >= 0)
-        m_attachment_id = (int)attachmentListBox_->GetItemData(item);
+        m_attachment_id = static_cast<int>(attachmentListBox_->GetItemData(item));
 }
 
 void mmAttachmentDialog::AddAttachment()

--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -229,7 +229,7 @@ void mmBDDialog::dataToControls()
     }
 
     if (m_bill_data.REPEATS < NONE || m_bill_data.REPEATS > MONTHLYLASTBUSINESSDAY) {
-        wxASSERT(false);
+        wxFAIL;
         m_choice_repeat->SetSelection(MONTHLY);
     }
     else {
@@ -380,7 +380,7 @@ void mmBDDialog::CreateControls()
     //mainBoxSizerOuter will align contents vertically
     mainBoxSizerOuter->Add(mainBoxSizerInner, g_flagsExpand);
 
-   
+
 
     /* Bills & Deposits Details */
     wxStaticBox* repeatDetailsStaticBox = new wxStaticBox(this, wxID_ANY, _("Recurring Transaction Details"));
@@ -401,7 +401,7 @@ void mmBDDialog::CreateControls()
     m_date_paid->SetValue(wxDateTime::Now()); // Required for Mac: Does not default to today
     m_date_paid->SetToolTip(_("Specify the date the user is requested to enter this transaction"));
     spinTransDate_ = new wxSpinButton(this, ID_DIALOG_TRANS_DATE_SPINNER
-        , wxDefaultPosition, wxSize(-1, wxSize(m_date_paid->GetSize()).GetHeight())
+        , wxDefaultPosition, wxSize(-1, m_date_paid->GetSize().GetHeight())
         , spinCtrlDirection | wxSP_ARROW_KEYS | wxSP_WRAP);
     spinTransDate_->SetToolTip(_("Advance or retard the user request date of this transaction"));
     spinTransDate_->SetRange(-32768, 32768);
@@ -491,7 +491,7 @@ void mmBDDialog::CreateControls()
     m_date_due->SetToolTip(_("Specify the date when this bill or deposit is due"));
 
     spinNextOccDate_ = new wxSpinButton(transactionPanel, ID_DIALOG_BD_REPEAT_DATE_SPINNER
-        , wxDefaultPosition, wxSize(-1, wxSize(m_date_due->GetSize()).GetHeight())
+        , wxDefaultPosition, wxSize(-1, m_date_due->GetSize().GetHeight())
         , spinCtrlDirection | wxSP_ARROW_KEYS | wxSP_WRAP);
     spinNextOccDate_->SetToolTip(_("Retard or advance the date of the 'next occurrence'"));
     spinNextOccDate_->SetRange(-32768, 32768);
@@ -618,7 +618,7 @@ void mmBDDialog::CreateControls()
     RightAlign_sizer->Add(bFrequentUsedNotes, g_flagsH);
 
     textNotes_ = new wxTextCtrl(transactionPanel, ID_DIALOG_TRANS_TEXTNOTES, ""
-        , wxDefaultPosition, wxSize(-1, wxSize(m_date_due->GetSize()).GetHeight() * 5), wxTE_MULTILINE);
+        , wxDefaultPosition, wxSize(-1, m_date_due->GetSize().GetHeight() * 5), wxTE_MULTILINE);
     textNotes_->SetToolTip(_("Specify any text notes you want to add to this transaction."));
 
     transPanelSizer->Add(RightAlign_sizer, wxSizerFlags(g_flagsH).Align(wxALIGN_RIGHT).Border(wxALL, 0));
@@ -891,8 +891,8 @@ void mmBDDialog::OnFrequentUsedNotes(wxCommandEvent& WXUNUSED(event))
 
 void mmBDDialog::onNoteSelected(wxCommandEvent& event)
 {
-    int i = event.GetId() - wxID_HIGHEST;
-    if (i > 0 && i <= (int)frequentNotes_.size()) {
+    size_t i = event.GetId() - wxID_HIGHEST;
+    if (i > 0 && i <= frequentNotes_.size()) {
         textNotes_->ChangeValue(frequentNotes_[i - 1]);
     }
 }
@@ -912,7 +912,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     Model_Account::Data* acc = Model_Account::instance().get(m_bill_data.ACCOUNTID);
     if (!acc)
     {
-        return mmErrorDialogs::InvalidAccount((wxWindow*)bAccount_, m_transfer, mmErrorDialogs::MESSAGE_POPUP_BOX);
+        return mmErrorDialogs::InvalidAccount(bAccount_, m_transfer, mmErrorDialogs::MESSAGE_POPUP_BOX);
     }
 
     m_bill_data.TOTRANSAMOUNT = m_bill_data.TRANSAMOUNT;
@@ -921,7 +921,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         Model_Account::Data *to_acc = Model_Account::instance().get(m_bill_data.TOACCOUNTID);
         if (!to_acc || to_acc->ACCOUNTID == acc->ACCOUNTID)
         {
-            return mmErrorDialogs::InvalidAccount((wxWindow*)bPayee_, true);
+            return mmErrorDialogs::InvalidAccount(bPayee_, true);
         }
 
         if (m_advanced && !toTextAmount_->checkValue(m_bill_data.TOTRANSAMOUNT)) return;
@@ -931,7 +931,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         Model_Payee::Data *payee = Model_Payee::instance().get(m_bill_data.PAYEEID);
         if (!payee)
         {
-            mmErrorDialogs::InvalidPayee((wxWindow*)bPayee_);
+            mmErrorDialogs::InvalidPayee(bPayee_);
             return;
         }
     }
@@ -939,7 +939,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     if ((cSplit_->IsChecked() && m_bill_data.local_splits.empty())
         || (!cSplit_->IsChecked() && Model_Category::full_name(m_bill_data.CATEGID, m_bill_data.SUBCATEGID).empty()))
     {
-        return mmErrorDialogs::InvalidCategory((wxWindow*)bCategory_, false);
+        return mmErrorDialogs::InvalidCategory(bCategory_, false);
     }
 
 
@@ -1003,7 +1003,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         m_bill_data.TRANSDATE = m_date_paid->GetValue().FormatISODate();
     }
 
-    wxStringClientData* status_obj = (wxStringClientData *)m_choice_status->GetClientObject(m_choice_status->GetSelection());
+    wxStringClientData* status_obj = static_cast<wxStringClientData *>(m_choice_status->GetClientObject(m_choice_status->GetSelection()));
     if (status_obj)
     {
         m_bill_data.STATUS = Model_Billsdeposits::toShortStatus(status_obj->GetData());

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -352,7 +352,7 @@ int mmBillsDepositsPanel::initVirtualListControl(int id)
         ++cnt;
     }
 
-    listCtrlAccount_->SetItemCount(static_cast<long>(bills_.size()));
+    listCtrlAccount_->SetItemCount(bills_.size());
     return selected_item;
 }
 
@@ -625,7 +625,7 @@ void billsDepositsListCtrl::OnEditBDSeries(wxCommandEvent& WXUNUSED(event))
 void billsDepositsListCtrl::OnDeleteBDSeries(wxCommandEvent& WXUNUSED(event))
 {
     if (m_selected_row < 0) return;
-    if (m_bdp->bills_.size() == 0) return;
+    if (m_bdp->bills_.empty()) return;
 
     wxMessageDialog msgDlg(this, _("Do you really want to delete the series?")
         , _("Confirm Series Deletion")
@@ -703,11 +703,11 @@ void mmBillsDepositsPanel::updateBottomPanelData(int selIndex)
 
 void mmBillsDepositsPanel::enableEditDeleteButtons(bool en)
 {
-    wxButton* bE = (wxButton*) FindWindow(wxID_EDIT);
-    wxButton* bD = (wxButton*) FindWindow(wxID_DELETE);
-    wxButton* bN = (wxButton*) FindWindow(wxID_PASTE);
-    wxButton* bS = (wxButton*) FindWindow(wxID_IGNORE);
-    wxButton* bA = (wxButton*)FindWindow(wxID_FILE);
+    wxButton* bE = static_cast<wxButton*>(FindWindow(wxID_EDIT));
+    wxButton* bD = static_cast<wxButton*>(FindWindow(wxID_DELETE));
+    wxButton* bN = static_cast<wxButton*>(FindWindow(wxID_PASTE));
+    wxButton* bS = static_cast<wxButton*>(FindWindow(wxID_IGNORE));
+    wxButton* bA = static_cast<wxButton*>(FindWindow(wxID_FILE));
     if (bE) bE->Enable(en);
     if (bD) bD->Enable(en);
     if (bN) bN->Enable(en);
@@ -811,7 +811,7 @@ wxString mmBillsDepositsPanel::tips()
 void billsDepositsListCtrl::refreshVisualList(int selected_index)
 {
 
-    if (selected_index >= (long)m_bdp->bills_.size() || selected_index < 0)
+    if (selected_index < 0 || static_cast<size_t>(selected_index) >= m_bdp->bills_.size())
         selected_index = - 1;
     if (!m_bdp->bills_.empty()) {
         RefreshItems(0, m_bdp->bills_.size() - 1);
@@ -831,7 +831,7 @@ void billsDepositsListCtrl::refreshVisualList(int selected_index)
 
 void billsDepositsListCtrl::RefreshList()
 {
-    if (m_bdp->bills_.size() == 0) return;
+    if (m_bdp->bills_.empty()) return;
     int id = -1;
     if (m_selected_row != -1)
     {

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -132,8 +132,9 @@ void mmBudgetingPanel::OnViewPopupSelected(wxCommandEvent& event)
         currentView_ = VIEW_EXPENSE;
     else if (evt == MENU_VIEW_SUMMARYBUDGETENTRIES)
         currentView_ = VIEW_SUMM;
-    else
-        wxASSERT(false);
+    else {
+        wxFAIL_MSG("unknown popup menu command");
+    }
 
     Model_Infotable::instance().Set("BUDGET_FILTER", currentView_);
 
@@ -205,7 +206,7 @@ void mmBudgetingPanel::UpdateBudgetHeading()
 {
     budgetReportHeading_->SetLabel(GetPanelTitle());
 
-    wxStaticText* header = (wxStaticText*)FindWindow(ID_PANEL_CHECKING_STATIC_PANELVIEW);
+    wxStaticText* header = static_cast<wxStaticText*>(FindWindow(ID_PANEL_CHECKING_STATIC_PANELVIEW));
     header->SetLabel(wxGetTranslation(currentView_));
 }
 
@@ -401,7 +402,8 @@ void mmBudgetingPanel::initVirtualListControl()
     }
     else
     {
-        int day = -1, month = -1;
+        int day = -1;
+        wxDateTime::Month month = wxDateTime::Month::Inv_Month;
         budgetDetails.AdjustYearValues(day, month, dtBegin);
         budgetDetails.AdjustDateForEndFinancialYear(dtEnd);
     }
@@ -484,12 +486,12 @@ void mmBudgetingPanel::initVirtualListControl()
             && DisplayEntryAllowed(-1, category.CATEGID))
         {
             budget_.push_back(std::make_pair(-1, category.CATEGID));
-            int transCatTotalIndex = (int)budget_.size() - 1;
+            size_t transCatTotalIndex = budget_.size() - 1;
             listCtrlBudget_->RefreshItem(transCatTotalIndex);
         }
     }
 
-    listCtrlBudget_->SetItemCount((int)budget_.size());
+    listCtrlBudget_->SetItemCount(budget_.size());
 
     wxString est_amount, act_amount, diff_amount;
     est_amount = Model_Currency::toCurrency(estIncome);
@@ -643,7 +645,7 @@ wxListItemAttr* budgetingListCtrl::OnGetItemAttr(long item) const
     if ((cp_->GetTransID(item) < 0) &&
         (cp_->GetCurrentView() != VIEW_SUMM))
     {
-        return (wxListItemAttr *)&attr3_;
+        return const_cast<wxListItemAttr*>(&attr3_);
     }
 
     /* Returns the alternating background pattern */

--- a/src/budgetyearentrydialog.cpp
+++ b/src/budgetyearentrydialog.cpp
@@ -89,7 +89,7 @@ void mmBudgetYearEntryDialog::CreateControls()
 
         int month = wxDate::GetCurrentMonth() + 1; // we require months(1..12)
         textMonth_ = new wxSpinCtrl(this, wxID_ANY
-            , wxEmptyString, wxDefaultPosition, wxSize(textYear_->GetSize())
+            , wxEmptyString, wxDefaultPosition, textYear_->GetSize()
             , wxSP_ARROW_KEYS, 1, 12, month);
         textMonth_->SetValue(month);
         textMonth_->SetToolTip(_("Specify the required month.\n"
@@ -107,7 +107,7 @@ void mmBudgetYearEntryDialog::CreateControls()
     itemYearStrings.Add("None");
 
     itemChoice_ = new wxChoice( this, wxID_ANY
-        , wxDefaultPosition, wxSize(textYear_->GetSize()), itemYearStrings );
+        , wxDefaultPosition, textYear_->GetSize(), itemYearStrings );
     itemGridSizer2->Add(itemChoice_, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
     itemChoice_->SetToolTip(_("Specify year to base budget on."));
 

--- a/src/customfieldlistdialog.cpp
+++ b/src/customfieldlistdialog.cpp
@@ -109,7 +109,7 @@ void mmCustomFieldListDialog::fillControls()
     fieldListBox_->DeleteAllItems();
 
     Model_CustomField::Data_Set fields = Model_CustomField::instance().find(Model_CustomField::DB_Table_CUSTOMFIELD::REFTYPE(m_RefType));
-    if (fields.size() == 0) return;
+    if (fields.empty()) return;
 
     std::sort(fields.begin(), fields.end(), SorterByDESCRIPTION());
     int firstInTheListID = -1;
@@ -126,7 +126,7 @@ void mmCustomFieldListDialog::fillControls()
             Properties.Replace("\n", "", true);
             data.push_back(wxVariant(Properties));
         }
-        fieldListBox_->AppendItem(data, (wxUIntPtr)entry.FIELDID);
+        fieldListBox_->AppendItem(data, static_cast<wxUIntPtr>(entry.FIELDID));
     }
 
     m_field_id = firstInTheListID;
@@ -138,14 +138,14 @@ void mmCustomFieldListDialog::OnListItemSelected(wxDataViewEvent& event)
     int selected_index = fieldListBox_->ItemToRow(item);
 
     if (selected_index >= 0)
-        m_field_id = (int)fieldListBox_->GetItemData(item);
+        m_field_id = static_cast<int>(fieldListBox_->GetItemData(item));
     else
         m_field_id = -1;
 }
 
 void mmCustomFieldListDialog::AddField()
 {
-    mmCustomFieldEditDialog dlg(this, (Model_CustomField::Data*)nullptr, m_RefType);
+    mmCustomFieldEditDialog dlg(this, nullptr, m_RefType);
     if (dlg.ShowModal() != wxID_OK)
         return;
     fillControls();

--- a/src/db/Table.h
+++ b/src/db/Table.h
@@ -25,7 +25,7 @@
 #include "rapidjson/stringbuffer.h"
 using namespace rapidjson;
 
-#include "html_template.h"
+#include <html_template.h>
 using namespace tmpl;
 
 class wxString;

--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -162,7 +162,7 @@ void dbUpgrade::UpgradeFailedMessage(const wxString& error, const wxString& step
         + error, _("MMEX database upgrade"), wxOK | wxICON_ERROR);
 }
 
-void dbUpgrade::BackupDB(const wxString& FileName, int BackupType, int FilesToKeep, int UpgradeVersion)
+void dbUpgrade::BackupDB(const wxString& FileName, enum BACKUPTYPE BackupType, unsigned FilesToKeep, int UpgradeVersion)
 {
     wxFileName fn(FileName);
     if (!fn.IsOk()) return;
@@ -222,7 +222,7 @@ void dbUpgrade::BackupDB(const wxString& FileName, int BackupType, int FilesToKe
             backupFile = wxFindNextFile();
         }
 
-        if (backupFileArray.Count() > (size_t)FilesToKeep)
+        if (backupFileArray.Count() > FilesToKeep)
         {
             backupFileArray.Sort(true);
             // ensure file is not read only before deleting file.

--- a/src/dbupgrade.h
+++ b/src/dbupgrade.h
@@ -32,7 +32,7 @@ public:
     static bool InitializeVersion(wxSQLite3Database* db, int version = dbLatestVersion);
     static bool CheckUpgradeDB(wxSQLite3Database* db);
     static bool UpgradeDB(wxSQLite3Database* db, const wxString& DbFileName);
-    static void BackupDB(const wxString& Filename, int BackupType, int FilesToKeep, int UpgradeVersion = 0);
     enum BACKUPTYPE { START = 0, CLOSE, VERSION_UPGRADE };
+    static void BackupDB(const wxString& Filename, enum BACKUPTYPE BackupType, unsigned FilesToKeep, int UpgradeVersion = 0);
     static void SqlFileDebug(wxSQLite3Database* db);
 };

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -585,7 +585,7 @@ void mmFilterTransactionsDialog::getFilterStatus()
     int item = choiceStatus_->GetSelection();
     if (!getStatusCheckBox() || item < 0) return;
     wxStringClientData* status_obj =
-        (wxStringClientData*)choiceStatus_->GetClientObject(item);
+        static_cast<wxStringClientData*>(choiceStatus_->GetClientObject(item));
     if (status_obj) {
         m_filterStatus = status_obj->GetData().Left(1);
     }
@@ -638,17 +638,17 @@ template<class MODEL, class FULL_DATA>
 bool mmFilterTransactionsDialog::checkAmount(const FULL_DATA& tran)
 {
     bool ok = true, split_ok = false;
-    if (!amountMinEdit_->GetValue().IsEmpty() && m_min_amount > tran.TRANSAMOUNT)
+    if (!amountMinEdit_->IsEmpty() && m_min_amount > tran.TRANSAMOUNT)
         ok = false;
-    else if (!amountMaxEdit_->GetValue().IsEmpty() && m_max_amount < tran.TRANSAMOUNT)
+    else if (!amountMaxEdit_->IsEmpty() && m_max_amount < tran.TRANSAMOUNT)
         ok = false;
 
     if (tran.has_split())
     {
         for (const auto s : tran.m_splits)
         {
-            if ((amountMinEdit_->GetValue().IsEmpty() || m_min_amount <= s.SPLITTRANSAMOUNT)
-                && (amountMaxEdit_->GetValue().IsEmpty() || m_max_amount >= s.SPLITTRANSAMOUNT))
+            if ((amountMinEdit_->IsEmpty() || m_min_amount <= s.SPLITTRANSAMOUNT)
+                && (amountMaxEdit_->IsEmpty() || m_max_amount >= s.SPLITTRANSAMOUNT))
             {
                 split_ok = true;
                 break;
@@ -832,7 +832,7 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
         const wxString acc = accountDropDown_->GetStringSelection();
         if (!acc.empty())
         {
-            json_writer.Key(wxString(i18n ? _("Account") : "ACCOUNT").c_str());
+            json_writer.Key((i18n ? _("Account") : "ACCOUNT").c_str());
             json_writer.String(acc.c_str());
         }
     }
@@ -842,27 +842,27 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
         int i = m_date_ranges->GetSelection();
         const auto& title = m_all_date_ranges[i]->title();
         if (!title.empty()) {
-            json_writer.Key(wxString(i18n ? _("Date") : "DATE").c_str());
-            json_writer.String(wxString(i18n ? wxGetTranslation(title) : title).c_str());
+            json_writer.Key((i18n ? _("Date") : "DATE").c_str());
+            json_writer.String((i18n ? wxGetTranslation(title) : title).c_str());
         }
 
-        json_writer.Key(wxString(i18n ? _("Since") : "DATE1").c_str());
+        json_writer.Key((i18n ? _("Since") : "DATE1").c_str());
         json_writer.String(m_fromDateCtrl->GetValue().FormatISODate().c_str());
-        json_writer.Key(wxString(i18n ? _("Before") : "DATE2").c_str());
+        json_writer.Key((i18n ? _("Before") : "DATE2").c_str());
         json_writer.String(m_toDateControl->GetValue().FormatISODate().c_str());
     }
 
     if (payeeCheckBox_->IsChecked())
     {
-        json_writer.Key(wxString(i18n ? _("Payee") : "PAYEE").c_str());
+        json_writer.Key((i18n ? _("Payee") : "PAYEE").c_str());
         json_writer.String(cbPayee_->GetValue().c_str());
     }
 
     if (categoryCheckBox_->IsChecked())
     {
-        json_writer.Key(wxString(i18n ? _("Include Similar") : "SIMILAR_YN").c_str());
+        json_writer.Key((i18n ? _("Include Similar") : "SIMILAR_YN").c_str());
         json_writer.Bool(bSimilarCategoryStatus_);
-        json_writer.Key(wxString(i18n ? _("Category") : "CATEGORY").c_str());
+        json_writer.Key((i18n ? _("Category") : "CATEGORY").c_str());
         json_writer.String(btnCategory_->GetLabel().c_str());
     }
 
@@ -873,12 +873,12 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
         s.Add(wxTRANSLATE("All Except Reconciled"));
         int item = choiceStatus_->GetSelection();
         wxString status;
-        if (0 <= item && item < (int)s.size())
+        if (0 <= item && static_cast<size_t>(item) < s.size())
             status = s[item];
         if (!status.empty())
         {
-            json_writer.Key(wxString(i18n ? _("Status") : "STATUS").c_str());
-            json_writer.String(wxString(i18n ? wxGetTranslation(status) : status).c_str());
+            json_writer.Key((i18n ? _("Status") : "STATUS").c_str());
+            json_writer.String((i18n ? wxGetTranslation(status) : status).c_str());
         }
     }
 
@@ -891,26 +891,26 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
             << (cbTypeTransferFrom_->GetValue() && typeCheckBox_->GetValue() ? "F" : "");
         if (!type.empty())
         {
-            json_writer.Key(wxString(i18n ? _("Type") : "TYPE").c_str());
+            json_writer.Key((i18n ? _("Type") : "TYPE").c_str());
             json_writer.String(type.c_str());
         }
     }
 
     if (amountRangeCheckBox_->IsChecked())
     {
-        if (!amountMinEdit_->GetValue().empty())
+        if (!amountMinEdit_->IsEmpty())
         {
             double amount_min;
             amountMinEdit_->GetDouble(amount_min);
-            json_writer.Key(wxString(i18n ? _("Amount Min.") : "AMOUNT_MIN").c_str());
+            json_writer.Key((i18n ? _("Amount Min.") : "AMOUNT_MIN").c_str());
             json_writer.Double(amount_min);
         }
 
-        if (!amountMaxEdit_->GetValue().empty())
+        if (!amountMaxEdit_->IsEmpty())
         {
             double amount_max;
             amountMaxEdit_->GetDouble(amount_max);
-            json_writer.Key(wxString(i18n ? _("Amount Max.") : "AMOUNT_MAX").c_str());
+            json_writer.Key((i18n ? _("Amount Max.") : "AMOUNT_MAX").c_str());
             json_writer.Double(amount_max);
         }
     }
@@ -918,14 +918,14 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
     if (transNumberCheckBox_->IsChecked())
     {
         const wxString num = transNumberEdit_->GetValue();
-        json_writer.Key(wxString(i18n ? _("Number") : "NUMBER").c_str());
+        json_writer.Key((i18n ? _("Number") : "NUMBER").c_str());
         json_writer.String(num.c_str());
     }
 
     if (notesCheckBox_->IsChecked())
     {
         wxString notes = notesEdit_->GetValue();
-        json_writer.Key(wxString(i18n ? _("Notes") : "NOTES").c_str());
+        json_writer.Key((i18n ? _("Notes") : "NOTES").c_str());
         json_writer.String(notes.c_str());
     }
 
@@ -939,7 +939,7 @@ wxString mmFilterTransactionsDialog::to_json(bool i18n)
     const wxString default_label = wxString::Format(_("%i: Empty"), m_setting_name->GetSelection() + 1);
     if (!label.empty() && label != default_label)
     {
-        json_writer.Key(wxString(i18n ? _("Label") : "LABEL").c_str());
+        json_writer.Key((i18n ? _("Label") : "LABEL").c_str());
         json_writer.String(label.c_str());
     }
 
@@ -1177,7 +1177,7 @@ bool mmFilterTransactionsDialog::getNotesCheckBox()
 
 void mmFilterTransactionsDialog::OnMoreFields(wxCommandEvent& WXUNUSED(event))
 {
-    wxBitmapButton* button = (wxBitmapButton*)FindWindow(wxID_MORE);
+    wxBitmapButton* button = static_cast<wxBitmapButton*>(FindWindow(wxID_MORE));
 
     if (m_custom_fields->IsCustomPanelShown())
     {
@@ -1198,7 +1198,7 @@ void mmFilterTransactionsDialog::OnDateRangeChanged(wxCommandEvent& WXUNUSED(eve
 {
     bool user_date = false;
     int i = this->m_date_ranges->GetSelection();
-    if (i >= 0 && i < (int)m_date_ranges->GetCount())
+    if (i >= 0 && static_cast<unsigned>(i) < m_date_ranges->GetCount())
     {
         const mmDateRange* date_range = static_cast<mmDateRange*>
             (m_date_ranges->GetClientData(i));
@@ -1210,7 +1210,7 @@ void mmFilterTransactionsDialog::OnDateRangeChanged(wxCommandEvent& WXUNUSED(eve
             m_fromDateCtrl->SetValue(date_range->start_date());
             m_toDateControl->SetValue(date_range->end_date());
 
-            user_date = (date_range->title() == wxString("Custom"));
+            user_date = date_range->title().IsSameAs("Custom");
         }
     }
     m_fromDateCtrl->Enable(user_date);

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -506,8 +506,8 @@ void mmGeneralReportManager::OnSqlTest(wxCommandEvent& WXUNUSED(event))
         MinimalEditor* templateText = static_cast<MinimalEditor*>(FindWindow(ID_TEMPLATE));
         std::vector<std::pair<wxString, int> > colHeaders;
         bool colsOK = this->getColumns(sql, colHeaders);
-        wxButton* b = (wxButton*) FindWindow(wxID_NEW);
-        b->Enable(colsOK && templateText->GetValue().empty());
+        wxButton* b = static_cast<wxButton*>(FindWindow(wxID_NEW));
+        b->Enable(colsOK && templateText->IsEmpty());
         int pos = 0;
         for (const auto& col : colHeaders)
         {
@@ -532,7 +532,7 @@ void mmGeneralReportManager::OnSqlTest(wxCommandEvent& WXUNUSED(event))
 void mmGeneralReportManager::OnNewTemplate(wxCommandEvent& WXUNUSED(event))
 {
     MinimalEditor* templateText = static_cast<MinimalEditor*>(FindWindow(ID_TEMPLATE));
-    if (!templateText->GetValue().empty()) return;
+    if (!templateText->IsEmpty()) return;
     MinimalEditor* sqlText = static_cast<MinimalEditor*>(FindWindow(ID_SQL_CONTENT));
 
     wxNotebook* n = static_cast<wxNotebook*>(FindWindow(ID_NOTEBOOK));
@@ -540,7 +540,7 @@ void mmGeneralReportManager::OnNewTemplate(wxCommandEvent& WXUNUSED(event))
 
     templateText->ChangeValue(this->getTemplate(sqlText->GetValue()));
 
-    wxButton* b = (wxButton*) FindWindow(wxID_NEW);
+    wxButton* b = static_cast<wxButton*>(FindWindow(wxID_NEW));
     b->Enable(false);
 
     wxCommandEvent evt;
@@ -729,7 +729,7 @@ void mmGeneralReportManager::OnSelChanged(wxTreeEvent& event)
     m_selectedItemID = event.GetItem();
     if (!m_selectedItemID) return;
 
-    wxNotebook* editors_notebook = (wxNotebook*) FindWindow(ID_NOTEBOOK);
+    wxNotebook* editors_notebook = static_cast<wxNotebook*>(FindWindow(ID_NOTEBOOK));
     MyTreeItemData* iData = dynamic_cast<MyTreeItemData*>(m_treeCtrl->GetItemData(m_selectedItemID));
     if (!iData)
     {
@@ -770,9 +770,9 @@ void mmGeneralReportManager::OnSelChanged(wxTreeEvent& event)
 
         if (m_sqlListBox) m_sqlListBox->DeleteAllItems();
         if (m_sqlListBox) m_sqlListBox->DeleteAllColumns();
-        wxButton* createTemplate = (wxButton*) FindWindow(wxID_NEW);
+        wxButton* createTemplate = static_cast<wxButton*>(FindWindow(wxID_NEW));
         if (createTemplate) createTemplate->Enable(false);
-        wxStaticText *info = (wxStaticText*)FindWindow(wxID_INFO);
+        wxStaticText *info = static_cast<wxStaticText*>(FindWindow(wxID_INFO));
         if (info) info->SetLabelText("");
 
         viewControls(true);
@@ -1011,10 +1011,10 @@ void mmGeneralReportManager::OnExportReport(wxCommandEvent& WXUNUSED(event))
 
 void mmGeneralReportManager::showHelp()
 {
-    wxFileName helpIndexFile(mmex::getPathDoc((mmex::EDocFile)mmex::HTML_CUSTOM_SQL));
+    wxFileName helpIndexFile(mmex::getPathDoc(mmex::HTML_CUSTOM_SQL));
     if (Option::instance().getLanguageISO6391() != "en")
         helpIndexFile.AppendDir(Option::instance().getLanguageISO6391());
-    wxString url = "file://" + mmex::getPathDoc((mmex::EDocFile)mmex::HTML_CUSTOM_SQL);
+    wxString url = "file://" + mmex::getPathDoc(mmex::HTML_CUSTOM_SQL);
     if (helpIndexFile.FileExists()) // Load the help file for the given language
     {
         url = "file://" + helpIndexFile.GetPathWithSep() + helpIndexFile.GetFullName();

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -336,7 +336,7 @@ void mmQIFImportDialog::CreateControls()
 void mmQIFImportDialog::fillControls()
 {
     refreshTabs(TRX_TAB | ACC_TAB | PAYEE_TAB | CAT_TAB);
-    btnOK_->Enable(!file_name_ctrl_->GetValue().empty());
+    btnOK_->Enable(!file_name_ctrl_->IsEmpty());
 }
 
 bool mmQIFImportDialog::mmReadQIFFile()
@@ -627,11 +627,11 @@ void mmQIFImportDialog::refreshTabs(int tabs)
             data.push_back(wxVariant(trx.find(Amount) != trx.end() ? trx.at(Amount) : ""));
             data.push_back(wxVariant(trx.find(Memo) != trx.end() ? trx.at(Memo) : ""));
 
-            dataListBox_->AppendItem(data, (wxUIntPtr) num++);
+            dataListBox_->AppendItem(data, static_cast<wxUIntPtr>(num++));
         }
     }
 
-    if (int(tabs / ACC_TAB) % 2)
+    if ((tabs / ACC_TAB) % 2)
     {
         num = 0;
         accListBox_->DeleteAllItems();
@@ -672,11 +672,11 @@ void mmQIFImportDialog::refreshTabs(int tabs)
             data.push_back(wxVariant(type));
             data.push_back(wxVariant(currencySymbol));
             data.push_back(wxVariant(status));
-            accListBox_->AppendItem(data, (wxUIntPtr) num++);
+            accListBox_->AppendItem(data, static_cast<wxUIntPtr>(num++));
         }
     }
 
-    if (int(tabs / PAYEE_TAB) % 2)
+    if ((tabs / PAYEE_TAB) % 2)
     {
         payeeListBox_->DeleteAllItems();
         for (const auto& payee : m_payee_names)
@@ -685,11 +685,11 @@ void mmQIFImportDialog::refreshTabs(int tabs)
             data.push_back(wxVariant(payee));
             Model_Payee::Data* p = Model_Payee::instance().get(payee);
             data.push_back(wxVariant(p ? _("OK") : _("Missing")));
-            payeeListBox_->AppendItem(data, (wxUIntPtr) num++);
+            payeeListBox_->AppendItem(data, static_cast<wxUIntPtr>(num++));
         }
     }
 
-    if (int(tabs / CAT_TAB) % 2)
+    if ((tabs / CAT_TAB) % 2)
     {
         num = 0;
         const auto &c(Model_Category::all_categories());
@@ -702,7 +702,7 @@ void mmQIFImportDialog::refreshTabs(int tabs)
                 data.push_back(wxVariant("Missing"));
             else
                 data.push_back(wxVariant(_("OK")));
-            categoryListBox_->AppendItem(data, (wxUIntPtr) num++);
+            categoryListBox_->AppendItem(data, static_cast<wxUIntPtr>(num++));
         }
     }
 }
@@ -727,7 +727,7 @@ void mmQIFImportDialog::OnFileSearch(wxCommandEvent& WXUNUSED(event))
 
 void mmQIFImportDialog::OnDateMaskChange(wxCommandEvent& WXUNUSED(event))
 {
-    wxStringClientData* data = (wxStringClientData*)(choiceDateFormat_->GetClientObject(choiceDateFormat_->GetSelection()));
+    wxStringClientData* data = static_cast<wxStringClientData*>(choiceDateFormat_->GetClientObject(choiceDateFormat_->GetSelection()));
     if (data) m_dateFormatStr = data->GetData();
     m_userDefinedDateMask = true;
     refreshTabs(TRX_TAB);
@@ -765,7 +765,7 @@ void mmQIFImportDialog::OnCheckboxClick( wxCommandEvent& event )
         {
             accountDropDown_->Enable(true);
             m_accountNameStr = "";
-            wxStringClientData* data_obj = (wxStringClientData*)accountDropDown_->GetClientObject(accountDropDown_->GetSelection());
+            wxStringClientData* data_obj = static_cast<wxStringClientData*>(accountDropDown_->GetClientObject(accountDropDown_->GetSelection()));
             if (data_obj)
                 m_accountNameStr = data_obj->GetData();
         }
@@ -781,7 +781,7 @@ void mmQIFImportDialog::OnCheckboxClick( wxCommandEvent& event )
 
 void mmQIFImportDialog::OnAccountChanged(wxCommandEvent& WXUNUSED(event))
 {
-    wxStringClientData* data_obj = (wxStringClientData*)accountDropDown_->GetClientObject(accountDropDown_->GetSelection());
+    wxStringClientData* data_obj = static_cast<wxStringClientData*>(accountDropDown_->GetClientObject(accountDropDown_->GetSelection()));
     if (data_obj)
         m_accountNameStr = data_obj->GetData();
     refreshTabs(TRX_TAB);
@@ -887,7 +887,7 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         joinSplit(trx_data_set, m_splitDataSets);
         saveSplit();
 
-        sMsg = _("Import finished successfully") + "\n" + wxString::Format(_("Total Imported: %ld"), (long)trx_data_set.size());
+        sMsg = _("Import finished successfully") + "\n" + wxString::Format(_("Total Imported: %zu"), trx_data_set.size());
         trx_data_set.clear();
         vQIF_trxs_.clear();
         btnOK_->Enable(false);
@@ -1264,7 +1264,7 @@ int mmQIFImportDialog::get_last_imported_acc()
 void mmQIFImportDialog::OnDecimalChange(wxCommandEvent& event)
 {
     int i = m_choiceDecimalSeparator->GetSelection();
-    wxStringClientData* type_obj = (wxStringClientData*)m_choiceDecimalSeparator->GetClientObject(i);
+    wxStringClientData* type_obj = static_cast<wxStringClientData*>(m_choiceDecimalSeparator->GetClientObject(i));
     if (type_obj) {
         decimal_ = type_obj->GetData();
     }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -618,7 +618,7 @@ void mmUnivCSVDialog::OnAdd(wxCommandEvent& WXUNUSED(event))
         if (item->getIndex() != UNIV_CSV_DONTCARE && item->getIndex() != UNIV_CSV_NOTES)
         {
             csvFieldCandicate_->Delete(index);
-            if (index < (int)csvFieldCandicate_->GetCount()) {
+            if (static_cast<size_t>(index) < csvFieldCandicate_->GetCount()) {
                 csvFieldCandicate_->SetSelection(index, true);
             }
             else {
@@ -642,8 +642,8 @@ void mmUnivCSVDialog::OnRemove(wxCommandEvent& WXUNUSED(event))
 
         if (item_index != UNIV_CSV_DONTCARE)
         {
-            int pos = 0;
-            for (pos = 0; pos < (int)csvFieldCandicate_->GetCount() - 1; pos++)
+            unsigned int pos;
+            for (pos = 0; pos < csvFieldCandicate_->GetCount() - 1; pos++)
             {
                 mmListBoxItem *item2 = static_cast<mmListBoxItem*>(csvFieldCandicate_->GetClientObject(pos));
                 if (item_index < item2->getIndex()) {
@@ -656,7 +656,7 @@ void mmUnivCSVDialog::OnRemove(wxCommandEvent& WXUNUSED(event))
         csvListBox_->Delete(index);
         csvFieldOrder_.erase(csvFieldOrder_.begin() + index);
 
-        if (index < (int)csvListBox_->GetCount()) {
+        if (static_cast<size_t>(index) < csvListBox_->GetCount()) {
             csvListBox_->SetSelection(index, true);
         }
         else {
@@ -703,7 +703,7 @@ void mmUnivCSVDialog::OnSave(wxCommandEvent& WXUNUSED(event))
     PrettyWriter<StringBuffer> json_writer(json_buffer);
     json_writer.StartObject();
 
-    wxRadioBox* c = (wxRadioBox*)FindWindow(wxID_APPLY);
+    wxRadioBox* c = static_cast<wxRadioBox*>(FindWindow(wxID_APPLY));
     int id = c->GetSelection();
     const wxString& settingsPrefix = GetSettingsPrfix();
     const wxString& setting_id = wxString::Format(settingsPrefix + "%d", id);
@@ -1204,7 +1204,7 @@ void mmUnivCSVDialog::update_preview()
                 if (!m_userDefinedDateMask
                     && row >= firstRow
                     && row < lastRow
-                    && (int)col == date_col)
+                    && col == static_cast<unsigned>(date_col))
                 {
                     dParser->doHandleStatistics(content);
                 }
@@ -1354,7 +1354,7 @@ void mmUnivCSVDialog::OnMoveUp(wxCommandEvent& WXUNUSED(event))
 void mmUnivCSVDialog::OnMoveDown(wxCommandEvent& WXUNUSED(event))
 {
     int index = csvListBox_->GetSelection();
-    if (index != wxNOT_FOUND && index != (int)csvListBox_->GetCount() - 1)
+    if (index != wxNOT_FOUND && static_cast<size_t>(index) != csvListBox_->GetCount() - 1)
     {
         mmListBoxItem* item = static_cast<mmListBoxItem*>(csvListBox_->GetClientObject(index));
         int item_index = item->getIndex();
@@ -1481,7 +1481,7 @@ void mmUnivCSVDialog::OnDelimiterChange(wxCommandEvent& event)
 void mmUnivCSVDialog::OnDecimalChange(wxCommandEvent& event)
 {
     int i = m_choiceDecimalSeparator->GetSelection();
-    wxStringClientData* type_obj = (wxStringClientData*)m_choiceDecimalSeparator->GetClientObject(i);
+    wxStringClientData* type_obj = static_cast<wxStringClientData*>(m_choiceDecimalSeparator->GetClientObject(i));
     if (type_obj) {
         decimal_ = type_obj->GetData();
     }
@@ -1597,7 +1597,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         break;
 
     default:
-        wxASSERT(false);
+        wxFAIL_MSG("not mapped column");
         break;
     }
 }
@@ -1646,7 +1646,7 @@ void mmUnivCSVDialog::OnDateFormatChanged(wxCommandEvent& event)
     int i = event.GetId();
     if (i == ID_DATE_FORMAT)
     {
-        wxStringClientData* data = (wxStringClientData*)(choiceDateFormat_->GetClientObject(choiceDateFormat_->GetSelection()));
+        wxStringClientData* data = static_cast<wxStringClientData*>(choiceDateFormat_->GetClientObject(choiceDateFormat_->GetSelection()));
         if (data) date_format_ = data->GetData();
         *log_field_ << date_format_ << "\n";
     }

--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -128,7 +128,7 @@ void mmMainCurrencyDialog::fillControls()
         data.push_back(wxVariant(wxGetTranslation(currency.CURRENCYNAME)));
         data.push_back(wxVariant(wxString()<<Model_CurrencyHistory::getLastRate(currencyID, today)));
         data.push_back(wxVariant(is_currency_historical ? L"\u2713" : L""));
-        currencyListBox_->AppendItem(data, (wxUIntPtr)currencyID);
+        currencyListBox_->AppendItem(data, static_cast<wxUIntPtr>(currencyID));
         if (m_currency_id == currencyID)
         {
             currencyListBox_->SelectRow(currencyListBox_->GetItemCount() - 1);
@@ -396,7 +396,7 @@ void mmMainCurrencyDialog::OnListItemSelected(wxDataViewEvent& event)
     if (selected_index >= 0)
     {
         wxDataViewItem item = event.GetItem();
-        m_currency_id = (int)currencyListBox_->GetItemData(item);
+        m_currency_id = static_cast<int>(currencyListBox_->GetItemData(item));
         Model_Currency::Data* currency = Model_Currency::instance().get(m_currency_id);
         if (currency)
         {
@@ -596,7 +596,7 @@ void mmMainCurrencyDialog::OnHistoryDelete(wxCommandEvent& WXUNUSED(event))
     {
         item = valueListBox_->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
         if (item == -1) break;
-        Model_CurrencyHistory::instance().remove((int)valueListBox_->GetItemData(item));
+        Model_CurrencyHistory::instance().remove(static_cast<int>(valueListBox_->GetItemData(item)));
     }
     Model_CurrencyHistory::instance().ReleaseSavepoint();
 
@@ -926,7 +926,7 @@ bool mmMainCurrencyDialog::GetOnlineHistory(std::map<wxDateTime, double> &histor
     for (rapidjson::SizeType i = 0; i < timestamp.Size(); i++)
     {
         wxASSERT(timestamp[i].IsInt());
-        const auto time = wxDateTime((time_t)timestamp[i].GetInt()).GetDateOnly();
+        const auto time = wxDateTime(static_cast<time_t>(timestamp[i].GetInt())).GetDateOnly();
         if (quotes_closed[i].IsFloat())
         {
             double rate = quotes_closed[i].GetFloat();
@@ -940,8 +940,7 @@ bool mmMainCurrencyDialog::GetOnlineHistory(std::map<wxDateTime, double> &histor
         }
         else
         {
-            wxDateTime dt = wxDateTime((time_t)timestamp[i].GetInt());
-            wxLogDebug("%s %s", dt.FormatISODate(), wxDateTime::GetWeekDayName(dt.GetWeekDay()));
+            wxLogDebug("%s %s", time.FormatISODate(), wxDateTime::GetWeekDayName(time.GetWeekDay()));
         }
     }
 

--- a/src/minimal_editor.cpp
+++ b/src/minimal_editor.cpp
@@ -26,7 +26,7 @@ MinimalEditor::MinimalEditor(wxWindow* parent, wxWindowID id)
     }
 bool MinimalEditor::SetFont(const wxFont& font)
     {
-        StyleSetFont(wxSTC_STYLE_DEFAULT, (wxFont&) font);
+        StyleSetFont(wxSTC_STYLE_DEFAULT, const_cast<wxFont&>(font));
         return wxStyledTextCtrl::SetFont(font);
     }
 

--- a/src/mmcombobox.h
+++ b/src/mmcombobox.h
@@ -49,10 +49,6 @@ public:
             this->AutoComplete(Model_Account::instance().all_checking_account_names());
 
     }
-    wxString GetValue() const
-    {
-        return wxTextCtrl::GetValue();
-    }
 
     void setSelection(int &id)
     {
@@ -79,7 +75,7 @@ public:
                     + "\n");
                 wxRichToolTip tip(errorHeader, errorMessage);
                 tip.SetIcon(wxICON_WARNING);
-                tip.ShowFor((wxWindow*) this);
+                tip.ShowFor(this);
                 this->SetFocus();
             }
         }

--- a/src/mmcustomdata.cpp
+++ b/src/mmcustomdata.cpp
@@ -79,8 +79,8 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
             fieldData->CONTENT = Model_CustomField::getDefault(field.PROPERTIES);
         }
 
-        wxWindowID controlID = GetBaseID() + (wxWindowID)field.FIELDID;
-        wxWindowID labelID = GetLabelID() + (wxWindowID)field.FIELDID;
+        wxWindowID controlID = GetBaseID() + field.FIELDID;
+        wxWindowID labelID = GetLabelID() + field.FIELDID;
 
         wxCheckBox* Description = new wxCheckBox(scrolled_window
             , labelID, field.DESCRIPTION
@@ -121,7 +121,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
                 value = 0;
             }
             else {
-                value = (int)test;
+                value = trunc(test);
                 SetWidgetChanged(controlID, wxString::Format("%i", value));
                 Description->SetValue(true);
             }
@@ -142,8 +142,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
                 value = 0;
             }
             else {
-                const auto& data = wxString::Format("%f", value);
-                SetWidgetChanged(controlID, data);
+                SetWidgetChanged(controlID, wxString::Format("%f", value));
                 Description->SetValue(true);
             }
 
@@ -229,7 +228,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
             CustomChoice->SetToolTip(Model_CustomField::getTooltip(field.PROPERTIES));
             grid_sizer_custom->Add(CustomChoice, g_flagsExpand);
 
-            if (Choices.size() == 0) {
+            if (Choices.empty()) {
                 CustomChoice->Enable(false);
             }
 
@@ -279,7 +278,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 void mmCustomData::OnMultiChoice(wxCommandEvent& event)
 {
     long controlID = event.GetId();
-    wxButton* button = (wxButton*)m_dialog->FindWindow(controlID);
+    wxButton* button = static_cast<wxButton*>(m_dialog->FindWindow(controlID));
     if (!button) {
         return;
     }
@@ -359,42 +358,42 @@ const wxString mmCustomData::GetWidgetData(wxWindowID controlID) const
             const wxString class_name = w->GetEventHandler()->GetClassInfo()->GetClassName();
             if (class_name == "wxDatePickerCtrl")
             {
-                wxDatePickerCtrl* d = (wxDatePickerCtrl*)w;
+                wxDatePickerCtrl* d = static_cast<wxDatePickerCtrl*>(w);
                 data = d->GetValue().FormatISODate();
             }
             else if (class_name == "wxTimePickerCtrl")
             {
-                wxTimePickerCtrl* d = (wxTimePickerCtrl*)w;
+                wxTimePickerCtrl* d = static_cast<wxTimePickerCtrl*>(w);
                 data = d->GetValue().FormatISOTime();
             }
             else if (class_name == "wxSpinCtrlDouble")
             {
-                wxSpinCtrlDouble* d = (wxSpinCtrlDouble*)w;
+                wxSpinCtrlDouble* d = static_cast<wxSpinCtrlDouble*>(w);
                 data = wxString::Format("%f", d->GetValue());
             }
             else if (class_name == "wxSpinCtrl")
             {
-                wxSpinCtrl* d = (wxSpinCtrl*)w;
+                wxSpinCtrl* d = static_cast<wxSpinCtrl*>(w);
                 data = wxString::Format("%i", d->GetValue());
             }
             else if (class_name == "wxChoice")
             {
-                wxChoice* d = (wxChoice*)w;
+                wxChoice* d = static_cast<wxChoice*>(w);
                 data = d->GetStringSelection();
             }
             else if (class_name == "wxButton")
             {
-                wxButton* d = (wxButton*)w;
+                wxButton* d = static_cast<wxButton*>(w);
                 data = d->GetLabel();
             }
             else if (class_name == "wxTextCtrl")
             {
-                wxTextCtrl* d = (wxTextCtrl*)w;
+                wxTextCtrl* d = static_cast<wxTextCtrl*>(w);
                 data = d->GetValue();
             }
             else if (class_name == "wxCheckBox")
             {
-                wxCheckBox* d = (wxCheckBox*)w;
+                wxCheckBox* d = static_cast<wxCheckBox*>(w);
                 data = (d->GetValue() ? "TRUE" : "FALSE");
             }
         }
@@ -408,7 +407,7 @@ bool mmCustomData::SaveCustomValues(int ref_id)
 
     for (const auto &field : m_fields)
     {
-        wxWindowID controlID = GetBaseID() + (wxWindowID)field.FIELDID;
+        wxWindowID controlID = GetBaseID() + field.FIELDID;
         const auto& data = IsWidgetChanged(controlID) ? GetWidgetData(controlID) : "";
 
         Model_CustomFieldData::Data* fieldData = Model_CustomFieldData::instance().get(field.FIELDID, ref_id);
@@ -461,7 +460,7 @@ void mmCustomData::ResetWidgetsChanged()
     for (const auto& entry : m_data_changed)
     {
         auto label_id = entry.first - GetBaseID() + GetLabelID();
-        wxCheckBox* Description = (wxCheckBox*)m_dialog->FindWindow(label_id);
+        wxCheckBox* Description = static_cast<wxCheckBox*>(m_dialog->FindWindow(label_id));
         if (Description) {
             Description->SetValue(false);
             wxLogDebug("Description %i value = %s", label_id, "FALSE");
@@ -475,9 +474,9 @@ void mmCustomData::ClearSettings() const
 {
     for (const auto &field : m_fields)
     {
-        //wxWindowID controlID = GetBaseID() + (wxWindowID)field.FIELDID;
-        wxWindowID labelID = GetLabelID() + (wxWindowID)field.FIELDID;
-        wxCheckBox* cb = (wxCheckBox*)FindWindowById(labelID);
+        //wxWindowID controlID = GetBaseID() + field.FIELDID;
+        wxWindowID labelID = GetLabelID() + field.FIELDID;
+        wxCheckBox* cb = static_cast<wxCheckBox*>(FindWindowById(labelID));
         if (cb) cb->SetValue(false);
     }
 }
@@ -517,7 +516,7 @@ int mmCustomData::GetWidgetType(wxWindowID controlID) const
             return Model_CustomField::type(entry);
         }
     }
-    wxASSERT(false);
+    wxFAIL_MSG("unknown custom field type");
     return -1;
 
 }
@@ -572,7 +571,7 @@ void mmCustomData::SetWidgetChanged(wxWindowID id, const wxString& data)
     m_data_changed[id] = data;
 
     auto label_id = id - GetBaseID() + GetLabelID();
-    wxCheckBox* Description = (wxCheckBox*)m_dialog->FindWindow(label_id);
+    wxCheckBox* Description = static_cast<wxCheckBox*>(m_dialog->FindWindow(label_id));
     if (Description) {
         Description->SetValue(true);
         wxLogDebug("Description %i value = %i", label_id, 1);

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -168,7 +168,7 @@ int mmGUIApp::FilterEvent(wxEvent &event)
 
     if (event.GetEventType() == wxEVT_SHOW)
     {
-        wxWindow *win = (wxWindow*)event.GetEventObject();
+        wxWindow *win = static_cast<wxWindow*>(event.GetEventObject());
 
         if (win && win->IsTopLevel() && win != this->m_frame) // wxDialog & wxFrame http://docs.wxwidgets.org/trunk/classwx_top_level_window.html
         {

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -309,7 +309,7 @@ mmGUIFrame::~mmGUIFrame()
         cleanup();
     }
     catch (...) {
-        wxASSERT(false);
+        wxFAIL;
     }
 
     // Report database statistics
@@ -490,7 +490,6 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& WXUNUSED(event))
         bills.decode_fields(q1);
         bool allow_transaction = bills.AllowTransaction(q1, bal);
         const wxDateTime payment_date = bills.TRANSDATE(q1);
-        const wxDateTime next_date = bills.NEXTOCCURRENCEDATE(q1);
         if (bills.autoExecuteManual() && bills.requireExecution())
         {
             if (allow_transaction && bills.allowExecution())
@@ -511,7 +510,9 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& WXUNUSED(event))
         {
             if (bills.allowExecution())
             {
-                wxLogDebug("Next Date:%s | Payment Date: %s", next_date.FormatISODate(), payment_date.FormatISODate());
+                wxLogDebug("Next Date:%s | Payment Date: %s",
+                    bills.NEXTOCCURRENCEDATE(q1).FormatISODate(),
+                    payment_date.FormatISODate());
                 continueExecution = true;
                 Model_Checking::Data* tran = Model_Checking::instance().create();
 
@@ -580,7 +581,7 @@ void mmGUIFrame::saveSettings()
     this->GetSize(&value_w, &value_h);
     Model_Setting::instance().Set("SIZEW", value_w);
     Model_Setting::instance().Set("SIZEH", value_h);
-    Model_Setting::instance().Set("ISMAXIMIZED", (bool)this->IsMaximized());
+    Model_Setting::instance().Set("ISMAXIMIZED", this->IsMaximized());
     Model_Setting::instance().ReleaseSavepoint();
 }
 //----------------------------------------------------------------------------
@@ -1019,8 +1020,7 @@ void mmGUIFrame::OnSelChanged(wxTreeEvent& event)
             }
             else
             {
-                /* cannot find accountid */
-                wxASSERT(false);
+                wxFAIL_MSG("cannot find accountid");
             }
         }
     }
@@ -1985,7 +1985,7 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const bool openingNew
         mmNewDatabaseWizard* wizard = new mmNewDatabaseWizard(this);
         wizard->CenterOnParent();
         wizard->RunIt(true);
-        wxButton* next = (wxButton*) wizard->FindWindow(wxID_FORWARD); //FIXME:
+        wxButton* next = static_cast<wxButton*>(wizard->FindWindow(wxID_FORWARD)); //FIXME:
         if (next) next->SetLabel(_("&Next ->"));
 
         SetDataBaseParameters(fileName);

--- a/src/mmhelppanel.cpp
+++ b/src/mmhelppanel.cpp
@@ -86,7 +86,7 @@ void mmHelpPanel::CreateControls()
 
     int helpFileIndex = m_frame->getHelpFileIndex();
     const wxString help_file = wxString::Format("file://%s?lang=%s"
-        , mmex::getPathDoc((mmex::EDocFile)helpFileIndex)
+        , mmex::getPathDoc(static_cast<mmex::EDocFile>(helpFileIndex))
         , Option::instance().getLanguageISO6391());
 
     //wxLogDebug("%s", help_file);

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -21,7 +21,7 @@ Copyright (C) 2014 Nikolay
 #include "mmex.h"
 #include "mmframe.h"
 #include "paths.h"
-#include "html_template.h"
+#include <html_template.h>
 #include "billsdepositspanel.h"
 #include "constants.h"
 #include "option.h"
@@ -714,9 +714,9 @@ void mmHomePagePanel::setExpensesIncomeStatsData(std::map<int, std::pair<double,
 
 /* Accounts */
 const wxString mmHomePagePanel::getAccountsHTML(double& tBalance
-    , std::map<int, std::pair<double, double> > &accountStats, int type) const
+    , std::map<int, std::pair<double, double> > &accountStats, enum Model_Account::TYPE type) const
 {
-    wxASSERT(acc_type_str.size() >= (size_t)type );
+    wxASSERT(acc_type_str.size() >= static_cast<size_t>(type));
     const wxString idStr = acc_type_str[type].first;
     wxString output = "<table class = 'sortable table'>\n";
     output += "<col style=\"width:50%\"><col style=\"width:25%\"><col style=\"width:25%\">\n";

--- a/src/mmhomepagepanel.h
+++ b/src/mmhomepagepanel.h
@@ -77,7 +77,7 @@ private:
     const wxString getGrandTotalsJSON(double& tBalance) const;
 
     const wxString getAccountsHTML(double& tBalance, std::map<int, std::pair<double, double> > &accountStats
-        , int type = Model_Account::CHECKING) const;
+        , enum Model_Account::TYPE type = Model_Account::CHECKING) const;
     void setAccountsData(std::map<int, std::pair<double, double> > &accountStats);
     void setExpensesIncomeStatsData(std::map<int, std::pair<double, double> > &incomeExpensesStats
         , mmDateRange* date_range) const;

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -121,10 +121,10 @@ void mmListCtrl::OnColRightClick(wxListEvent& event)
     if (m_columns.size() > 0 && !m_col_width.IsEmpty())
     {
         m_ColumnHeaderNbr = event.GetColumn();
-        if (0 > m_ColumnHeaderNbr || m_ColumnHeaderNbr >= (int)m_columns.size()) return;
+        if (m_ColumnHeaderNbr < 0 || static_cast<size_t>(m_ColumnHeaderNbr) >= m_columns.size()) return;
         wxMenu menu;
         wxMenu *submenu = new wxMenu;
-        for (int i = 0; i < (int)m_columns.size(); i++)
+        for (int i = 0; i < static_cast<int>(m_columns.size()); i++)
         {
             const int id = MENU_HEADER_COLUMN + i;
             submenu->AppendCheckItem(id, m_columns[i].HEADER);
@@ -179,7 +179,7 @@ void mmListCtrl::OnHeaderSort(wxCommandEvent& WXUNUSED(event))
 void mmListCtrl::OnHeaderReset(wxCommandEvent& WXUNUSED(event))
 {
     wxString parameter_name;
-    for (int i = 0; i < (int)m_columns.size(); i++)
+    for (int i = 0; i < static_cast<int>(m_columns.size()); i++)
     {
         SetColumnWidth(i, m_columns[i].WIDTH);
         if (!m_col_width.IsEmpty())
@@ -199,7 +199,7 @@ void mmListCtrl::OnHeaderColumn(wxCommandEvent& event)
 {
     int id = event.GetId();
     int columnNbr = id - MENU_HEADER_COLUMN;
-    if (columnNbr >= 0 && columnNbr < (int)m_columns.size() && !m_col_width.IsEmpty())
+    if (columnNbr >= 0 && static_cast<size_t>(columnNbr) < m_columns.size() && !m_col_width.IsEmpty())
     {
         int default_width = m_columns[columnNbr].WIDTH;
         if (default_width == 0)

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -305,10 +305,10 @@ void mmReportsPanel::CreateControls()
             {
                 m_date_ranges->Append(date_range->local_title(), date_range);
             }
-            m_date_ranges->Append(_("Custom"), (mmDateRange *)nullptr);
+            m_date_ranges->Append(_("Custom"), static_cast<mmDateRange*>(nullptr));
 
             int sel_id = rb_->getDateSelection();
-            if (sel_id < 0 || sel_id >= m_all_date_ranges.size()) {
+            if (sel_id < 0 || static_cast<size_t>(sel_id) >= m_all_date_ranges.size()) {
                 sel_id = 0;
             }
             m_date_ranges->SetSelection(sel_id);
@@ -507,7 +507,7 @@ void mmReportsPanel::OnAccountChanged(wxCommandEvent& WXUNUSED(event))
         if ((sel == 1) || (sel != rb_->getAccountSelection()))
         {
             wxString accountSelection;
-            wxStringClientData* type_obj = (wxStringClientData *)m_accounts->GetClientObject(m_accounts->GetSelection());
+            wxStringClientData* type_obj = static_cast<wxStringClientData *>(m_accounts->GetClientObject(m_accounts->GetSelection()));
             if (type_obj) accountSelection = type_obj->GetData();
             rb_->setAccounts(sel, accountSelection);
 

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -168,7 +168,7 @@ Model_Currency::Data* Model_Account::currency(const Data* r)
         return currency;
     else
     {
-        wxASSERT(false);
+        wxFAIL_MSG("currency not found");
         return Model_Currency::GetBaseCurrency();
     }
 }

--- a/src/model/Model_Category.cpp
+++ b/src/model/Model_Category.cpp
@@ -167,13 +167,13 @@ void Model_Category::getCategoryStats(
     const auto &allSubcategories = Model_Subcategory::instance().all();
     double value = 0;
     int columns = group_by_month ? 12 : 1;
-    const wxDateTime start_date = wxDateTime(date_range->end_date()).SetDay(1);
+    const wxDateTime start_date(1, date_range->end_date().GetMonth(), date_range->end_date().GetYear());
     for (const auto& category: Model_Category::instance().all())
     {
         for (int m = 0; m < columns; m++)
         {
             const wxDateTime d = start_date.Subtract(wxDateSpan::Months(m));
-            int idx = group_by_month ? (d.GetYear()*100 + (int)d.GetMonth()) : 0;
+            int idx = group_by_month ? (d.GetYear()*100 + d.GetMonth()) : 0;
             categoryStats[category.CATEGID][-1][idx] = value;
             for (const auto & sub_category : allSubcategories)
             {
@@ -202,7 +202,7 @@ void Model_Category::getCategoryStats(
         const double convRate = Model_CurrencyHistory::getDayRate(
             Model_Account::instance().get(transaction.ACCOUNTID)->CURRENCYID, transaction.TRANSDATE);
         const wxDateTime &d = Model_Checking::TRANSDATE(transaction);
-        int idx = group_by_month ? (d.GetYear()*100 + (int)d.GetMonth()) : 0;
+        int idx = group_by_month ? (d.GetYear()*100 + d.GetMonth()) : 0;
         int categID = transaction.CATEGID;
 
         if (categID > -1)

--- a/src/model/Model_CustomFieldData.cpp
+++ b/src/model/Model_CustomFieldData.cpp
@@ -54,7 +54,7 @@ Model_CustomFieldData::Data* Model_CustomFieldData::get(int FieldID, int RefID)
     Model_CustomFieldData::Data_Set items = this->find(FIELDID(FieldID), REFID(RefID));
     if (!items.empty())
         return this->get(items[0].FIELDATADID, this->db_);
-    return (Model_CustomFieldData::Data*)nullptr;
+    return nullptr;
 }
 
 std::map<int, Model_CustomFieldData::Data_Set> Model_CustomFieldData::get_all(Model_Attachment::REFTYPE reftype)

--- a/src/model/Model_Report.cpp
+++ b/src/model/Model_Report.cpp
@@ -171,8 +171,8 @@ bool Model_Report::PrepareSQL(wxString& sql, std::map <wxString, wxString>& rep_
 
     if (pos != wxNOT_FOUND)
     {
-        wxDatePickerCtrl* start_date = (wxDatePickerCtrl*)
-            wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_START_DATE);
+        wxDatePickerCtrl* start_date = static_cast<wxDatePickerCtrl*>
+            (wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_START_DATE));
         wxString date = wxDateTime::Today().FormatISODate();
         if (start_date) {
             date = start_date->GetValue().FormatISODate();
@@ -191,8 +191,8 @@ bool Model_Report::PrepareSQL(wxString& sql, std::map <wxString, wxString>& rep_
     len = wxString("&single_date").size();
     if (pos != wxNOT_FOUND)
     {
-        wxDatePickerCtrl* start_date = (wxDatePickerCtrl*)
-            wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_START_DATE);
+        wxDatePickerCtrl* start_date = static_cast<wxDatePickerCtrl*>
+            (wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_START_DATE));
         wxString date = wxDateTime::Today().FormatISODate();
         if (start_date) {
             date = start_date->GetValue().FormatISODate();
@@ -211,8 +211,8 @@ bool Model_Report::PrepareSQL(wxString& sql, std::map <wxString, wxString>& rep_
 
     if (pos != wxNOT_FOUND)
     {
-        wxDatePickerCtrl* end_date = (wxDatePickerCtrl*)
-            wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_END_DATE);
+        wxDatePickerCtrl* end_date = static_cast<wxDatePickerCtrl*>
+            (wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_END_DATE));
         wxString date = wxDateTime::Today().FormatISODate();
         if (end_date) {
             date = end_date->GetValue().FormatISODate();
@@ -230,8 +230,8 @@ bool Model_Report::PrepareSQL(wxString& sql, std::map <wxString, wxString>& rep_
     len = wxString("&budget_years").size();
     if (pos != wxNOT_FOUND)
     {
-        wxChoice* years = (wxChoice*)
-            wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_DATE_RANGE);
+        wxChoice* years = static_cast<wxChoice*>
+            (wxWindow::FindWindowById(mmReportsPanel::RepPanel::ID_CHOICE_DATE_RANGE));
         wxString date = wxString::Format("%i", wxDate::Today().GetYear());
         if (years) {
             date = years->GetStringSelection();

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -442,7 +442,7 @@ int Option::getAccountImageId(int account_id, bool def) const
         else selectedImage = img::CRYPTO_ACC_NORMAL_PNG;
         break;
     default:
-        wxASSERT(false);
+        wxFAIL_MSG("unknown account type");
     }
     return selectedImage;
 }

--- a/src/optionsettingsattachment.cpp
+++ b/src/optionsettingsattachment.cpp
@@ -191,7 +191,7 @@ void OptionSettingsAttachment::OnAttachmentsButton(wxCommandEvent& WXUNUSED(even
 
 void OptionSettingsAttachment::OnAttachmentsMenu(wxCommandEvent& event)
 {
-    wxTextCtrl* att = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT);
+    wxTextCtrl* att = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT));
     if (!att) return;
     wxString AttachmentsFolder = mmex::getPathAttachment(att->GetValue());
 
@@ -224,11 +224,11 @@ void OptionSettingsAttachment::OnAttachmentsMenu(wxCommandEvent& event)
 
 void OptionSettingsAttachment::OnAttachmentsPathChanged(wxCommandEvent& WXUNUSED(event))
 {
-    wxTextCtrl* att = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT);
+    wxTextCtrl* att = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT));
     if (!att) return;
     wxString AttachmentsFolder = mmex::getPathAttachment(att->GetValue());
 
-    wxStaticText* text = (wxStaticText*) FindWindow(ID_DIALOG_OPTIONS_STATICTEXT_ATTACHMENTSTEXT);
+    wxStaticText* text = static_cast<wxStaticText*>(FindWindow(ID_DIALOG_OPTIONS_STATICTEXT_ATTACHMENTSTEXT));
     text->SetLabelText(_("Real path:") + "\n" + AttachmentsFolder);
 }
 
@@ -240,7 +240,7 @@ void OptionSettingsAttachment::OnAttachmentsSubfolderChanged(wxCommandEvent& eve
 
 void OptionSettingsAttachment::SaveSettings()
 {
-    wxTextCtrl* attTextCtrl = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT);
+    wxTextCtrl* attTextCtrl = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_ATTACHMENT));
     wxString attachmentFolder = attTextCtrl->GetValue().Trim();
     Model_Infotable::instance().Set("ATTACHMENTSFOLDER:" + mmPlatformType(), attachmentFolder);
     Model_Infotable::instance().Set("ATTACHMENTSSUBFOLDER", m_attachments_subfolder->GetValue());

--- a/src/optionsettingsgeneral.cpp
+++ b/src/optionsettingsgeneral.cpp
@@ -170,14 +170,14 @@ void OptionSettingsGeneral::OnCurrency(wxCommandEvent& WXUNUSED(event))
     mmMainCurrencyDialog(this, currencyID, false).ShowModal();
     currencyID = Option::instance().getBaseCurrencyID();
     Model_Currency::Data* currency = Model_Currency::instance().get(currencyID);
-    wxButton* bn = (wxButton*)FindWindow(ID_DIALOG_OPTIONS_BUTTON_CURRENCY);
+    wxButton* bn = static_cast<wxButton*>(FindWindow(ID_DIALOG_OPTIONS_BUTTON_CURRENCY));
     bn->SetLabelText(wxGetTranslation(currency->CURRENCYNAME));
     m_currency_id = currencyID;
 }
 
 void OptionSettingsGeneral::OnDateFormatChanged(wxCommandEvent& WXUNUSED(event))
 {
-    wxStringClientData* data = (wxStringClientData*)
+    wxStringClientData* data = static_cast<wxStringClientData*>
         (m_date_format_choice->GetClientObject(m_date_format_choice->GetSelection()));
 
     if (data)
@@ -197,7 +197,7 @@ bool OptionSettingsGeneral::SaveFinancialYearStart()
     int last_month_day = wxDateTime(1, wxDateTime::Month(month-1), 2015).GetLastMonthDay().GetDay();
 
     //Save Financial Year Start Day
-    wxSpinCtrl* fysDay = (wxSpinCtrl*) FindWindow(ID_DIALOG_OPTIONS_FINANCIAL_YEAR_START_DAY);
+    wxSpinCtrl* fysDay = static_cast<wxSpinCtrl*>(FindWindow(ID_DIALOG_OPTIONS_FINANCIAL_YEAR_START_DAY));
     int day = fysDay->GetValue();
     if (last_month_day < day)
         day = last_month_day;
@@ -208,7 +208,7 @@ bool OptionSettingsGeneral::SaveFinancialYearStart()
 
 void OptionSettingsGeneral::SaveSettings()
 {
-    wxTextCtrl* stun = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_USERNAME);
+    wxTextCtrl* stun = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_USERNAME));
     Option::instance().setUserName(stun->GetValue());
 
     //Model_Infotable::instance().SetBaseCurrency(m_currency_id); Handled only inside MainCurrencyDialog to better manage CurrencyHistory changes

--- a/src/optionsettingsmisc.cpp
+++ b/src/optionsettingsmisc.cpp
@@ -187,14 +187,14 @@ void OptionSettingsMisc::Create()
 
 void OptionSettingsMisc::OnBackupChanged(wxCommandEvent& WXUNUSED(event))
 {
-    wxCheckBox* ChkBackup = (wxCheckBox*)FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP);
-    wxCheckBox* ChkBackupUpdate = (wxCheckBox*)FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP_UPDATE);
+    wxCheckBox* ChkBackup = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP));
+    wxCheckBox* ChkBackupUpdate = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP_UPDATE));
     m_max_files->Enable(ChkBackup->GetValue() || ChkBackupUpdate->GetValue());
 }
 
 void OptionSettingsMisc::SaveStocksUrl()
 {
-    wxTextCtrl* url = (wxTextCtrl*)FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_STOCKURL);
+    wxTextCtrl* url = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_STOCKURL));
     wxString stockURL = url->GetValue();
     if (!stockURL.IsEmpty())
     {
@@ -210,30 +210,30 @@ void OptionSettingsMisc::SaveStocksUrl()
 
 void OptionSettingsMisc::SaveSettings()
 {
-    wxChoice* itemChoice = (wxChoice*)FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_PAYEE);
+    wxChoice* itemChoice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_PAYEE));
     Option::instance().setTransPayeeSelection(itemChoice->GetSelection());
 
-    itemChoice = (wxChoice*)FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_CATEGORY);
+    itemChoice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_CATEGORY));
     Option::instance().setTransCategorySelection(itemChoice->GetSelection());
 
-    itemChoice = (wxChoice*)FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS);
+    itemChoice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS));
     Option::instance().setTransStatusReconciled(itemChoice->GetSelection());
 
-    itemChoice = (wxChoice*)FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_DATE);
+    itemChoice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_DATE));
     Option::instance().setTransDateDefault(itemChoice->GetSelection());
 
     SaveStocksUrl();
     Option::instance().setSharePrecision(m_share_precision->GetValue());
 
-    wxCheckBox* itemCheckBox = (wxCheckBox*)FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP);
+    wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP));
     Model_Setting::instance().Set("BACKUPDB", itemCheckBox->GetValue());
 
-    wxCheckBox* itemCheckBoxUpdate = (wxCheckBox*)FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP_UPDATE);
+    wxCheckBox* itemCheckBoxUpdate = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP_UPDATE));
     Model_Setting::instance().Set("BACKUPDB_UPDATE", itemCheckBoxUpdate->GetValue());
 
     Model_Setting::instance().Set("MAX_BACKUP_FILES", m_max_files->GetValue());
 
-    wxTextCtrl* st = (wxTextCtrl*)FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_DELIMITER4);
+    wxTextCtrl* st = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_DELIMITER4));
     const wxString& delim = st->GetValue();
     if (!delim.IsEmpty()) Model_Infotable::instance().Set("DELIMITER", delim);
 }

--- a/src/optionsettingsnet.cpp
+++ b/src/optionsettingsnet.cpp
@@ -198,10 +198,10 @@ void OptionSettingsNet::SaveSettings()
     Model_Setting::instance().Set("PROXYIP", m_proxy_address->GetValue());
     Model_Setting::instance().Set("PROXYPORT", m_proxy_port->GetValue());
 
-    wxTextCtrl* WebAppURL = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_WEBAPPURL);
+    wxTextCtrl* WebAppURL = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_WEBAPPURL));
     Model_Infotable::instance().Set("WEBAPPURL", WebAppURL->GetValue());
 
-    wxTextCtrl* WebAppGUID = (wxTextCtrl*) FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_WEBAPPGUID);
+    wxTextCtrl* WebAppGUID = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_WEBAPPGUID));
     Model_Infotable::instance().Set("WEBAPPGUID", WebAppGUID->GetValue());
 
     Option::instance().setSendUsageStatistics(m_send_data->GetValue());

--- a/src/optionsettingsview.cpp
+++ b/src/optionsettingsview.cpp
@@ -232,13 +232,13 @@ void OptionSettingsView::OnNavTreeColorChanged(wxCommandEvent& event)
 void OptionSettingsView::SaveSettings()
 {
     wxString accVisible = VIEW_ACCOUNTS_ALL_STR;
-    wxStringClientData* visible_acc_obj = (wxStringClientData *)m_choice_visible->GetClientObject(m_choice_visible->GetSelection());
+    wxStringClientData* visible_acc_obj = static_cast<wxStringClientData*>(m_choice_visible->GetClientObject(m_choice_visible->GetSelection()));
     if (visible_acc_obj)
         accVisible = visible_acc_obj->GetData();
     Model_Setting::instance().SetViewAccounts(accVisible);
 
     wxString transVisible = VIEW_TRANS_ALL_STR;
-    wxStringClientData* visible_obj = (wxStringClientData *)m_choice_trans_visible->GetClientObject(m_choice_trans_visible->GetSelection());
+    wxStringClientData* visible_obj = static_cast<wxStringClientData*>(m_choice_trans_visible->GetClientObject(m_choice_trans_visible->GetSelection()));
     if (visible_obj)
         transVisible = visible_obj->GetData();
     Model_Setting::instance().SetViewTransactions(transVisible);

--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -145,7 +145,7 @@ void mmPayeeDialog::fillControls()
         if (debug_) data.push_back(wxVariant(wxString::Format("%i", payee.PAYEEID)));
         data.push_back(wxVariant(payee.PAYEENAME));
         data.push_back(wxVariant(full_category_name));
-        payeeListBox_->AppendItem(data, (wxUIntPtr)payee.PAYEEID);
+        payeeListBox_->AppendItem(data, static_cast<wxUIntPtr>(payee.PAYEEID));
     }
 }
 

--- a/src/recentfiles.cpp
+++ b/src/recentfiles.cpp
@@ -65,7 +65,7 @@ void mmFileHistory::Save()
     {
         wxString buf;
         buf.Printf("RECENT_DB_%d", i);
-        if (i < (int)GetCount())
+        if (static_cast<size_t>(i) < GetCount())
             Model_Setting::instance().Set(buf, GetHistoryFile(i));
         else
             Model_Setting::instance().Set(buf, wxString(""));

--- a/src/reports/budget.cpp
+++ b/src/reports/budget.cpp
@@ -28,17 +28,17 @@ mmReportBudget::mmReportBudget(): mmPrintableBase("mmReportBudget")
 mmReportBudget::~mmReportBudget()
 {}
 
-void mmReportBudget::SetDateToEndOfMonth(int month, wxDateTime& date) const
+void mmReportBudget::SetDateToEndOfMonth(const wxDateTime::Month month, wxDateTime& date) const
 {
     date.SetDay(28);
-    date.SetMonth((wxDateTime::Month)month);
+    date.SetMonth(month);
     date.SetToLastMonthDay();
 }
 
-void mmReportBudget::SetDateToEndOfYear(const int day, const int month, wxDateTime& date, bool isEndDate) const
+void mmReportBudget::SetDateToEndOfYear(const int day, const wxDateTime::Month month, wxDateTime& date, bool isEndDate) const
 {
     date.SetDay(day);
-    date.SetMonth((wxDateTime::Month)month);
+    date.SetMonth(month);
     if (isEndDate)
     {
         date.Subtract(wxDateSpan::Day());
@@ -51,15 +51,15 @@ void mmReportBudget::SetBudgetMonth(wxString budgetYearStr, wxDateTime& startDat
     wxStringTokenizer tz(budgetYearStr,"-");
     wxString yearStr = tz.GetNextToken();
     wxString monthStr = tz.GetNextToken();
-    int month = wxAtoi(monthStr) - 1;
-    startDate.SetMonth((wxDateTime::Month)month);
+    wxDateTime::Month month = static_cast<wxDateTime::Month>(wxAtoi(monthStr) - 1);
+    startDate.SetMonth(month);
     SetDateToEndOfMonth(month,endDate);
 }
 
-void mmReportBudget::GetFinancialYearValues(int& day, int& month) const
+void mmReportBudget::GetFinancialYearValues(int& day, wxDateTime::Month& month) const
 {
     day = wxAtoi(Option::instance().getFinancialYearStartDay());
-    month = wxAtoi(Option::instance().getFinancialYearStartMonth()) - 1;
+    month = static_cast<wxDateTime::Month>(wxAtoi(Option::instance().getFinancialYearStartMonth()) - 1);
     if ((day > 28) && (month == wxDateTime::Feb))
     {
         day = 28;
@@ -73,7 +73,7 @@ void mmReportBudget::GetFinancialYearValues(int& day, int& month) const
     }
 }
 
-const wxString mmReportBudget::AdjustYearValues(int day, int month, long year, const wxString& yearStr) const
+const wxString mmReportBudget::AdjustYearValues(int day, wxDateTime::Month month, int year, const wxString& yearStr) const
 {
     wxString ret = yearStr;
     if ((ret.length() < 5))
@@ -81,7 +81,7 @@ const wxString mmReportBudget::AdjustYearValues(int day, int month, long year, c
         if (Option::instance().getBudgetFinancialYears())
         {
             GetFinancialYearValues(day, month);
-            ret = wxString::Format(_("Financial Year: %s - %li"), yearStr, (year + 1));
+            ret = wxString::Format(_("Financial Year: %s - %i"), yearStr, (year + 1));
         }
         else
         {
@@ -96,7 +96,7 @@ const wxString mmReportBudget::AdjustYearValues(int day, int month, long year, c
     return ret;
 }
 
-void mmReportBudget::AdjustYearValues(int day, int month, wxDateTime& date) const
+void mmReportBudget::AdjustYearValues(int day, wxDateTime::Month month, wxDateTime& date) const
 {
     if (Option::instance().getBudgetFinancialYears())
     {
@@ -109,7 +109,8 @@ void mmReportBudget::AdjustDateForEndFinancialYear(wxDateTime& date) const
 {
     if (Option::instance().getBudgetFinancialYears())
     {
-        int day, month;
+        int day;
+        wxDateTime::Month month;
         GetFinancialYearValues(day, month);
         SetDateToEndOfYear(day, month, date);
     }

--- a/src/reports/budget.h
+++ b/src/reports/budget.h
@@ -34,23 +34,23 @@ public:
     virtual ~mmReportBudget();
 
     /// Returns correct values for day and month, adjusted to financial year if required.
-    void AdjustYearValues(int day, int month, wxDateTime& year) const;
+    void AdjustYearValues(int day, wxDateTime::Month month, wxDateTime& year) const;
 
     /// Returns correct values for day and month, adjusted to financial year if required.
     /// Also returns a heading string for Month or Year reports.
-    const wxString AdjustYearValues(int day, int month, long year, const wxString& yearStr) const;
+    const wxString AdjustYearValues(int day, wxDateTime::Month month, int year, const wxString& yearStr) const;
 
     /// Sets date to end of financial year if required by user.
     void AdjustDateForEndFinancialYear(wxDateTime& date) const;
 
     /// Return day and month values to user defined financial year.
-    void GetFinancialYearValues(int& day, int& month) const;
+    void GetFinancialYearValues(int& day, wxDateTime::Month& month) const;
 
     /// Advance the given date to the end of the current month.
-    void SetDateToEndOfMonth(int month, wxDateTime& date) const;
+    void SetDateToEndOfMonth(const wxDateTime::Month month, wxDateTime& date) const;
 
     /// Advance the given date by one year.
-    void SetDateToEndOfYear(int day, int month, wxDateTime& date, bool isEndDate = true) const;
+    void SetDateToEndOfYear(int day, const wxDateTime::Month month, wxDateTime& date, bool isEndDate = true) const;
 
     /// sets the start and end dates for a budget month
     void SetBudgetMonth(wxString budgetYearStr, wxDateTime& startDate, wxDateTime& endDate) const;

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -63,32 +63,32 @@ const wxString mmReportBudgetCategorySummary::actualAmountColour(double amount, 
 
 wxString mmReportBudgetCategorySummary::getHTMLText()
 {
-    unsigned short startDay = 1;
-    long startMonth, startYear;
+    wxDateTime::wxDateTime_t startDay = 1;
+    long tmp;
+    wxDateTime::Month startMonth = wxDateTime::Jan;
+    int startYear;
 
     wxString value = Model_Budgetyear::instance().Get(m_date_selection);
     wxString budget_month, budget_year = value;
 
-    wxRegEx pattern("^([0-9]{4})(|-[0-9]{2})$");
+    wxRegEx pattern("^([0-9]{4})(-([0-9]{2}))?$");
     if (pattern.Matches(value))
     {
         budget_year = pattern.GetMatch(value, 1);
-        budget_month = pattern.GetMatch(value, 2);
-        budget_month.Replace("-", "");
+        budget_month = pattern.GetMatch(value, 3);
     }
 
-    if (!budget_year.ToLong(&startYear)) {
-        startYear = static_cast<long>(wxDateTime::Today().GetYear());
-        budget_year = wxString::Format("%ld", startYear);
+    if (!budget_year.ToLong(&tmp)) {
+        startYear = wxDateTime::Today().GetYear();
+        budget_year = wxString::Format("%d", startYear);
     }
-
-    if (!budget_month.ToLong(&startMonth))
-        startMonth = static_cast<long>(wxDateTime::Jan);
     else
-        startMonth--;
+        startYear = static_cast<int>(tmp); // 0 <= tmp <= 9999
 
-    wxDateTime yearBegin(startDay, (wxDateTime::Month)startMonth
-        , static_cast<int>(startYear));
+    if (budget_month.ToLong(&tmp))
+        startMonth = static_cast<wxDateTime::Month>(--tmp);
+
+    wxDateTime yearBegin(startDay, startMonth, startYear);
     wxDateTime yearEnd = yearBegin;
 
     bool monthlyBudget = (!budget_month.empty());
@@ -122,7 +122,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     int categID = -1;
     mmHTMLBuilder hb;
     //---------------------------------
-    const wxString& headingStr = AdjustYearValues(static_cast<int>(startDay)
+    const wxString& headingStr = AdjustYearValues(startDay
         , startMonth, startYear, budget_year);
     hb.init();
     hb.addDivContainer();

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -182,7 +182,7 @@ void mmReportCashFlow::getStats(double& tInitialBalance, std::vector<ValueTrio>&
     } //end query
 
     const wxDateTime& dtBegin = today_;
-    for (int idx = 0; idx < (int) forecastVector.size(); idx++)
+    for (size_t idx = 0; idx < forecastVector.size(); idx++)
     {
         wxDateTime dtEnd = cashFlowReportType_ == MONTHLY
             ? dtBegin.Add(wxDateSpan::Months(idx)) : dtBegin.Add(wxDateSpan::Days(idx));
@@ -276,7 +276,7 @@ wxString mmReportCashFlow::getHTMLText_i()
 
     hb.startTbody();
     int colorNum = 0;
-    for (int idx = 0; idx < (int)forecastVector.size(); idx++)
+    for (size_t idx = 0; idx < forecastVector.size(); idx++)
     {
         double balance = forecastVector[idx].amount + tInitialBalance;
         double diff = (idx == 0 ? 0 : forecastVector[idx].amount - forecastVector[idx-1].amount) ;

--- a/src/reports/categovertimeperf.cpp
+++ b/src/reports/categovertimeperf.cpp
@@ -75,7 +75,7 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
         int categID = category.CATEGID;
         line.name = category.CATEGNAME;
         line.overall = 0;
-        int month = 0;
+        unsigned month = 0;
         for (const auto &i : categoryStats[categID][-1])
         {
             double value = i.second;
@@ -125,7 +125,7 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
         BarGraphData data_positive;
         for (int i = 0; i < MONTHS_IN_PERIOD; i++)
         {
-            wxDateTime d = wxDateTime(start_date).Add(wxDateSpan::Months(i));
+            wxDateTime d = start_date.Add(wxDateSpan::Months(i));
 
             double val_negative = 0;
             double val_positive = 0;
@@ -170,7 +170,7 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
 
     for (int i = 0; i < MONTHS_IN_PERIOD; i++)
     {
-        wxDateTime d = wxDateTime(start_date).Add(wxDateSpan::Months(i));
+        wxDateTime d = start_date.Add(wxDateSpan::Months(i));
         hb.addTableHeaderCell(wxGetTranslation(wxDateTime::GetEnglishMonthName(d.GetMonth()
             , wxDateTime::Name_Abbr)) + wxString::Format("<br>%i", d.GetYear()), true);
     }

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -71,7 +71,7 @@ wxString mmReportForecast::getHTMLText()
     mm_html_template report(this->m_template);
     report(L"REPORTNAME") = this->getReportTitle();
     report(L"CONTENTS") = contents;
-    report(L"GRAND") = wxString::Format("%ld", (long)amount_by_day.size());
+    report(L"GRAND") = wxString::Format("%zu", amount_by_day.size());
     report(L"HTMLSCALE") = wxString::Format("%d", Option::instance().getHtmlFontSize());
 
     wxString out = wxEmptyString;

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -89,7 +89,7 @@ static const wxString BR = "<br>\n";
 static const wxString NBSP = "&nbsp;";
 static const wxString CENTER = "<center>\n";
 static const wxString CENTER_END = "</center>\n";
-static const wxString TABLE_CELL_SPAN = "    <td colspan=\"%i\" >";
+static const wxString TABLE_CELL_SPAN = "    <td colspan=\"%zu\" >";
 static const wxString TABLE_CELL_RIGHT = "    <td style='text-align: right'>";
 static const wxString COLORS [] = {
       "rgba(135,206,250,0.7)"
@@ -202,7 +202,7 @@ void mmHTMLBuilder::addTotalRow(const wxString& caption, int cols
     , const std::vector<wxString>& data)
 {
     this->startTotalTableRow();
-    html_+= wxString::Format(tags::TABLE_CELL_SPAN, cols - (int)data.size());
+    html_+= wxString::Format(tags::TABLE_CELL_SPAN, cols - data.size());
     html_ += caption;
 
     for (unsigned long idx = 0; idx < data.size(); idx++)
@@ -292,12 +292,12 @@ const wxString mmHTMLBuilder::getColor(int i) const
     return color;
 }
 
-void mmHTMLBuilder::addTableCellMonth(int month)
+void mmHTMLBuilder::addTableCellMonth(const wxDateTime::Month month)
 {
     if (month >= 0 && month < 12) {
-        wxString f = wxString::Format(" sorttable_customkey = '%i'", (wxDateTime::Month)month);
+        wxString f = wxString::Format(" sorttable_customkey = '%i'", month);
         html_ += wxString::Format(tags::TABLE_CELL, f);
-        html_ += wxGetTranslation(wxDateTime::GetEnglishMonthName((wxDateTime::Month)month));
+        html_ += wxGetTranslation(wxDateTime::GetEnglishMonthName(month));
         this->endTableCell();
     }
     else
@@ -624,7 +624,7 @@ void mmHTMLBuilder::addBarChart(const wxArrayString& labels
     optionsValue.AddMember("scaleStartValue", 0, allocator);
     optionsValue.AddMember("scaleSteps", 0, allocator);
     Value scale(kArrayType);
-    scale.PushBack((int)scaleStepWidth, allocator);
+    scale.PushBack(static_cast<int>(scaleStepWidth), allocator);
     optionsValue.AddMember("scaleStepWidth", scale, allocator);
     Value steps(kArrayType);
     steps.PushBack(vertical_steps, allocator);

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -23,7 +23,7 @@
 #include "defs.h"
 #include <vector>
 #include "Model_Currency.h"
-#include "html_template.h"
+#include <html_template.h>
 #include "util.h"
 
 class mmHTMLBuilder
@@ -66,7 +66,7 @@ public:
 
     void addCurrencyCell(double amount, const Model_Currency::Data *currency = Model_Currency::instance().GetBaseCurrency(), int precision = -1);
     void addMoneyCell(double amount, int precision = -1);
-    void addTableCellMonth(int month);
+    void addTableCellMonth(const wxDateTime::Month month);
     void addColorMarker(const wxString& color);
     const wxString getColor(int i) const;
 

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -176,7 +176,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
         if (account) convRate = Model_CurrencyHistory::getDayRate(Model_Account::currency(account)->CURRENCYID, transaction.TRANSDATE);
 
         int idx = (Model_Checking::TRANSDATE(transaction).GetYear() * 100
-            + (int) Model_Checking::TRANSDATE(transaction).GetMonth());
+            + Model_Checking::TRANSDATE(transaction).GetMonth());
 
         if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT)
             incomeExpensesStats[idx].first += transaction.TRANSAMOUNT * convRate;
@@ -220,8 +220,8 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
             total_income += stats.second.first;
 
             hb.startTableRow();
-            hb.addTableCell(wxString() << (int) (stats.first / 100));
-            hb.addTableCellMonth(stats.first % 100);
+            hb.addTableCell(wxString() << stats.first / 100);
+            hb.addTableCellMonth(static_cast<wxDateTime::Month>(stats.first % 100));
             hb.addMoneyCell(stats.second.first);
             hb.addMoneyCell(stats.second.second);
             hb.addMoneyCell(stats.second.first - stats.second.second);

--- a/src/reports/mmDateRange.cpp
+++ b/src/reports/mmDateRange.cpp
@@ -38,17 +38,17 @@ void mmDateRange::destroy()
 
 const wxDateTime mmDateRange::start_date() const
 {
-    return this->start_date_;
+    return start_date_;
 }
 
 const wxDateTime mmDateRange::end_date() const
 {
-    return this->end_date_;
+    return end_date_;
 }
 
 const wxDateTime mmDateRange::today() const
 {
-    return this->today_;
+    return today_;
 }
 
 bool mmDateRange::is_with_date() const
@@ -69,146 +69,138 @@ const wxString mmDateRange::local_title() const
 mmCurrentMonth::mmCurrentMonth()
 : mmDateRange()
 {
-    this->start_date_ = wxDateTime(today_).SetDay(1);
-    this->end_date_ = today_.GetLastMonthDay();
-    this->title_ = wxTRANSLATE("Current Month");
+    start_date_.SetDay(1);
+    end_date_ = end_date_.GetLastMonthDay();
+    title_ = wxTRANSLATE("Current Month");
 }
 
 mmToday::mmToday()
 : mmDateRange()
 {
-    this->start_date_ = today_;
-    this->end_date_ = today_;
-    this->title_ = wxTRANSLATE("Today");
+    title_ = wxTRANSLATE("Today");
 }
 
 mmCurrentMonthToDate::mmCurrentMonthToDate()
 : mmDateRange()
 {
-    this->start_date_ = wxDateTime(today_).SetDay(1);
+    start_date_.SetDay(1);
     // no change to end_date_
-    this->title_ = wxTRANSLATE("Current Month to Date");
+    title_ = wxTRANSLATE("Current Month to Date");
 }
 
 mmLastMonth::mmLastMonth()
 : mmDateRange()
 {
-    this->start_date_.Subtract(wxDateSpan::Months(1)).SetDay(1);
-    this->end_date_ = wxDateTime(this->start_date_).GetLastMonthDay();
-    this->title_ = wxTRANSLATE("Last Month");
+    start_date_.Subtract(wxDateSpan::Months(1)).SetDay(1);
+    end_date_ = start_date_.GetLastMonthDay();
+    title_ = wxTRANSLATE("Last Month");
 }
 
 mmLast30Days::mmLast30Days()
 : mmDateRange()
 {
-    this->start_date_ = wxDateTime(start_date_)
-        .Subtract(wxDateSpan::Months(1))
-        .Add(wxDateSpan::Days(1));
+    start_date_.Subtract(wxDateSpan::Months(1)).Add(wxDateSpan::Days(1));
     // no change to end_date_
-    this->title_ = wxTRANSLATE("Last 30 Days");
+    title_ = wxTRANSLATE("Last 30 Days");
 }
 
 mmLast90Days::mmLast90Days()
 : mmDateRange()
 {
-    this->start_date_ = wxDateTime(start_date_)
-        .Subtract(wxDateSpan::Months(3))
-        .Add(wxDateSpan::Days(1));
+    start_date_.Subtract(wxDateSpan::Months(3)).Add(wxDateSpan::Days(1));
     // no change to end_date_
-    this->title_ = wxTRANSLATE("Last 90 Days");
+    title_ = wxTRANSLATE("Last 90 Days");
 }
 
 mmLast3Months::mmLast3Months()
 : mmDateRange()
 {
-    this->end_date_ = wxDateTime(this->start_date_).GetLastMonthDay();
-    this->start_date_ = wxDateTime(end_date_).SetDay(1)
+    end_date_ = end_date_.GetLastMonthDay();
+    start_date_.SetDay(1)
         .Add(wxDateSpan::Months(1))
         .Subtract(wxDateSpan::Months(3));
-    this->title_ = wxTRANSLATE("Last 3 Months");
+    title_ = wxTRANSLATE("Last 3 Months");
 }
 
 mmLast12Months::mmLast12Months()
 : mmDateRange()
 {
-    this->end_date_ = wxDateTime(this->start_date_).GetLastMonthDay();
-    this->start_date_ = wxDateTime(end_date_).SetDay(1)
+    end_date_ = end_date_.GetLastMonthDay();
+    start_date_.SetDay(1)
         .Add(wxDateSpan::Months(1))
         .Subtract(wxDateSpan::Years(1));
-    this->title_ = wxTRANSLATE("Last 12 Months");
+    title_ = wxTRANSLATE("Last 12 Months");
 }
 
 mmCurrentYear::mmCurrentYear()
 : mmDateRange()
 {
-    this->start_date_.SetDay(1).SetMonth(wxDateTime::Jan);
-    this->end_date_ = wxDateTime(start_date_).SetMonth(wxDateTime::Dec).SetDay(31);
-    this->title_ = wxTRANSLATE("Current Year");
+    start_date_.SetDay(1).SetMonth(wxDateTime::Jan);
+    end_date_.SetMonth(wxDateTime::Dec).SetDay(31);
+    title_ = wxTRANSLATE("Current Year");
 }
 
 mmCurrentYearToDate::mmCurrentYearToDate()
 : mmDateRange()
 {
-    this->start_date_.SetDay(1).SetMonth(wxDateTime::Jan);
+    start_date_.SetDay(1).SetMonth(wxDateTime::Jan);
     // no change to end_date_
-    this->title_ = wxTRANSLATE("Current Year to Date");
+    title_ = wxTRANSLATE("Current Year to Date");
 }
 
 mmLastYear::mmLastYear()
 : mmDateRange()
 {
-    this->start_date_.Subtract(wxDateSpan::Years(1)).SetDay(1).SetMonth(wxDateTime::Jan);
-    this->end_date_ = wxDateTime(start_date_).SetMonth(wxDateTime::Dec).SetDay(31);
-    this->title_ = wxTRANSLATE("Last Year");
+    start_date_.Subtract(wxDateSpan::Years(1)).SetDay(1).SetMonth(wxDateTime::Jan);
+    end_date_ = start_date_.SetMonth(wxDateTime::Dec).SetDay(31);
+    title_ = wxTRANSLATE("Last Year");
 }
 
 mmCurrentFinancialYear::mmCurrentFinancialYear(const int day, const int month)
 : mmDateRange()
 {
-    int this_month = this->start_date_.GetMonth() + 1;
-    auto finDate = wxDateTime(this->start_date_).SetDay(1).SetMonth(wxDateTime::Month(month - 1));
+    int this_month = today_.GetMonth() + 1;
+    auto finDate = start_date_.SetDay(1).SetMonth(wxDateTime::Month(month - 1));
     auto last_month_day = finDate.GetLastMonthDay().GetDay();
     wxASSERT(day <= last_month_day);
     finDate.SetDay(day <= last_month_day ? day : last_month_day);
 
-    if (finDate.IsLaterThan(this->start_date_))
-        this->start_date_.Subtract(wxDateSpan::Year()).Add(wxDateSpan::Months(month - this_month));
+    if (finDate.IsLaterThan(start_date_))
+        start_date_.Subtract(wxDateSpan::Year()).Add(wxDateSpan::Months(month - this_month));
     else
-        this->start_date_.Subtract(wxDateSpan::Months(this_month - month));
+        start_date_.Subtract(wxDateSpan::Months(this_month - month));
 
-    this->start_date_.Subtract(wxDateSpan::Days(this->start_date_.GetDay() - 1)).Add(wxDateSpan::Days(day - 1));
+    start_date_.Subtract(wxDateSpan::Days(start_date_.GetDay() - 1)).Add(wxDateSpan::Days(day - 1));
 
-    this->end_date_ = this->start_date_;
-    this->end_date_.Add(wxDateSpan::Year()).Subtract(wxDateSpan::Day());
-    this->title_ = wxTRANSLATE("Current Financial Year");
+    end_date_ = start_date_;
+    end_date_.Add(wxDateSpan::Year()).Subtract(wxDateSpan::Day());
+    title_ = wxTRANSLATE("Current Financial Year");
 }
 
 mmCurrentFinancialYearToDate::mmCurrentFinancialYearToDate(const int day, const int month)
 : mmDateRange()
 {
     mmCurrentFinancialYear current_financial_year(day, month);
-    this->start_date_ = current_financial_year.start_date();
+    start_date_ = current_financial_year.start_date();
     // no change to end_date_
-
-    this->title_ = wxTRANSLATE("Current Financial Year to Date");
+    title_ = wxTRANSLATE("Current Financial Year to Date");
 }
 
 mmLastFinancialYear::mmLastFinancialYear(const int day, const int month)
 : mmDateRange()
 {
     mmCurrentFinancialYear current_financial_year(day, month);
-    this->start_date_ = current_financial_year.start_date().Subtract(wxDateSpan::Year());
-    this->end_date_ = current_financial_year.end_date().Subtract(wxDateSpan::Year());
-
-    this->title_ = wxTRANSLATE("Last Financial Year");
+    start_date_ = current_financial_year.start_date().Subtract(wxDateSpan::Year());
+    end_date_ = current_financial_year.end_date().Subtract(wxDateSpan::Year());
+    title_ = wxTRANSLATE("Last Financial Year");
 }
 
 mmAllTime::mmAllTime()
 : mmDateRange()
 {
-    this->start_date_.SetDay(1).SetMonth(wxDateTime::Jan).SetYear(1601);
-    this->end_date_ = wxDateTime(31, wxDateTime::Dec, 9999);
-    this->title_ = wxTRANSLATE("Over Time");
+    start_date_ = wxDateTime(1, wxDateTime::Jan, 1601);
+    end_date_ = wxDateTime(31, wxDateTime::Dec, 9999);
+    title_ = wxTRANSLATE("Over Time");
 }
 
 bool mmAllTime::is_with_date() const
@@ -219,14 +211,14 @@ bool mmAllTime::is_with_date() const
 mmSpecifiedRange::mmSpecifiedRange(const wxDateTime& start, const wxDateTime& end)
 : mmDateRange()
 {
-    this->title_ = wxTRANSLATE("Custom");
-    this->start_date_ = start;
-    this->end_date_ = end;
+    title_ = wxTRANSLATE("Custom");
+    start_date_ = start;
+    end_date_ = end;
 }
 
 mmLast365Days::mmLast365Days() : mmDateRange()
 {
-    this->start_date_ = wxDateTime(end_date_).Subtract(wxDateSpan::Months(12)).Add(wxDateSpan::Days(1));
+    start_date_.Subtract(wxDateSpan::Months(12)).Add(wxDateSpan::Days(1));
     // no change to end_date_
-    this->title_ = wxTRANSLATE("Last 365 Days");
+    title_ = wxTRANSLATE("Last 365 Days");
 }

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -217,7 +217,7 @@ wxString mmReportMyUsage::getHTMLText()
                             _end_date.GetMonth(),
                             _end_date.GetDay());
     report(L"CONTENTS") = contents;
-    report(L"GRAND") = wxString::Format("%ld", (long)all_usage.size());
+    report(L"GRAND") = wxString::Format("%zu", all_usage.size());
     report(L"HTMLSCALE") = wxString::Format("%d", Option::instance().getHtmlFontSize());
 
     wxString out = wxEmptyString;

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -221,7 +221,9 @@ wxString mmReportSummaryByDate::getHTMLText()
         span = wxDateSpan::Years(1);
     }
     else
-        wxASSERT(0);
+    {
+        wxFAIL_MSG("unknown report mode");
+    }
 
     date = dateEnd;
     while (date.IsLaterThan(dateStart)) {

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -419,19 +419,19 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         if (g_err == UserTransactionPanel::GUI_ERROR::ACCOUNT)
         {
-            mmErrorDialogs::InvalidAccount((wxWindow*)m_transaction_panel->m_account, false, mmErrorDialogs::MESSAGE_POPUP_BOX);
+            mmErrorDialogs::InvalidAccount(m_transaction_panel->m_account, false, mmErrorDialogs::MESSAGE_POPUP_BOX);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::PAYEE)
         {
-            mmErrorDialogs::InvalidPayee((wxWindow*)m_transaction_panel->m_payee, mmErrorDialogs::MESSAGE_POPUP_BOX);
+            mmErrorDialogs::InvalidPayee(m_transaction_panel->m_payee, mmErrorDialogs::MESSAGE_POPUP_BOX);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::CATEGORY)
         {
-            mmErrorDialogs::InvalidCategory((wxWindow*)m_transaction_panel->m_category, true);
+            mmErrorDialogs::InvalidCategory(m_transaction_panel->m_category, true);
         }
         else if (g_err == UserTransactionPanel::GUI_ERROR::ENTRY)
         {
-            mmErrorDialogs::InvalidAmount((wxWindow*)m_transaction_panel->m_entered_amount);
+            mmErrorDialogs::InvalidAmount(m_transaction_panel->m_entered_amount);
         }
 
         return;
@@ -443,19 +443,19 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void ShareTransactionDialog::OnTextEntered(wxCommandEvent& WXUNUSED(event))
 {
     double share_num = 0;
-    if (!m_share_num_ctrl->GetValue().empty())
+    if (!m_share_num_ctrl->IsEmpty())
     {
         m_share_num_ctrl->GetDouble(share_num);
     }
 
     double share_price = 0;
-    if (!m_share_price_ctrl->GetValue().empty())
+    if (!m_share_price_ctrl->IsEmpty())
     {
         m_share_price_ctrl->GetDouble(share_price);
     }
 
     double share_commission = 0;
-    if (m_commission_ctrl != NULL && !m_commission_ctrl->GetValue().empty())
+    if (m_commission_ctrl != NULL && !m_commission_ctrl->IsEmpty())
     {
         m_commission_ctrl->GetDouble(share_commission);
     }

--- a/src/splittransactionsdialog.cpp
+++ b/src/splittransactionsdialog.cpp
@@ -110,7 +110,7 @@ void SplitTransactionDialog::DataToControls()
         wxVector<wxVariant> data;
         data.push_back(wxVariant(Model_Category::full_name(entry.CATEGID, entry.SUBCATEGID)));
         data.push_back(wxVariant(Model_Currency::toString(entry.SPLITTRANSAMOUNT, currency)));
-        lcSplit_->AppendItem(data, (wxUIntPtr)lcSplit_->GetItemCount());
+        lcSplit_->AppendItem(data, static_cast<wxUIntPtr>(lcSplit_->GetItemCount()));
     }
     if (lcSplit_->GetItemCount() > selectedIndex_ && selectedIndex_ >= 0)
         lcSplit_->SelectRow(selectedIndex_);
@@ -215,7 +215,7 @@ void SplitTransactionDialog::OnOk( wxCommandEvent& WXUNUSED(event) )
 
 void SplitTransactionDialog::OnButtonRemoveClick(wxCommandEvent& WXUNUSED(event))
 {
-    if (selectedIndex_ < 0 || selectedIndex_ >= (int)this->m_local_splits.size())
+    if (selectedIndex_ < 0 || static_cast<size_t>(selectedIndex_) >= this->m_local_splits.size())
         return;
     this->m_local_splits.erase(this->m_local_splits.begin() + selectedIndex_);
     selectedIndex_ = -1;
@@ -235,7 +235,7 @@ void SplitTransactionDialog::UpdateSplitTotal()
 
 void SplitTransactionDialog::EditEntry(int index)
 {
-    if (index < 0 || index >= (int)this->m_local_splits.size()) return;
+    if (index < 0 || static_cast<size_t>(index) >= this->m_local_splits.size()) return;
     SplitDetailDialog sdd(this, m_local_splits[index], transType_, accountID_);
     if (sdd.ShowModal() == wxID_OK)
     {
@@ -268,7 +268,7 @@ void SplitTransactionDialog::SetDisplaySplitCategories()
 
 void SplitTransactionDialog::SetDisplayEditDeleteButtons()
 {
-    bool active = selectedIndex_ >= 0 && selectedIndex_ < (int)this->m_local_splits.size();
+    bool active = selectedIndex_ >= 0 && static_cast<size_t>(selectedIndex_) < this->m_local_splits.size();
     itemButtonEdit_->Enable(active);
     itemButtonDelete_->Enable(active);
 }

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -137,13 +137,13 @@ void mmStockDialog::UpdateControls()
     m_value_investment->SetLabelText(Model_Account::toCurrency(numShares*pPrice, account));
 
     //Disable history buttons on new stocks
-    wxBitmapButton* buttonDownload = (wxBitmapButton*) FindWindow(ID_BUTTON_DOWNLOAD);
+    wxBitmapButton* buttonDownload = static_cast<wxBitmapButton*>(FindWindow(ID_BUTTON_DOWNLOAD));
     buttonDownload->Enable(m_edit);
-    wxBitmapButton* buttonImport = (wxBitmapButton*) FindWindow(ID_BUTTON_IMPORT);
+    wxBitmapButton* buttonImport = static_cast<wxBitmapButton*>(FindWindow(ID_BUTTON_IMPORT));
     buttonImport->Enable(m_edit);
-    wxBitmapButton* buttonDel = (wxBitmapButton*) FindWindow(wxID_DELETE);
+    wxBitmapButton* buttonDel = static_cast<wxBitmapButton*>(FindWindow(wxID_DELETE));
     buttonDel->Enable(m_edit);
-    wxBitmapButton* buttonAdd = (wxBitmapButton*) FindWindow(wxID_ADD);
+    wxBitmapButton* buttonAdd = static_cast<wxBitmapButton*>(FindWindow(wxID_ADD));
     buttonAdd->Enable(m_edit);
 
     bool initial_shares = !Model_Translink::HasShares(m_stock_id);
@@ -597,7 +597,7 @@ void mmStockDialog::OnHistoryImportButton(wxCommandEvent& WXUNUSED(event))
             const wxString& delimiter = Model_Infotable::instance().GetStringInfo("DELIMITER", mmex::DEFDELIMTER);
             csv2tab_separated_values(line, delimiter);
             wxStringTokenizer tkz(line, "\t", wxTOKEN_RET_EMPTY_ALL);
-            if ((int)tkz.CountTokens() < 2)
+            if (tkz.CountTokens() < 2)
                 continue;
 
             std::vector<wxString> tokens;
@@ -798,21 +798,21 @@ void mmStockDialog::OnHistoryDownloadButton(wxCommandEvent& WXUNUSED(event))
     for (const auto &entry: history)
     {
         float dPrice = entry.second;
-        const wxString date_str = wxDateTime((time_t)entry.first).FormatISODate();
+        const wxString date_str = wxDateTime(static_cast<time_t>(entry.first)).FormatISODate();
         if (date_str == today) continue;
 
         if (Model_StockHistory::instance()
                 .find(
                     Model_StockHistory::SYMBOL(m_stock->SYMBOL)
                     , Model_StockHistory::DB_Table_STOCKHISTORY::DATE(date_str)
-                ).size() == 0
+                ).empty()
                 && dPrice > 0
             )
         {
             Model_StockHistory::Data *ndata = Model_StockHistory::instance().create();
             ndata->SYMBOL = m_stock->SYMBOL;
             ndata->DATE = date_str;
-            ndata->VALUE = (double)dPrice;
+            ndata->VALUE = dPrice;
             ndata->UPDTYPE = Model_StockHistory::ONLINE;
             Model_StockHistory::instance().save(ndata);
         }
@@ -882,7 +882,7 @@ void mmStockDialog::OnHistoryDeleteButton(wxCommandEvent& WXUNUSED(event))
 
         if (item == -1)
             break;
-        Model_StockHistory::instance().remove((int) m_price_listbox->GetItemData(item));
+        Model_StockHistory::instance().remove(static_cast<int>(m_price_listbox->GetItemData(item)));
     }
     Model_StockHistory::instance().ReleaseSavepoint();
     ShowStockHistory();

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -452,9 +452,9 @@ void StocksListCtrl::OnColClick(wxListEvent& event)
 void StocksListCtrl::doRefreshItems(int trx_id)
 {
     int selectedIndex = initVirtualListControl(trx_id, m_selected_col, m_asc);
-    long cnt = static_cast<long>(m_stocks.size());
+    size_t cnt = m_stocks.size();
 
-    if (selectedIndex >= cnt || selectedIndex < 0)
+    if (selectedIndex < 0 || static_cast<size_t>(selectedIndex) >= cnt)
         selectedIndex = m_asc ? cnt - 1 : 0;
 
     if (cnt>0)
@@ -913,13 +913,10 @@ wxString StocksListCtrl::getStockInfo(int selectedIndex) const
     stockavgPurchasePrice /= stocktotalnumShares;
 
     double numShares = m_stocks[selectedIndex].NUMSHARES;
-    wxString sNumShares = wxString::Format("%i", (int)numShares);
-    if (numShares - static_cast<long>(numShares) != 0.0)
-        sNumShares = wxString::Format("%.4f", numShares);
-
-    wxString sTotalNumShares = wxString::Format("%i", (int)stocktotalnumShares);
-    if ((stocktotalnumShares - static_cast<long>(stocktotalnumShares)) != 0.0)
-        sTotalNumShares = wxString::Format("%.4f", stocktotalnumShares);
+    wxString sNumShares = wxString::Format("%.*f",
+        (trunc(numShares) == numShares) ? 0 : 4, numShares);
+    wxString sTotalNumShares = wxString::Format("%.*f",
+        (trunc(stocktotalnumShares) == stocktotalnumShares) ? 0 : 4, stocktotalnumShares);
 
     double stockPurchasePrice = m_stocks[selectedIndex].PURCHASEPRICE;
     double stockCurrentPrice = m_stocks[selectedIndex].CURRENTPRICE;
@@ -958,17 +955,17 @@ wxString StocksListCtrl::getStockInfo(int selectedIndex) const
             , sTotalDifference, sTotalNumShares
             , Model_Currency::toCurrency(stocktotalgainloss)
             , wxNumberFormatter::ToString(stocktotalPercentage, 2)
-            , OnGetItemText(selectedIndex, (long)COL_NOTES));
+            , OnGetItemText(selectedIndex, COL_NOTES));
     }
     return additionInfo;
 }
 void mmStocksPanel::enableEditDeleteButtons(bool en)
 {
-    wxButton* bE = (wxButton*) FindWindow(wxID_EDIT);
-    wxButton* bA = (wxButton*) FindWindow(wxID_ADD);
-    wxButton* bV = (wxButton*)FindWindow(wxID_VIEW_DETAILS);
-    wxButton* bD = (wxButton*)FindWindow(wxID_DELETE);
-    wxButton* bM = (wxButton*)FindWindow(wxID_MOVE_FRAME);
+    wxButton* bE = static_cast<wxButton*>(FindWindow(wxID_EDIT));
+    wxButton* bA = static_cast<wxButton*>(FindWindow(wxID_ADD));
+    wxButton* bV = static_cast<wxButton*>(FindWindow(wxID_VIEW_DETAILS));
+    wxButton* bD = static_cast<wxButton*>(FindWindow(wxID_DELETE));
+    wxButton* bM = static_cast<wxButton*>(FindWindow(wxID_MOVE_FRAME));
 
     if (bE) bE->Enable(en);
     if (bA) bA->Enable(en);

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -228,7 +228,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     wxString status = "";
     if (m_status_checkbox->IsChecked())
     {
-        wxStringClientData* status_obj = (wxStringClientData*)m_status_choice->GetClientObject(m_status_choice->GetSelection());
+        wxStringClientData* status_obj = static_cast<wxStringClientData*>(m_status_choice->GetClientObject(m_status_choice->GetSelection()));
         if (status_obj)
             status = Model_Checking::toShortStatus(status_obj->GetData());
         else
@@ -239,8 +239,8 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     if (m_type_checkbox->IsChecked())
     {
         int i = m_type_choice->GetSelection();
-        wxStringClientData* type_obj = ((i >= 0) && (i < (int)m_type_choice->GetCount()))
-            ? (wxStringClientData*)m_type_choice->GetClientObject(i) : nullptr;
+        wxStringClientData* type_obj = (i >= 0 && static_cast<unsigned>(i) < m_type_choice->GetCount())
+            ? static_cast<wxStringClientData*>(m_type_choice->GetClientObject(i)) : nullptr;
         if (type_obj)
             type = type_obj->GetData();
         else

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -424,7 +424,7 @@ void mmTransDialog::CreateControls()
     // Display the day of the week
 
     spinCtrl_ = new wxSpinButton(this, ID_DIALOG_TRANS_DATE_SPINNER
-        , wxDefaultPosition, wxSize(-1, wxSize(dpc_->GetSize()).GetHeight())
+        , wxDefaultPosition, wxSize(-1, dpc_->GetSize().GetHeight())
         , wxSP_VERTICAL | wxSP_ARROW_KEYS | wxSP_WRAP);
     spinCtrl_->SetRange (-32768, 32768);
 
@@ -563,7 +563,7 @@ void mmTransDialog::CreateControls()
     RightAlign_sizer->Add(bFrequentUsedNotes, wxSizerFlags().Border(wxLEFT, 5));
 
     textNotes_ = new wxTextCtrl(this, ID_DIALOG_TRANS_TEXTNOTES
-        , "", wxDefaultPosition, wxSize(-1, wxSize(dpc_->GetSize()).GetHeight() * 5), wxTE_MULTILINE);
+        , "", wxDefaultPosition, wxSize(-1, dpc_->GetSize().GetHeight() * 5), wxTE_MULTILINE);
     box_sizer_left->Add(textNotes_, wxSizerFlags(g_flagsExpand).Border(wxLEFT | wxRIGHT | wxBOTTOM, 10));
 
     /**********************************************************************************************
@@ -613,7 +613,7 @@ bool mmTransDialog::ValidateData()
     Model_Account::Data* account = Model_Account::instance().get(cbAccount_->GetValue());
     if (!account || Model_Account::type(account) == Model_Account::INVESTMENT)
     {
-        mmErrorDialogs::InvalidAccount((wxWindow*)cbAccount_);
+        mmErrorDialogs::InvalidAccount(cbAccount_);
         return false;
     }
     m_trx_data.ACCOUNTID = account->ACCOUNTID;
@@ -623,7 +623,7 @@ bool mmTransDialog::ValidateData()
         wxString payee_name = cbPayee_->GetValue();
         if (payee_name.IsEmpty())
         {
-            mmErrorDialogs::InvalidPayee((wxWindow*)cbPayee_);
+            mmErrorDialogs::InvalidPayee(cbPayee_);
             return false;
         }
 
@@ -667,7 +667,7 @@ bool mmTransDialog::ValidateData()
         if (!to_account || to_account->ACCOUNTID == m_trx_data.ACCOUNTID
             || Model_Account::type(to_account) == Model_Account::INVESTMENT)
         {
-            mmErrorDialogs::InvalidAccount((wxWindow*)cbPayee_, true);
+            mmErrorDialogs::InvalidAccount(cbPayee_, true);
             return false;
         }
         m_trx_data.TOACCOUNTID = to_account->ACCOUNTID;
@@ -683,7 +683,7 @@ bool mmTransDialog::ValidateData()
     if ((cSplit_->IsChecked() && local_splits.empty())
         || (!cSplit_->IsChecked() && Model_Category::full_name(m_trx_data.CATEGID, m_trx_data.SUBCATEGID).empty()))
     {
-        mmErrorDialogs::InvalidCategory((wxWindow*)bCategory_, false);
+        mmErrorDialogs::InvalidCategory(bCategory_, false);
         return false;
     }
 
@@ -905,7 +905,7 @@ void mmTransDialog::OnTransDateSpin(wxSpinEvent& event)
 void mmTransDialog::OnTransTypeChanged(wxCommandEvent& event)
 {
     const wxString old_type = m_trx_data.TRANSCODE;
-    wxStringClientData *client_obj = (wxStringClientData *) event.GetClientObject();
+    wxStringClientData *client_obj = static_cast<wxStringClientData*>(event.GetClientObject());
     if (client_obj) m_trx_data.TRANSCODE = client_obj->GetData();
     if (old_type != m_trx_data.TRANSCODE)
     {
@@ -1119,7 +1119,7 @@ void mmTransDialog::OnFrequentUsedNotes(wxCommandEvent& WXUNUSED(event))
 void mmTransDialog::OnNoteSelected(wxCommandEvent& event)
 {
     int i = event.GetId() - wxID_HIGHEST;
-    if (i > 0 && i <= (int)frequentNotes_.size())
+    if (i > 0 && static_cast<size_t>(i) <= frequentNotes_.size())
         textNotes_->ChangeValue(frequentNotes_[i - 1]);
 }
 
@@ -1129,7 +1129,7 @@ void mmTransDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     m_trx_data.NOTES = textNotes_->GetValue();
     m_trx_data.TRANSACTIONNUMBER = textNumber_->GetValue();
     m_trx_data.TRANSDATE = dpc_->GetValue().FormatISODate();
-    wxStringClientData* status_obj = (wxStringClientData*) choiceStatus_->GetClientObject(choiceStatus_->GetSelection());
+    wxStringClientData* status_obj = static_cast<wxStringClientData*>(choiceStatus_->GetClientObject(choiceStatus_->GetSelection()));
     if (status_obj)
     {
         m_status.SetStatus(Model_Checking::toShortStatus(status_obj->GetData()), m_account_id, m_trx_data);
@@ -1172,7 +1172,7 @@ void mmTransDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void mmTransDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 {
 #ifndef __WXMAC__
-    if (object_in_focus_ != itemButtonCancel_->GetId() && wxGetKeyState(wxKeyCode(WXK_ESCAPE)))
+    if (object_in_focus_ != itemButtonCancel_->GetId() && wxGetKeyState(WXK_ESCAPE))
             return itemButtonCancel_->SetFocus();
 #endif
 
@@ -1247,7 +1247,7 @@ void mmTransDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 
 void mmTransDialog::OnMoreFields(wxCommandEvent& WXUNUSED(event))
 {
-    wxBitmapButton* button = (wxBitmapButton*)FindWindow(ID_DIALOG_TRANS_CUSTOMFIELDS);
+    wxBitmapButton* button = static_cast<wxBitmapButton*>(FindWindow(ID_DIALOG_TRANS_CUSTOMFIELDS));
 
     if (m_custom_fields->IsCustomPanelShown())
     {

--- a/src/usertransactionpanel.cpp
+++ b/src/usertransactionpanel.cpp
@@ -396,7 +396,7 @@ void UserTransactionPanel::OnFrequentNotes(wxCommandEvent& WXUNUSED(event))
 void UserTransactionPanel::onSelectedNote(wxCommandEvent& event)
 {
     int i = event.GetId() - wxID_HIGHEST;
-    if (i > 0 && i <= (int) m_frequent_notes.size())
+    if (i > 0 && static_cast<size_t>(i) <= m_frequent_notes.size())
         m_entered_notes->ChangeValue(m_frequent_notes[i - 1]);
 }
 

--- a/src/webappdialog.cpp
+++ b/src/webappdialog.cpp
@@ -131,7 +131,7 @@ void mmWebAppDialog::fillControls()
 
         data.push_back(wxVariant(WebTran.Notes)); //WEBTRAN_NOTES
         data.push_back(wxVariant(WebTran.Attachments)); //WEBTRAN_ATTACHMENTS
-        webtranListBox_->AppendItem(data, (wxUIntPtr)WebTran.ID);
+        webtranListBox_->AppendItem(data, static_cast<wxUIntPtr>(WebTran.ID));
     }
 }
 
@@ -142,7 +142,7 @@ void mmWebAppDialog::OnListItemActivated(wxDataViewEvent& event)
 
     if (selected_index >= 0)
     {
-        int WebTrID = (int)webtranListBox_->GetItemData(item);
+        int WebTrID = static_cast<int>(webtranListBox_->GetItemData(item));
         mmWebAppDialog::ImportWebTr(WebTrID, true);
         fillControls();
     }
@@ -210,7 +210,7 @@ void mmWebAppDialog::ImportWebTrSelected()
     wxDataViewItemArray Selected;
     webtranListBox_->GetSelections(Selected);
 
-    if (Selected.size() == 0)
+    if (Selected.empty())
         return;
 
     for (wxDataViewItem Item : Selected)
@@ -218,7 +218,7 @@ void mmWebAppDialog::ImportWebTrSelected()
         int selectedIndex_ = webtranListBox_->ItemToRow(Item);
         if (selectedIndex_ >= 0)
         {
-            int WebTrID = (int)webtranListBox_->GetItemData(Item);
+            int WebTrID = static_cast<int>(webtranListBox_->GetItemData(Item));
             mmWebAppDialog::ImportWebTr(WebTrID, true);
         }
     }
@@ -230,7 +230,7 @@ void mmWebAppDialog::DeleteWebTr()
     wxDataViewItemArray Selected;
     webtranListBox_->GetSelections(Selected);
 
-    if (Selected.size() == 0)
+    if (Selected.empty())
         return;
 
     for (wxDataViewItem Item : Selected)
@@ -238,7 +238,7 @@ void mmWebAppDialog::DeleteWebTr()
         int selectedIndex_ = webtranListBox_->ItemToRow(Item);
         if (selectedIndex_ >= 0)
         {
-            mmWebApp::WebApp_DeleteOneTransaction((int)webtranListBox_->GetItemData(Item));
+            mmWebApp::WebApp_DeleteOneTransaction(static_cast<int>(webtranListBox_->GetItemData(Item)));
         }
     }
     fillControls();

--- a/src/wizard_newdb.cpp
+++ b/src/wizard_newdb.cpp
@@ -68,11 +68,11 @@ mmNewDatabaseWizard::mmNewDatabaseWizard(wxFrame *frame)
     GetPageAreaSizer()->Add(page1);
 
 /*
-    wxButton* back = (wxButton*) FindWindow(wxID_BACKWARD);
+    wxButton* back = static_cast<wxButton*>(FindWindow(wxID_BACKWARD));
     if (back) back->SetLabel(_("<- &Back"));
-    wxButton* next = (wxButton*) FindWindow(wxID_FORWARD); //FIXME:
+    wxButton* next = static_cast<wxButton*>(FindWindow(wxID_FORWARD)); //FIXME:
     if (next) next->SetLabel(_("&Next ->"));
-    wxButton* ca = (wxButton*) FindWindow(wxID_CANCEL);
+    wxButton* ca = static_cast<wxButton*>(FindWindow(wxID_CANCEL));
     if (ca) ca->SetLabel(wxGetTranslation(g_CancelLabel));
 */
 }

--- a/src/wizard_update.cpp
+++ b/src/wizard_update.cpp
@@ -34,7 +34,7 @@ wxEND_EVENT_TABLE()
 
 mmUpdateWizard::mmUpdateWizard(wxFrame *frame, const Value& new_version)
     : wxWizard(frame, wxID_ANY, _("Update Wizard")
-    , wxBitmap(wxNullBitmap), wxDefaultPosition, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
+    , wxNullBitmap, wxDefaultPosition, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
     , m_new_version(new_version)
 {
     page1 = new wxWizardPageSimple(this);

--- a/util/sqlite2cpp.py
+++ b/util/sqlite2cpp.py
@@ -828,7 +828,7 @@ def generate_base_class(header, fields=set):
 #include "rapidjson/stringbuffer.h"
 using namespace rapidjson;
 
-#include "html_template.h"
+#include <html_template.h>
 using namespace tmpl;
 
 class wxString;


### PR DESCRIPTION
and some optimizations...
and warnings removal...
and gcc updates in dockers...

Any old-style cast will trigger compile error now (with gcc >=6).

small step for #1950

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2156)
<!-- Reviewable:end -->
