### PR TITLE
fix(#3148): clear payee patterns before reinit

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -2147,6 +2147,7 @@ void mmUnivCSVDialog::OnDecimalChange(wxCommandEvent& event)
 void mmUnivCSVDialog::compilePayeeRegEx() {
     // pre-compile all payee match strings if not already done
     if (payeeMatchCheckBox_->IsChecked() && !payeeRegExInitialized_) {
+        payeeMatchPatterns_.clear();
         // only look at payees that have a match pattern set
         Model_Payee::Data_Set payees = Model_Payee::instance().find(Model_Payee::PATTERN(wxEmptyString, NOT_EQUAL));
         for (const auto& payee : payees) {


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5841)
<!-- Reviewable:end -->
