### PR TITLE
refactor(usage): replace date and time with msecs

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1335,8 +1335,7 @@ void mmGUIFrame::createBudgetingPage(int budgetYearID)
     json_writer.Key("module");
     json_writer.String("Budget Panel");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     m_nav_tree_ctrl->SetEvtHandlerEnabled(false);
     if (panelCurrent_->GetId() == mmID_BUDGET)
@@ -1357,8 +1356,8 @@ void mmGUIFrame::createBudgetingPage(int budgetYearID)
         windowsFreezeThaw(homePanel_);
     }
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());
@@ -1377,8 +1376,7 @@ void mmGUIFrame::createHomePage()
     json_writer.Key("module");
     json_writer.String("Home Page");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     m_nav_tree_ctrl->SetEvtHandlerEnabled(false);
     int id = panelCurrent_ ? panelCurrent_->GetId() : -1;
@@ -1405,8 +1403,8 @@ void mmGUIFrame::createHomePage()
         m_nav_tree_ctrl->SelectItem(m_nav_tree_ctrl->GetRootItem());
     m_nav_tree_ctrl->SetEvtHandlerEnabled(true);
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     const auto  j = json_buffer.GetString();
@@ -2649,8 +2647,7 @@ void mmGUIFrame::createBillsDeposits()
     json_writer.Key("module");
     json_writer.String("Bills & Deposits Panel");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     if (panelCurrent_->GetId() == mmID_BILLS)
     {
@@ -2669,8 +2666,8 @@ void mmGUIFrame::createBillsDeposits()
         menuPrintingEnable(true);
     }
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());
@@ -2686,8 +2683,7 @@ void mmGUIFrame::createCheckingAccountPage(int accountID)
     json_writer.Key("module");
     json_writer.String("Checking Panel");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     if (panelCurrent_->GetId() == mmID_CHECKING)
     {
@@ -2705,8 +2701,8 @@ void mmGUIFrame::createCheckingAccountPage(int accountID)
         windowsFreezeThaw(homePanel_);
     }
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());
@@ -2727,8 +2723,7 @@ void mmGUIFrame::createStocksAccountPage(int accountID)
     json_writer.Key("module");
     json_writer.String("Stock Panel");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     //TODO: Refresh Panel
     {
@@ -2741,8 +2736,8 @@ void mmGUIFrame::createStocksAccountPage(int accountID)
         windowsFreezeThaw(homePanel_);
     }
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());
@@ -2779,8 +2774,7 @@ void mmGUIFrame::OnAssets(wxCommandEvent& WXUNUSED(event))
     json_writer.Key("module");
     json_writer.String("Asset Panel");
 
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    const auto time = wxDateTime::UNow();
 
     windowsFreezeThaw(homePanel_);
     wxSizer *sizer = cleanupHomePanel();
@@ -2790,8 +2784,8 @@ void mmGUIFrame::OnAssets(wxCommandEvent& WXUNUSED(event))
     windowsFreezeThaw(homePanel_);
     menuPrintingEnable(true);
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -313,7 +313,7 @@ mmGUIFrame::~mmGUIFrame()
     }
 
     // Report database statistics
-    for (const auto & model : this->m_all_models)
+    for (const auto & model : m_all_models)
     {
         model->show_statistics();
         Model_Usage::instance().AppendToCache(model->GetTableStatsAsJson());
@@ -570,18 +570,18 @@ void mmGUIFrame::saveSettings()
     Model_Setting::instance().Set("AUIPERSPECTIVE", m_mgr.SavePerspective());
 
     // prevent values being saved while window is in an iconised state.
-    if (this->IsIconized()) this->Restore();
+    if (IsIconized()) Restore();
 
     int value_x = 0, value_y = 0;
-    this->GetPosition(&value_x, &value_y);
+    GetPosition(&value_x, &value_y);
     Model_Setting::instance().Set("ORIGINX", value_x);
     Model_Setting::instance().Set("ORIGINY", value_y);
 
     int value_w = 0, value_h = 0;
-    this->GetSize(&value_w, &value_h);
+    GetSize(&value_w, &value_h);
     Model_Setting::instance().Set("SIZEW", value_w);
     Model_Setting::instance().Set("SIZEH", value_h);
-    Model_Setting::instance().Set("ISMAXIMIZED", this->IsMaximized());
+    Model_Setting::instance().Set("ISMAXIMIZED", IsMaximized());
     Model_Setting::instance().ReleaseSavepoint();
 }
 //----------------------------------------------------------------------------
