### PR TITLE
fix(#5643): remove default locale for curr string conversion

### DIFF
--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -335,7 +335,7 @@ const wxString Model_Currency::fromString2CLocale(const wxString &s, const Data*
     wxRegEx pattern(R"([^0-9.,+-/*()])");
     pattern.ReplaceAll(&str, wxEmptyString);
 
-    auto locale = Model_Infotable::instance().GetStringInfo("LOCALE", "en_US.UTF8");
+    auto locale = Model_Infotable::instance().GetStringInfo("LOCALE", "");
 
     if (locale.empty())
     {


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5679)
<!-- Reviewable:end -->
