### PR TITLE
fix(#1868): numshares in daily balance calc

### DIFF
--- a/src/model/Model_Stock.cpp
+++ b/src/model/Model_Stock.cpp
@@ -188,10 +188,10 @@ double Model_Stock::getDailyBalanceAt(const Model_Account::Data *account, const 
         double numShares = 0.0;
 
         Model_Translink::Data_Set linkrecords = Model_Translink::instance().find(Model_Translink::LINKRECORDID(stock.STOCKID));
-        for (const auto& txn : linkrecords)
+        for (const auto& linkrecord : linkrecords)
         {
-            if (Model_Checking::instance().get(txn.CHECKINGACCOUNTID)->TRANSDATE <= strDate) {
-                numShares += Model_Shareinfo::instance().ShareEntry(txn.CHECKINGACCOUNTID)->SHARENUMBER;
+            if (Model_Checking::instance().get(linkrecord.CHECKINGACCOUNTID)->TRANSDATE <= strDate) {
+                numShares += Model_Shareinfo::instance().ShareEntry(linkrecord.CHECKINGACCOUNTID)->SHARENUMBER;
             }
         }
 

--- a/src/model/Model_Stock.h
+++ b/src/model/Model_Stock.h
@@ -66,7 +66,7 @@ public:
     static double RealGainLoss(const Data& r);
 
     /** Update current price across accounts */
-    static double UpdateCurrentPrice(const Data* r);
+    static void UpdateCurrentPrice(const wxString& symbol, const double price = -1);
 
 public:
     /**

--- a/src/model/Model_StockHistory.cpp
+++ b/src/model/Model_StockHistory.cpp
@@ -17,6 +17,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ********************************************************/
 
 #include "Model_StockHistory.h"
+#include "Model_Stock.h"
 
 Model_StockHistory::Model_StockHistory()
 : Model<DB_Table_STOCKHISTORY_V1>()
@@ -78,5 +79,10 @@ int Model_StockHistory::addUpdate(const wxString& symbol, const wxDate& date, do
     stockHist->DATE = date.FormatISODate();
     stockHist->VALUE = price;
     stockHist->UPDTYPE = type;
+
+    if (Model_StockHistory::instance().find(Model_StockHistory::SYMBOL(symbol), Model_StockHistory::DATE(date, GREATER)).size() == 0) {
+        Model_Stock::UpdateCurrentPrice(symbol, price);
+    }
+
     return save(stockHist);
 }

--- a/src/model/Model_Translink.cpp
+++ b/src/model/Model_Translink.cpp
@@ -172,6 +172,8 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     double total_initial_value = 0;
     double total_commission = 0;
     double avg_share_price = 0;
+    wxString earliest_date = wxDate::Today().FormatISODate();
+
     for (const auto trans : trans_list)
     {
         Model_Shareinfo::Data* share_entry = Model_Shareinfo::ShareEntry(trans.CHECKINGACCOUNTID);
@@ -190,6 +192,9 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
         if (total_shares > 0) avg_share_price = total_initial_value / total_shares;
 
         total_commission += share_entry->SHARECOMMISSION;
+
+        wxString transdate = Model_Checking::instance().get(trans.CHECKINGACCOUNTID)->TRANSDATE;
+        if (transdate < earliest_date) earliest_date = transdate;
     }
 
     // The stock record contains the total of share transactions.
@@ -199,6 +204,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     }
     else
     {
+        stock_entry->PURCHASEDATE = earliest_date;
         stock_entry->PURCHASEPRICE = avg_share_price;
         stock_entry->NUMSHARES = total_shares;
         stock_entry->VALUE = total_initial_value;

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -398,7 +398,7 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         int checking_id = m_transaction_panel->SaveChecking();
 
         /*
-        // The PURCHASEDATE, field in STOCK table becomes obsolete.
+        // The PURCHASEDATE field in STOCK table holds the earliest purchase date of the stock.
         // NUMSHARES, PURCHASEPRICE and COMMISSION fields in the Stocks table are used as
         // a summary and allows Stock history to work in its current form.
         // The Shares table now maintains share_num, share_price, and commission on the
@@ -415,12 +415,7 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         if (!loyalty_shares)
         {
             Model_StockHistory::instance().addUpdate(m_stock->SYMBOL, m_transaction_panel->TransactionDate(), share_price, Model_StockHistory::MANUAL);
-
-            //If this is the most recent date in the price history update the value of this stock in all accounts
-            if (Model_StockHistory::instance().find(Model_StockHistory::SYMBOL(m_stock->SYMBOL), Model_StockHistory::DATE(m_transaction_panel->TransactionDate(), GREATER)).size() == 0) {
-                Model_Stock::UpdateCurrentPrice(m_stock);
-            }
-        }
+        }         
     }
     else
     {

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -899,7 +899,10 @@ void mmStockDialog::OnHistoryAddButton(wxCommandEvent& /*event*/)
         m_price_listbox->SetItem(i, 0, mmGetDateForDisplay(m_history_date_ctrl->GetValue().FormatISODate()));
         m_price_listbox->SetItem(i, 1, listStr);
     }
-    m_current_price_ctrl->SetValue(Model_Stock::UpdateCurrentPrice(m_stock), Option::instance().SharePrecision());
+    //refresh m_stock to get updated attributes
+    m_stock = Model_Stock::instance().get(m_stock->STOCKID);
+    m_current_price_ctrl->SetValue(m_stock->CURRENTPRICE, Option::instance().SharePrecision());
+    m_value_investment->SetLabelText(Model_Account::toCurrency(Model_Stock::instance().CurrentValue(m_stock), account));
 }
 
 void mmStockDialog::OnHistoryDeleteButton(wxCommandEvent& /*event*/)
@@ -919,7 +922,11 @@ void mmStockDialog::OnHistoryDeleteButton(wxCommandEvent& /*event*/)
     }
     Model_StockHistory::instance().ReleaseSavepoint();
     ShowStockHistory();
-    m_current_price_ctrl->SetValue(Model_Stock::UpdateCurrentPrice(m_stock), Option::instance().SharePrecision());
+    Model_Stock::UpdateCurrentPrice(m_stock->SYMBOL);
+    //refresh m_stock to get updated attributes
+    m_stock = Model_Stock::instance().get(m_stock->STOCKID);
+    m_current_price_ctrl->SetValue(m_stock->CURRENTPRICE, Option::instance().SharePrecision());
+    m_value_investment->SetLabelText(Model_Account::toCurrency(Model_Stock::instance().CurrentValue(m_stock), Model_Account::instance().get(m_stock->HELDAT)));
 }
 
 void mmStockDialog::ShowStockHistory()

--- a/src/stockdialog.h
+++ b/src/stockdialog.h
@@ -63,7 +63,6 @@ private:
     void OnHistoryDeleteButton(wxCommandEvent& event);
     void OnListItemSelected(wxListEvent& event);
     void OnFocusChange(wxChildFocusEvent& event);
-    void UpdateCurrentPrice();
 
     void CreateControls();
     void UpdateControls();


### PR DESCRIPTION
Fix for issues #1868 and #5058 where wrong number of shares is used to calculate the daily balance of an investment account.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5076)
<!-- Reviewable:end -->
