### PR TITLE
fix(#5372): clear MSVC compiler warnings

### DIFF
--- a/src/currencydialog.cpp
+++ b/src/currencydialog.cpp
@@ -157,7 +157,7 @@ void mmCurrencyDialog::fillControls()
             mctrl_prefix->SetValue(true);
             mctrl_symbol->ChangeValue(m_currency->PFX_SYMBOL);
         }
-        int i;
+        unsigned int i;
         for (i = 0; i<mctrl_decimalSep->GetCount(); i++)
             if (static_cast<wxStringClientData *>(mctrl_decimalSep->GetClientObject(i))->GetData()
                                  == m_currency->DECIMAL_POINT)

--- a/src/images_list.cpp
+++ b/src/images_list.cpp
@@ -255,7 +255,7 @@ wxVector<wxBitmapBundle> navtree_images_list(const int size)
 }
 
 
-static unsigned int getIconSizeIdx(const int iconSize)
+static int getIconSizeIdx(const int iconSize)
 {
     const int x = (iconSize > 0) ? iconSize : Option::instance().getIconSize();
     auto it = find_if(sizes.begin(), sizes.end(), [x](const std::pair<int, int>& p) { return p.second == x; });

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -137,8 +137,6 @@ void mmReportCashFlow::getTransactions()
 
         int repeatsType = entry.REPEATS;
         int numRepeats = entry.NUMOCCURRENCES;
-        double amt = entry.TRANSAMOUNT;
-        double toAmt = entry.TOTRANSAMOUNT;
 
         // DeMultiplex the Auto Executable fields from the db entry: REPEATS
         repeatsType %= BD_REPEATS_MULTIPLEX_BASE;

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -95,7 +95,6 @@ wxString mmReportMyUsage::getHTMLText()
 
              if (!pobj.HasMember("seconds") || !pobj["seconds"].IsDouble())
                  continue;
-             const auto s = pobj["seconds"].GetDouble();
 
              usage_by_module[module] += 1;
          }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5373)
<!-- Reviewable:end -->
