### PR TITLE
fix(billsdepositsdialog): check if account is not null

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -886,6 +886,12 @@ void mmBDDialog::onNoteSelected(wxCommandEvent& event)
 
 void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 {
+    Model_Account::Data* acc = Model_Account::instance().get(m_bill_data.ACCOUNTID);
+    if (!acc)
+    {
+        return mmErrorDialogs::InvalidAccount(bAccount_, m_transfer, mmErrorDialogs::MESSAGE_POPUP_BOX);
+    }
+
     Model_Billsdeposits::Data bill_data;
     bill_data.ACCOUNTID = m_bill_data.ACCOUNTID;
     bill_data.TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
@@ -895,12 +901,6 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
     if (!Model_Billsdeposits::instance().AllowTransaction(bill_data, bal)) return;
     if (!textAmount_->checkValue(m_bill_data.TRANSAMOUNT)) return;
-
-    Model_Account::Data* acc = Model_Account::instance().get(m_bill_data.ACCOUNTID);
-    if (!acc)
-    {
-        return mmErrorDialogs::InvalidAccount(bAccount_, m_transfer, mmErrorDialogs::MESSAGE_POPUP_BOX);
-    }
 
     m_bill_data.TOTRANSAMOUNT = m_bill_data.TRANSAMOUNT;
     if (m_transfer)

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -270,6 +270,7 @@ bool Model_Billsdeposits::AllowTransaction(const Data& r, AccountBalance& bal)
 {
     const int acct_id = r.ACCOUNTID;
     Model_Account::Data* account = Model_Account::instance().get(acct_id);
+    if (!account) return false;
     double current_account_balance = 0;
 
     AccountBalance::iterator itr_bal = bal.find(acct_id);


### PR DESCRIPTION
Billsdeposits dialog crashes without warning when the dialog is saved without account selected.
Now pop-up about account will be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2289)
<!-- Reviewable:end -->
