### PR TITLE
fix(#6339): selected transactions summary on macOS

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -377,6 +377,7 @@ void TransactionListCtrl::setExtraTransactionData(const bool single)
 
 void TransactionListCtrl::OnListItemSelected(wxListEvent& event)
 {
+    SetItemState(event.GetIndex(), wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
     wxLogDebug("OnListItemSelected: %i selected", GetSelectedItemCount());
     FindSelectedTransactions();
     setExtraTransactionData(GetSelectedItemCount() == 1);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -657,9 +657,6 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, bool foreign)
                 msg += "\n";
             }
             msg += wxString::Format(_("Days between selected transactions: %d"), days);
-#ifdef __WXMAC__    // See issue #2914
-            msg = "";
-#endif
             m_info_panel->SetLabelText(msg);
         }
         else


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6349)
<!-- Reviewable:end -->
