### PR TITLE
fix(#5296): Allow delete categories & payees used in deleted transactions

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2553,6 +2553,9 @@ void mmGUIFrame::refreshPanelData()
     case mmID_BILLS:
         wxDynamicCast(panelCurrent_, mmBillsDepositsPanel)->RefreshList();
         break;
+    case mmID_DELETEDTRANSACTIONS:
+        wxDynamicCast(panelCurrent_, mmCheckingPanel)->RefreshList();
+        break;
     case mmID_BUDGET:
         wxDynamicCast(panelCurrent_, mmBudgetingPanel)->RefreshList();
         break;
@@ -2575,6 +2578,7 @@ void mmGUIFrame::OnOrgCategories(wxCommandEvent& /*event*/)
     if (dlg.getRefreshRequested())
     {
         refreshPanelData();
+        RefreshNavigationTree();
     }
 }
 //----------------------------------------------------------------------------
@@ -2586,6 +2590,7 @@ void mmGUIFrame::OnOrgPayees(wxCommandEvent& /*event*/)
     if (dlg.getRefreshRequested())
     {
         refreshPanelData();
+        RefreshNavigationTree();
     }
 }
 //----------------------------------------------------------------------------

--- a/src/model/Model_Category.cpp
+++ b/src/model/Model_Category.cpp
@@ -157,10 +157,15 @@ bool Model_Category::is_hidden(int catID, int subcatID)
 
 bool Model_Category::is_used(int id, int sub_id)
 {
-    const auto &trans = Model_Checking::instance().find(Model_Checking::CATEGID(id), Model_Checking::SUBCATEGID(sub_id));
+    const auto &trans = Model_Checking::instance().find(Model_Checking::CATEGID(id), Model_Checking::SUBCATEGID(sub_id), Model_Checking::DELETEDTIME(wxEmptyString));
     if (!trans.empty()) return true;
     const auto &split = Model_Splittransaction::instance().find(Model_Checking::CATEGID(id), Model_Checking::SUBCATEGID(sub_id));
-    if (!split.empty()) return true;
+    if (!split.empty())
+    {
+        for (const auto& txn : split)
+            if (Model_Checking::instance().get(txn.TRANSID)->DELETEDTIME.IsEmpty())
+                return true;
+    }
     const auto &deposits = Model_Billsdeposits::instance().find(Model_Billsdeposits::CATEGID(id), Model_Billsdeposits::SUBCATEGID(sub_id));
     if (!deposits.empty()) return true;
     const auto &deposit_split = Model_Budgetsplittransaction::instance().find(Model_Billsdeposits::CATEGID(id), Model_Billsdeposits::SUBCATEGID(sub_id));
@@ -171,10 +176,15 @@ bool Model_Category::is_used(int id, int sub_id)
 
 bool Model_Category::is_used(int id)
 {
-    const auto& trans = Model_Checking::instance().find(Model_Checking::CATEGID(id));
+    const auto& trans = Model_Checking::instance().find(Model_Checking::CATEGID(id), Model_Checking::DELETEDTIME(wxEmptyString));
     if (!trans.empty()) return true;
     const auto& split = Model_Splittransaction::instance().find(Model_Checking::CATEGID(id));
-    if (!split.empty()) return true;
+    if (!split.empty())
+    {
+        for (const auto& txn : split)
+            if (Model_Checking::instance().get(txn.TRANSID)->DELETEDTIME.IsEmpty())
+                return true;
+    }
     const auto& deposits = Model_Billsdeposits::instance().find(Model_Billsdeposits::CATEGID(id));
     if (!deposits.empty()) return true;
     const auto& deposit_split = Model_Budgetsplittransaction::instance().find(Model_Billsdeposits::CATEGID(id));
@@ -186,7 +196,7 @@ bool Model_Category::has_income(int id, int sub_id)
 {
     double sum = 0.0;
     auto splits = Model_Splittransaction::instance().get_all();
-    for (const auto& tran: Model_Checking::instance().find(Model_Checking::CATEGID(id), Model_Checking::SUBCATEGID(sub_id)))
+    for (const auto& tran: Model_Checking::instance().find(Model_Checking::CATEGID(id), Model_Checking::SUBCATEGID(sub_id), Model_Checking::DELETEDTIME(wxEmptyString)))
     {
         switch (Model_Checking::type(tran))
         {

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -95,6 +95,7 @@ bool Model_Checking::remove(int id)
     //Model_Splittransaction::instance().remove(Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(id)));
     for (const auto& r : Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(id)))
         Model_Splittransaction::instance().remove(r.SPLITTRANSID);
+    if(foreignTransaction(*instance().get(id))) Model_Translink::RemoveTranslinkEntry(id);
     return this->remove(id, db_);
 }
 

--- a/src/model/Model_Payee.cpp
+++ b/src/model/Model_Payee.cpp
@@ -153,7 +153,7 @@ bool Model_Payee::is_hidden(const Data& record)
 
 bool Model_Payee::is_used(int id)
 {
-    const auto &trans = Model_Checking::instance().find(Model_Checking::PAYEEID(id));
+    const auto &trans = Model_Checking::instance().find(Model_Checking::PAYEEID(id), Model_Checking::DELETEDTIME(wxEmptyString));
     if (!trans.empty()) return true;
     const auto &bills = Model_Billsdeposits::instance().find(Model_Billsdeposits::PAYEEID(id));
     if (!bills.empty()) return true;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5307)
<!-- Reviewable:end -->
