### PR TITLE
fix(#6693): remove developer_name tag deprecated by appstream 1.0.3

### DIFF
--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -93,7 +93,6 @@
   
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
-  <developer_name>MMEX team</developer_name>
   <developer id="moneymanagerex.org">
     <name>MMEX team</name>
   </developer>


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6696)
<!-- Reviewable:end -->
