### PR TITLE
fix(#6481): `MMB Files (*.mmb)`: 1. Add a space ` `; and, 2. allow translation

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2245,7 +2245,7 @@ void mmGUIFrame::OnNew(wxCommandEvent& /*event*/)
         _("Choose database file to create"),
         wxEmptyString,
         wxEmptyString,
-        "MMB Files(*.mmb)|*.mmb",
+        _("MMB Files (*.mmb)|*.mmb"),
         wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 
@@ -2267,7 +2267,7 @@ void mmGUIFrame::OnOpen(wxCommandEvent& /*event*/)
     autoRepeatTransactionsTimer_.Stop();
     wxString fileName = wxFileSelector(_("Choose database file to open")
         , wxEmptyString, wxEmptyString, wxEmptyString
-        , "MMB Files(*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb"
+        , _("MMB Files (*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb")
         , wxFD_FILE_MUST_EXIST | wxFD_OPEN
         , this
     );
@@ -2309,7 +2309,7 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
         , _("Choose database file to Save As")
         , wxEmptyString
         , wxEmptyString
-        , "MMB Files(*.mmb)|*.mmb"
+        , _("MMB Files (*.mmb)|*.mmb")
         , wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 
@@ -2449,7 +2449,7 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
         _("Save database file as"),
         wxEmptyString,
         wxEmptyString,
-        "MMB Files(*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb",
+        _("MMB Files (*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb"),
         wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2245,7 +2245,7 @@ void mmGUIFrame::OnNew(wxCommandEvent& /*event*/)
         _("Choose database file to create"),
         wxEmptyString,
         wxEmptyString,
-        _("MMB Files (*.mmb)|*.mmb"),
+        _("MMB Database (*.mmb)|*.mmb"),
         wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 
@@ -2267,7 +2267,7 @@ void mmGUIFrame::OnOpen(wxCommandEvent& /*event*/)
     autoRepeatTransactionsTimer_.Stop();
     wxString fileName = wxFileSelector(_("Choose database file to open")
         , wxEmptyString, wxEmptyString, wxEmptyString
-        , _("MMB Files (*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb")
+        , _("MMB Database (*.mmb)|*.mmb|Encrypted MMB Database (*.emb)|*.emb")
         , wxFD_FILE_MUST_EXIST | wxFD_OPEN
         , this
     );
@@ -2293,7 +2293,7 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
 {
     wxString encFileName = wxFileSelector(_("Choose Encrypted database file to open")
         , wxEmptyString, wxEmptyString, wxEmptyString
-        , "Encrypted MMB files (*.emb)|*.emb"
+        , "Encrypted MMB Database (*.emb)|*.emb"
         , wxFD_FILE_MUST_EXIST
         , this
     );
@@ -2309,7 +2309,7 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
         , _("Choose database file to Save As")
         , wxEmptyString
         , wxEmptyString
-        , _("MMB Files (*.mmb)|*.mmb")
+        , _("MMB Database (*.mmb)|*.mmb")
         , wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 
@@ -2449,7 +2449,7 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
         _("Save database file as"),
         wxEmptyString,
         wxEmptyString,
-        _("MMB Files (*.mmb)|*.mmb|Encrypted MMB files (*.emb)|*.emb"),
+        _("MMB Database (*.mmb)|*.mmb|Encrypted MMB Database (*.emb)|*.emb"),
         wxFD_SAVE | wxFD_OVERWRITE_PROMPT
     );
 


### PR DESCRIPTION
https://github.com/moneymanagerex/moneymanagerex/issues/6481

@whalley @n-stein can you please check that this patch works? If not, please help.

Thank you

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6482)
<!-- Reviewable:end -->
