### PR TITLE
Add --no-net to metainfo validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,7 +678,7 @@ if(LINUX)
         DESTINATION share/mime/packages)
     execute_process(COMMAND appstreamcli news-to-metainfo --format=markdown ${PROJECT_SOURCE_DIR}/NEWS ${PROJECT_SOURCE_DIR}/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in org.moneymanagerex.MMEX.metainfo.xml
 	            COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND appstreamcli validate --strict org.moneymanagerex.MMEX.metainfo.xml
+    execute_process(COMMAND appstreamcli validate --strict --no-net org.moneymanagerex.MMEX.metainfo.xml
                     COMMAND_ERROR_IS_FATAL ANY)
     install(FILES
         org.moneymanagerex.MMEX.metainfo.xml


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6417)
<!-- Reviewable:end -->
