### PR TITLE
fix(#5769): replace delimiters in saved category filter

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -264,14 +264,13 @@ void mmFilterTransactionsDialog::mmDoDataToControls(const wxString& json)
     const wxString& delimiter = Model_Infotable::instance().GetStringInfo("CATEG_DELIMITER", ":");
     if (delimiter != ":" && s_category.Contains(":"))
     {
-        wxStringTokenizer categ_token(s_category, ":", wxTOKEN_RET_EMPTY_ALL);
-        wxRegEx regex;
-        const auto& categ_name = categ_token.GetNextToken();
-        Model_Category::Data_Set categs = Model_Category::instance().all();
-        for (const auto& categ : categs) {
-            if (categ.CATEGNAME == categ_name) {
-                regex.Compile(categ_name + " ?: ?");
-                regex.Replace(&s_category, categ_name + delimiter);
+        for (const auto& category : Model_Category::all_categories()) {
+            wxString full_name = category.first;
+            wxRegEx regex(delimiter);
+            regex.Replace(&full_name, ":");
+            if (s_category == full_name)
+            {
+                s_category = category.first;
                 break;
             }
         }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5856)
<!-- Reviewable:end -->
