### PR TITLE
fix(#5564): fix crash when all historical stock prices deleted

### DIFF
--- a/src/model/Model_Stock.cpp
+++ b/src/model/Model_Stock.cpp
@@ -250,13 +250,19 @@ void Model_Stock::UpdateCurrentPrice(const wxString& symbol, const double price)
     double current_price = price;
     if (price == -1) {
         Model_StockHistory::Data_Set histData = Model_StockHistory::instance().find(Model_StockHistory::SYMBOL(symbol));
-        std::sort(histData.begin(), histData.end(), SorterByDATE());
-        current_price = histData.back().VALUE;
+        if (!histData.empty())
+        {
+            std::sort(histData.begin(), histData.end(), SorterByDATE());
+            current_price = histData.back().VALUE;
+        }
     }
-    Model_Stock::Data_Set stocks = Model_Stock::instance().find(Model_Stock::SYMBOL(symbol));
-    for (auto& stock : stocks) {
-        Model_Stock::Data* stockRecord = Model_Stock::instance().get(stock.STOCKID);
-        stockRecord->CURRENTPRICE = current_price;
-        Model_Stock::instance().save(stockRecord);
+    if (current_price != -1)
+    {
+        Model_Stock::Data_Set stocks = Model_Stock::instance().find(Model_Stock::SYMBOL(symbol));
+        for (auto& stock : stocks) {
+            Model_Stock::Data* stockRecord = Model_Stock::instance().get(stock.STOCKID);
+            stockRecord->CURRENTPRICE = current_price;
+            Model_Stock::instance().save(stockRecord);
+        }
     }
 }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5569)
<!-- Reviewable:end -->
