### PR TITLE
fix(#5599): always allow subcategory filter on txn report

### DIFF
--- a/src/filtertransdialog.h
+++ b/src/filtertransdialog.h
@@ -211,6 +211,7 @@ private:
     //Selected accountns ID
     wxArrayInt m_selected_accounts_id;
     wxArrayInt m_selected_columns_id;
+    wxArrayInt m_selected_categories_id;
     wxSharedPtr<mmCustomData> m_custom_fields;
 
     enum


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5605)
<!-- Reviewable:end -->
