### PR TITLE
fix(#5791): save & restore color settings

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -790,6 +790,22 @@ void mmUnivCSVDialog::SetSettings(const wxString &json_data)
             payeeMatchAddNotes_->SetValue(json_doc["PAYEE_PATTERN_MATCH_ADD_NOTES"].GetBool());
         else
             payeeMatchAddNotes_->SetValue(false);
+
+        if (json_doc.HasMember("APPLY_COLOR"))
+        {
+            colorCheckBox_->SetValue(json_doc["APPLY_COLOR"].GetBool());
+            colorButton_->Enable(colorCheckBox_->IsChecked());
+        }
+        else
+        {
+            colorCheckBox_->SetValue(false);
+            colorButton_->Disable();
+        }
+
+        if (json_doc.HasMember("COLOR_SELECTION"))
+            colorButton_->SetBackgroundColor(json_doc["COLOR_SELECTION"].GetInt());
+        else
+            colorButton_->SetBackgroundColor(-1);
     }
     else
     {
@@ -1038,6 +1054,12 @@ void mmUnivCSVDialog::OnSettingsSave(wxCommandEvent& WXUNUSED(event))
 
         json_writer.Key("PAYEE_PATTERN_MATCH_ADD_NOTES");
         json_writer.Bool(payeeMatchAddNotes_->IsChecked());
+
+        json_writer.Key("APPLY_COLOR");
+        json_writer.Bool(colorCheckBox_->IsChecked());
+
+        json_writer.Key("COLOR_SELECTION");
+        json_writer.Int(colorButton_->GetColorId());
     }
     else
     {


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5794)
<!-- Reviewable:end -->
