### PR TITLE
Add custom column ordering to transactions view (all platforms)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ add_executable(${MMEX_EXE} WIN32 MACOSX_BUNDLE
     budgetyearentrydialog.h
     categdialog.cpp
     categdialog.h
+    columnorder.cpp
+    columnorder.h
     constants.cpp
     constants.h
     currencydialog.cpp

--- a/src/columnorder.cpp
+++ b/src/columnorder.cpp
@@ -1,0 +1,105 @@
+#include "columnorder.h"
+#include "constants.h"
+#include "model/Model_Setting.h"
+#include "model/Model_Infotable.h"
+#include "paths.h"
+#include "option.h"
+#include "util.h"
+
+wxIMPLEMENT_DYNAMIC_CLASS(mmColumnsDialog, wxDialog);
+
+wxBEGIN_EVENT_TABLE(mmColumnsDialog, wxDialog)
+    EVT_BUTTON(wxID_OK, mmColumnsDialog::OnOk)
+    EVT_BUTTON(wxID_CANCEL, mmColumnsDialog::OnCancel)
+    EVT_BUTTON(wxID_UP, mmColumnsDialog::OnUp)
+    EVT_BUTTON(wxID_DOWN, mmColumnsDialog::OnDown)
+wxEND_EVENT_TABLE()
+
+mmColumnsDialog::mmColumnsDialog() {}
+
+mmColumnsDialog::mmColumnsDialog(wxWindow *parent) : wxDialog(parent, wxID_ANY, _("Column Order"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+{
+    Create(parent);
+    SetMinSize(wxSize(400, 300));
+    SetTitle(_("Column Order"));
+}
+
+mmColumnsDialog::~mmColumnsDialog()
+{
+    Model_Infotable::instance().Set("COLUMNORDER_DIALOG_SIZE", GetSize());
+    // TODO: Save the column order
+}
+
+
+bool mmColumnsDialog::Create(wxWindow *parent)
+{
+    SetEvtHandlerEnabled(false);
+    CreateControls();
+    SetEvtHandlerEnabled(true);
+
+    GetSizer()->Fit(this);
+    GetSizer()->SetSizeHints(this);
+    this->SetInitialSize();
+    SetIcon(mmex::getProgramIcon());
+
+    Fit();
+    mmSetSize(this);
+    Centre();
+    return true;
+}
+
+void mmColumnsDialog::CreateControls()
+{
+    wxBoxSizer* boxSizer = new wxBoxSizer(wxVERTICAL);
+    this->SetSizer(boxSizer);
+
+    // Get the Colum names. Use dummy array for now.
+    wxArrayString columnList = { "Column 1", "Column 2", "Column 3", "Column 4", "Column 5" };
+
+    // Put colum names into the list box
+    m_listBox = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, columnList, wxLB_SINGLE | wxLB_NEEDED_SB);
+    boxSizer->Add(m_listBox, 1, wxEXPAND | wxALL, 5);
+
+    wxPanel* buttonsPanel = new wxPanel(this, wxID_ANY);
+    boxSizer->Add(buttonsPanel, wxSizerFlags(g_flagsV).Center());
+    wxBoxSizer* buttonsSizer = new wxBoxSizer(wxHORIZONTAL);
+    buttonsPanel->SetSizer(buttonsSizer);
+
+    m_upButton = new wxButton(this, wxID_UP, _("Up"));
+    m_downButton = new wxButton(this, wxID_DOWN, _("Down"));
+    m_OkButton = new wxButton(this, wxID_OK, _("OK"));
+    m_CancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
+
+    // arrange the buttons inside the buttonsPanel.
+    buttonsSizer->Add(m_upButton, 0, wxALL, 5);
+    buttonsSizer->Add(m_downButton, 0, wxALL, 5);
+    buttonsSizer->AddStretchSpacer();
+    buttonsSizer->Add(m_OkButton, 0, wxALL, 5);
+    buttonsSizer->Add(m_CancelButton, 0, wxALL, 5);
+
+}
+
+void mmColumnsDialog::OnOk(wxCommandEvent& event)
+{
+    // Save the column order
+    // Close the dialog
+    EndModal(wxID_OK);
+}   
+
+void mmColumnsDialog::OnCancel(wxCommandEvent& event)
+{
+    // Close the dialog
+    EndModal(wxID_CANCEL);
+}
+
+void mmColumnsDialog::OnUp(wxCommandEvent& event)
+{
+    // Move the selected item up
+}
+
+void mmColumnsDialog::OnDown(wxCommandEvent& event)
+{
+    // Move the selected item down
+}   
+
+// Other member function implementations go here...

--- a/src/columnorder.cpp
+++ b/src/columnorder.cpp
@@ -48,35 +48,47 @@ bool mmColumnsDialog::Create(wxWindow *parent)
     return true;
 }
 
+void mmColumnsDialog::OnUp(wxCommandEvent& event) {
+    Move(-1);
+}
+
+void mmColumnsDialog::OnDown(wxCommandEvent& event) {
+    Move(1);
+}
+
 void mmColumnsDialog::CreateControls()
 {
-    wxBoxSizer* boxSizer = new wxBoxSizer(wxVERTICAL);
-    this->SetSizer(boxSizer);
+    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-    // Get the Colum names. Use dummy array for now.
+    // Get the Colum names. Use dummy array for now. Put colum names into the list box
     wxArrayString columnList = { "Column 1", "Column 2", "Column 3", "Column 4", "Column 5" };
-
-    // Put colum names into the list box
     m_listBox = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, columnList, wxLB_SINGLE | wxLB_NEEDED_SB);
-    boxSizer->Add(m_listBox, 1, wxEXPAND | wxALL, 5);
 
-    wxPanel* buttonsPanel = new wxPanel(this, wxID_ANY);
-    boxSizer->Add(buttonsPanel, wxSizerFlags(g_flagsV).Center());
-    wxBoxSizer* buttonsSizer = new wxBoxSizer(wxHORIZONTAL);
-    buttonsPanel->SetSizer(buttonsSizer);
+    // Buttons for moving items up and down
+    wxBoxSizer* buttonSizer = new wxBoxSizer(wxVERTICAL);
+    wxButton* upButton = new wxButton(this, wxID_ANY, "Up");
+    wxButton* downButton = new wxButton(this, wxID_ANY, "Down");
 
-    m_upButton = new wxButton(this, wxID_UP, _("Up"));
-    m_downButton = new wxButton(this, wxID_DOWN, _("Down"));
-    m_OkButton = new wxButton(this, wxID_OK, _("OK"));
-    m_CancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
+    buttonSizer->Add(upButton, 0, wxALL, 5);
+    buttonSizer->Add(downButton, 0, wxALL, 5);
 
-    // arrange the buttons inside the buttonsPanel.
-    buttonsSizer->Add(m_upButton, 0, wxALL, 5);
-    buttonsSizer->Add(m_downButton, 0, wxALL, 5);
-    buttonsSizer->AddStretchSpacer();
-    buttonsSizer->Add(m_OkButton, 0, wxALL, 5);
-    buttonsSizer->Add(m_CancelButton, 0, wxALL, 5);
+    // Horizontal sizer for listbox and up/down buttons
+    wxBoxSizer* listSizer = new wxBoxSizer(wxHORIZONTAL);
+    listSizer->Add(m_listBox, 1, wxEXPAND | wxALL, 5);
+    listSizer->Add(buttonSizer, 0, wxALIGN_CENTER_VERTICAL);
 
+    // OK and Cancel buttons
+    wxSizer* okCancelSizer = CreateButtonSizer(wxOK | wxCANCEL);
+
+    // Add components to main sizer
+    mainSizer->Add(listSizer, 1, wxEXPAND | wxALL, 5);
+    mainSizer->Add(okCancelSizer, 0, wxALIGN_CENTER | wxALL, 5);
+
+    SetSizer(mainSizer);
+
+    // Event bindings
+    upButton->Bind(wxEVT_BUTTON, &mmColumnsDialog::OnUp, this);
+    downButton->Bind(wxEVT_BUTTON, &mmColumnsDialog::OnDown, this);
 }
 
 void mmColumnsDialog::OnOk(wxCommandEvent& event)