@@ -763,7 +763,7 @@ void mmGUIFrame::updateNavTreeControl()
     m_nav_tree_ctrl->SetItemBold(reports, true);
     m_nav_tree_ctrl->SetItemData(reports, new mmTreeItemData("Reports"));
 
-    this->updateReportNavigation(reports, have_budget);
+    updateReportNavigation(reports, have_budget);
 
     ///////////////////////////////////////////////////////////////////
 
@@ -1407,8 +1407,7 @@ void mmGUIFrame::createHomePage()
     json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
-    const auto  j = json_buffer.GetString();
-    Model_Usage::instance().AppendToUsage(j);
+    Model_Usage::instance().AppendToUsage(json_buffer.GetString());
 }
 //----------------------------------------------------------------------------
 
@@ -1908,7 +1907,7 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const bool openingNew
 
     if (m_db)
     {
-        this->SetTitle(mmex::getCaption(mmex::isPortableMode() ? _("[portable mode]") : ""));
+        SetTitle(mmex::getCaption(mmex::isPortableMode() ? _("[portable mode]") : ""));
         resetNavTreeControl();
         cleanupHomePanel(false);
         menuEnableItems(false);
@@ -2251,7 +2250,7 @@ void mmGUIFrame::OnImportQIF(wxCommandEvent& WXUNUSED(event))
         Model_Account::Data* account = Model_Account::instance().get(account_id);
         setAccountNavTreeSection(account->ACCOUNTNAME);
         wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_GOTOACCOUNT);
-        this->GetEventHandler()->AddPendingEvent(evt);
+        GetEventHandler()->AddPendingEvent(evt);
     }
     else
     {
@@ -2493,7 +2492,7 @@ void mmGUIFrame::OnOptions(wxCommandEvent& WXUNUSED(event))
 {
     if (!m_db.get()) return;
 
-    mmOptionsDialog systemOptions(this, this->m_app);
+    mmOptionsDialog systemOptions(this, m_app);
     if (systemOptions.ShowModal() == wxID_OK)
     {
         //set the View Menu Option items the same as the options saved.
@@ -3053,7 +3052,7 @@ void mmGUIFrame::setGotoAccountID(int account_id, long transID)
 void mmGUIFrame::OnToggleFullScreen(wxCommandEvent& WXUNUSED(event))
 {
 #if (wxMAJOR_VERSION >= 3 && wxMINOR_VERSION >= 0)
-   this->ShowFullScreen(!IsFullScreen());
+   ShowFullScreen(!IsFullScreen());
 #endif
 }
 

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -259,16 +259,17 @@ bool mmReportsPanel::saveReportText(wxString& error, bool initial)
     json_writer.String("Report");
     json_writer.Key("name");
     json_writer.String(rb_->getReportTitle().c_str());
-    json_writer.Key("start");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
 
     const auto file_name = rb_->getFileName();
     wxLogDebug("Report File Name: %s", file_name);
+
+    const auto time = wxDateTime::UNow();
+
     if (!Model_Report::outputReportFile(rb_->getHTMLText(), file_name))
         error = _("Error");
 
-    json_writer.Key("end");
-    json_writer.String(wxDateTime::Now().FormatISOCombined().c_str());
+    json_writer.Key("seconds");
+    json_writer.Double((wxDateTime::UNow()-time).GetMilliseconds().ToDouble()/1000);
     json_writer.EndObject();
 
     Model_Usage::instance().AppendToUsage(json_buffer.GetString());

--- a/src/model/Model_Usage.cpp
+++ b/src/model/Model_Usage.cpp
@@ -62,7 +62,7 @@ void Model_Usage::AppendToUsage(const wxString& json_string)
     wxLogDebug("===== Model_Usage::AppendToUsage =================");
     wxLogDebug("%s", json_string);
     wxLogDebug("\n");
-    this->m_json_usage.Add(json_string);
+    m_json_usage.Add(json_string);
 }
 
 void Model_Usage::AppendToCache(const wxString& json_string)
@@ -70,7 +70,7 @@ void Model_Usage::AppendToCache(const wxString& json_string)
     wxLogDebug("===== Model_Usage::AppendToCache =================");
     wxLogDebug("%s", json_string);
     wxLogDebug("\n");
-    this->m_json_cache.Add(json_string);
+    m_json_cache.Add(json_string);
 }
 
 wxString Model_Usage::To_JSON_String() const
@@ -90,8 +90,8 @@ wxString Model_Usage::To_JSON_String() const
         json_writer.StartArray();
         for (size_t i = 0; i < m_json_usage.GetCount(); i++)
         {
-            wxString item = m_json_usage.Item(i);
-            json_writer.String(item.c_str());
+            const char* item = m_json_usage.Item(i).c_str();
+            json_writer.RawValue(item, strlen(item), kObjectType);
         }
         json_writer.EndArray();
     }
