### PR TITLE
fix(#1158): disable fields if locale used

### DIFF
--- a/src/currencydialog.cpp
+++ b/src/currencydialog.cpp
@@ -340,7 +340,7 @@ void mmCurrencyDialog::OnDataChanged(wxCommandEvent& WXUNUSED(event))
     double base_amount = 1234567.89;
 
     dispAmount = wxString::Format(_("%.2f Shown As: %s"), base_amount, Model_Currency::toCurrency(base_amount, m_currency, scale));
-    if (!mctrl_groupSep->IsEnabled())
+    if (m_locale_used)
         dispAmount = dispAmount + "  " + _("(Using Locale)");
     mctrl_sampleText->SetLabelText(dispAmount);
 }

--- a/src/currencydialog.h
+++ b/src/currencydialog.h
@@ -61,6 +61,7 @@ private:
 
     Model_Currency::Data* m_currency;
     int m_scale;
+    bool m_locale_used;
 
     wxTextCtrl* mctrl_name;
     wxTextCtrl* mctrl_code;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5190)
<!-- Reviewable:end -->
