### PR TITLE
Fix reports panel layout

### DIFF
--- a/resources/home_page.htt
+++ b/resources/home_page.htt
@@ -1,11 +1,11 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv='content-type' content='text/html; charset=utf-8' />
     <title>Home Page</title>
-    <script src="ChartNew.js"></script>
-    <script src="sorttable.js"></script>
-    <link href="master.css" rel="stylesheet" />
+    <script src='ChartNew.js'></script>
+    <script src='sorttable.js'></script>
+    <link href='master.css' rel='stylesheet' />
     <style>
         body {
             font-size: <TMPL_VAR HTMLSCALE>%;
@@ -14,9 +14,9 @@
 </head>
 <body>
 <div class='container'>
-    <table class="table-bordered" width="100%">
-        <tr valign="top">
-            <td width="50%">
+    <table class='table-bordered' width='100%'>
+        <tr valign='top'>
+            <td width='50%'>
                 <table class='table'>
                     <tfoot>
                         <tr class='success' style='font-weight:bold'>
@@ -61,24 +61,24 @@
                 <table class='table'>
                     <thead>
                         <tr class='active'>
-                            <th id="ive_name">#</th>
+                            <th id='ive_name'>#</th>
                             <th></th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td style='vertical-align:middle' width="70%">
+                            <td style='vertical-align:middle' width='70%'>
                             <div class='col-xs-11' style='min-width: 256px'>
-                                <canvas id="reportChart" width="312" height="256"></canvas>
+                                <canvas id='reportChart' width='312' height='256'></canvas>
                             </div>
                             </td>
-                            <td style='vertical-align:middle' width="30%">
+                            <td style='vertical-align:middle' width='30%'>
                             <div class='col-xs-11'>
                                 <table class='table'>
                                     <thead>
                                         <tr>
                                             <th id='ive_type'>Type</th>
-                                            <th id='ive_amount' class="text-right">Amount</th>
+                                            <th id='ive_amount' class='text-right'>Amount</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -92,7 +92,7 @@
                                         </tr>
                                     </tbody>
                                     <tfoot>
-                                        <tr class="total">
+                                        <tr class='total'>
                                             <td id='ive_difference_l'>Difference:</td>
                                             <td id='ive_difference' class='money'></td>
                                         </tr>
@@ -120,24 +120,24 @@
                     <!-- Chart -->
                     var font_size = 10 + 4*(<TMPL_VAR HTMLSCALE>/100 -1);
                     var data = {
-                        labels : [""],
+                        labels : [''],
                         datasets : [
                             {
-                                fillColor : "rgba(151,187,205,0.5)",
-                                strokeColor : "rgba(151,187,205,1)",
+                                fillColor : 'rgba(151,187,205,0.5)',
+                                strokeColor : 'rgba(151,187,205,1)',
                                 data : [ive_json[10]],
                                 title : ive_json[3]
                             },
                             {
-                                fillColor : "rgba(220,66,66,0.5)",
-                                strokeColor : "rgba(220,220,220,1)",
+                                fillColor : 'rgba(220,66,66,0.5)',
+                                strokeColor : 'rgba(220,220,220,1)',
                                 data : [ive_json[11]],
                                 title : ive_json[5]
                             },
                         ]
                     };
                     var options = {
-                        animationEasing: "easeOutQuint",
+                        animationEasing: 'easeOutQuint',
                         annotateDisplay : true,
                         responsive : true,
                         scaleOverride: true,
@@ -147,7 +147,7 @@
                         annotateFontSize: font_size,
                         scaleFontSize: font_size,
                     };
-                    var ctx = document.getElementById("reportChart").getContext("2d");
+                    var ctx = document.getElementById('reportChart').getContext('2d');
                     var reportChart = new Chart(ctx).Bar(data, options);
 
                 </script>
@@ -174,15 +174,15 @@
 <script>
     function toggleTable(id) {
         var elem = document.getElementById(id)
-        var label = document.getElementById(id + "_label")
-        var hide = elem.style.display == "none"
+        var label = document.getElementById(id + '_label')
+        var hide = elem.style.display == 'none'
         if (hide) {
-            elem.style.display = ""
-            label.innerHTML = "[-]"
+            elem.style.display = ''
+            label.innerHTML = '[-]'
         }
         else {
-            elem.style.display = "none"
-            label.innerHTML = "[+]"
+            elem.style.display = 'none'
+            label.innerHTML = '[+]'
         }
     }
     function createTableRowContent(rowObject, data, cellType){
@@ -215,27 +215,27 @@
     {toggleTable('TOP_CATEGORIES')};
 </script>
 <script>
-    var elements= document.getElementsByClassName("money");
+    var elements= document.getElementsByClassName('money');
     for (var i = 0; i < elements.length; i++) {
         var element = elements[i];
         element.style.textAlign='right';
-        if (element.innerHTML.indexOf("-") > -1) {
-            element.style.color="#ff0000";
+        if (element.innerHTML.indexOf('-') > -1) {
+            element.style.color='red';
         }
-        element.style.whiteSpace = "nowrap";
+        element.style.whiteSpace = 'nowrap';
     }
 </script>
 <script>
     var stats_json = <TMPL_VAR STATISTICS>;
     var tbody = document.getElementById('stats');
-    tbody.innerHTML = "";
+    tbody.innerHTML = '';
     for(var obj in stats_json){
         if (obj != 'NAME') {
             var row = document.createElement('tr');
             createTableData(row, obj);
-            var cell = document.createElement("td");    
+            var cell = document.createElement('td');
             var cellText = document.createTextNode(stats_json[obj]);
-			cell.style.textAlign='right';
+            cell.style.textAlign='right';
             cell.appendChild(cellText);
             row.appendChild(cell);
             tbody.appendChild(row);

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -116,7 +116,7 @@ R"(<!DOCTYPE html>
         var element = elements[i];
         element.style.textAlign='right';
         if (element.innerHTML.indexOf("-") > -1) {
-            element.style.color="#ff0000";
+            element.style.color="red";
         }
         element.innerHTML = '<TMPL_VAR PFX_SYMBOL>' + currency(element.innerHTML) +'<TMPL_VAR SFX_SYMBOL>';
     }
@@ -178,7 +178,7 @@ R"(<!DOCTYPE html>
         var element = elements[i];
         element.style.textAlign='right';
         if (element.innerHTML.indexOf("-") > -1) {
-            element.style.color="#ff0000";
+            element.style.color="red";
         }
         element.innerHTML = '<TMPL_VAR PFX_SYMBOL>' + currency(element.innerHTML) +'<TMPL_VAR SFX_SYMBOL>';
     }

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -56,7 +56,7 @@ void mmReportBudgetingPerformance::DisplayRow(mmHTMLBuilder &hb
 
             const auto val = Model_Currency::toString(i.second, Model_Currency::GetBaseCurrency());
             hb.startTableCell(wxString::Format(" style='text-align:right;%s' nowrap"
-                , (i.second - est < 0) ? "color:#FF0000;" : ""));
+                , (i.second - est < 0) ? "color:red;" : ""));
             hb.addText(val);
             hb.endTableCell();
         }
@@ -69,7 +69,7 @@ void mmReportBudgetingPerformance::DisplayRow(mmHTMLBuilder &hb
 
         const auto val = Model_Currency::toString(actual, Model_Currency::GetBaseCurrency());
         hb.startTableCell(wxString::Format(" style='text-align:right;%s' nowrap"
-            , (actual - estimated < 0) ? "color:#FF0000;" : "color:#009900;"));
+            , (actual - estimated < 0) ? "color:red;" : "color:#009900;"));
         hb.addText(val);
         hb.endTableCell();
 

