### PR TITLE
fix(#6474): use decimal of defined locale

### DIFF
--- a/src/mmTextCtrl.cpp
+++ b/src/mmTextCtrl.cpp
@@ -123,12 +123,29 @@ bool mmTextCtrl::checkValue(double &amount, bool positive_value)
 
 wxChar mmTextCtrl::GetDecimalPoint()
 {
-    wxChar dp;
-    if (!m_currency->DECIMAL_POINT.empty()) {
-        dp = m_currency->DECIMAL_POINT[0];
+    wxString dp;
+
+    auto localeStr = Model_Infotable::instance().GetStringInfo("LOCALE", "");
+
+    // If there is no defined locale, use the currency decimal
+    if (localeStr.empty())
+    {
+        if (!m_currency->DECIMAL_POINT.empty())
+        {
+            dp = m_currency->DECIMAL_POINT;
+        }
+        else
+        {
+            dp = Model_Currency::GetBaseCurrency()->DECIMAL_POINT;
+        }
     }
-    else {
-        dp = Model_Currency::GetBaseCurrency()->DECIMAL_POINT[0];
+    else 
+    {
+        // Locale is set, so use the locale decimal
+        dp = Model_Currency::toString(1.0);
+        wxRegEx pattern2(R"([^.,])");
+        pattern2.ReplaceAll(&dp, wxEmptyString);
     }
-    return dp;
+
+    return dp[0];
 }

--- a/src/validators.h
+++ b/src/validators.h
@@ -95,11 +95,14 @@ inline void mmCalcValidator::OnChar(wxKeyEvent& event)
         str = wxString(decChar);
 
     // if decimal point, check if it's already in the string
-    if (str == '.' || str == ',')
+    if (str == decChar)
     {
         const wxString value = text_field->GetValue();
         size_t ind = value.rfind(decChar);
-        if (ind < value.Length())
+        // Determine selection start/end to allow overwrite of decimal
+        long selStart, selEnd;
+        text_field->GetSelection(&selStart, &selEnd);
+        if (ind < value.Length() && (ind < selStart || ind >= selEnd))
         {
             // check if after last decimal point there is an operation char (+-/*)
             if (value.find('+', ind + 1) >= value.Length() && value.find('-', ind + 1) >= value.Length() &&


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6485)
<!-- Reviewable:end -->
