### PR TITLE
fix(#5790): save default preset for export

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -2556,17 +2556,18 @@ void mmUnivCSVDialog::OnCheckboxClick(wxCommandEvent& event)
             payeeMatchAddNotes_->SetValue(false);
             refreshTabs(PAYEE_TAB);
         }
-        else if (id == wxID_DEFAULT)
-        {
-            wxString preset_name = m_choice_preset_name->GetStringSelection();
+    }
 
-            if (m_checkbox_preset_default->IsChecked())
-                m_acct_default_preset[m_account_id] = m_preset_id[preset_name];
-            else if (m_acct_default_preset[m_account_id] == m_preset_id[preset_name])
-                m_acct_default_preset[m_account_id] = "";
+    if (id == wxID_DEFAULT)
+    {
+        wxString preset_name = m_choice_preset_name->GetStringSelection();
 
-            saveAccountPresets();
-        }
+        if (m_checkbox_preset_default->IsChecked())
+            m_acct_default_preset[m_account_id] = m_preset_id[preset_name];
+        else if (m_acct_default_preset[m_account_id] == m_preset_id[preset_name])
+            m_acct_default_preset[m_account_id] = "";
+
+        saveAccountPresets();
     }
 }
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6012)
<!-- Reviewable:end -->
