### PR TITLE
feat(#5685): add charts to Transaction Report

### DIFF
--- a/src/filtertransdialog.h
+++ b/src/filtertransdialog.h
@@ -76,9 +76,14 @@ public:
         GROUPBY_ACCOUNT,
         GROUPBY_PAYEE,
         GROUPBY_CATEGORY,
-        GROUPBY_TYPE
+        GROUPBY_TYPE,
+        GROUPBY_DAY,
+        GROUPBY_MONTH,
+        GROUPBY_YEAR
     };
     int mmGetGroupBy() const;
+
+    int mmGetChart() const;
 
     const wxArrayInt mmGetAccountsID() const;
     const wxArrayInt mmGetHideColumnsID() const;
@@ -203,6 +208,8 @@ private:
     wxButton* bHideColumns_ = nullptr;
     wxCheckBox* groupByCheckBox_ = nullptr;
     wxChoice* bGroupBy_ = nullptr;
+    wxCheckBox* chartCheckBox_ = nullptr;
+    wxChoice* bChart_ = nullptr;
     wxCheckBox* combineSplitsCheckBox_ = nullptr;
 private:
     wxString m_settings_json;

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -37,7 +37,8 @@ struct GraphSeries
 struct GraphData
 {
     wxString title;
-    enum { BAR = 0, LINE, LINE_DATETIME, PIE, DONUT, RADAR, BARLINE, STACKEDBARLINE, STACKEDAREA } type;
+    enum GraphType { BAR = 0, LINE, LINE_DATETIME, PIE, DONUT, RADAR, BARLINE, STACKEDBARLINE, STACKEDAREA } type;
+    //Keep type aligned in FilterTransDialog CHART_OPTIONS
     std::vector<wxString> labels;
     std::vector<GraphSeries> series;
     std::vector<wxColour> colors;

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -457,22 +457,17 @@ table {
     // Chart
     if (chart > -1 && values_chart.size() > 0)
     {
-        hb.addDivContainer("shadow");
+        GraphData gd;
+        GraphSeries gs;
+        for (const auto& kv : values_chart)
         {
-            GraphData gd;
-            GraphSeries gs;
-            for (const auto& kv : values_chart)
-            {
-                gd.labels.push_back(kv.first);
-                gs.values.push_back(kv.second);
-            }
-            gd.series.push_back(gs);
-            //gd.colors = { mmThemeMetaColour(meta::COLOR_REPORT_DELTA) };
-            gd.type = static_cast<GraphData::GraphType>(chart);
-            hb.addChart(gd);
-            hb.end();
+            gd.labels.push_back(kv.first);
+            gs.values.push_back(kv.second);
         }
-        hb.endDiv();
+        gd.series.push_back(gs);
+        //gd.colors = { mmThemeMetaColour(meta::COLOR_REPORT_DELTA) };
+        gd.type = static_cast<GraphData::GraphType>(chart);
+        hb.addChart(gd);
     }
 
     // Filters recap

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -195,7 +195,7 @@ table {
             }
             hb.addDivContainer("shadow");
             if (groupBy > -1)
-                hb.addHeader(2, sortLabel);
+                hb.addHeader(3, sortLabel);
             hb.startSortTable();
             hb.startThead();
             hb.startTableRow();

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "model/allmodel.h"
 #include <algorithm>
+#include <numeric>
 #include <vector>
 #include <float.h>
 
@@ -127,6 +128,7 @@ table {
     m_noOfCols = (m_transDialog->mmIsHideColumnsChecked()) ? m_transDialog->mmGetHideColumnsID().GetCount() : 11;
     const wxString& AttRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
     const int groupBy = m_transDialog->mmGetGroupBy();
+    const int chart = m_transDialog->mmGetChart();
     wxString lastSortLabel = "";
 
     std::map<int, double> total; //Store transaction amount with original currency
@@ -135,6 +137,7 @@ table {
     std::map<int, double> grand_total_in_base_curr; //Grad - Store transactions amount daily converted to base currency
     std::map<int, double> grand_total_extrans; //Grand - Store transaction amount with original currency - excluding TRANSFERS
     std::map<int, double> grand_total_in_base_curr_extrans; //Grand - Store transactions amount daily converted to base currency - excluding TRANSFERS
+    std::map<wxString, double> values_chart; // Store grouped values for chart
 
     const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
     Model_CustomField::FIELDTYPE UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
@@ -161,6 +164,12 @@ table {
             sortLabel = transaction.CATEGNAME;
         else if (groupBy == mmFilterTransactionsDialog::GROUPBY_TYPE)
             sortLabel = wxGetTranslation(transaction.TRANSCODE);
+        else if (groupBy == mmFilterTransactionsDialog::GROUPBY_DAY)
+            sortLabel = mmGetDateForDisplay(transaction.TRANSDATE);
+        else if (groupBy == mmFilterTransactionsDialog::GROUPBY_MONTH)
+            sortLabel = Model_Checking::TRANSDATE(transaction).Format("%Y-%m");
+        else if (groupBy == mmFilterTransactionsDialog::GROUPBY_YEAR)
+            sortLabel = Model_Checking::TRANSDATE(transaction).Format("%Y");
 
         if (sortLabel != lastSortLabel)
         {
@@ -174,6 +183,13 @@ table {
                 hb.endTbody();
                 hb.endTable();
                 hb.endDiv();
+
+                if (chart > -1)
+                {
+                    double value_chart = std::accumulate(total_in_base_curr.begin(), total_in_base_curr.end(), 0,
+                                                         [](const double previous, decltype(*total_in_base_curr.begin()) p) { return previous + p.second; });
+                    values_chart[lastSortLabel] += value_chart;
+                }
                 total.clear();
                 total_in_base_curr.clear();
             }
@@ -287,6 +303,10 @@ table {
                         grand_total_extrans[curr->CURRENCYID] += amount;
                         grand_total_in_base_curr_extrans[curr->CURRENCYID] += amount * convRate;
                     }
+                    if (chart > -1 && groupBy == -1)
+                    {
+                        values_chart[std::to_string(transaction.TRANSID)] += (amount * convRate);
+                    }
                 }
                 else
                 {
@@ -378,11 +398,18 @@ table {
         hb.startTable();
         hb.startTbody();
         displayTotals(total, total_in_base_curr, m_noOfCols);
+        if (chart > -1)
+        {
+            double value_chart = std::accumulate(total_in_base_curr.begin(), total_in_base_curr.end(), 0,
+                                                 [](const double previous, decltype(*total_in_base_curr.begin()) p) { return previous + p.second; });
+            values_chart[lastSortLabel] += value_chart;
+        }
     }
     hb.endTbody();
     hb.endTable();
     hb.endDiv();
 
+    // Totals box
     hb.addDivContainer("shadow");
     {
         hb.startTable();
@@ -426,6 +453,29 @@ table {
         hb.endTable();
     }
     hb.endDiv();
+
+    // Chart
+    if (chart > -1 && values_chart.size() > 0)
+    {
+        hb.addDivContainer("shadow");
+        {
+            GraphData gd;
+            GraphSeries gs;
+            for (const auto& kv : values_chart)
+            {
+                gd.labels.push_back(kv.first);
+                gs.values.push_back(kv.second);
+            }
+            gd.series.push_back(gs);
+            //gd.colors = { mmThemeMetaColour(meta::COLOR_REPORT_DELTA) };
+            gd.type = static_cast<GraphData::GraphType>(chart);
+            hb.addChart(gd);
+            hb.end();
+        }
+        hb.endDiv();
+    }
+
+    // Filters recap
     hb.addDivContainer("shadow");
     {
         m_transDialog->mmGetDescription(hb);
@@ -502,6 +552,15 @@ void mmReportTransactions::Run(wxSharedPtr<mmFilterTransactionsDialog>& dlg)
         break;
     case mmFilterTransactionsDialog::GROUPBY_TYPE:
         std::stable_sort(trans_.begin(), trans_.end(), SorterByTRANSCODE());
+        break;
+    case mmFilterTransactionsDialog::GROUPBY_DAY:
+        std::stable_sort(trans_.begin(), trans_.end(), SorterByTRANSDATE());
+        break;
+    case mmFilterTransactionsDialog::GROUPBY_MONTH:
+        std::stable_sort(trans_.begin(), trans_.end(), SorterByTRANSDATE());
+        break;
+    case mmFilterTransactionsDialog::GROUPBY_YEAR:
+        std::stable_sort(trans_.begin(), trans_.end(), SorterByTRANSDATE());
         break;
     }
 }


### PR DESCRIPTION
Transaction Report has now option to show a chart.
If "grouping" is enabled, it considers the grouping item total, otherwise it considers the single transaction.

Three new "Group By" have been added: day, month, year:
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/02cfbe01-ace3-4fb6-af4c-5e5958f6d454)

Chart types are all ones supported by MMEX graphing library:
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/b4e71f19-2980-4217-b871-501ae166ac1e)

Result:
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/92119449-4c0f-419c-9ef2-ebe320368091)
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/08c2b9db-4129-425f-b7b4-31cd474775f9)
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/7e78166b-c1f1-4157-989f-2457c1eed8d9)
![image](https://github.com/moneymanagerex/moneymanagerex/assets/7106290/7d3014a1-679e-46c1-9656-2d731f7f0350)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6440)
<!-- Reviewable:end -->
