### PR TITLE
fix(#5885): revert color button height

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -646,9 +646,6 @@ void mmFilterTransactionsDialog::mmDoCreateControls()
     itemPanelSizer->Add(colorCheckBox_, g_flagsH);
 
     colorButton_ = new mmColorButton(itemPanel, wxID_HIGHEST);
-#ifdef __WXGTK__
-    colorButton_->SetMinSize(wxSize(-1, 2 * colorButton_->GetBestSize().GetHeight()));
-#endif
     itemPanelSizer->Add(colorButton_, g_flagsExpand);
     
     itemPanel->SetSizerAndFit(itemPanelSizer);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).
