### PR TITLE
fix(#1832): useless cast to type 'int'

### DIFF
--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -179,7 +179,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     }
 
     const wxString& headingStr = wxString::Format(_("Budget Performance for %s"),
-        AdjustYearValues(static_cast<int>(startDay)
+        AdjustYearValues(startDay
             , startMonth, startYear, budget_year)
     );
     mmHTMLBuilder hb;


### PR DESCRIPTION
make sure your code would work on both windows, linux and osx
