### PR TITLE
fix(#3743): use coincap if yahoo can't find crypto price

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -158,6 +158,12 @@ const wxString mmex::weblink::YahooQuotes = "https://query1.finance.yahoo.com/v7
    Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]*/
 const wxString mmex::weblink::YahooQuotesHistory = "https://query1.finance.yahoo.com/v8/finance/chart/%s?%s&fields=currency";
 
+// coincap asset search by symbol and id 
+const wxString mmex::weblink::CoinCapSearch = "http://api.coincap.io/v2/assets?search=%s";
+
+// coincap asset price history, all values in USD
+// Valid intervals: [m1, m5, m15, m30, h1, h2, h6, h12, d1]
+const wxString mmex::weblink::CoinCapHistory = "http://api.coincap.io/v2/assets/%s/history?interval=%s&start=%lld&end=%lld";
 
 /* End namespace weblink */
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -86,6 +86,8 @@ namespace weblink
     extern const wxString Crowdin;
     extern const wxString YahooQuotes;
     extern const wxString YahooQuotesHistory;
+    extern const wxString CoinCapSearch;
+    extern const wxString CoinCapHistory;
 } // namespace weblink
 } // namespace mmex
 

--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -662,6 +662,13 @@ void mmMainCurrencyDialog::OnHistoryUpdate(wxCommandEvent& WXUNUSED(event))
     std::map<wxDateTime, double> historical_rates;
     bool UpdStatus = GetOnlineHistory(CurrentCurrency->CURRENCY_SYMBOL, begin_date, historical_rates, msg);
 
+    if (!UpdStatus && !g_fiat_curr().Contains(CurrentCurrency->CURRENCY_SYMBOL)) {
+        wxString coincap_id;
+        double coincap_price_usd;
+        UpdStatus = getCoincapInfoFromSymbol(CurrentCurrency->CURRENCY_SYMBOL, coincap_id, coincap_price_usd, msg)
+                    && getCoincapAssetHistory(coincap_id, begin_date, historical_rates, msg);
+    }
+
     if (!UpdStatus)
     {
         return mmErrorDialogs::MessageError(this

--- a/src/util.h
+++ b/src/util.h
@@ -137,6 +137,8 @@ bool get_yahoo_prices(std::map<wxString, double>& symbols
     , const wxString base_currency_symbol
     , wxString& output
     , int type);
+bool getCoincapInfoFromSymbol(const wxString symbol, wxString& out_id, double& price_usd, wxString& output);
+bool getCoincapAssetHistory(const wxString asset_id, wxDateTime begin_date, std::map<wxDateTime, double> &historical_rates, wxString &msg);
 
 const wxString mmPlatformType();
 


### PR DESCRIPTION
Quick hack to search coincap.io after yahoo if Yahoo can't find a crypto symbol.

fixes #3743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/3747)
<!-- Reviewable:end -->
