### PR TITLE
fix(#3892):stock fixes & enhancements

### DIFF
--- a/src/model/Model_Stock.h
+++ b/src/model/Model_Stock.h
@@ -60,6 +60,14 @@ public:
     static double CurrentValue(const Data* r);
     static double CurrentValue(const Data& r);
 
+    /** Realized gain/loss from sales */
+    static double RealGainLoss(const Data* r);
+    /** Realized gain/loss from sales */
+    static double RealGainLoss(const Data& r);
+
+    /** Update current price across accounts */
+    static double UpdateCurrentPrice(const Data* r);
+
 public:
     /**
     * Remove the Data record from memory and the database.

--- a/src/model/Model_Translink.cpp
+++ b/src/model/Model_Translink.cpp
@@ -171,6 +171,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     double total_shares = 0;
     double total_initial_value = 0;
     double total_commission = 0;
+    double avg_share_price = 0;
     for (const auto trans : trans_list)
     {
         Model_Shareinfo::Data* share_entry = Model_Shareinfo::ShareEntry(trans.CHECKINGACCOUNTID);
@@ -178,8 +179,15 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
         total_shares += share_entry->SHARENUMBER;
         if (total_shares < 0) total_shares = 0;
 
-        total_initial_value += share_entry->SHARENUMBER * share_entry->SHAREPRICE;
+        if (share_entry->SHARENUMBER > 0) {
+            total_initial_value += share_entry->SHARENUMBER * share_entry->SHAREPRICE + share_entry->SHARECOMMISSION;
+        }
+        else {
+            total_initial_value += share_entry->SHARENUMBER * avg_share_price;
+        }
+
         if (total_initial_value < 0) total_initial_value = 0;
+        if (total_shares > 0) avg_share_price = total_initial_value / total_shares;
 
         total_commission += share_entry->SHARECOMMISSION;
     }
@@ -191,7 +199,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     }
     else
     {
-        stock_entry->PURCHASEPRICE = 0;
+        stock_entry->PURCHASEPRICE = avg_share_price;
         stock_entry->NUMSHARES = total_shares;
         stock_entry->VALUE = total_initial_value;
         stock_entry->COMMISSION = total_commission;

--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -34,7 +34,8 @@
 
 mmReportSummaryStocks::mmReportSummaryStocks()
     : mmPrintableBase(wxTRANSLATE("Summary of Stocks"))
-    , m_gain_loss_sum_total(0.0)
+    , m_real_gain_loss_sum_total(0.0)
+    , m_unreal_gain_loss_sum_total(0.0)
     , m_stock_balance(0.0)
 {
     setReportParameters(Reports::StocksReportSummary);
@@ -43,7 +44,8 @@ mmReportSummaryStocks::mmReportSummaryStocks()
 void  mmReportSummaryStocks::RefreshData()
 {
     m_stocks.clear();
-    m_gain_loss_sum_total = 0.0;
+    m_real_gain_loss_sum_total = 0.0;
+    m_unreal_gain_loss_sum_total = 0.0;
     m_stock_balance = 0.0;
 
     data_holder line;
@@ -57,7 +59,8 @@ void  mmReportSummaryStocks::RefreshData()
 
         account.id = a.id();
         account.name = a.ACCOUNTNAME;
-        account.gainloss = 0.0;
+        account.realgainloss = 0.0;
+        account.unrealgainloss = 0.0;
         account.total = Model_Account::investment_balance(a).first;
         account.data.clear();
 
@@ -66,9 +69,13 @@ void  mmReportSummaryStocks::RefreshData()
             const Model_Currency::Data* currency = Model_Account::currency(a);
             const double today_rate = Model_CurrencyHistory::getDayRate(currency->CURRENCYID, today);
             m_stock_balance += today_rate * Model_Stock::CurrentValue(stock);
-            account.gainloss += Model_Stock::CurrentValue(stock) - Model_Stock::InvestmentValue(stock);
+            line.realgainloss = Model_Stock::RealGainLoss(stock);
+            account.realgainloss += line.realgainloss;
+            line.unrealgainloss = Model_Stock::CurrentValue(stock) - Model_Stock::InvestmentValue(stock);
+            account.unrealgainloss += line.unrealgainloss;
             const double purchase_rate = Model_CurrencyHistory::getDayRate(currency->CURRENCYID, stock.PURCHASEDATE);
-            m_gain_loss_sum_total += (Model_Stock::CurrentValue(stock) * today_rate - Model_Stock::InvestmentValue(stock) * purchase_rate);
+            m_unreal_gain_loss_sum_total += (Model_Stock::CurrentValue(stock) * today_rate - Model_Stock::InvestmentValue(stock) * purchase_rate);
+            m_real_gain_loss_sum_total += line.realgainloss * today_rate;
 
             line.name = stock.STOCKNAME;
             line.symbol = stock.SYMBOL;
@@ -77,7 +84,6 @@ void  mmReportSummaryStocks::RefreshData()
             line.purchase = Model_Stock::InvestmentValue(stock);
             line.current = stock.CURRENTPRICE;
             line.commission = stock.COMMISSION;
-            line.gainloss = Model_Stock::CurrentValue(stock) - Model_Stock::InvestmentValue(stock);
             line.value = Model_Stock::CurrentValue(stock);
             account.data.push_back(line);
         }
@@ -110,7 +116,8 @@ wxString mmReportSummaryStocks::getHTMLText()
                     hb.addTableHeaderCell(_("Initial Value"), "text-right");
                     hb.addTableHeaderCell(_("Current Price"), "text-right");
                     hb.addTableHeaderCell(_("Commission"), "text-right");
-                    hb.addTableHeaderCell(_("Gain/Loss"), "text-right");
+                    hb.addTableHeaderCell(_("Realized Gain/Loss"), "text-right");
+                    hb.addTableHeaderCell(_("Unrealized Gain/Loss"), "text-right");
                     hb.addTableHeaderCell(_("Current Value"), "text-right");
                 }
                 hb.endTableRow();
@@ -145,7 +152,8 @@ wxString mmReportSummaryStocks::getHTMLText()
                             hb.addCurrencyCell(entry.purchase, currency, 4);
                             hb.addCurrencyCell(entry.current, currency, 4);
                             hb.addCurrencyCell(entry.commission, currency, 4);
-                            hb.addCurrencyCell(entry.gainloss, currency);
+                            hb.addCurrencyCell(entry.realgainloss, currency);
+                            hb.addCurrencyCell(entry.unrealgainloss, currency);
                             hb.addCurrencyCell(entry.value, currency);
                         }
                         hb.endTableRow();
@@ -154,7 +162,8 @@ wxString mmReportSummaryStocks::getHTMLText()
                     {
                         hb.addTableCell(_("Total:"));
                         hb.addEmptyTableCell(6);
-                        hb.addCurrencyCell(acct.gainloss, currency);
+                        hb.addCurrencyCell(acct.realgainloss, currency);
+                        hb.addCurrencyCell(acct.unrealgainloss, currency);
                         hb.addCurrencyCell(acct.total, currency);
                     }
                     hb.endTableRow();
@@ -165,9 +174,10 @@ wxString mmReportSummaryStocks::getHTMLText()
 
             hb.startTfoot();
             {
-                const std::vector<wxString> v{ Model_Currency::toCurrency(m_gain_loss_sum_total),
+                const std::vector<wxString> v{ Model_Currency::toCurrency(m_real_gain_loss_sum_total),
+                                               Model_Currency::toCurrency(m_unreal_gain_loss_sum_total),
                                                Model_Currency::toCurrency(m_stock_balance) };
-                hb.addTotalRow(_("Grand Total:"), 9, v);
+                hb.addTotalRow(_("Grand Total:"), 10, v);
             }
             hb.endTfoot();
         }

--- a/src/reports/summarystocks.h
+++ b/src/reports/summarystocks.h
@@ -33,10 +33,11 @@ public:
 
 private:
     // structure for sorting of data
-    struct data_holder { wxString name; wxString symbol; wxString date; double qty; double purchase; double current; double commission; double gainloss; double value; };
-    struct account_holder { int id; wxString name; std::vector<data_holder> data; double gainloss; double total; };
+    struct data_holder { wxString name; wxString symbol; wxString date; double qty; double purchase; double current; double commission; double realgainloss; double unrealgainloss; double value; };
+    struct account_holder { int id; wxString name; std::vector<data_holder> data; double realgainloss; double unrealgainloss; double total; };
     std::vector<account_holder> m_stocks;
-    double m_gain_loss_sum_total;
+    double m_real_gain_loss_sum_total;
+    double m_unreal_gain_loss_sum_total;
     double m_stock_balance;
 };
 

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -899,6 +899,7 @@ void mmStockDialog::OnHistoryAddButton(wxCommandEvent& /*event*/)
         m_price_listbox->SetItem(i, 0, mmGetDateForDisplay(m_history_date_ctrl->GetValue().FormatISODate()));
         m_price_listbox->SetItem(i, 1, listStr);
     }
