### PR TITLE
fix(#3980): graceful exit on missing themes

### DIFF
--- a/src/images_list.cpp
+++ b/src/images_list.cpp
@@ -517,6 +517,13 @@ void LoadTheme()
     {
         wxMessageBox(wxString::Format(_("Theme %s has missing items and is incompatible. Reverting to default theme"), Model_Setting::instance().Theme()), _("Warning"), wxOK | wxICON_WARNING);
         reverttoDefaultTheme();
+        if (!checkThemeContents(filesInVFS.get()))
+        {
+            // Time to give up as we couldn't find a workable theme
+            wxMessageBox(_("No workable theme found, the installation may be corrupt")
+                , _("Error"), wxOK | wxICON_ERROR);
+            exit(EXIT_FAILURE);
+        }
     } 
 }
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4076)
<!-- Reviewable:end -->
