### PR TITLE
fix(#4087):Share precision in Stock Summary report

### DIFF
--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -141,7 +141,7 @@ wxString mmReportSummaryStocks::getHTMLText()
                             hb.addTableCell(entry.name);
                             hb.addTableCell(entry.symbol);
                             hb.addTableCellDate(entry.date);
-                            hb.addTableCell(Model_Account::toString(entry.qty, account, floor(entry.qty) ? 0 : 4), "text-right");
+                            hb.addTableCell(Model_Account::toString(entry.qty, account, trunc(entry.qty) == entry.qty ? 0 : 4), "text-right");
                             hb.addCurrencyCell(entry.purchase, currency, 4);
                             hb.addCurrencyCell(entry.current, currency, 4);
                             hb.addCurrencyCell(entry.commission, currency, 4);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5071)
<!-- Reviewable:end -->
