### PR TITLE
fix(#2405): Now closes gracefully when closed from OSX dock

### DIFF
--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -425,3 +425,13 @@ int mmGUIApp::OnExit()
 
     return 0;
 }
+
+#if defined (__WXMAC__)
+// Handle a closure for OSX dock correctly - just close the window.
+
+bool mmGUIApp::OSXOnShouldTerminate()
+{
+    wxLogDebug("Called: OSXOnShouldTerminate");
+    this->GetTopWindow()->Close();
+}
+#endif

--- a/src/mmex.h
+++ b/src/mmex.h
@@ -57,6 +57,9 @@ private:
     int OnExit();
     void OnFatalException(); // called when a crash occurs in this application
     void HandleEvent(wxEvtHandler *handler, wxEventFunction func, wxEvent& event) const;
+#if defined (__WXMAC__)
+    bool OSXOnShouldTerminate(); // called when OSX app is closed from dock
+#endif
     wxLanguage m_lang; // GUI translation language displayed
     wxLocale m_locale;
 


### PR DESCRIPTION
Added correct closure method for __WXMAC__ builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2781)
<!-- Reviewable:end -->
