### PR TITLE
feat(htmlbuilder): always print curr symbol

### DIFF
--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -240,12 +240,10 @@ void mmHTMLBuilder::addCurrencyCell(double amount, const Model_Currency::Data* c
 
 void mmHTMLBuilder::addMoneyCell(double amount, int precision)
 {
-    if (precision == -1)
-        precision = Model_Currency::precision(Model_Currency::GetBaseCurrency());
-    wxString f = wxString::Format( " class='money' sorttable_customkey = '%f' nowrap", amount);
-    html_ += wxString::Format(tags::TABLE_CELL, f);
-    html_ += Model_Currency::toString(amount, Model_Currency::GetBaseCurrency(), precision);
-    endTableCell();
+    // We should always present currency for monetary values
+    addCurrencyCell(amount, Model_Currency::GetBaseCurrency(), precision);
+
+    // TODO: verify if all values are in base currency at addMoneyCell call
 }
 
 void mmHTMLBuilder::addTableCellDate(const wxString& iso_date)


### PR DESCRIPTION
It's unclear if some reports' values are calculated in the account currency or default currency.
This PR will always print currency symbol in reports.

This simply replaces `Model_Currency::toString()` with `Model_Currency::toCurrency()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2162)
<!-- Reviewable:end -->
