### PR TITLE
Coincap fallback fixes

### DIFF
--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -666,7 +666,8 @@ void mmMainCurrencyDialog::OnHistoryUpdate(wxCommandEvent& WXUNUSED(event))
         wxString coincap_id;
         double coincap_price_usd;
         UpdStatus = getCoincapInfoFromSymbol(CurrentCurrency->CURRENCY_SYMBOL, coincap_id, coincap_price_usd, msg);
-        UpdStatus &= getCoincapAssetHistory(coincap_id, begin_date, historical_rates, msg);
+        if (UpdStatus)
+            UpdStatus = getCoincapAssetHistory(coincap_id, begin_date, historical_rates, msg);
     }
 
     if (!UpdStatus)


### PR DESCRIPTION
Fixes some issues with the coincap.io fallback (#3743)

Fixed:

1. only run `getCoincapAssetHistory` if the previous call succeeded
2. try coincap even if yahoo fails
3. small style change to how USD conversion rates were handled

There's still two main issues that are a bit more tricky:

1. coincap.io has some pretty harsh rate limits, which leads to `invalid value` if the user presses the update currency too many times
2. USD conversion rate is required, if it's not updated the conversion rates fetched will be in USD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/3759)
<!-- Reviewable:end -->
