### PR TITLE
fix(#5828): disable paste foreign transactions

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -810,6 +810,7 @@ void TransactionListCtrl::OnPaste(wxCommandEvent& WXUNUSED(event))
     for (const auto& i : m_selectedForCopy)
     {
         Model_Checking::Data* tran = Model_Checking::instance().get(i);
+        if (Model_Checking::foreignTransaction(*tran)) continue;
         OnPaste(tran);
     }
     Model_Checking::instance().ReleaseSavepoint();


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5829)
<!-- Reviewable:end -->
