### PR TITLE
fix(#5101): Hide blank UDFC fields

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -311,7 +311,7 @@ TransactionListCtrl::TransactionListCtrl(
     {
         if (udfc_entry.empty()) continue;
         const auto& name = Model_CustomField::getUDFCName(ref_type, udfc_entry);
-        if (name != udfc_entry)
+        if (!name.IsEmpty() && name != udfc_entry)
         {
             const auto& type = Model_CustomField::getUDFCType(ref_type, udfc_entry);
             int align;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5102)
<!-- Reviewable:end -->