@@ -92,14 +104,30 @@ void mmColumnsDialog::OnCancel(wxCommandEvent& event)
     EndModal(wxID_CANCEL);
 }
 
-void mmColumnsDialog::OnUp(wxCommandEvent& event)
-{
-    // Move the selected item up
+
+void mmColumnsDialog::Move(int direction) {
+    //print debug message to stderr 
+    wxLogDebug("Move %d", direction);
+
+    wxArrayInt selections;
+    int count = m_listBox->GetSelections(selections);
+
+    if (count == 0) return;
+
+    if ((direction == -1 && selections[0] > 0) ||
+        (direction == 1 && selections[count - 1] < m_listBox->GetCount() - 1)) {
+        for (int i = (direction == 1 ? count - 1 : 0);
+             (direction == 1 ? i >= 0 : i < count);
+             i += (direction == 1 ? -1 : 1)) {
+
+            int pos = selections[i];
+            wxString item = m_listBox->GetString(pos);
+            m_listBox->Delete(pos);
+            m_listBox->Insert(item, pos + direction);
+            m_listBox->SetSelection(pos + direction, true);
+        }
+    }
 }
 
-void mmColumnsDialog::OnDown(wxCommandEvent& event)
-{
-    // Move the selected item down
-}   
 
 // Other member function implementations go here...

--- a/src/columnorder.h
+++ b/src/columnorder.h
@@ -35,6 +35,9 @@ public:
     ~mmColumnsDialog();
     mmColumnsDialog(wxWindow* parent);
 
+    // called from mmcheckingpanel.cpp
+    static wxArrayString updateColumnsOrder(wxArrayString defaultColumns);
+
 private:
     // Declare your dialog controls here
     wxListBox* m_listBox;
@@ -43,6 +46,11 @@ private:
     wxButton* m_OkButton; // Added: Correctly declare the OK button
     wxButton* m_CancelButton; // Added: Correctly declare the cancel button
 
+    wxArrayString columnList_;
+
+    void SetColumnsOrder();
+    wxArrayString GetColumnsOrder();
+
     bool Create(wxWindow* parent);
     void CreateControls();
     void OnCancel(wxCommandEvent& event);
@@ -50,8 +58,6 @@ private:
     void OnUp(wxCommandEvent& event);
     void OnDown(wxCommandEvent& event);
     void Move(int direction);
-
-    wxArrayString columnList_;
 };
 
 #endif // COLUMNORDER_H