--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -178,7 +178,7 @@ wxString mmReportCategoryExpenses::getHTMLText()
         hb.addTableCell(entry.name);
         hb.addMoneyCell(entry.amount);
         if (group_counter[entry.categs] > 1)
-            hb.addTableCell("");
+            hb.addEmptyTableCell();
         else
             hb.addMoneyCell(entry.amount);
         hb.endTableRow();
@@ -187,9 +187,9 @@ wxString mmReportCategoryExpenses::getHTMLText()
         {
             group = 0;
             hb.startTableRow("WhiteSmoke");
-            if (getChartSelection() == 0) hb.addTableCell("");
+            if (getChartSelection() == 0) hb.addEmptyTableCell();
             hb.addTableCell(_("Category Total: "));
-            hb.addTableCell("");
+            hb.addEmptyTableCell();
             hb.addMoneyCell(group_total[entry.categs]);
             hb.endTableRow();
         }

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -228,7 +228,7 @@ void mmPrintableBase::setSettings(const wxString& settings)
 void mmPrintableBase::date_range(const mmDateRange* date_range, int selection)
 {
     m_date_range = date_range;
-    if (date_range != nullptr)
+    if (date_range)
     {
         m_begin_date = date_range->start_date();
         m_end_date = date_range->end_date();
@@ -277,13 +277,13 @@ mmGeneralReport::mmGeneralReport(const Model_Report::Data* report)
 
 wxString mmGeneralReport::getHTMLText()
 {
-    return Model_Report::instance().get_html(this->m_report);
+    return Model_Report::instance().get_html(m_report);
 }
 
 int mmGeneralReport::report_parameters()
 {
     int params = 0;
-    const auto content = this->m_report->SQLCONTENT.Lower();
+    const auto content = m_report->SQLCONTENT.Lower();
     if (content.Contains("&begin_date")
         || content.Contains("&end_date"))
         params |= RepParams::DATE_RANGE;
@@ -297,7 +297,7 @@ int mmGeneralReport::report_parameters()
 
 mm_html_template::mm_html_template(const wxString& arg_template): html_template(arg_template.ToStdWstring())
 {
-    this->load_context();
+    load_context();
 }
 
 void mm_html_template::load_context()

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -317,9 +317,7 @@ wxString mmReportSummaryByDate::getHTMLText()
         {
             hb.startTotalTableRow();
             hb.addTableCell(totBalanceData[k].Left(4));
-            for (int j = 0; j < x - 1; j++) {
-                hb.addTableCell("");
-            }
+            hb.addEmptyTableCell(x-1);
             hb.endTableRow();
         }
         hb.startTableRow();


### PR DESCRIPTION
# Before

There are multiple problems with reports panel's toolbar:
1. `wxStaticText` labels are cropped
2. labels are not vertically aligned with controls
3. right-most controls are invisible when MMEX window is resized

![screenshot](https://user-images.githubusercontent.com/3155552/56930731-0c1caa80-6ade-11e9-82c4-dec984d2f5f7.png)
The first problem can be easily fixed by resizing the MMEX window, but 2nd and 3rd problems remain.
![screenshot2](https://user-images.githubusercontent.com/3155552/56931025-e8a62f80-6ade-11e9-84df-41edd9ab6482.png)

# After

All problems are fixed:
1. `mmSetOwnFont()` is added to fix `wxStaticText` with changed font settings
2. `wxALIGN_CENTER_VERTICAL` is added to the text labels
3. `wxBoxSizer` is replaced with `wxWrapSizer` to always display all report controls

![screenshot3](https://user-images.githubusercontent.com/3155552/56931201-87329080-6adf-11e9-8ad8-2e45219b300d.png)
![screenshot4](https://user-images.githubusercontent.com/3155552/56931208-8b5eae00-6adf-11e9-9a62-636416eeeb37.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2163)
<!-- Reviewable:end -->
