### PR TITLE
fix(#5630): don't update timestmp if txn not found in DB

### DIFF
--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -671,7 +671,7 @@ bool Model_Checking::foreignTransactionAsTransfer(const Data& data)
 void Model_Checking::updateTimestamp(int id)
 {
     Data* r = instance().get(id);
-    if (r) {
+    if (r && r->TRANSID == id) {
         r->LASTUPDATEDTIME = wxDateTime::Now().ToUTC().FormatISOCombined();
         this->save(r, db_);
     }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5634)
<!-- Reviewable:end -->
