### PR TITLE
use model_usage.m_start as session_id

### DIFF
--- a/src/model/Model_Usage.cpp
+++ b/src/model/Model_Usage.cpp
@@ -219,6 +219,9 @@ void Model_Usage::pageview(const wxString& documentPath, const wxString& documen
     Value ip("$remote", document.GetAllocator());
     event.AddMember("ip", ip, document.GetAllocator());
 
+    Value session_id(wxString::Format("%lld", this->m_start.GetTicks()).utf8_str(), document.GetAllocator());
+    event.AddMember("session_id", session_id, document.GetAllocator());
+
     Value event_properties(kObjectType);
     Value page_title(documentTitle.utf8_str(), document.GetAllocator());
     event_properties.AddMember("page_title", page_title, document.GetAllocator());


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6286)
<!-- Reviewable:end -->
