### PR TITLE
fix(#3933): currency rates are not currency

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -677,13 +677,13 @@ bool getOnlineCurrencyRates(wxString& msg, int curr_id, bool used_only)
     msg << "\n\n";
     for (const auto & item : fiat)
     {
-        const wxString value0_str(fmt::format("{:>{}}", Model_Currency::toCurrency(item.second, b, 4).mb_str(), 20));
+        const wxString value0_str(fmt::format("{:>{}}", Model_Currency::toString(item.second, b, 4).mb_str(), 20));
         const wxString symbol(fmt::format("{:<{}}", item.first.mb_str(), 10));
 
         if (currency_data.find(item.first) != currency_data.end())
         {
             auto value1 = currency_data[item.first];
-            const wxString value1_str(fmt::format("{:>{}}", Model_Currency::toCurrency(value1, b, 4).mb_str(), 20));
+            const wxString value1_str(fmt::format("{:>{}}", Model_Currency::toString(value1, b, 4).mb_str(), 20));
             msg << wxString::Format("%s\t%s\t\t%s\n", symbol, value0_str, value1_str);
         }
         else


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/3943)
<!-- Reviewable:end -->
