### PR TITLE
fix(transdialog): Fix entering "to amount" for transfers

### DIFF
--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -799,7 +799,7 @@ void mmTransDialog::OnFocusChange(wxChildFocusEvent& event)
     case mmID_TOTEXTAMOUNT:
     {
         if (toTextAmount_->Calculate(Model_Currency::precision(m_trx_data.TOACCOUNTID))) {
-            toTextAmount_->GetDouble(m_trx_data.TRANSAMOUNT);
+            toTextAmount_->GetDouble(m_trx_data.TOTRANSAMOUNT);
         }
         skip_amount_init_ = false;
         break;


### PR DESCRIPTION
Maybe fixes #4648 but fixes manually entering "to amount" for sure. The logic had a typo and the "from amount" was set to the "to amount" after focusing out of the text box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4657)
<!-- Reviewable:end -->
