### PR TITLE
fix(#4692): support for non-active window

### DIFF
--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -473,7 +473,19 @@ bool mmGUIApp::OSXOnShouldTerminate()
     wxLogDebug("Called: OSXOnShouldTerminate");
 
     // Don't allow closure if dialogs are open
-    if (this->m_frame->wxTopLevelWindow::IsActive())
+    bool modalExists = false;
+    wxWindowList& children = GetTopWindow()->GetChildren();
+    for (wxWindowList::Node *node=children.GetFirst(); node; node = node->GetNext())
+    {
+        wxWindow *current = (wxWindow *)node->GetData();
+        if (current->IsKindOf(CLASSINFO(wxDialog)))
+        {
+            modalExists = true;
+            break;
+        }
+    }
+
+    if (!modalExists)
         this->GetTopWindow()->Close();
 }
 #endif


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4707)
<!-- Reviewable:end -->
