### PR TITLE
switch default cipher to SQLCipher4(AES256) from AES128

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -42,7 +42,9 @@ wxSharedPtr<wxSQLite3Database> mmDBWrapper::Open(const wxString &dbpath, const w
 
     int err = SQLITE_OK;
     wxString errStr=wxEmptyString;
-    wxSQLite3CipherAes128 cipher;
+    wxSQLite3CipherSQLCipher cipher;
+    cipher.InitializeVersionDefault(4);
+    cipher.SetLegacy(true);
     try
     {
         if (debug)

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -42,13 +42,14 @@ wxSharedPtr<wxSQLite3Database> mmDBWrapper::Open(const wxString &dbpath, const w
 
     int err = SQLITE_OK;
     wxString errStr=wxEmptyString;
+    wxSQLite3CipherAes128 cipher;
     try
     {
         if (debug)
             // open and disable flag SQLITE_CorruptRdOnly = 0x200000000
-            db->Open(dbpath, password, (WXSQLITE_OPEN_READWRITE | WXSQLITE_OPEN_CREATE) & ~0x200000000);
+            db->Open(dbpath, cipher, password, (WXSQLITE_OPEN_READWRITE | WXSQLITE_OPEN_CREATE) & ~0x200000000);
         else
-            db->Open(dbpath, password);
+            db->Open(dbpath, cipher, password);
         // Ensure that an existing mmex database is not encrypted.
         if ((db->IsOpen()) && (db->TableExists("INFOTABLE_V1")))
         {

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2371,7 +2371,7 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
     wxSQLite3CipherAes128 cipher;
 
     db.Open(fileName, cipher, password);
-    db.ReKey(wxEmptyString);
+    db.ReKey(cipher, wxEmptyString);
     db.Close();
 
     mmErrorDialogs::MessageError(this, _("Converted database!"), _("MMEX message"));
@@ -2558,7 +2558,7 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
         wxSQLite3CipherAes128 cipher;
 
         dbx.Open(newFileName.GetFullPath(), cipher, m_password);
-        dbx.ReKey(new_password); // empty password resets encryption
+        dbx.ReKey(cipher, new_password); // empty password resets encryption
         dbx.Close();
     }
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2368,7 +2368,9 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
     wxCopyFile(encFileName, fileName);
 
     wxSQLite3Database db;
-    db.Open(fileName, password);
+    wxSQLite3CipherAes128 cipher;
+
+    db.Open(fileName, cipher, password);
     db.ReKey(wxEmptyString);
     db.Close();
 
@@ -2397,7 +2399,8 @@ void mmGUIFrame::OnChangeEncryptPassword(wxCommandEvent& /*event*/)
                 wxString confirm_password = confirm_dlg.GetValue();
                 if (!confirm_password.IsEmpty() && (new_password == confirm_password))
                 {
-                    m_db->ReKey(confirm_password);
+                    wxSQLite3CipherAes128 cipher;
+                    m_db->ReKey(cipher, confirm_password);
                     wxMessageBox(_("Password change completed"), password_change_heading);
                 }
                 else
@@ -2551,7 +2554,10 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
     if (rekey) // encrypt or reset encryption
     {
         wxSQLite3Database dbx;
-        dbx.Open(newFileName.GetFullPath(), m_password);
+
+        wxSQLite3CipherAes128 cipher;
+
+        dbx.Open(newFileName.GetFullPath(), cipher, m_password);
         dbx.ReKey(new_password); // empty password resets encryption
         dbx.Close();
     }

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2368,7 +2368,9 @@ void mmGUIFrame::OnConvertEncryptedDB(wxCommandEvent& /*event*/)
     wxCopyFile(encFileName, fileName);
 
     wxSQLite3Database db;
-    wxSQLite3CipherAes128 cipher;
+    wxSQLite3CipherSQLCipher cipher;
+    cipher.InitializeVersionDefault(4);
+    cipher.SetLegacy(true);
 
     db.Open(fileName, cipher, password);
     db.ReKey(cipher, wxEmptyString);
@@ -2399,7 +2401,10 @@ void mmGUIFrame::OnChangeEncryptPassword(wxCommandEvent& /*event*/)
                 wxString confirm_password = confirm_dlg.GetValue();
                 if (!confirm_password.IsEmpty() && (new_password == confirm_password))
                 {
-                    wxSQLite3CipherAes128 cipher;
+                    wxSQLite3CipherSQLCipher cipher;
+                    cipher.InitializeVersionDefault(4);
+                    cipher.SetLegacy(true);
+
                     m_db->ReKey(cipher, confirm_password);
                     wxMessageBox(_("Password change completed"), password_change_heading);
                 }
@@ -2555,7 +2560,9 @@ void mmGUIFrame::OnSaveAs(wxCommandEvent& /*event*/)
     {
         wxSQLite3Database dbx;
 
-        wxSQLite3CipherAes128 cipher;
+        wxSQLite3CipherSQLCipher cipher;
+        cipher.InitializeVersionDefault(4);
+        cipher.SetLegacy(true);
 
         dbx.Open(newFileName.GetFullPath(), cipher, m_password);
         dbx.ReKey(cipher, new_password); // empty password resets encryption


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6532)
<!-- Reviewable:end -->
