### PR TITLE
fix(#4295): html class for report tables

### DIFF
--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -114,8 +114,8 @@ namespace tags
     static const wxString DIV_COL3 = "<div class='col-xs-3'></div>\n<div class='col-xs-6'>\n"; //25_50%
     static const wxString DIV_COL1 = "<div class='col-xs-1'></div>\n<div class='col-xs-10'>\n"; //8%
     static const wxString DIV_END = "</div>\n";
-    static const wxString TABLE_START = "<table class='table table-bordered'>\n";
-    static const wxString SORTTABLE_START = "<table class='sortable table'>\n";
+    static const wxString TABLE_START = "<table class='table table-bordered report-table'>\n";
+    static const wxString SORTTABLE_START = "<table class='sortable table report-table'>\n";
     static const wxString TABLE_END = "</table>\n";
     static const wxString THEAD_START = "<thead>\n";
     static const wxString THEAD_END = "</thead>\n";


### PR DESCRIPTION
Adds report-table class to table tags generated by htmlbuilder. This allows report tables to be targeted by the theme master.css.

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5380)
<!-- Reviewable:end -->
