### PR TITLE
fix(mmex): big file split - clang needed

### DIFF
--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -31,6 +31,7 @@ Copyright (C) 2013, 2014 Nikolay
 class mmCheckingPanel;
 class mmFilterTransactionsDialog;
 class mmGUIFrame;
+class TransactionListCtrl;
 //----------------------------------------------------------------------------
 
 class mmCheckingPanel : public mmPanelBase


### PR DESCRIPTION
Won't build on MacOS without the class def.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2869)
<!-- Reviewable:end -->
