### PR TITLE
fix(#2848): updateExtraTransactionData correction

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -214,21 +214,21 @@ void TransactionListCtrl::OnListItemSelected(wxListEvent& event)
 {
     wxLogDebug("OnListItemSelected: %i selected", GetSelectedItemCount());
     FindSelectedTransactions();
-    m_cp->updateExtraTransactionData();
+    m_cp->updateExtraTransactionData(GetSelectedItemCount() == 1);
 }
 
 void TransactionListCtrl::OnListItemDeSelected(wxListEvent& event)
 {
     wxLogDebug("OnListItemDeSelected: %i selected", GetSelectedItemCount());
     FindSelectedTransactions();
-    m_cp->updateExtraTransactionData();
+    m_cp->updateExtraTransactionData(GetSelectedItemCount() == 1);
 }
 
 void TransactionListCtrl::OnListItemFocused(wxListEvent& WXUNUSED(event))
 {
     wxLogDebug("OnListItemFocused: %i selected", GetSelectedItemCount());
     FindSelectedTransactions();
-    m_cp->updateExtraTransactionData();
+    m_cp->updateExtraTransactionData(false);
 }
 
 void TransactionListCtrl::OnListLeftClick(wxMouseEvent& event)
@@ -949,7 +949,6 @@ void TransactionListCtrl::refreshVisualList(bool filter)
         EnsureVisible(m_topItemIndex);
 
     m_cp->setAccountSummary();
-    m_cp->updateExtraTransactionData();
     this->SetEvtHandlerEnabled(true);
     Refresh();
     Update();

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -423,9 +423,9 @@ void mmCheckingPanel::enableEditDeleteButtons(bool en)
 }
 //----------------------------------------------------------------------------
 
-void mmCheckingPanel::updateExtraTransactionData()
+void mmCheckingPanel::updateExtraTransactionData(bool single)
 {
-    if (m_listCtrlAccount->getSelectedId().size() == 1)
+    if (single)
     {
         enableEditDeleteButtons(true);
         int trx_id = m_listCtrlAccount->getSelectedId()[0];

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -170,7 +170,7 @@ private:
 
     /* updates the checking panel data */
     void showTips();
-    void updateExtraTransactionData();
+    void updateExtraTransactionData(bool single);
     wxString GetPanelTitle(const Model_Account::Data& account) const;
 
     static void mmPlayTransactionSound();


### PR DESCRIPTION
Regardless of what GetSelectedItemCount says, when OnListItemFocused is called I think we always have more than one transaction highlighted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/2901)
<!-- Reviewable:end -->
