### PR TITLE
fix(#5892): restrict categname display width

### DIFF
--- a/src/budgetentrydialog.cpp
+++ b/src/budgetentrydialog.cpp
@@ -107,8 +107,11 @@ void mmBudgetEntryDialog::CreateControls()
     wxStaticText* itemTextActCatAmt = new wxStaticText(itemPanel7, wxID_STATIC, catActualAmountStr_);
     
     itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, _("Category: ")), g_flagsH);
-    itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, Model_Category::full_name(category))
-        , wxSizerFlags(g_flagsH).Align(wxALIGN_RIGHT));
+    wxString categname = Model_Category::full_name(category);
+    wxStaticText* categNameLabel = new wxStaticText(itemPanel7, wxID_STATIC,
+        (categname.size() > 50 ? "..." + categname.substr(categname.size() - 50) : categname));
+    if (categname.size() > 50) categNameLabel->SetToolTip(categname);
+    itemGridSizer2->Add(categNameLabel, wxSizerFlags(g_flagsH).Align(wxALIGN_RIGHT));
     itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, _("Estimated:")), g_flagsH);
     itemGridSizer2->Add(itemTextEstCatAmt, wxSizerFlags(g_flagsH).Align(wxALIGN_RIGHT));
     itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, _("Actual:")), g_flagsH);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5899)
<!-- Reviewable:end -->
