### PR TITLE
Fix HTML nbsp tags in output

### DIFF
--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -264,7 +264,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
                         }
                         categLevel[subcats[i].CATEGID].second = "";
                         for (int j = categLevel[subcats[i].CATEGID].first; j > 0; j--) {
-                            categLevel[subcats[i].CATEGID].second.Prepend("&nbsp&nbsp&nbsp&nbsp");
+                            categLevel[subcats[i].CATEGID].second.Prepend("&nbsp;&nbsp;&nbsp;&nbsp;");
                         }
                         if (amply) {
                             hb.startTableRow();

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -176,7 +176,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
                     double estimate = 0;
                     double actual = 0;
                     for (auto child : categ_children[catID]) {
-                        formattedNames[child.CATEGID] = wxString("&nbsp&nbsp&nbsp&nbsp").Append(formattedNames[catID]);
+                        formattedNames[child.CATEGID] = wxString("&nbsp;&nbsp;&nbsp;&nbsp;").Append(formattedNames[catID]);
                         categ_stack.push_back(child);
                     }
                     int month = -1;

--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -254,14 +254,14 @@ wxString mmReportCategoryExpenses::getHTMLText()
 
                     if(group_counter[entry.catID]){
                         hb.startTableRow("toggle' data-row-id='" + row_id + "' data-row-pid='" + row_pid);
-                        hb.addTableCell(wxString::Format(indent + "<a>+&nbsp%s</a>", entry.name));
+                        hb.addTableCell(wxString::Format(indent + "<a>+&nbsp;%s</a>", entry.name));
                         hb.addEmptyTableCell();
                         hb.addMoneyCell(group_total[entry.categs][entry.catID]);
                         hb.endTableRow();
                     }
                     if (entry.amount != 0) {
                         if (group_counter[entry.catID]) {
-                            indent.Append("&nbsp&nbsp&nbsp&nbsp");
+                            indent.Append("&nbsp;&nbsp;&nbsp;&nbsp;");
                         }
                         hb.startTableRow("xtoggle' data-row-id='" + row_id + "' data-row-pid='" + (group_counter[entry.catID] ? row_id : row_pid));
                         hb.addTableCell(wxString::Format(indent +"<a href=\"viewtrans:%d\" target=\"_blank\">%s</a>", entry.catID, entry.name));


### PR DESCRIPTION
Fix missing ';' after "&nbsp" in a few strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5837)
<!-- Reviewable:end -->
