### PR TITLE
fix(#5122): secondary sort default is ID

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -228,7 +228,7 @@ TransactionListCtrl::TransactionListCtrl(
     m_attr17(new wxListItemAttr(*bestFontColour(mmColors::userDefColor7), mmColors::userDefColor7, wxNullFont)),
     m_sortCol(COL_DEF_SORT),
     g_sortcol(COL_DEF_SORT),
-    prev_g_sortcol(COL_DEF_SORT),
+    prev_g_sortcol(COL_DEF_SORT2),
     g_asc(true),
     prev_g_asc(true),
     m_firstSort(true),

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -64,7 +64,8 @@ public:
         COL_UDFC04,
         COL_UDFC05,
         COL_MAX, // number of columns
-        COL_DEF_SORT = COL_DATE // don't omit any columns before this
+        COL_DEF_SORT = COL_DATE, // don't omit any columns before this
+        COL_DEF_SORT2 = COL_ID 
     };
     EColumn toEColumn(long col);
 public:

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -326,7 +326,7 @@ void mmCheckingPanel::CreateControls()
     long val = m_listCtrlAccount->COL_DEF_SORT;
     wxString strVal = Model_Setting::instance().GetStringSetting(wxString::Format("%s_SORT_COL", m_sortSaveTitle), wxString() << val);
     if (strVal.ToLong(&val)) m_listCtrlAccount->g_sortcol = m_listCtrlAccount->toEColumn(val);
-    val = m_listCtrlAccount->COL_DEF_SORT;
+    val = m_listCtrlAccount->COL_DEF_SORT2;
     strVal = Model_Setting::instance().GetStringSetting(wxString::Format("%s_SORT_COL2", m_sortSaveTitle), wxString() << val);
     if (strVal.ToLong(&val)) m_listCtrlAccount->prev_g_sortcol = m_listCtrlAccount->toEColumn(val);
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5135)
<!-- Reviewable:end -->