--- a/src/columnorder.h
+++ b/src/columnorder.h
@@ -49,6 +49,7 @@ private:
     void OnOk(wxCommandEvent& event);
     void OnUp(wxCommandEvent& event);
     void OnDown(wxCommandEvent& event);
+    void Move(int direction);
 
     wxArrayString columnList_;
 };

--- a/src/columnorder.h
+++ b/src/columnorder.h
@@ -36,7 +36,7 @@ public:
     mmColumnsDialog(wxWindow* parent);
 
     // called from mmcheckingpanel.cpp
-    static wxArrayString updateColumnsOrder(wxArrayString defaultColumns);
+    wxArrayString updateColumnsOrder(wxArrayString defaultColumns);
 
 private:
     // Declare your dialog controls here
@@ -49,7 +49,7 @@ private:
     wxArrayString columnList_;
 
     void SetColumnsOrder();
-    wxArrayString GetColumnsOrder();
+    void GetColumnsOrder();
 
     bool Create(wxWindow* parent);
     void CreateControls();

--- a/src/columnorder.h
+++ b/src/columnorder.h
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2024 Jens Benecke
+
+This Program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef COLUMNORDER_H
+#define COLUMNORDER_H
+
+#include "wx/dialog.h"
+#include <wx/listbox.h>
+#include <wx/button.h>
+#include <wx/listbase.h>
+
+class mmColumnsDialog : public wxDialog
+{
+    wxDECLARE_DYNAMIC_CLASS(mmColumnsDialog);
+    wxDECLARE_EVENT_TABLE();
+
+public:
+    // mmColumnsDialog(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Column Order"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE);
+    mmColumnsDialog();
+    ~mmColumnsDialog();
+    mmColumnsDialog(wxWindow* parent);
+
+private:
+    // Declare your dialog controls here
+    wxListBox* m_listBox;
+    wxButton* m_upButton; // Fixed: Correctly declare the button for moving items up
+    wxButton* m_downButton; // Fixed: Correctly declare the button for moving items down
+    wxButton* m_OkButton; // Added: Correctly declare the OK button
+    wxButton* m_CancelButton; // Added: Correctly declare the cancel button
+
+    bool Create(wxWindow* parent);
+    void CreateControls();
+    void OnCancel(wxCommandEvent& event);
+    void OnOk(wxCommandEvent& event);
+    void OnUp(wxCommandEvent& event);
+    void OnDown(wxCommandEvent& event);
+
+    wxArrayString columnList_;
+};
+
+#endif // COLUMNORDER_H

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -38,6 +38,7 @@
 #include "sharetransactiondialog.h"
 #include "assetdialog.h"
 #include "billsdepositsdialog.h"
