### PR TITLE
fmt is available in fedora repositories

### DIFF
--- a/dockers/fedora.36/Dockerfile
+++ b/dockers/fedora.36/Dockerfile
@@ -4,7 +4,7 @@ RUN ln -snf /usr/share/zoneinfo/Europe/London /etc/localtime && echo "Europe/Lon
     dnf -y install --setopt=install_weak_deps=False \
       ccache \
       cmake \
-      fmt \
+      fmt-devel \
       gcc-c++ \
       gettext \
       git \

--- a/dockers/fedora.36/Dockerfile
+++ b/dockers/fedora.36/Dockerfile
@@ -4,6 +4,7 @@ RUN ln -snf /usr/share/zoneinfo/Europe/London /etc/localtime && echo "Europe/Lon
     dnf -y install --setopt=install_weak_deps=False \
       ccache \
       cmake \
+      fmt \
       gcc-c++ \
       gettext \
       git \


### PR DESCRIPTION
This need not be downloaded separately

Not sure this needs an update of release notes. Can do so though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5184)
<!-- Reviewable:end -->
