### PR TITLE
fix(#2848): refactor to avoid click counting

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -45,7 +45,7 @@ const wxString mmex::version::string = mmex::version::getProgramVersion();
 bool mmex::version::isStable()
 {
     const wxString ver = wxString() << MMEX_VERSION_WITH_UNSTABLE;
-    wxRegEx pattern = "(Beta|Alpha|RC)";
+    wxRegEx pattern("(Beta|Alpha|RC)");
     bool is_stable = !pattern.Matches(ver);
     return is_stable;
 }

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -193,6 +193,7 @@ private:
     void OnMouseRightClick(wxMouseEvent& event);
     void OnListLeftClick(wxMouseEvent& event);
     void OnListItemSelected(wxListEvent& event);
+    void OnListItemDeSelected(wxListEvent& event);
     void OnListItemActivated(wxListEvent& event);
     void OnMarkTransaction(wxCommandEvent& event);
     void OnMarkAllTransactions(wxCommandEvent& event);
@@ -204,6 +205,7 @@ private:
     void OnListItemFocused(wxListEvent & WXUNUSED);
 
     bool TransactionLocked(const wxString& transdate);
+    void FindSelectedTransactions();
 private:
     /* The topmost visible item - this will be used to set
     where to display the list again after refresh */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -237,7 +237,7 @@ bool getNewsRSS(std::vector<WebsiteNews>& WebsiteNewsList)
         RssRoot = RssRoot->GetNext();
     }
 
-    wxLogDebug("getNewsRSS: New articles = %u", (int)WebsiteNewsList.size());
+    wxLogDebug("getNewsRSS: New articles = %i", static_cast<int>(WebsiteNewsList.size()));
     if (WebsiteNewsList.size() == 0)
         return false;
 


### PR DESCRIPTION
I'm hoping that by avoiding having to keep track of leftclick/select/unselect/focus events it will make the logic easier to understand. Just need to pull the list of selected transactions when needed.

Have done testing to check that major functionality works, possibly a few edges cases....  Please test.

Todo: Consider ditching the class wide m_selected_id and just use as a local variable, also need to consider if we should add back in the 'Number of Selected Transactions, etc (though not convinced about usefulness of date range and balance, etc. Could also easily support MOVE of multiple transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2899)
<!-- Reviewable:end -->
