### PR TITLE
#5290 Fix new transaction data validation

### DIFF
--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -702,32 +702,32 @@ bool mmTransDialog::ValidateData()
     //Checking account does not exceed limits
     if (m_new_trx || m_duplicate)
     {
-        bool abort_transaction = false;
-        double new_value = m_trx_data.TRANSAMOUNT;
-
-        if (m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::WITHDRAWAL])
+        if ((m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::WITHDRAWAL]) ||
+            (m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::TRANSFER]))
         {
-            new_value *= -1;
-        }
+            const auto fromAccount{ Model_Account::instance().get(m_trx_data.ACCOUNTID) };
+            const double fromAccountBalance = Model_Account::balance(fromAccount);
+            const double new_value = fromAccountBalance - m_trx_data.TRANSAMOUNT;
 
-        new_value += m_current_balance;
+            bool abort_transaction = false;
 
-        if ((account->MINIMUMBALANCE != 0) && (new_value < account->MINIMUMBALANCE))
-        {
-            abort_transaction = true;
-        }
+            if ((account->MINIMUMBALANCE != 0) && (new_value < account->MINIMUMBALANCE))
+            {
+                abort_transaction = true;
+            }
 
-        if ((account->CREDITLIMIT != 0) && (new_value < (account->CREDITLIMIT * -1)))
-        {
-            abort_transaction = true;
-        }
+            if ((account->CREDITLIMIT != 0) && (new_value < (account->CREDITLIMIT * -1)))
+            {
+                abort_transaction = true;
+            }
 
-        if (abort_transaction && wxMessageBox(_(
-            "This transaction will exceed your account limit.\n\n"
-            "Do you wish to continue?")
-            , _("MMEX Transaction Check"), wxYES_NO | wxICON_WARNING) == wxNO)
-        {
-            return false;
+            if (abort_transaction && wxMessageBox(_(
+                "This transaction will exceed your account limit.\n\n"
+                "Do you wish to continue?")
+                , _("MMEX Transaction Check"), wxYES_NO | wxICON_WARNING) == wxNO)
+            {
+                return false;
+            }
         }
     }
 

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -702,8 +702,8 @@ bool mmTransDialog::ValidateData()
     //Checking account does not exceed limits
     if (m_new_trx || m_duplicate)
     {
-        if ((m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::WITHDRAWAL]) ||
-            (m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::TRANSFER]))
+        if ((m_trx_data.TRANSCODE == Model_Checking::WITHDRAWAL_STR) ||
+            (m_trx_data.TRANSCODE == Model_Checking::TRANSFER_STR))
         {
             const double fromAccountBalance = Model_Account::balance(account);
             const double new_value = fromAccountBalance - m_trx_data.TRANSAMOUNT;

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -705,8 +705,7 @@ bool mmTransDialog::ValidateData()
         if ((m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::WITHDRAWAL]) ||
             (m_trx_data.TRANSCODE == Model_Checking::all_type()[Model_Checking::TRANSFER]))
         {
-            const auto fromAccount{ Model_Account::instance().get(m_trx_data.ACCOUNTID) };
-            const double fromAccountBalance = Model_Account::balance(fromAccount);
+            const double fromAccountBalance = Model_Account::balance(account);
             const double new_value = fromAccountBalance - m_trx_data.TRANSAMOUNT;
 
             bool abort_transaction = false;


### PR DESCRIPTION
Fixes the validation of a new transaction against the minimum balance and the credit limit for the target account.

- The check is performed only for withdrawals and transfers
- The reference account is specifically the source one; this fixes an issue when the transaction is created from the target account page (the balance was incorrectly the target account's).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5291)
<!-- Reviewable:end -->
