### PR TITLE
fix(#2832): chartdata now locale independent

### DIFF
--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -533,9 +533,20 @@ void mmHTMLBuilder::addChart(const GraphData& gd)
         for (const auto& item : entry.values)
         {
             double v = (floor(item * round) / round);
-            seriesEntries += wxString::Format("%s%f", first ? "":",", fabs(v));
+
+            // avoid locale usage with standard printf functionality. Always want 00000.00 format
+            std::ostringstream oss;
+            oss.imbue(std::locale::classic());
+            
+            oss << fabs(v);
+            wxString valueAbs = oss.str();
+            oss.str(std::string());
+            oss << v;
+            wxString value = oss.str();
+
+            seriesEntries += wxString::Format("%s%s", first ? "":",", valueAbs);
             if (gd.type == GraphData::PIE || gd.type == GraphData::DONUT)
-                pieEntries += wxString::Format("%s%f", first ? "":",", v);
+                pieEntries += wxString::Format("%s%s", first ? "":",", value);
             first = false;
         }
         if (gd.type == GraphData::PIE || gd.type == GraphData::DONUT) 


### PR DESCRIPTION
Used std::ostringstream with a 'classic' locale to avoid locale dependent output from usual string formatters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2834)
<!-- Reviewable:end -->
