### PR TITLE
fix(#5964): clear Model caches on database shutdown

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -374,6 +374,8 @@ void mmGUIFrame::ShutdownDatabase()
         m_db->SetCommitHook(nullptr);
         m_db->Close();
         m_db.reset();
+        for (auto& model : m_all_models)
+            model->destroyCache();
     }
 }
 

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -81,7 +81,7 @@ public:
 
 private:
     std::vector<WebsiteNews> websiteNewsArray_;
-    std::vector<const ModelBase*> m_all_models;
+    std::vector<ModelBase*> m_all_models;
 
     /* handles to SQLite Database */
     wxSharedPtr<wxSQLite3Database> m_db;

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -53,7 +53,7 @@ class ModelBase
 public:
     ModelBase() :db_(0) {};
     virtual ~ModelBase() {};
-
+    
 public:
     void Begin()
     {
@@ -92,6 +92,7 @@ protected:
 public:
     virtual wxString  GetTableStatsAsJson() const = 0;
     virtual void show_statistics() const = 0;
+    virtual void destroyCache() = 0;
 
 protected:
     wxSQLite3Database* db_;
@@ -241,6 +242,11 @@ public:
         wxLogDebug("%s", wxString::FromUTF8(json_buffer.GetString()));
 
         return wxString::FromUTF8(json_buffer.GetString());
+    }
+
+    void destroyCache()
+    {
+        if (this->cache_.size() > 0) this->destroy_cache();
     }
 
     /** Show table statistics*/


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5967)
<!-- Reviewable:end -->
