### PR TITLE
fix(#5835): retain selection during autocomplete init

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -129,7 +129,9 @@ void mmComboBox::OnSetFocus(wxFocusEvent& event)
 
        this->AutoComplete(auto_complete);
        if (!auto_complete.empty()) {
+           wxString selection = GetValue();
            Set(auto_complete);
+           SetStringSelection(selection);
        }
        if (auto_complete.GetCount() == 1) {
            Select(0);

--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -131,7 +131,7 @@ void mmComboBox::OnSetFocus(wxFocusEvent& event)
        if (!auto_complete.empty()) {
            wxString selection = GetValue();
            Set(auto_complete);
-           SetStringSelection(selection);
+           if (!selection.IsEmpty()) SetStringSelection(selection);
        }
        if (auto_complete.GetCount() == 1) {
            Select(0);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5839)
<!-- Reviewable:end -->
