### PR TITLE
Enable flags for x86_64 only to improve aarch64 build compatibility

### DIFF
--- a/3rd/CMakeLists.txt
+++ b/3rd/CMakeLists.txt
@@ -225,7 +225,9 @@ if(NOT wxSQLite3_FOUND OR NOT (WXSQLITE3_HAVE_CODEC OR MMEX_ENCRYPTION_OPTIONAL)
     endif()
 
     if(NOT MSVC) # wxSQLite3 security ext doesn't require C 99 for MSVC
-        set (CMAKE_C_FLAGS "-msse4.2 -maes")
+        if(";i386;i686;amd64;x86_64;" MATCHES ";${CMAKE_HOST_SYSTEM_PROCESSOR};")
+            set (CMAKE_C_FLAGS "-msse4.2 -maes")
+        endif()
         if(";${CMAKE_C_COMPILE_FEATURES};" MATCHES ";c_std_99;")
             target_compile_features(SQLite3 PRIVATE c_std_99)
         elseif(";${CMAKE_C_COMPILE_FEATURES};" MATCHES ";c_restrict;")


### PR DESCRIPTION
Fixes https://github.com/moneymanagerex/moneymanagerex/issues/5953

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6017)
<!-- Reviewable:end -->