+#include "columnorder.h"
 #include <wx/clipbrd.h>
 #include <float.h>
 
@@ -399,6 +400,11 @@ void mmCheckingPanel::CreateControls()
 
     m_listCtrlAccount->setSortOrder(m_listCtrlAccount->g_asc);
     m_listCtrlAccount->setSortColumn(m_listCtrlAccount->g_sortcol);
+
+    // Get sorted columns list and update the sorted columns with missing columns if needed.
+    wxArrayString columnList, sortedColumnList;
+    for(const auto& i : m_listCtrlAccount->m_columns) columnList.Add(i.HEADER.c_str());
+    sortedColumnList = mmColumnsDialog::updateColumnsOrder(columnList);
 
     m_listCtrlAccount->createColumns(*m_listCtrlAccount);
 

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -404,7 +404,9 @@ void mmCheckingPanel::CreateControls()
     // Get sorted columns list and update the sorted columns with missing columns if needed.
     wxArrayString columnList, sortedColumnList;
     for(const auto& i : m_listCtrlAccount->m_columns) columnList.Add(i.HEADER.c_str());
-    sortedColumnList = mmColumnsDialog::updateColumnsOrder(columnList);
+    mmColumnsDialog dialog;
+    sortedColumnList = dialog.updateColumnsOrder(columnList);
+//    sortedColumnList = mmColumnsDialog::updateColumnsOrder(columnList);
 
     m_listCtrlAccount->createColumns(*m_listCtrlAccount);
 

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -406,7 +406,8 @@ void mmCheckingPanel::CreateControls()
     for(const auto& i : m_listCtrlAccount->m_columns) columnList.Add(i.HEADER.c_str());
     mmColumnsDialog dialog;
     sortedColumnList = dialog.updateColumnsOrder(columnList);
-//    sortedColumnList = mmColumnsDialog::updateColumnsOrder(columnList);
+
+    // FIXME: apply the sorted columns list to the list control
 
     m_listCtrlAccount->createColumns(*m_listCtrlAccount);
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -34,6 +34,7 @@
 #include "budgetyeardialog.h"
 #include "categdialog.h"
 #include "constants.h"
