### PR TITLE
fix(#6572): linux fix notebook width in account dialog

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -274,7 +274,7 @@ void mmNewAcctDialog::CreateControls()
     credit_grid_sizer->Add(m_minimum_payment_ctrl, g_flagsExpand);
     //-------------------------------------------------------------------------------------
 
-    itemBoxSizer3->Add(m_notebook);
+    itemBoxSizer3->Add(m_notebook, g_flagsExpand);
 
     //Buttons
     wxPanel* itemPanel27 = new wxPanel(this, wxID_STATIC, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6578)
<!-- Reviewable:end -->
