### PR TITLE
fix(#6040): workaround for cURL UA block

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1306,6 +1306,7 @@ CURLcode getYahooFinanceQuotes(const wxString& URL, wxString& output) {
 
     struct curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8");
+    headers = curl_slist_append(headers, "User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/117.0");
     if (!savedCookie.IsEmpty()) headers = curl_slist_append(headers, static_cast<const char*>(("Cookie: " + savedCookie).mb_str()));
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6209)
<!-- Reviewable:end -->
