### PR TITLE
fix(#4946): mmTextCtrl - revert some changes

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -1424,4 +1424,11 @@ void mmBDDialog::OnFocusChange(wxChildFocusEvent& event)
     if (w) {
         object_in_focus_ = w->GetId();
     }
+
+    if (textAmount_->Calculate(Model_Currency::precision(m_bill_data.ACCOUNTID))) {
+        textAmount_->GetDouble(m_bill_data.TRANSAMOUNT);
+    }
+    if (m_advanced && toTextAmount_->Calculate(Model_Currency::precision(m_bill_data.TOACCOUNTID))) {
+        toTextAmount_->GetDouble(m_bill_data.TOTRANSAMOUNT);
+    }
 }

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -71,6 +71,11 @@ mmTransDialog::~mmTransDialog()
 
 void mmTransDialog::SetEventHandlers()
 {
+    m_textAmount->Connect(mmID_TEXTAMOUNT, wxEVT_COMMAND_TEXT_ENTER
+        , wxCommandEventHandler(mmTransDialog::OnTextEntered), nullptr, this);
+    toTextAmount_->Connect(mmID_TOTEXTAMOUNT, wxEVT_COMMAND_TEXT_ENTER
+        , wxCommandEventHandler(mmTransDialog::OnTextEntered), nullptr, this);
+
 #ifdef __WXGTK__ // Workaround for bug http://trac.wxwidgets.org/ticket/11630
     dpc_->Connect(ID_DIALOG_TRANS_BUTTONDATE, wxEVT_KILL_FOCUS
         , wxFocusEventHandler(mmTransDialog::OnDpcKillFocus), nullptr, this);
@@ -753,6 +758,18 @@ void mmTransDialog::OnFocusChange(wxChildFocusEvent& event)
     case mmID_CATEGORY:
         cbCategory_->ChangeValue(cbCategory_->GetValue());
         break;
+    case mmID_TEXTAMOUNT:
+        if (m_textAmount->Calculate(Model_Currency::precision(m_trx_data.ACCOUNTID))) {
+            m_textAmount->GetDouble(m_trx_data.TRANSAMOUNT);
+        }
+        skip_amount_init_ = false;
+        break;
+    case mmID_TOTEXTAMOUNT:
+        if (toTextAmount_->Calculate(Model_Currency::precision(m_trx_data.TOACCOUNTID))) {
+            toTextAmount_->GetDouble(m_trx_data.TOTRANSAMOUNT);
+        }
+        skip_amount_init_ = false;
+        break;
     }
 
     object_in_focus_ = w->GetId();
@@ -990,6 +1007,25 @@ void mmTransDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
     dlg.ShowModal();
 }
 
+void mmTransDialog::OnTextEntered(wxCommandEvent& WXUNUSED(event))
+{
+    if (object_in_focus_ == m_textAmount->GetId())
+    {
+        if (m_textAmount->Calculate(Model_Currency::precision(m_trx_data.ACCOUNTID)))
+        {
+            m_textAmount->GetDouble(m_trx_data.TRANSAMOUNT);
+        }
+    }
+    else if (object_in_focus_ == toTextAmount_->GetId())
+    {
+        if (toTextAmount_->Calculate(Model_Currency::precision(m_trx_data.TOACCOUNTID)))
+        {
+            toTextAmount_->GetDouble(m_trx_data.TOTRANSAMOUNT);
+        }
+    }
+    skip_amount_init_ = false;
+    dataToControls();
+}
 
 void mmTransDialog::OnFrequentUsedNotes(wxCommandEvent& WXUNUSED(event))
 {

--- a/src/transdialog.h
+++ b/src/transdialog.h
@@ -89,6 +89,7 @@ private:
     void OnTransTypeChanged(wxCommandEvent& event);
     void OnPayeeChanged(wxCommandEvent& event);
     void OnFocusChange(wxChildFocusEvent& event);
+    void OnTextEntered(wxCommandEvent& event);
     void OnAdvanceChecked(wxCommandEvent& event);
     void SetTooltips();
     void SetCategoryForPayee(const Model_Payee::Data *payee = nullptr);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/4964)
<!-- Reviewable:end -->
