### PR TITLE
Revert "fix(#3226): reference name used where available"

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -1,6 +1,5 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
- Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -411,7 +410,7 @@ void mmNewAcctDialog::OnCurrency(wxCommandEvent& /*event*/)
 void mmNewAcctDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
     wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT);
-    mmAttachmentDialog dlg(this, RefType, m_account->ACCOUNTID, m_account->ACCOUNTNAME);
+    mmAttachmentDialog dlg(this, RefType, m_account->ACCOUNTID);
     dlg.ShowModal();
 }
 

--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -1,6 +1,5 @@
 /*******************************************************
  Copyright (C) 2013 - 2016, 2020, 2022 Nikolay Akimov
- Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
 
   This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -470,17 +469,13 @@ void mmAssetDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
     const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
     int RefId;
-    wxString RefName = "";
     
     if (!this->m_asset)
         RefId = 0;
     else
-    {
         RefId= m_asset->ASSETID;
-        RefName = m_asset->ASSETNAME;
-    }
 
-    mmAttachmentDialog dlg(this, RefType, RefId, RefName);
+    mmAttachmentDialog dlg(this, RefType, RefId);
     dlg.ShowModal();
 }
 

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -1,7 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2015 -2021 Nikolay Akimov
- Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -270,9 +269,8 @@ void mmAssetsListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 
     wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
     int RefId = m_panel->m_assets[m_selected_row].ASSETID;
-    wxString RefName = m_panel->m_assets[m_selected_row].ASSETNAME;
 
-    mmAttachmentDialog dlg(this, RefType, RefId, RefName);
+    mmAttachmentDialog dlg(this, RefType, RefId);
     dlg.ShowModal();
 
     doRefreshItems(RefId);

--- a/src/attachmentdialog.cpp
+++ b/src/attachmentdialog.cpp
@@ -42,11 +42,10 @@ wxBEGIN_EVENT_TABLE( mmAttachmentDialog, wxDialog )
 wxEND_EVENT_TABLE()
 
 
-mmAttachmentDialog::mmAttachmentDialog (wxWindow* parent, const wxString& RefType, int RefId, const wxString& RefName, const wxString& name) :
+mmAttachmentDialog::mmAttachmentDialog (wxWindow* parent, const wxString& RefType, int RefId, const wxString& name) :
     m_attachment_id(-1)
     , m_RefType(RefType)
     , m_RefId(RefId)
-    , m_RefName(RefName)
     #ifdef _DEBUG
         , debug_(true)
     #else
@@ -84,10 +83,7 @@ void mmAttachmentDialog::Create(wxWindow* parent, const wxString& name)
 
     wxString WindowTitle;
     if (m_RefId > 0)
-        if (m_RefName.IsEmpty())
-            WindowTitle = wxString::Format(_("Organize Attachments | %s | %i"), wxGetTranslation(m_RefType), m_RefId);
-        else
-            WindowTitle = wxString::Format(_("Organize Attachments | %s | %s"), wxGetTranslation(m_RefType), m_RefName);           
+        WindowTitle = wxString::Format(_("Organize Attachments | %s %i"), wxGetTranslation(m_RefType), m_RefId);
     else
         WindowTitle = wxString::Format(_("Organize Attachments | New %s"), wxGetTranslation(m_RefType));
 

--- a/src/attachmentdialog.h
+++ b/src/attachmentdialog.h
@@ -30,7 +30,7 @@ class mmAttachmentDialog : public wxDialog
     wxDECLARE_EVENT_TABLE();
 
 public:
-    mmAttachmentDialog(wxWindow* parent, const wxString& RefType, int RefId, const wxString& RefName = "", const wxString& name = "mmAttachmentDialog");
+    mmAttachmentDialog(wxWindow* parent, const wxString& RefType, int RefId, const wxString& name = "mmAttachmentDialog");
 
 private:
     enum cols
@@ -58,7 +58,6 @@ private:
 
     wxString m_RefType;
     int m_RefId;
-    wxString m_RefName;
 
     mmAttachmentDialog() : m_attachment_id(-1) {}
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1121,7 +1121,7 @@ void mmGUIFrame::OnAccountAttachments(wxCommandEvent& /*event*/)
         int RefId = selectedItemData_->getData();
         wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT);
 
-        mmAttachmentDialog dlg(this, RefType, RefId, Model_Account::get_account_name(RefId));
+        mmAttachmentDialog dlg(this, RefType, RefId);
         dlg.ShowModal();
     }
 }

--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -341,7 +341,7 @@ void mmPayeeDialog::OnOrganizeAttachments()
 {
     wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::PAYEE);
 
-    mmAttachmentDialog dlg(this, RefType, m_payee_id, Model_Payee::get_payee_name(m_payee_id));
+    mmAttachmentDialog dlg(this, RefType, m_payee_id);
     dlg.ShowModal();
     refreshRequested_ = true;
 }

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -1,7 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2016, 2020 Nikolay Akimov
- Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -384,7 +383,7 @@ void mmStockDialog::OnAttachments(wxCommandEvent& /*event*/)
     if (RefId < 0)
         RefId = 0;
 
-    mmAttachmentDialog dlg(this, RefType, RefId, m_stock_name_ctrl->GetValue());
+    mmAttachmentDialog dlg(this, RefType, RefId);
     dlg.ShowModal();
 }
 

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -1,7 +1,6 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2010-2021 Nikolay Akimov
- Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -329,7 +328,7 @@ void StocksListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
     wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
     int RefId = m_stocks[m_selected_row].STOCKID;
 
-    mmAttachmentDialog dlg(this, RefType, RefId, m_stocks[m_selected_row].STOCKNAME);
+    mmAttachmentDialog dlg(this, RefType, RefId);
     dlg.ShowModal();
 
     doRefreshItems(RefId);


### PR DESCRIPTION
This reverts commit ad45abe9c03534af7768ea2c0073c5da01619306.


Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4850)
<!-- Reviewable:end -->
