### PR TITLE
fix(#6503): fix crash when not on a checking panel

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2902,7 +2902,9 @@ void mmGUIFrame::OnOptions(wxCommandEvent& /*event*/)
         RefreshNavigationTree();
 
         // Reset columns of the checking panel in case the time columns was added/removed
-        wxDynamicCast(panelCurrent_, mmCheckingPanel)->ResetColumnView();
+        int id = panelCurrent_->GetId();
+        if (id == mmID_CHECKING || id == mmID_ALLTRANSACTIONS || id == mmID_DELETEDTRANSACTIONS)
+            wxDynamicCast(panelCurrent_, mmCheckingPanel)->ResetColumnView();
 
         const wxString& sysMsg = _("MMEX Options have been updated.") + "\n\n"
             + _("Some settings take effect only after an application restart.");


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6683)
<!-- Reviewable:end -->
