### PR TITLE
`&Browse...` and swap `0` and `.` buttons on calculator

### DIFF
--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -132,7 +132,7 @@ void mmQIFImportDialog::CreateControls()
     file_name_ctrl_->Connect(wxID_FILE
         , wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(mmQIFImportDialog::OnFileNameChanged), nullptr, this);
 
-    button_search_ = new wxButton(file_panel, wxID_OPEN, _("&Browse"));
+    button_search_ = new wxButton(file_panel, wxID_OPEN, _("&Browse..."));
     itemBoxSizer7->Add(button_search_, g_flagsH);
     button_search_->Connect(wxID_OPEN, wxEVT_COMMAND_BUTTON_CLICKED
         , wxCommandEventHandler(mmQIFImportDialog::OnFileSearch), nullptr, this);

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -198,7 +198,7 @@ void mmUnivCSVDialog::CreateControls()
     m_text_ctrl_->Connect(ID_FILE_NAME
         , wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(mmUnivCSVDialog::OnFileNameEntered), nullptr, this);
 
-    const wxString& file_button_label = IsImporter() ? _("&Browse") : _("File");
+    const wxString& file_button_label = IsImporter() ? _("&Browse...") : _("File");
     wxButton* button_browse = new wxButton(itemPanel6, wxID_BROWSE, file_button_label);
     itemBoxSizer7->Add(button_browse, g_flagsH);
 

--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -205,15 +205,15 @@ mmCalculatorPopup::mmCalculatorPopup(wxWindow* parent, mmTextCtrl* target) : wxP
     button_minus_->SetFont(font);
     buttonSizer->Add(button_minus_, wxSizerFlags(g_flagsH).Border(wxALL, 1));
 
-    button_dec_ = new wxButton(panel, wxID_ANY, ".", wxDefaultPosition, btnSize);
-    button_dec_->Bind(wxEVT_BUTTON, &mmCalculatorPopup::OnButtonPressed, this);
-    button_dec_->SetFont(font);
-    buttonSizer->Add(button_dec_, wxSizerFlags(g_flagsH).Border(wxALL, 1));
-
     button_0_ = new wxButton(panel, wxID_ANY, "0", wxDefaultPosition, btnSize);
     button_0_->Bind(wxEVT_BUTTON, &mmCalculatorPopup::OnButtonPressed, this);
     button_0_->SetFont(font);
     buttonSizer->Add(button_0_, wxSizerFlags(g_flagsH).Border(wxALL, 1));
+
+    button_dec_ = new wxButton(panel, wxID_ANY, ".", wxDefaultPosition, btnSize);
+    button_dec_->Bind(wxEVT_BUTTON, &mmCalculatorPopup::OnButtonPressed, this);
+    button_dec_->SetFont(font);
+    buttonSizer->Add(button_dec_, wxSizerFlags(g_flagsH).Border(wxALL, 1));
 
     button_equal_ = new wxButton(panel, wxID_ANY, "=", wxDefaultPosition, btnSize);
     button_equal_->Bind(wxEVT_BUTTON, &mmCalculatorPopup::OnButtonPressed, this);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6762)
<!-- Reviewable:end -->

https://github.com/moneymanagerex/moneymanagerex/issues/6703#issuecomment-2119107775

fixes "1. Should the decimal point . and 0 be interchanged?"
