### PR TITLE
Default to primary display when creating mmGuiFrame

### DIFF
--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -326,8 +326,17 @@ bool OnInitImpl(mmGUIApp* app)
     /* set preffered GUI language */
     app->setGUILanguage(Option::instance().getLanguageID());
 
-    // Get a 'sensible' location on the primary display in case we can't fit it into the window
+    // iterate through each display until the primary is found, default to display 0
     wxSharedPtr<wxDisplay> display(new wxDisplay(static_cast<unsigned int>(0)));
+    for (unsigned int i = 0; i < wxDisplay::GetCount(); ++i) {
+        if (display->IsPrimary()) {
+            break;
+        }
+
+        display = new wxDisplay(i);
+    }
+
+    // Get a 'sensible' location on the primary display in case we can't fit it into the window
     wxRect rect = display->GetClientArea();
     int defValX = rect.GetX() + 50;
     int defValY = rect.GetY() + 50;


### PR DESCRIPTION
MMEX always opens on display 0, which may not always be the primary display. This PR adds a small loop to find the primary display and use it instead. If `IsPrimary()` returns false for all displays display 0 is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/3728)
<!-- Reviewable:end -->
