### PR TITLE
fix(#5668): don't include custom panel in saved size

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -99,7 +99,10 @@ mmBDDialog::mmBDDialog()
 
 mmBDDialog::~mmBDDialog()
 {
-    Model_Infotable::instance().Set("RECURRINGTRANS_DIALOG_SIZE", GetSize());
+    wxSize size = GetSize();
+    if (m_custom_fields->IsCustomPanelShown())
+        size = wxSize(GetSize().GetWidth() - m_custom_fields->GetMinWidth(), GetSize().GetHeight());
+    Model_Infotable::instance().Set("RECURRINGTRANS_DIALOG_SIZE", size);
 }
 
 mmBDDialog::mmBDDialog(wxWindow* parent, int bdID, bool duplicate, bool enterOccur)

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -67,7 +67,10 @@ wxEND_EVENT_TABLE()
 
 mmTransDialog::~mmTransDialog()
 {
-    Model_Infotable::instance().Set("TRANSACTION_DIALOG_SIZE", GetSize());
+    wxSize size = GetSize();
+    if (m_custom_fields->IsCustomPanelShown())
+        size = wxSize(GetSize().GetWidth() - m_custom_fields->GetMinWidth(), GetSize().GetHeight());
+    Model_Infotable::instance().Set("TRANSACTION_DIALOG_SIZE", size);
 }
 
 void mmTransDialog::SetEventHandlers()


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5757)
<!-- Reviewable:end -->
