### PR TITLE
Revert "Add validation to the metainfo file generated at build time"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,8 +678,6 @@ if(LINUX)
         DESTINATION share/mime/packages)
     execute_process(COMMAND appstreamcli news-to-metainfo --format=markdown ${PROJECT_SOURCE_DIR}/NEWS ${PROJECT_SOURCE_DIR}/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in org.moneymanagerex.MMEX.metainfo.xml
 	            COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND appstreamcli validate --strict org.moneymanagerex.MMEX.metainfo.xml
-                    COMMAND_ERROR_IS_FATAL ANY)
     install(FILES
         org.moneymanagerex.MMEX.metainfo.xml
         DESTINATION share/metainfo)


### PR DESCRIPTION
Reverts moneymanagerex/moneymanagerex#6415

@joshua-stone  This fails to build. https://app.circleci.com/pipelines/github/moneymanagerex/moneymanagerex/1180/workflows/fb401f1a-ac0f-4b46-8acf-195fcdd7a31a/jobs/1173

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6418)
<!-- Reviewable:end -->
