### PR TITLE
fix(#4223): navtree_images Loan Acc size fix

### DIFF
--- a/src/images_list.cpp
+++ b/src/images_list.cpp
@@ -204,7 +204,7 @@ static const std::map<int, wxBitmap> navtree_images(int size)
         , { TERMACCOUNT_NORMAL_PNG, mmBitmap(png::TERM_NORMAL, size) }
         , { STOCK_ACC_NORMAL_PNG, mmBitmap(png::STOCKS_NORMAL, size) }
         , { CASH_ACC_NORMAL_PNG, mmBitmap(png::CASH_NORMAL, size) }
-        , { LOAN_ACC_NORMAL_PNG, mmBitmap(png::LOAN_ACC_NORMAL) }
+        , { LOAN_ACC_NORMAL_PNG, mmBitmap(png::LOAN_ACC_NORMAL, size) }
         , { ACCOUNT_CLOSED_PNG, mmBitmap(png::ACCOUNT_CLOSED, size) }
     };
 };


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4253)
<!-- Reviewable:end -->
