### PR TITLE
Fix(#5191): Initialize account image vector

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -69,6 +69,7 @@ mmNewAcctDialog::mmNewAcctDialog()
 mmNewAcctDialog::mmNewAcctDialog(Model_Account::Data* account, wxWindow* parent)
     : m_account(account)
 {
+    m_images = navtree_images_list();
     m_currencyID = m_account->CURRENCYID;
     Model_Currency::Data* currency = Model_Currency::instance().get(m_currencyID);
     wxASSERT(currency);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5192)
<!-- Reviewable:end -->
