### PR TITLE
fix(2766): toolbar creation order caused OSX issue

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -230,10 +230,9 @@ mmGUIFrame::mmGUIFrame(mmGUIApp* app, const wxString& title
 
     /* Create the Controls for the frame */
     createMenu();
-        createControls();
+    createControls();
     CreateToolBar();
-
-
+    
 #if wxUSE_STATUSBAR
     CreateStatusBar();
 #endif // wxUSE_STATUSBAR

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -230,8 +230,9 @@ mmGUIFrame::mmGUIFrame(mmGUIApp* app, const wxString& title
 
     /* Create the Controls for the frame */
     createMenu();
+        createControls();
     CreateToolBar();
-    createControls();
+
 
 #if wxUSE_STATUSBAR
     CreateStatusBar();


### PR DESCRIPTION
Test on OSX and Windows.

OSX seems a bit more particular about the control/toolbar ordering when the toolbar is hidden!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2783)
<!-- Reviewable:end -->
