### PR TITLE
fix(#1718): yy parser

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -397,7 +397,7 @@ const std::map<wxString, wxString> &date_formats_regex()
     // First time this function is called, fill the map.
     const wxString dd = "((([0 ][1-9])|([1-2][0-9])|(3[0-1]))|([1-9]))";
     const wxString mm = "((([0 ][1-9])|(1[0-2]))|([1-9]))";
-    const wxString yy = "([0-9]{1,2})";
+    const wxString yy = "(([ ][0-9])|([0-9]{1,2}))";
     const wxString yyyy = "(((19)|([2]([0]{1})))([0-9]{2}))";
     const wxString tail = "($|[^0-9])+";
 


### PR DESCRIPTION
fix for dates like this:
```D8/ 1' 7```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2755)
<!-- Reviewable:end -->
