### PR TITLE
Update developer ID to be compliant with appstream 1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     if(NOT APPSTREAMCLI)
         message(SEND_ERROR "appstreamcli tool not found.")
     endif()
-    find_program(APPSTREAMCLI perl
-        DOC "command for patching metainfo file")
-    if(NOT APPSTREAMCLI)
-        message(SEND_ERROR "perl not found.") 
-    endif()
 
     # Detect Linux distribution (if possible)
     find_program(LSB_RELEASE lsb_release
@@ -683,8 +678,6 @@ if(LINUX)
         DESTINATION share/mime/packages)
     execute_process(COMMAND appstreamcli news-to-metainfo --format=markdown ${PROJECT_SOURCE_DIR}/NEWS ${PROJECT_SOURCE_DIR}/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in org.moneymanagerex.MMEX.metainfo.xml
 	            COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND perl -0777 -i -pe "s@<developer>\n    <name>MMEX team</name>\n  </developer>@<developer_name>MMEX team</developer_name>@g" org.moneymanagerex.MMEX.metainfo.xml
-                    COMMAND_ERROR_IS_FATAL ANY)
     execute_process(COMMAND appstreamcli validate --strict --no-net org.moneymanagerex.MMEX.metainfo.xml
                     COMMAND_ERROR_IS_FATAL ANY)
     install(FILES

--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -94,6 +94,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
   <developer_name>MMEX team</developer_name>
+  <developer id="moneymanagerex.org">
+    <name>MMEX team<</name>
+  </developer>
   <update_contact>moneymanagerex@gmail.com</update_contact>
 
   <categories>


### PR DESCRIPTION
It would appear that the metainfo file needs additional fields to work with the newest appstream spec:

https://gitlab.gnome.org/GNOME/loupe/-/blob/bee10be168639a082576e8a6eea34d40a364c680/data/org.gnome.Loupe.metainfo.xml.in.in#L6

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6421)
<!-- Reviewable:end -->
