### PR TITLE
fix(#6480): prevent value clearing on combobox autocomplete init

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -124,25 +124,27 @@ void mmComboBox::OnDropDown(wxCommandEvent& event)
 
 void mmComboBox::OnSetFocus(wxFocusEvent& event)
 {
-    if (!is_initialized_)
-    {
-       wxArrayString auto_complete;
-       for (const auto& item : all_elements_) {
-           auto_complete.Add(item.first);
+   if (!is_initialized_)
+   {
+      wxArrayString auto_complete;
+      for (const auto& item : all_elements_) {
+          auto_complete.Add(item.first);
+      }
+      auto_complete.Sort(CaseInsensitiveLocaleCmp);
+   
+       this->AutoComplete(auto_complete);
+       if (!auto_complete.empty()) {
+           wxString selection = GetValue();
+           Set(auto_complete);
+           ChangeValue(selection);
+           if (!selection.IsEmpty() && FindString(selection, false) != wxNOT_FOUND)
+               SetStringSelection(selection);
        }
-       auto_complete.Sort(CaseInsensitiveLocaleCmp);
-
-        this->AutoComplete(auto_complete);
-        if (!auto_complete.empty()) {
-            wxString selection = GetValue();
-            Set(auto_complete);
-            if (!selection.IsEmpty()) SetStringSelection(selection);
-        }
-        if (auto_complete.GetCount() == 1) {
-            Select(0);
-        }
-        is_initialized_ = true;   
-    }
+       if (auto_complete.GetCount() == 1) {
+           Select(0);
+       }
+       is_initialized_ = true;   
+   }
     event.Skip();
 }
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6483)
<!-- Reviewable:end -->
