### PR TITLE
fix(#6098): remove lock restriction for statement date filter

### DIFF
--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -764,16 +764,14 @@ void mmCheckingPanel::initFilterSettings()
     case  MENU_VIEW_LASTFINANCIALYEAR:
         date_range = new mmLastFinancialYear(); break;
     case  MENU_VIEW_STATEMENTDATE:
-        if (Model_Account::BoolOf(m_account->STATEMENTLOCKED))
-        {
-            date_range = new mmSpecifiedRange(
-                Model_Account::DateOf(m_account->STATEMENTDATE).Add(wxDateSpan::Day())
-                , wxDateTime::Today()
-            );
+        date_range = new mmSpecifiedRange(
+            Model_Account::DateOf(m_account->STATEMENTDATE).Add(wxDateSpan::Day())
+            , wxDateTime::Today()
+        );
 
-            if (!Option::instance().getIgnoreFutureTransactions())
-                date_range->set_end_date(date_range->future_date());
-        }
+        if (!Option::instance().getIgnoreFutureTransactions())
+            date_range->set_end_date(date_range->future_date());
+        
         break;
     case MENU_VIEW_FILTER_DIALOG:
         m_transFilterActive = true;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6105)
<!-- Reviewable:end -->
