### PR TITLE
fix(#6452): remove newline at end of notes

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -2512,7 +2512,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
 
     case UNIV_CSV_NOTES:
         token.Replace("\\n", "\n");
-        holder.Notes += token + "\n";
+        holder.Notes += (holder.Notes.IsEmpty() ? "" : "\n") + token;
         break;
 
     case UNIV_CSV_WITHDRAWAL:


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6454)
<!-- Reviewable:end -->
