### PR TITLE
fix (#5328): months

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1787,7 +1787,7 @@ void mmGUIFrame::createMenu()
     menuDatabase->Append(menuItemChangeEncryptPassword);
     menuDatabase->Append(menuItemVacuumDB);
     menuDatabase->Append(menuItemCheckDB);
-    menuTools->AppendSubMenu(menuDatabase, _("Databa&se")
+    menuTools->AppendSubMenu(menuDatabase, _("&Database")
         , _("Database management"));
     menuItemChangeEncryptPassword->Enable(false);
 

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -383,7 +383,8 @@ wxString mmReportCashFlowTransactions::getHTMLText()
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format("%s (%i %s)", getReportTitle(), getForwardMonths(), _("months"));
+    const wxString& headingStr = wxString::Format(_("%s (%i months)")
+        , getReportTitle(), getForwardMonths());
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());
 

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -254,7 +254,8 @@ wxString mmReportCashFlow::getHTMLText_DayOrMonth(bool monthly)
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format("%s (%i %s)", getReportTitle(), getForwardMonths(), _("months"));
+    const wxString& headingStr = wxString::Format(_("%s (%i months)")
+        , getReportTitle(), getForwardMonths());
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());
 

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -254,7 +254,7 @@ wxString mmReportCashFlow::getHTMLText_DayOrMonth(bool monthly)
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format(_("%s (%i months)")
+    const wxString& headingStr = wxString::Format(_("%1$s (%2$i months)")
         , getReportTitle(), getForwardMonths());
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());
@@ -383,7 +383,7 @@ wxString mmReportCashFlowTransactions::getHTMLText()
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format(_("%s (%i months)")
+    const wxString& headingStr = wxString::Format(_("%1$s (%2$i months)")
         , getReportTitle(), getForwardMonths());
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());


### PR DESCRIPTION
Hopefully this works.

An improvement would be to have singular `%1$s (%2$i month)` and plural `%1$s (%2$i months)` working.

@n-stein are you able to advise the code to do the improvement?

Thank you

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6165)
<!-- Reviewable:end -->
