### PR TITLE
fix(#6305): Revert to native DatePicker on MacOS

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -418,11 +418,6 @@ mmDatePickerCtrl::mmDatePickerCtrl(wxWindow* parent, wxWindowID id, wxDateTime d
     , itemStaticTextWeek_(nullptr)
     , spinButton_(nullptr)
 {
-    // The standard date control for MacOS does not have a date picker so make one available when right-click
-    // over the date field.
-#if defined (__WXMAC__)
-    Bind(wxEVT_RIGHT_DOWN, &mmDatePickerCtrl::OnCalendar, this);
-#endif
 }
 
 mmDatePickerCtrl::~mmDatePickerCtrl()
@@ -493,19 +488,6 @@ wxBoxSizer* mmDatePickerCtrl::mmGetLayout()
     date_sizer->Add(this->getTextWeek(), g_flagsH);
 
     return date_sizer;
-}
-
-void mmDatePickerCtrl::OnCalendar(wxMouseEvent& event)
-{
-    mmCalendarPopup* m_simplePopup = new mmCalendarPopup( parent_, this );
-
-    // make sure we correctly position the popup below the date
-    wxWindow *dateCtrl = static_cast<wxWindow*>(event.GetEventObject());
-    wxSize dimensions = dateCtrl->GetSize();
-    wxPoint pos = dateCtrl->ClientToScreen(wxPoint(0, dimensions.GetHeight()));
-    m_simplePopup->SetPosition(pos);
-
-    m_simplePopup->Popup();
 }
 
 void mmDatePickerCtrl::OnDateChanged(wxDateEvent& event)

--- a/src/mmSimpleDialogs.h
+++ b/src/mmSimpleDialogs.h
@@ -172,7 +172,6 @@ private:
     wxStaticText* getTextWeek();
     wxSpinButton* getSpinButton();
 
-    void OnCalendar(wxMouseEvent& event);
     void OnDateChanged(wxDateEvent& event);
     void OnDateSpin(wxSpinEvent& event);
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6306)
<!-- Reviewable:end -->
