### PR TITLE
fix(#6618): default '.' for undefined decimal

### DIFF
--- a/src/mmTextCtrl.cpp
+++ b/src/mmTextCtrl.cpp
@@ -147,5 +147,5 @@ wxChar mmTextCtrl::GetDecimalPoint()
         pattern2.ReplaceAll(&dp, wxEmptyString);
     }
 
-    return dp[0];
+    return dp.IsEmpty() ? '.' : dp[0];
 }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6619)
<!-- Reviewable:end -->