+#include "columnorder.h"
 #include "customfieldlistdialog.h"
 #include "dbcheck.h"
 #include "dbupgrade.h"
@@ -135,6 +136,7 @@ EVT_MENU(MENU_REFRESH_WEBAPP, mmGUIFrame::OnRefreshWebApp)
 EVT_MENU(wxID_BROWSE, mmGUIFrame::OnCustomFieldsManager)
 EVT_MENU(wxID_VIEW_LIST, mmGUIFrame::OnGeneralReportManager)
 EVT_MENU(MENU_THEME_MANAGER, mmGUIFrame::OnThemeManager)
+EVT_MENU(MENU_COLUMN_ORDER, mmGUIFrame::OnColumnOrderManager)
 EVT_MENU(MENU_TREEPOPUP_LAUNCHWEBSITE, mmGUIFrame::OnLaunchAccountWebsite)
 EVT_MENU(MENU_TREEPOPUP_ACCOUNTATTACHMENTS, mmGUIFrame::OnAccountAttachments)
 EVT_MENU(MENU_VIEW_TOOLBAR, mmGUIFrame::OnViewToolbar)
@@ -1790,6 +1792,10 @@ wxMenuItem* menuItemResetView = new wxMenuItem(menuView, MENU_VIEW_RESET
         , _("T&heme Manager..."), _("Theme Manager"));
     menuTools->Append(menuItemThemes);
 
+    wxMenuItem* menuItemColumnOrder = new wxMenuItem(menuTools, MENU_COLUMN_ORDER
+        , _("C&olumn Order Manager..."), _("Column Order Manager"));
+    menuTools->Append(menuItemColumnOrder);
+
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemTransactions = new wxMenuItem(menuTools, MENU_TRANSACTIONREPORT
@@ -2940,6 +2946,12 @@ void mmGUIFrame::OnCustomFieldsManager(wxCommandEvent& WXUNUSED(event))
 void mmGUIFrame::OnThemeManager(wxCommandEvent& /*event*/)
 {
     mmThemesDialog dlg(this);
+    dlg.ShowModal();
+}
+
+void mmGUIFrame::OnColumnOrderManager(wxCommandEvent& /*event*/)
+{
+    mmColumnsDialog dlg(this);
     dlg.ShowModal();
 }
 

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -239,6 +239,7 @@ private:
     void OnCustomFieldsManager(wxCommandEvent& event);
     void OnGeneralReportManager(wxCommandEvent& event);
     void OnThemeManager(wxCommandEvent& event);
+    void OnColumnOrderManager(wxCommandEvent& event);
     void OnRefreshWebApp(wxCommandEvent&);
     bool OnRefreshWebApp(bool is_silent);
 
@@ -353,6 +354,7 @@ private:
         MENU_TAG_RELOCATION,
         MENU_RELOCATION,
         MENU_THEME_MANAGER,
+        MENU_COLUMN_ORDER,
         MENU_CONVERT_ENC_DB,
         MENU_CHANGE_ENCRYPT_PASSWORD,
         MENU_DB_VACUUM,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1866,6 +1866,9 @@ void mmSetSize(wxWindow* w)
     else if (name == "Organize Currencies") {
         my_size = Model_Infotable::instance().GetSizeSetting("CURRENCY_DIALOG_SIZE");
     }
+    else if (name == "Column Order Dialog") {
+        my_size = Model_Infotable::instance().GetSizeSetting("COLUMNORDER_DIALOG_SIZE");
+    }
     else if (name == "Themes Dialog") {
         my_size = Model_Infotable::instance().GetSizeSetting("THEMES_DIALOG_SIZE");
     }


### PR DESCRIPTION
This adds a column ordering dialog for transactions, see #4160 .
Final step - actually applying the new ordered columns to the transactions view - is still tbd (see FIXME).