### PR TITLE
fix(#5056):Correct sorting of child nodes

### DIFF
--- a/src/categdialog.cpp
+++ b/src/categdialog.cpp
@@ -397,6 +397,7 @@ void mmCategDialog::OnAdd(wxCommandEvent& /*event*/)
         wxTreeItemId tid = m_treeCtrl->AppendItem(m_selectedItemId, text);
         Model_Subcategory::Data subcat;
         m_treeCtrl->SetItemData(tid, new mmTreeItemCateg(*category, subcat));
+        m_treeCtrl->SortChildren(m_selectedItemId);
         m_treeCtrl->Expand(m_selectedItemId);
         m_treeCtrl->SelectItem(tid);
         m_treeCtrl->SetFocus();
@@ -428,6 +429,7 @@ void mmCategDialog::OnAdd(wxCommandEvent& /*event*/)
 
         wxTreeItemId tid = m_treeCtrl->AppendItem(m_selectedItemId, text);
         m_treeCtrl->SetItemData(tid, new mmTreeItemCateg(*iData->getCategData(), *subcategory));
+        m_treeCtrl->SortChildren(m_selectedItemId);
         m_treeCtrl->Expand(m_selectedItemId);
         m_treeCtrl->SelectItem(tid);
         m_treeCtrl->SetFocus();


### PR DESCRIPTION
#5056 
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5064)
<!-- Reviewable:end -->
