### PR TITLE
fix(#4098): ctrl + a

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -637,9 +637,12 @@ void TransactionListCtrl::OnChar(wxKeyEvent& event)
 
 void TransactionListCtrl::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 {
+    SetEvtHandlerEnabled(false);
     for (int row = 0; row < GetItemCount(); row++) {
         SetItemState(row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
     }
+    SetEvtHandlerEnabled(true);
+    setExtraTransactionData(false);
 }
 
 void TransactionListCtrl::OnCopy(wxCommandEvent& WXUNUSED(event))


### PR DESCRIPTION
Disable event handler before items state change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4108)
<!-- Reviewable:end -->
