### PR TITLE
fix(#6608): align "Other Assets" current value on dashboard

### DIFF
--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -621,7 +621,7 @@ const wxString htmlWidgetAssets::getHTMLText()
                 , _("Other Assets"), _("Other Assets"), rows - MAX_ASSETS);
             output += wxString::Format("<td class='money' sorttable_customkey='%f'>%s</td>\n"
                 , initialTotal - initialDisplayed, Model_Currency::toCurrency(initialTotal - initialDisplayed));
-            output += wxString::Format("<td class='money' sorttable_customkey='%f'>%s</td>\n"
+            output += wxString::Format("<td colspan='2' class='money' sorttable_customkey='%f'>%s</td>\n"
                 , currentTotal - currentDisplayed, Model_Currency::toCurrency(currentTotal - currentDisplayed));
             output += "</tr>";
     }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6612)
<!-- Reviewable:end -->
