### PR TITLE
fix(#6584): fix spin button height in mmDatePickerCtrl

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -457,7 +457,7 @@ wxSpinButton* mmDatePickerCtrl::getSpinButton()
     if (!spinButton_)
     {
         spinButton_ = new wxSpinButton(parent_, wxID_ANY
-            , wxDefaultPosition, wxSize(-1, this->GetSize().GetHeight())
+            , wxDefaultPosition, wxSize(-1, GetBestSize().GetHeight())
             , wxSP_VERTICAL | wxSP_ARROW_KEYS | wxSP_WRAP);
         spinButton_->Bind(wxEVT_SPIN, &mmDatePickerCtrl::OnDateSpin, this);
         spinButton_->SetRange(-32768, 32768);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6587)
<!-- Reviewable:end -->
