### PR TITLE
chore(circleci.yml): disable MacOS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,4 +66,4 @@ workflows:
   mmex-builds:
     jobs:
       - build-linux
-      - build-macos
+#      - build-macos


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5011)
<!-- Reviewable:end -->
