### PR TITLE
fix(#5550): allow debug on corrupt databases

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -36,7 +36,7 @@ wxSharedPtr<wxSQLite3Database> static_db_ptr()
     return db;
 }
 
-wxSharedPtr<wxSQLite3Database> mmDBWrapper::Open(const wxString &dbpath, const wxString &password)
+wxSharedPtr<wxSQLite3Database> mmDBWrapper::Open(const wxString &dbpath, const wxString &password, bool debug)
 {
     wxSharedPtr<wxSQLite3Database> db = static_db_ptr();
 
@@ -44,7 +44,11 @@ wxSharedPtr<wxSQLite3Database> mmDBWrapper::Open(const wxString &dbpath, const w
     wxString errStr=wxEmptyString;
     try
     {
-        db->Open(dbpath, password);
+        if (debug)
+            // open and disable flag SQLITE_CorruptRdOnly = 0x200000000
+            db->Open(dbpath, password, (WXSQLITE_OPEN_READWRITE | WXSQLITE_OPEN_CREATE) & ~0x200000000);
+        else
+            db->Open(dbpath, password);
         // Ensure that an existing mmex database is not encrypted.
         if ((db->IsOpen()) && (db->TableExists("INFOTABLE_V1")))
         {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -28,7 +28,7 @@ class wxSQLite3Database;
 namespace mmDBWrapper
 {
 
-    wxSharedPtr<wxSQLite3Database> Open(const wxString &dbpath, const wxString &key = "");
+    wxSharedPtr<wxSQLite3Database> Open(const wxString &dbpath, const wxString &key = "", const bool debug = false);
 
 } // namespace mmDBWrapper
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1957,7 +1957,12 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const wxString& pwd, 
             {
                 int response = wxMessageBox(_("Have MMEX support provided you a debug/patch file?"), _("MMEX upgrade"), wxYES_NO);
                 if (response == wxYES)
+                {
+                    ShutdownDatabase();
+                    // reopen database in debug mode (bypassing SQLITE_CorruptRdOnly flag)
+                    m_db = mmDBWrapper::Open(fileName, password, true);
                     dbUpgrade::SqlFileDebug(m_db.get());
+                }
                 ShutdownDatabase();
                 return false;
             }

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1952,17 +1952,15 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const wxString& pwd, 
         //Check if DB upgrade needed
         if (dbUpgrade::isUpgradeDBrequired(m_db.get()))
         {
+            ShutdownDatabase();
+            // reopen database in debug mode (bypassing SQLITE_CorruptRdOnly flag)
+            m_db = mmDBWrapper::Open(fileName, password, true);
             //DB backup is handled inside UpgradeDB
             if (!dbUpgrade::UpgradeDB(m_db.get(), fileName))
             {
                 int response = wxMessageBox(_("Have MMEX support provided you a debug/patch file?"), _("MMEX upgrade"), wxYES_NO);
                 if (response == wxYES)
-                {
-                    ShutdownDatabase();
-                    // reopen database in debug mode (bypassing SQLITE_CorruptRdOnly flag)
-                    m_db = mmDBWrapper::Open(fileName, password, true);
                     dbUpgrade::SqlFileDebug(m_db.get());
-                }
                 ShutdownDatabase();
                 return false;
             }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5623)
<!-- Reviewable:end -->
