### PR TITLE
fix(CMakeList.txt): Fix to detect Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
                 set(LINUX_DISTRO "${CMAKE_MATCH_1}")
                 set(LINUX_DISTRO_REL ${CMAKE_MATCH_2})
             endif()
+        elseif(EXISTS /etc/arch-release)            
+            execute_process(COMMAND  uname -r
+                OUTPUT_VARIABLE LINUX_DISTRO_REL
+                OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+            set(LINUX_DISTRO "Arch") 	             
         else()
             message(SEND_ERROR "lsb_release tool not found.")
         endif()


### PR DESCRIPTION
Update to avoid errors when running CMake on Arch.
Checks if the "arch-release" file exists to identify an Arch distro.


make sure your code would work on both windows, linux and osx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2677)
<!-- Reviewable:end -->
