### PR TITLE
fix(#6476): protect filter parsing

### DIFF
--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -815,7 +815,7 @@ void mmCheckingPanel::initFilterSettings()
         , Model_Setting::instance().ViewTransactions());
     wxString json = Model_Infotable::instance().GetStringInfo(wxString::Format("CHECK_FILTER_ID_%d", m_AccountID), def_view);
     Document j_doc;
-    if (j_doc.Parse(json.utf8_str()).HasParseError()) {
+    if (j_doc.Parse(json.utf8_str()).HasParseError() || !j_doc.IsArray()) {
         j_doc.Parse("{}");
     }
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6477)
<!-- Reviewable:end -->
