### PR TITLE
fix(#5439): delete split taglinks when txn is deleted

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -941,6 +941,8 @@ mmTagTextCtrl::mmTagTextCtrl(wxWindow* parent, wxWindowID id,
     AutoCompSetAutoHide(false);
     StyleSetBackground(1, wxColour(186, 226, 185));
     StyleSetForeground(1, *wxBLACK);
+    StyleSetBackground(0, wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
+    StyleSetForeground(0, wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
     SetExtraAscent(2);
     SetExtraDescent(2);
     SetMaxClientSize(wxSize(-1, TextHeight(0)));

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -635,6 +635,9 @@ void mmGUIFrame::menuEnableItems(bool enable)
     menuBar_->FindItem(wxID_VIEW_LIST)->Enable(enable);
     menuBar_->FindItem(wxID_BROWSE)->Enable(enable);
     menuBar_->FindItem(MENU_CONVERT_ENC_DB)->Enable(enable);
+    menuBar_->FindItem(MENU_RATES)->Enable(enable);
+    menuBar_->FindItem(MENU_ORGTAGS)->Enable(enable);
+    menuBar_->FindItem(MENU_THEME_MANAGER)->Enable(enable);
 
     menuBar_->FindItem(MENU_IMPORT)->Enable(enable);
     menuBar_->FindItem(wxID_PRINT)->Enable(enable);
@@ -669,6 +672,8 @@ void mmGUIFrame::menuEnableItems(bool enable)
     toolBar_->EnableTool(wxID_PREFERENCES, enable);
     toolBar_->EnableTool(wxID_NEW, enable);
     toolBar_->EnableTool(wxID_PRINT, enable);
+    toolBar_->EnableTool(MENU_ORGTAGS, enable);
+    toolBar_->EnableTool(MENU_RATES, enable);
     toolBar_->Refresh();
     toolBar_->Update();
 }

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -186,6 +186,8 @@ bool Model_Billsdeposits::remove(int id)
 {
     for (auto &item : Model_Billsdeposits::splittransaction(get(id)))
         Model_Budgetsplittransaction::instance().remove(item.SPLITTRANSID);
+    // Delete tags for the recurring transaction
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), id);
     return this->remove(id, db_);
 }
 

--- a/src/model/Model_Budgetsplittransaction.cpp
+++ b/src/model/Model_Budgetsplittransaction.cpp
@@ -18,6 +18,8 @@
  ********************************************************/
 
 #include "Model_Budgetsplittransaction.h"
+#include "Model_Attachment.h"
+#include "Model_Taglink.h"
 
 Model_Budgetsplittransaction::Model_Budgetsplittransaction()
 : Model<DB_Table_BUDGETSPLITTRANSACTIONS_V1>()
@@ -54,6 +56,13 @@ double Model_Budgetsplittransaction::get_total(const Data_Set& rows)
     for (auto& r : rows) total += r.SPLITTRANSAMOUNT;
 
     return total;
+}
+
+bool Model_Budgetsplittransaction::remove(int id)
+{
+    // Delete all tags for the split before removing it
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT), id);
+    return this->remove(id, db_);
 }
 
 std::map<int, Model_Budgetsplittransaction::Data_Set> Model_Budgetsplittransaction::get_all()

--- a/src/model/Model_Budgetsplittransaction.h
+++ b/src/model/Model_Budgetsplittransaction.h
@@ -43,10 +43,13 @@ public:
     */
     static Model_Budgetsplittransaction& instance();
 
+    using Model<DB_Table_BUDGETSPLITTRANSACTIONS_V1>::remove;
+
 public:
     double get_total(const Data_Set& rows);
     std::map<int, Data_Set> get_all();
     int update(Data_Set& rows, int transactionID);
+    bool remove(int id);
 };
 
 #endif // 

--- a/src/model/Model_Splittransaction.cpp
+++ b/src/model/Model_Splittransaction.cpp
@@ -50,6 +50,13 @@ Model_Splittransaction& Model_Splittransaction::instance()
     return Singleton<Model_Splittransaction>::instance();
 }
 
+bool Model_Splittransaction::remove(int id)
+{
+    // Delete all tags for the split before removing it
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), id);
+    return this->remove(id, db_);
+}
+
 double Model_Splittransaction::get_total(const Data_Set& rows)
 {
     double total = 0.0;

--- a/src/model/Model_Splittransaction.h
+++ b/src/model/Model_Splittransaction.h
@@ -53,12 +53,15 @@ public:
     */
     static Model_Splittransaction& instance();
 
+    using Model<DB_Table_SPLITTRANSACTIONS_V1>::remove;
+
 public:
     static double get_total(const Data_Set& rows);
     static double get_total(const std::vector<Split>& local_splits);
     static const wxString get_tooltip(const std::vector<Split>& local_splits, const Model_Currency::Data* currency);
     std::map<int, Model_Splittransaction::Data_Set> get_all();
     int update(Data_Set& rows, int transactionID);
+    bool remove(int id);
 };
 
 #endif // 

--- a/src/tagdialog.cpp
+++ b/src/tagdialog.cpp
@@ -307,8 +307,9 @@ void mmTagDialog::OnDelete(wxCommandEvent& WXUNUSED(event))
         {
             Model_Taglink::Data_Set taglinks = Model_Taglink::instance().find(Model_Taglink::TAGID(tag->TAGID));
             for (const auto& link : taglinks)
+                // Taglinks for deleted transactions are either TRANSACTION or TRANSACTIONSPLIT type.
+                // Remove the transactions which will delete all associated tags.
                 if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
-                    // Removing the checking record also deletes the taglinks
                     Model_Checking::instance().remove(link.REFID);
                 else if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT))
                     Model_Checking::instance().remove(Model_Splittransaction::instance().get(link.REFID)->TRANSID);

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -390,6 +390,7 @@ void mmTransDialog::dataToControls()
         cAdvanced_->Enable(false);
         cbPayee_->Enable(false);
         cbCategory_->Enable(false);
+        tagTextCtrl_->Enable(false);
         bSplit_->Enable(false);
         bAuto->Enable(false);
         textNumber_->Enable(false);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6095)
<!-- Reviewable:end -->
