### PR TITLE
fix(#2028): Negative values on tooltips for pie

### DIFF
--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -149,7 +149,7 @@ wxString mmReportCategoryExpenses::getHTMLText()
             hb.addDivContainer("shadow"); 
             {
                 gdExpenses.title = _("Expenses");
-                gdExpenses.type = GraphData::DONUT;
+                gdExpenses.type = GraphData::PIE;
                 hb.addChart(gdExpenses);
             }
             hb.endDiv();
@@ -159,7 +159,7 @@ wxString mmReportCategoryExpenses::getHTMLText()
             hb.addDivContainer("shadow");  
             {
                 gdIncome.title = _("Income"); 
-                gdIncome.type = GraphData::DONUT;
+                gdIncome.type = GraphData::PIE;
                 hb.addChart(gdIncome);
             }
             hb.endDiv();

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -106,31 +106,29 @@ wxString mmReportIncomeExpenses::getHTMLText()
         hb.endDiv();
     }
 
-    hb.addDivContainer("shadow"); // Table Container
-    hb.startTable();
+    hb.addDivContainer("shadow");
     {
-        hb.startThead();
+        hb.startTable();
         {
-            hb.startTableRow();
-            hb.addTableHeaderCell(_("Type"));
-            hb.addTableHeaderCell(_("Amount"), true);
-            hb.endTableRow();
+            hb.startThead();
+            {
+                hb.startTableRow();
+                    hb.addTableHeaderCell(_("Type"));
+                    hb.addTableHeaderCell(_("Amount"), true);
+                hb.endTableRow();
+            }
             hb.endThead();
+            hb.startTbody();
+            {
+                hb.addTableRow(_("Income:"), income_expenses_pair.first);
+                hb.addTableRow(_("Expenses:"), income_expenses_pair.second);
+                hb.addTotalRow(_("Difference:"), 2, income_expenses_pair.first - income_expenses_pair.second);
+            }
+            hb.endTbody();
         }
-        hb.endThead();
-        hb.startTbody();
-        {
-            hb.addTableRow(_("Income:"), income_expenses_pair.first);
-            hb.addTableRow(_("Expenses:"), income_expenses_pair.second);
-            hb.addTotalRow(_("Difference:"), 2, income_expenses_pair.first - income_expenses_pair.second);
-        }
-        hb.endTbody();
+        hb.endTable();
     }
-    hb.endTable();
-    
-    hb.endDiv();// Table container
-    hb.endDiv(); // Report Container
-    hb.endDiv(); // Main container
+    hb.endDiv(); 
     hb.end();
 
     wxLogDebug("======= mmReportIncomeExpenses:getHTMLText =======");

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -138,7 +138,7 @@ wxString mmReportMyUsage::getHTMLText()
         {
             hb.addDivContainer("shadow");
             {
-                gd.type = GraphData::DONUT;
+                gd.type = GraphData::PIE;
                 hb.addChart(gd);
             }
             hb.endDiv();

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -82,7 +82,7 @@ void  mmReportPayeeExpenses::RefreshData()
     for (const auto& entry : data_) {
         ValuePair vt;
         vt.label = entry.name;
-        vt.amount = fabs(entry.incomes + entry.expenses);
+        vt.amount = entry.incomes + entry.expenses;
         valueList_.push_back(vt);
     }
 
@@ -125,7 +125,7 @@ wxString mmReportPayeeExpenses::getHTMLText()
         {
             hb.addDivContainer("shadow");
             {
-                gd.type = GraphData::DONUT;
+                gd.type = GraphData::PIE;
                 hb.addChart(gd);
             }
             hb.endDiv();


### PR DESCRIPTION
Added support for presenting negative values in tooltips for Pie Charts. Had to revert recent change to donut charts as the central labels on these don;t seem to support formatters that allow the negative values to be presented. Moving back to Pie charts has not lost any real value with the bonus of this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2821)
<!-- Reviewable:end -->
