### PR TITLE
fix(#5394): enable copy/paste in "all transactions"

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -441,17 +441,14 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
         menu.Append(MENU_TREEPOPUP_EDIT2, wxPLURAL("&Edit Transaction...", "&Edit Transactions...", selected));
         if (is_nothing_selected) menu.Enable(MENU_TREEPOPUP_EDIT2, false);
 
-        if (!m_cp->isAllAccounts_)     // Copy/Paste not suitable if all accounts visible
-        {
-            menu.Append(MENU_ON_COPY_TRANSACTION, wxPLURAL("&Copy Transaction", "&Copy Transactions", selected));
-            if (is_nothing_selected) menu.Enable(MENU_ON_COPY_TRANSACTION, false);
+        menu.Append(MENU_ON_COPY_TRANSACTION, wxPLURAL("&Copy Transaction", "&Copy Transactions", selected));
+        if (is_nothing_selected) menu.Enable(MENU_ON_COPY_TRANSACTION, false);
 
-            int toPaste = m_selectedForCopy.size();
-            menu.Append(MENU_ON_PASTE_TRANSACTION,
-                wxString::Format(wxPLURAL(_("&Paste Transaction"), _("&Paste Transactions (%d)"), (toPaste < 2) ? 1 : toPaste), toPaste)
-            );
-            if (toPaste < 1) menu.Enable(MENU_ON_PASTE_TRANSACTION, false);
-        }
+        int toPaste = m_selectedForCopy.size();
+        menu.Append(MENU_ON_PASTE_TRANSACTION,
+            wxString::Format(wxPLURAL(_("&Paste Transaction"), _("&Paste Transactions (%d)"), (toPaste < 2) ? 1 : toPaste), toPaste)
+        );
+        if (toPaste < 1) menu.Enable(MENU_ON_PASTE_TRANSACTION, false);
 
         menu.Append(MENU_ON_DUPLICATE_TRANSACTION, __(wxTRANSLATE("D&uplicate Transaction")));
         if (is_nothing_selected || multiselect) menu.Enable(MENU_ON_DUPLICATE_TRANSACTION, false);
@@ -747,8 +744,8 @@ void TransactionListCtrl::OnSelectAll(wxCommandEvent& WXUNUSED(event))
 
 void TransactionListCtrl::OnCopy(wxCommandEvent& WXUNUSED(event))
 {
-    // we can't copy with multiple accounts open, deleted items, or there is nothing to copy
-    if (m_cp->isAllAccounts_ || m_cp->isTrash_ || GetSelectedItemCount() < 1) return;
+    // we can't copy deleted items or there is nothing to copy
+    if (m_cp->isTrash_ || GetSelectedItemCount() < 1) return;
 
     // collect the selected transactions for copy
     FindSelectedTransactions();
@@ -798,8 +795,8 @@ void TransactionListCtrl::OnDuplicateTransaction(wxCommandEvent& WXUNUSED(event)
 
 void TransactionListCtrl::OnPaste(wxCommandEvent& WXUNUSED(event))
 {
-    // we can't paste with multiple accounts open, deleted items, or there is nothing to paste
-    if (m_cp->isAllAccounts_ || m_cp->isTrash_ || m_selectedForCopy.size() < 1) return;
+    // we can't paste deleted items or there is nothing to paste
+    if (m_cp->isTrash_ || m_selectedForCopy.size() < 1) return;
     
     FindSelectedTransactions();
     Model_Checking::instance().Savepoint();
@@ -815,15 +812,15 @@ void TransactionListCtrl::OnPaste(wxCommandEvent& WXUNUSED(event))
 
 int TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
 {
-    wxASSERT(!m_cp->isAllAccounts_ && !m_cp->isTrash_);
+    wxASSERT(!m_cp->isTrash_);
 
     bool useOriginalDate = Model_Setting::instance().GetBoolSetting(INIDB_USE_ORG_DATE_COPYPASTE, false);
 
     //TODO: the clone function can't clone split transactions, or custom data
     Model_Checking::Data* copy = Model_Checking::instance().clone(tran); 
     if (!useOriginalDate) copy->TRANSDATE = wxDateTime::Now().FormatISODate();
-    if ((Model_Checking::type(copy->TRANSCODE) != Model_Checking::TRANSFER) ||
-            (m_cp->m_AccountID != copy->ACCOUNTID && m_cp->m_AccountID != copy->TOACCOUNTID))
+    if (!m_cp->isAllAccounts_ && ((Model_Checking::type(copy->TRANSCODE) != Model_Checking::TRANSFER) ||
+            (m_cp->m_AccountID != copy->ACCOUNTID && m_cp->m_AccountID != copy->TOACCOUNTID)))
         copy->ACCOUNTID = m_cp->m_AccountID;
     int transactionID = Model_Checking::instance().save(copy);
     m_pasted_id.push_back(transactionID);   // add the newly pasted transaction


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5399)
<!-- Reviewable:end -->
