### PR TITLE
fix(#6553): translate db debug dialog labels

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2426,6 +2426,11 @@ void mmGUIFrame::OnDebugDB(wxCommandEvent& /*event*/)
             textCtrl->SetEditable(false);
             textCtrl->SetInsertionPointEnd();
         }
+
+        wxButton* ok = static_cast<wxButton*>(checkDlg.FindWindow(wxID_OK));
+        if (ok)
+            ok->SetLabel(wxGetTranslation(g_OkLabel));
+
         checkDlg.Centre();
         checkDlg.ShowModal();
     }
@@ -2433,6 +2438,9 @@ void mmGUIFrame::OnDebugDB(wxCommandEvent& /*event*/)
     wxMessageDialog msgDlg(this
         , wxString::Format("%s\n\n%s", _("Please use this function only if requested by MMEX support and you have been supplied with a .mmdbg debug file"), _("Do you want to proceed?"))
         , _("Database Debug"), wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
+
+    msgDlg.SetYesNoLabels(_("Yes"), _("No"));
+
     if (msgDlg.ShowModal() == wxID_YES)
     {
         dbUpgrade::SqlFileDebug(m_db.get());


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6564)
<!-- Reviewable:end -->
