### PR TITLE
fix(#5298): Default to autoshow "Deleted Transactions" node

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -972,6 +972,7 @@ void TransactionListCtrl::OnRestoreViewedTransaction(wxCommandEvent& event)
     }
     
     refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
 }
 
 void TransactionListCtrl::OnRestoreTransaction(wxCommandEvent& WXUNUSED(event))
@@ -1015,6 +1016,7 @@ void TransactionListCtrl::OnRestoreTransaction(wxCommandEvent& WXUNUSED(event))
     }
 
     refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
 }
 
 void TransactionListCtrl::OnDeleteViewedTransaction(wxCommandEvent& event)
@@ -1065,6 +1067,7 @@ void TransactionListCtrl::OnDeleteViewedTransaction(wxCommandEvent& event)
         }
     }
     refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
 }
 
 void TransactionListCtrl::DeleteTransactionsByStatus(const wxString& status)
@@ -1194,6 +1197,7 @@ void TransactionListCtrl::OnDeleteTransaction(wxCommandEvent& WXUNUSED(event))
         }
     }
     refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
 }
 
 //----------------------------------------------------------------------------

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -901,7 +901,7 @@ void mmGUIFrame::DoRecreateNavTreeControl()
         {
             m_nav_tree_ctrl->Delete(shareAccounts);
         }
-        if (Option::instance().HideDeletedTransactions())
+        if (Model_Checking::instance().find(Model_Checking::DELETEDTIME(wxEmptyString, NOT_EQUAL)).empty() || Option::instance().HideDeletedTransactions())
         {
             m_nav_tree_ctrl->Delete(trash);
         }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -72,7 +72,7 @@ void Option::LoadOptions(bool include_infotable)
     m_language = Option::instance().getLanguageID(true);
 
     m_hideShareAccounts = Model_Setting::instance().GetBoolSetting(INIDB_HIDE_SHARE_ACCOUNTS, true);
-    m_hideDeletedTransactions = Model_Setting::instance().GetBoolSetting(INIDB_HIDE_DELETED_TRANSACTIONS, true);
+    m_hideDeletedTransactions = Model_Setting::instance().GetBoolSetting(INIDB_HIDE_DELETED_TRANSACTIONS, false);
     m_budgetFinancialYears = Model_Setting::instance().GetBoolSetting(INIDB_BUDGET_FINANCIAL_YEARS, false);
     m_budgetIncludeTransfers = Model_Setting::instance().GetBoolSetting(INIDB_BUDGET_INCLUDE_TRANSFERS, false);
     m_budgetReportWithSummaries = Model_Setting::instance().GetBoolSetting(INIDB_BUDGET_SUMMARY_WITHOUT_CATEG, true);


### PR DESCRIPTION
Default to auto show/hide based on deleted transactions present, but allow user to suppress the node in the Nav Panel via View menu.

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5300)
<!-- Reviewable:end -->
