### PR TITLE
adding multiple payees delete at once

### DIFF
--- a/src/payeedialog.h
+++ b/src/payeedialog.h
@@ -27,6 +27,7 @@
 #include <wx/srchctrl.h>
 #include <wx/grid.h>
 #include <map>
+#include <list>
 #include "mmSimpleDialogs.h"
 
 class mmEditPayeeDialog : public wxDialog
@@ -126,6 +127,7 @@ private:
     void OnOrganizeAttachments();
     void OnPayeeRelocate();
     int FindSelectedPayee();
+    void FindSelectedPayees(std::list<int>& indexes);
     void OnCancel(wxCommandEvent& /*event*/);
     void OnOk(wxCommandEvent& /*event*/);
 


### PR DESCRIPTION
Hi,
this is my first ever pull request (so sorry if this isn't the right way)
I have modified _payeedialog.cpp_ to allow select multiple items and delete all in once.

I tested it a little on my PC and it seems workinng right.

Maybe Yuo fidn a better way to implement this (so take this like a suggested feature)
for this issue:
https://github.com/moneymanagerex/moneymanagerex/issues/6181

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6184)
<!-- Reviewable:end -->
