### PR TITLE
fix(#5310): save asset widget state

### DIFF
--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -293,7 +293,7 @@ void mmHomePagePanel::OnLinkClicked(wxWebViewEvent& event)
 
         const wxString type[] = { "TOP_CATEGORIES", "INVEST", "ACCOUNTS_INFO"
             ,"CARD_ACCOUNTS_INFO" ,"CASH_ACCOUNTS_INFO", "LOAN_ACCOUNTS_INFO"
-            , "TERM_ACCOUNTS_INFO", "ASSET_ACCOUNTS_INFO", "SHARE_ACCOUNTS_INFO"
+            , "TERM_ACCOUNTS_INFO", "ASSETS", "SHARE_ACCOUNTS_INFO"
             , "CURRENCY_RATES", "BILLS_AND_DEPOSITS" };
 
         for (const auto& entry : type)


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5317)
<!-- Reviewable:end -->