+    m_current_price_ctrl->SetValue(Model_Stock::UpdateCurrentPrice(m_stock), Option::instance().SharePrecision());
 }
 
 void mmStockDialog::OnHistoryDeleteButton(wxCommandEvent& /*event*/)
@@ -918,6 +919,7 @@ void mmStockDialog::OnHistoryDeleteButton(wxCommandEvent& /*event*/)
     }
     Model_StockHistory::instance().ReleaseSavepoint();
     ShowStockHistory();
+    m_current_price_ctrl->SetValue(Model_Stock::UpdateCurrentPrice(m_stock), Option::instance().SharePrecision());
 }
 
 void mmStockDialog::ShowStockHistory()

--- a/src/stockdialog.h
+++ b/src/stockdialog.h
@@ -63,6 +63,7 @@ private:
     void OnHistoryDeleteButton(wxCommandEvent& event);
     void OnListItemSelected(wxListEvent& event);
     void OnFocusChange(wxChildFocusEvent& event);
+    void UpdateCurrentPrice();
 
     void CreateControls();
     void UpdateControls();

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -91,9 +91,10 @@ StocksListCtrl::StocksListCtrl(mmStocksPanel* cp, wxWindow *parent, wxWindowID w
     m_columns.push_back(PANEL_COLUMN(_("Company Name"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT));
     m_columns.push_back(PANEL_COLUMN(_("Symbol"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT));
     m_columns.push_back(PANEL_COLUMN(_("Share Total"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
-    m_columns.push_back(PANEL_COLUMN(_("*Share Price"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
-    m_columns.push_back(PANEL_COLUMN(_("Init Value"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
-    m_columns.push_back(PANEL_COLUMN(_("Gain/Loss"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
+    m_columns.push_back(PANEL_COLUMN(_("Avg Share Price"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
+    m_columns.push_back(PANEL_COLUMN(_("Total Cost"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
+    m_columns.push_back(PANEL_COLUMN(_("Realized Gain/Loss"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
+    m_columns.push_back(PANEL_COLUMN(_("Unrealized Gain/Loss"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
     m_columns.push_back(PANEL_COLUMN(_("Curr. Share Price"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
     m_columns.push_back(PANEL_COLUMN(_("Curr. Total Value"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT));
     m_columns.push_back(PANEL_COLUMN(_("Price Date"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT));
@@ -171,6 +172,7 @@ wxString StocksListCtrl::OnGetItemText(long item, long column) const
     }
     if (column == COL_PRICE)        return Model_Currency::toString(m_stocks[item].PURCHASEPRICE, m_stock_panel->m_currency, 4);
     if (column == COL_VALUE)        return Model_Currency::toString(m_stocks[item].VALUE, m_stock_panel->m_currency);
+    if (column == COL_REAL_GAIN_LOSS)    return Model_Currency::toString(GetRealGainLoss(item), m_stock_panel->m_currency);
     if (column == COL_GAIN_LOSS)    return Model_Currency::toString(GetGainLoss(item), m_stock_panel->m_currency);
     if (column == COL_CURRENT)      return Model_Currency::toString(m_stocks[item].CURRENTPRICE, m_stock_panel->m_currency, 4);
     if (column == COL_CURRVALUE)    return Model_Currency::toString(Model_Stock::CurrentValue(m_stocks[item]), m_stock_panel->m_currency);
@@ -196,6 +198,16 @@ double StocksListCtrl::GetGainLoss(long item) const
 double StocksListCtrl::getGainLoss(const Model_Stock::Data& stock)
 {
     return Model_Stock::CurrentValue(stock) - Model_Stock::InvestmentValue(stock);
+}
+
+double StocksListCtrl::GetRealGainLoss(long item) const
+{
+    return getRealGainLoss(m_stocks[item]);
+}
+
+double StocksListCtrl::getRealGainLoss(const Model_Stock::Data& stock)
+{
+    return Model_Stock::RealGainLoss(stock);
 }
 
 void StocksListCtrl::OnListItemSelected(wxListEvent& event)

--- a/src/stocks_list.h
+++ b/src/stocks_list.h
@@ -79,6 +79,7 @@ private:
         COL_NUMBER,
         COL_PRICE,
         COL_VALUE,
+        COL_REAL_GAIN_LOSS,
         COL_GAIN_LOSS,
         COL_CURRENT,
         COL_CURRVALUE,
@@ -90,6 +91,8 @@ private:
     wxImageList* m_imageList;
     double GetGainLoss(long item) const;
     static double getGainLoss(const Model_Stock::Data& stock);
+    double GetRealGainLoss(long item) const;
+    static double getRealGainLoss(const Model_Stock::Data& stock);
     void sortTable();
 };
 

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -463,7 +463,7 @@ wxString StocksListCtrl::getStockInfo(int selectedIndex) const
     m_stock_panel->stock_details_short_->SetLabelText(miniInfo);
 
     //Selected share info
-    wxString additionInfo = wxString::Format("|%s - %s| = %s, %s * %s = %s %s\n"
+    wxString additionInfo = wxString::Format("This Account: |%s - %s| = %s, %s * %s = %s %s\n"
         , sCurrentPrice, sPurchasePrice, sDifference
         , sDifference, sNumShares
         , Model_Currency::toCurrency(GetGainLoss(selectedIndex), m_stock_panel->m_currency)
@@ -472,7 +472,7 @@ wxString StocksListCtrl::getStockInfo(int selectedIndex) const
     //Summary for account for selected symbol
     if (purchasedTime > 1)
     {
-        additionInfo += wxString::Format( "|%s - %s| = %s, %s * %s = %s ( %s %% )\n%s"
+        additionInfo += wxString::Format( "All Accounts: |%s - %s| = %s, %s * %s = %s ( %s %% )\n%s"
             ,  sCurrentPrice, sAvgPurchasePrice, sTotalDifference
             , sTotalDifference, sTotalNumShares
             , Model_Currency::toCurrency(stocktotalgainloss)


### PR DESCRIPTION
Fix #3892, #4969, and #5049.

Adds a new "Realized Gain/Loss" column to the stock list and renames the "Gain/Loss" as "Unrealized Gain/Loss" to better describe what the value represents. Realized Gain/Loss is calculated based on the difference between the sale transaction share price and the weighted average price of all currently owned shares at the time of the transaction (less any sales commission).

Various other corrections have been made:
- Adding/deleting the most recent price for a stock will update the CURRENTPRICE for that stock on all accounts. New transactions will also update the CURRENTPRICE if the transaction date is newer than the latest date in history.
- In stock list the "*Share Price" column now holds the weighted average cost per share for currently held shares. Similarly the "Init Value" column holds the total cost of currently held shares, inclusive of commissions. This corrects the calculations at the bottom of the panel. 
- Selling shares now reduces investment value by SHARENUMBER * Average Share Price. This ensures the accuracy of the remaining shares cost basis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5073)
<!-- Reviewable:end -->
