### PR TITLE
fix(#6658): save txn filter dialog size in report mode only

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -83,7 +83,8 @@ mmFilterTransactionsDialog::mmFilterTransactionsDialog()
 mmFilterTransactionsDialog::~mmFilterTransactionsDialog()
 {
     wxLogDebug("~mmFilterTransactionsDialog");
-    Model_Infotable::instance().Set("TRANSACTION_FILTER_SIZE", GetSize());
+    if (isReportMode_)
+        Model_Infotable::instance().Set("TRANSACTION_FILTER_SIZE", GetSize());
 }
 
 mmFilterTransactionsDialog::mmFilterTransactionsDialog(wxWindow* parent, int accountID, bool isReport, wxString selected)


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6661)
<!-- Reviewable:end -->
