### PR TITLE
fix(#6404): translate language list in options

### DIFF
--- a/po/common.po
+++ b/po/common.po
@@ -63,7 +63,7 @@ msgid "Kannada (India)"
 msgstr "kn-IN ಕನ್ನಡ (ಭಾರತ)"
 
 msgid "Korean (Korea)"
-msgstr "ko-KR 韓国語 (韓国)"
+msgstr "ko-KR 한국어 (한국)"
 
 msgid "Lithuanian (Lithuania)"
 msgstr "lt-LT lietuvių (Lietuva)"

--- a/src/optionsettingsgeneral.cpp
+++ b/src/optionsettingsgeneral.cpp
@@ -94,7 +94,7 @@ void OptionSettingsGeneral::Create()
     wxStaticBoxSizer* langFormatStaticBoxSizer = new wxStaticBoxSizer(langStaticBox, wxHORIZONTAL);
     generalPanelSizer->Add(langFormatStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
 
-    wxButton* langButton = new wxButton(general_panel, ID_DIALOG_OPTIONS_BUTTON_LANG, langName);
+    wxButton* langButton = new wxButton(general_panel, ID_DIALOG_OPTIONS_BUTTON_LANG, wxGetTranslation(langName));
     langButton->SetMinSize(wxSize(200, -1));
     langFormatStaticBoxSizer->Add(langButton, g_flagsH);
     mmToolTip(langButton, _("Change user interface language"));
@@ -376,9 +376,9 @@ void OptionSettingsGeneral::OnMouseLeftDown(wxCommandEvent& event)
     {
         const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
         if (info)
-            langs[info->Description] = std::make_pair(info->Language, info->CanonicalName);
+            langs[wxGetTranslation(info->Description)] = std::make_pair(info->Language, info->CanonicalName);
     }
-    langs[wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US)] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
+    langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
     for (auto const& lang : langs)
     {
         menuLang.AppendRadioItem(wxID_LAST + 1 + lang.second.first, lang.first, lang.second.second)


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6436)
<!-- Reviewable:end -->
