### PR TITLE
fix wxWidgets version for macOS in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -214,16 +214,16 @@ macOS with Homebrew
 
 #### 2. Build wxWidgets
 
-Current stable version that has been tested with MMEX is v3.1.5
+Current stable version that has been tested with MMEX is v3.2.5
 
 1. Download Sources
         
-        /bin/bash -c "$(curl -fsSL -O https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2)"
+        /bin/bash -c "$(curl -fsSL -O https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5.tar.bz2)"
         tar xzf wxWidgets-*.tar.bz2
 
 2. Build from source
 
-        cd wxWidgets-3.1.5
+        cd wxWidgets-3.2.5
         mkdir build-cocoa
         cd build-cocoa
         export MAKEFLAGS=-j4
@@ -250,7 +250,7 @@ Current stable version that has been tested with MMEX is v3.1.5
     cd moneymanagerex/build
     export MAKEFLAGS=-j4
     cmake -DCMAKE_CXX_FLAGS="-w" \
-    -DwxWidgets_CONFIG_EXECUTABLE={PATH-TO-wxWidgets}/wxWidgets-3.1.5/build-cocoa/wx-config \
+    -DwxWidgets_CONFIG_EXECUTABLE={PATH-TO-wxWidgets}/wxWidgets-3.2.5/build-cocoa/wx-config \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 ..


### PR DESCRIPTION
I could compile MMEX on macOS from master branch using wxWidgets v3.2.5, but there were compilation errors when I tried with wxWidgets v3.1.5, as instructed in BUILD.md. Apparently MMEX has been updated to use wxWidgets v3.2.5 (as seen in commit messages), but BUILD.md was not updated.

There is one more reference to wxWidgets v3.1.5 in BUILD.md, in the instructions for Linux. Most probably this also needs to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6825)
<!-- Reviewable:end -->
