### PR TITLE
fix(CMakeList.txt): added option to detect Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
                 set(LINUX_DISTRO "${CMAKE_MATCH_1}")
                 set(LINUX_DISTRO_REL ${CMAKE_MATCH_2})
             endif()
+        elseif(EXISTS /etc/arch-release)            
+                execute_process(COMMAND  uname -r
+            OUTPUT_VARIABLE LINUX_DISTRO_REL
+            OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+            set(LINUX_DISTRO "Arch")            
         else()
             message(SEND_ERROR "lsb_release tool not found.")
         endif()


### PR DESCRIPTION
Using /etc/arch-release to detect an Arch distro.


make sure your code would work on both windows, linux and osx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2562)
<!-- Reviewable:end -->
