### PR TITLE
fix(#6155): fix browse button width

### DIFF
--- a/src/optionsettingsattachment.cpp
+++ b/src/optionsettingsattachment.cpp
@@ -92,7 +92,7 @@ void OptionSettingsAttachment::Create()
     m_attachments_path->ChangeValue(attachmentFolder);
 
     wxButton* AttachmentsFolderButton = new wxButton(attachment_panel, ID_DIALOG_OPTIONS_BUTTON_ATTACHMENTSFOLDER, "..."
-        , wxDefaultPosition, wxSize(Option::instance().getIconSize(), -1), 0);
+        , wxDefaultPosition, m_attachments_path->GetSizeFromTextSize(GetTextExtent("...")), 0);
     mmToolTip(AttachmentsFolderButton, _("Browse for folder"));
 
     attachDefinedSizer->Add(m_attachments_path, g_flagsExpand);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6540)
<!-- Reviewable:end -->
