### PR TITLE
Recurring Transaction Check Fix

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -505,11 +505,10 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
     for (const auto& q1 : bills.all())
     {
         bills.decode_fields(q1);
-        bool allow_transaction = bills.AllowTransaction(q1, bal);
         const wxDateTime payment_date = bills.TRANSDATE(q1);
         if (bills.autoExecuteManual() && bills.requireExecution())
         {
-            if (allow_transaction && bills.allowExecution())
+            if (bills.allowExecution() && bills.AllowTransaction(q1, bal))
             {
                 continueExecution = true;
                 mmBDDialog repeatTransactionsDlg(this, q1.BDID, false, true);
@@ -523,9 +522,9 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
             }
         }
 
-        if (allow_transaction && bills.autoExecuteSilent() && bills.requireExecution())
+        if (bills.autoExecuteSilent() && bills.requireExecution())
         {
-            if (bills.allowExecution())
+            if (bills.allowExecution() && bills.AllowTransaction(q1, bal))
             {
                 continueExecution = true;
                 Model_Checking::Data* tran = Model_Checking::instance().create();

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -299,26 +299,32 @@ bool Model_Billsdeposits::AllowTransaction(const Data& r, AccountBalance& bal)
 
     if (abort_transaction)
     {
-        std::stringstream message;
-        message
-            << "A recurring transaction will exceed your account limit.\n\n"
-            << "Account: " << account->ACCOUNTNAME << "\n"
-            << "Current Balance: " << current_account_balance << "\n"
-            << "Transaction amount: " << r.TRANSAMOUNT << "\n\n"
-            << "Do you wish to continue ?";
+        wxString message = _("A recurring transaction will exceed your account limit.\n\n"
+            "Account: %s\n"
+            "Current Balance: %6.2f\n"
+            "Transaction amount: %6.2f\n"
+            "%s: %6.2f\n\n"
+            "Do you wish to continue ?"
+        );
+
+        wxString limitDescription;
+        double limitAmount{ 0.0L };
 
         if (account->MINIMUMBALANCE > 0)
         {
-            message << "Minimum Balance: " << account->MINIMUMBALANCE << "\n";
+            limitDescription = _("Minimum Balance");
+            limitAmount = account->MINIMUMBALANCE;
         }
 
         if (account->CREDITLIMIT > 0)
         {
-            message << "Credit Limit: " << account->CREDITLIMIT << "\n";
+            limitDescription = _("Credit Limit");
+            limitAmount = account->CREDITLIMIT;
         }
 
-        if (wxMessageBox(message.str()
-            , _("MMEX Recurring Transaction Check"), wxYES_NO | wxICON_WARNING) == wxYES)
+        message.Printf(message, account->ACCOUNTNAME, current_account_balance, r.TRANSAMOUNT, limitDescription, limitAmount);
+
+        if (wxMessageBox(message, _("MMEX Recurring Transaction Check"), wxYES_NO | wxICON_WARNING) == wxYES)
         {
             abort_transaction = false;
         }

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -297,12 +297,31 @@ bool Model_Billsdeposits::AllowTransaction(const Data& r, AccountBalance& bal)
         abort_transaction = true;
     }
 
-    if (abort_transaction && wxMessageBox(_(
-        "A recurring transaction will exceed your account limit.\n\n"
-        "Do you wish to continue?")
-        , _("MMEX Recurring Transaction Check"), wxYES_NO | wxICON_WARNING) == wxYES)
+    if (abort_transaction)
     {
-        abort_transaction = false;
+        std::stringstream message;
+        message
+            << "A recurring transaction will exceed your account limit.\n\n"
+            << "Account: " << account->ACCOUNTNAME << "\n"
+            << "Current Balance: " << current_account_balance << "\n"
+            << "Transaction amount: " << r.TRANSAMOUNT << "\n\n"
+            << "Do you wish to continue ?";
+
+        if (account->MINIMUMBALANCE > 0)
+        {
+            message << "Minimum Balance: " << account->MINIMUMBALANCE << "\n";
+        }
+
+        if (account->CREDITLIMIT > 0)
+        {
+            message << "Credit Limit: " << account->CREDITLIMIT << "\n";
+        }
+
+        if (wxMessageBox(message.str()
+            , _("MMEX Recurring Transaction Check"), wxYES_NO | wxICON_WARNING) == wxYES)
+        {
+            abort_transaction = false;
+        }
     }
 
     if (!abort_transaction)


### PR DESCRIPTION
This is a fix (plus a small improvement) of the Recurring Transaction Check.
Currently, the check is performed for all recurring transactions, regardless of whether they will be applied.
This results in an incorrect calculation in case the sum of all the transactions, even the ones that would not be immediately applied, would bring the balance below the minimum balance.

In short:
- The check is now performed just before the transaction is applied.
- The message box shows some details to help the user decide

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5244)
<!-- Reviewable:end -->