@@ -100,8 +100,8 @@ wxString Model_Usage::To_JSON_String() const
         json_writer.StartArray();
         for (size_t i = 0; i < m_json_cache.GetCount(); i++)
         {
-            wxString item = m_json_cache.Item(i);
-            json_writer.String(item.c_str());
+            const char* item = m_json_cache.Item(i).c_str();
+            json_writer.RawValue(item, strlen(item), kObjectType);
         }
         json_writer.EndArray();
     }
@@ -133,7 +133,7 @@ protected:
     virtual ExitCode Entry();
 };
 
-void Model_Usage::pageview(const wxWindow* window, int plt /* = 0 msec*/)
+void Model_Usage::pageview(const wxWindow* window, long plt /* = 0 msec*/)
 {
     if (!window) return;
     if (window->GetName().IsEmpty()) return;
@@ -160,7 +160,7 @@ void Model_Usage::pageview(const wxWindow* window, int plt /* = 0 msec*/)
     return pageview(wxURI(documentPath).BuildURI(), wxURI(documentTitle).BuildURI(), plt);
 }
 
-void Model_Usage::timing(const wxString& documentPath, const wxString& documentTitle, int plt /* = 0 msec*/)
+void Model_Usage::timing(const wxString& documentPath, const wxString& documentTitle, long plt /* = 0 msec*/)
 {
     if (!Option::instance().getSendUsageStatistics())
     {
@@ -186,7 +186,7 @@ void Model_Usage::timing(const wxString& documentPath, const wxString& documentT
         { "av", mmex::version::string }, // application version
                                          // custom dimensions
         { "cd1", wxPlatformInfo::Get().GetPortIdShortName() },
-        { "plt", wxString::Format("%d", plt)}
+        { "plt", wxString::Format("%ld", plt)}
     };
 
     for (const auto& kv : parameters)
@@ -200,7 +200,7 @@ void Model_Usage::timing(const wxString& documentPath, const wxString& documentT
     thread->Run();
 }
 
-void Model_Usage::pageview(const wxString& documentPath, const wxString& documentTitle, int plt /* = 0 msec*/)
+void Model_Usage::pageview(const wxString& documentPath, const wxString& documentTitle, long plt /* = 0 msec*/)
 {
     if (!Option::instance().getSendUsageStatistics())
     {
@@ -226,7 +226,7 @@ void Model_Usage::pageview(const wxString& documentPath, const wxString& documen
         { "av", mmex::version::string }, // application version
                                          // custom dimensions
         { "cd1", wxPlatformInfo::Get().GetPortIdShortName() },
-        { "plt", wxString::Format("%d", plt)}
+        { "plt", wxString::Format("%ld", plt)}
     };
 
     for (const auto& kv : parameters)

--- a/src/model/Model_Usage.h
+++ b/src/model/Model_Usage.h
@@ -57,7 +57,7 @@ public:
     wxString To_JSON_String() const;
 
 public:
-    void pageview(const wxString& documentPath, const wxString& documentTitle, int plt = 0 /*msec*/);
-    void timing(const wxString& documentPath, const wxString& documentTitle, int plt = 0 /*msec*/);
-    void pageview(const wxWindow* window, int plt = 0 /*msec*/);
+    void pageview(const wxString& documentPath, const wxString& documentTitle, long plt = 0 /*msec*/);
+    void timing(const wxString& documentPath, const wxString& documentTitle, long plt = 0 /*msec*/);
+    void pageview(const wxWindow* window, long plt = 0 /*msec*/);
 };

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -140,49 +140,49 @@ wxString mmReportMyUsage::getHTMLText()
     {
         usage_by_day[usage.USAGEDATE].first += 1;
 
-        Document json_doc;
-        if (json_doc.Parse(usage.JSONCONTENT.c_str()).HasParseError()) {
-            continue;
-        }
+        // Document json_doc;
+        // if (json_doc.Parse(usage.JSONCONTENT.c_str()).HasParseError()) {
+        //     continue;
+        // }
 
-        // wxLogDebug("======= mmReportMyUsage::getHTMLText =======");
-        // wxLogDebug("RapidJson\n%s", JSON_PrettyFormated(json_doc));
+        // // wxLogDebug("======= mmReportMyUsage::getHTMLText =======");
+        // // wxLogDebug("RapidJson\n%s", JSON_PrettyFormated(json_doc));
 
-        if (!json_doc.HasMember("usage") || !json_doc["usage"].IsArray())
-            continue;
-        Value u = json_doc["usage"].GetArray();
+        // if (!json_doc.HasMember("usage") || !json_doc["usage"].IsArray())
+        //     continue;
+        // Value u = json_doc["usage"].GetArray();
 
-        for (Value::ConstValueIterator it = u.Begin(); it != u.End(); ++it)
-        {
-            if (!it->IsObject()) continue;
-            const auto pobj = it->GetObject();
+        // for (Value::ConstValueIterator it = u.Begin(); it != u.End(); ++it)
+        // {
+        //     if (!it->IsObject()) continue;
+        //     const auto pobj = it->GetObject();
 
-            if (!pobj.HasMember("module") || !pobj["module"].IsString())
-                continue;
-            auto module = wxString::FromUTF8(pobj["symbol"].GetString());
+        //     if (!pobj.HasMember("module") || !pobj["module"].IsString())
+        //         continue;
+        //     auto module = wxString::FromUTF8(pobj["module"].GetString());
 
-            if (!pobj.HasMember("module") || !pobj["module"].IsString())
-                continue;
-            module += wxString::FromUTF8(pobj["name"].GetString());
+        //     if (!pobj.HasMember("name") || !pobj["name"].IsString())
+        //         continue;
+        //     module += wxString::FromUTF8(pobj["name"].GetString());
 
-            if (!pobj.HasMember("start") || !pobj["start"].IsString())
-                continue;
-            const auto s = wxString::FromUTF8(pobj["start"].GetString());
+        //     if (!pobj.HasMember("start") || !pobj["start"].IsString())
+        //         continue;
+        //     const auto s = wxString::FromUTF8(pobj["start"].GetString());
 
-            if (!pobj.HasMember("end") || !pobj["end"].IsString())
-                continue;
-            const auto e = wxString::FromUTF8(pobj["end"].GetString());
+        //     if (!pobj.HasMember("end") || !pobj["end"].IsString())
+        //         continue;
+        //     const auto e = wxString::FromUTF8(pobj["end"].GetString());
 
-            wxDateTime start, end;
-            start.ParseISOCombined(s);
-            end.ParseISOCombined(e);
+        //     wxDateTime start, end;
+        //     start.ParseISOCombined(s);
+        //     end.ParseISOCombined(e);
 
-            long delta = end.Subtract(start).GetSeconds().ToLong();
-            if (delta < 1)
-                continue;
+        //     long delta = end.Subtract(start).GetSeconds().ToLong();
+        //     if (delta < 1)
+        //         continue;
 
-            // usage_by_day[usage.USAGEDATE].second += module + ";";
-        }
+        //     usage_by_day[usage.USAGEDATE].second += module + ";";
+        // }
     }
 
     if (usage_by_day.empty()) {
@@ -204,7 +204,7 @@ wxString mmReportMyUsage::getHTMLText()
     }
 
     mm_html_template report(usage_template);
-    report(L"REPORTNAME") = this->getReportTitle();
+    report(L"REPORTNAME") = getReportTitle();
     // report(L"_LINECHART") = _("Line Chart");
     // report(L"_BARCHART") = _("Bar Chart");
     report(L"_FREQUENCY") = _("Frequency");


### PR DESCRIPTION
Simplified usage data as proposed in #1699.

BTW: All `USAGE_V1.JSONCONTENT` values are not valid JSON !

```
22:07:25: Debug: ===== mmGUIApp::OnExit ===========================
22:07:25: Debug: RapidJson
{
    "start": "2019-06-18 22:05:05",
    "end": "2019-06-18 22:07:25",
    "usage": [
        {"module":"Home Page","seconds":0.453},
        {"module":"Report","name":"Category Income/Expenses - Last 12 Months","seconds":0.115},
        {"module":"Report","name":"Categories - Over Time","seconds":0.061},
        {"module":"Report","name":"Cash Flow","seconds":0.072},
        {"module":"Report","name":"mmReportTransactions","seconds":0.311},
        {"module":"Report","name":"Where the Money Goes - Over Time","seconds":0.059},
        {"module":"Checking Panel","seconds":0.069},
        {"module":"Checking Panel","seconds":0.091},
        {"module":"Checking Panel","seconds":0.061}
    ],
    "cache": [
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2220)
<!-- Reviewable:end -->
