### PR TITLE
fix(#5204): fix default locale for non-US

### DIFF
--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -266,7 +266,7 @@ const wxString Model_Currency::toString(double value, const Data* currency, int 
         precision = log10(currency ? currency->SCALE : GetBaseCurrency()->SCALE);
     }
 
-    auto l = (use_locale == "Y" ? std::locale(locale.c_str()) : std::locale("en_US.UTF-8"));
+    auto l = (use_locale == "Y" ? std::locale(locale.c_str()) : (d == "Y" ? std::locale("en_US.UTF-8") : std::locale()));
     std::string s;
     value += LIMIT; //to ignore the negative sign on values of zero #564
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5700)
<!-- Reviewable:end -->
