### PR TITLE
fix(#5706): export split notes in QIF

### DIFF
--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -179,6 +179,13 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
         const wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
         buffer << "S" << split_categ << "\n"
             << "$" << split_amount << "\n";
+        if (!split_entry.NOTES.IsEmpty())
+        {
+            notes = split_entry.NOTES;
+            notes.Replace("''", "'");
+            notes.Replace("\n", "\nE");
+            buffer << "E" << notes << "\n";
+        }
     }
 
     buffer << "^" << "\n";

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1215,10 +1215,16 @@ bool mmQIFImportDialog::completeTransaction(/*in*/ const std::unordered_map <int
             amtSplit.ToCDouble(&amount);
 
             wxString memo;
-            if (!notes.empty()) {
+            while (!notes.empty()) {
                 wxRegEx pattern(wxString::Format("^%d:(.*)", split_id), wxRE_NEWLINE);
                 if (pattern.Matches(notes))
-                    memo = pattern.GetMatch(notes, 1);
+                {
+                    memo += (!memo.IsEmpty() ? "\n" : "" ) + pattern.GetMatch(notes, 1);
+                    pattern.ReplaceFirst(&notes, "");
+                    notes.Replace("\n", "", false);
+                }
+                else
+                    break;
             }
 
             s->SPLITTRANSAMOUNT = (Model_Checking::is_deposit(trx) ? amount : -amount);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5708)
<!-- Reviewable:end -->
