### PR TITLE
fix(#5969): database submodule update for USD group separator

### DIFF
--- a/src/db/DB_Table_Currencyformats_V1.h
+++ b/src/db/DB_Table_Currencyformats_V1.h
@@ -12,7 +12,7 @@
  *      @brief
  *
  *      Revision History:
- *          AUTO GENERATED at 2023-03-10 09:16:48.384520.
+ *          AUTO GENERATED at 2023-06-02 12:09:36.042173.
  *          DO NOT EDIT!
  */
 //=============================================================================
@@ -109,7 +109,7 @@ struct DB_Table_CURRENCYFORMATS_V1 : public DB_Table
     void ensure_data(wxSQLite3Database* db)
     {
         db->Begin();
-        db->ExecuteUpdate(wxString::Format("INSERT INTO CURRENCYFORMATS_V1 VALUES ('1', '%s', '$', '', '.', ' ', '', '', '100', '1', 'USD', 'Fiat')", _("US dollar")));
+        db->ExecuteUpdate(wxString::Format("INSERT INTO CURRENCYFORMATS_V1 VALUES ('1', '%s', '$', '', '.', ',', 'Dollar', 'Cent', '100', '1', 'USD', 'Fiat')", _("US dollar")));
         db->ExecuteUpdate(wxString::Format("INSERT INTO CURRENCYFORMATS_V1 VALUES ('2', '%s', '%s', '', '.', ' ', '', '', '100', '1', 'EUR', 'Fiat')", _("Euro"), L"€"));
         db->ExecuteUpdate(wxString::Format("INSERT INTO CURRENCYFORMATS_V1 VALUES ('3', '%s', '%s', '', '.', ' ', 'Pound', 'Pence', '100', '1', 'GBP', 'Fiat')", _("British pound"), L"£"));
         db->ExecuteUpdate(wxString::Format("INSERT INTO CURRENCYFORMATS_V1 VALUES ('4', '%s', '', '%s', ',', ' ', '%s', '%s', '100', '1', 'RUB', 'Fiat')", _("Russian ruble"), L"р", L"руб.", L"коп."));

--- a/util/sql_tables.sql
+++ b/util/sql_tables.sql
@@ -219,7 +219,7 @@ CREATE INDEX IDX_CURRENCYFORMATS_SYMBOL ON CURRENCYFORMATS_V1(CURRENCY_SYMBOL);
 -- Note: All strings requiring translation are prefix by: ''
 -- The  prefix is removed when generating .h files by sqlite2cpp.py
 -- strings containing unicode should not be translated.
-INSERT INTO CURRENCYFORMATS_V1 VALUES(1,'US dollar','$','','.',' ','','',100,1,'USD','Fiat');
+INSERT INTO CURRENCYFORMATS_V1 VALUES(1,'US dollar','$','','.',',','Dollar','Cent',100,1,'USD','Fiat');
 INSERT INTO CURRENCYFORMATS_V1 VALUES(2,'Euro','€','','.',' ','','',100,1,'EUR','Fiat');
 INSERT INTO CURRENCYFORMATS_V1 VALUES(3,'British pound','£','','.',' ','Pound','Pence',100,1,'GBP','Fiat');
 INSERT INTO CURRENCYFORMATS_V1 VALUES(4,'Russian ruble','','р',',',' ','руб.','коп.',100,1,'RUB','Fiat');


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/5972)
<!-- Reviewable:end -->
