### PR TITLE
fix(#6827), part 1: Repetitions, special values of NUMOCCURRENCES

### DIFF
--- a/src/billsdepositspanel.h
+++ b/src/billsdepositspanel.h
@@ -108,6 +108,7 @@ public:
     int col_sort();
 
     const wxString GetFrequency(const Model_Billsdeposits::Data* item) const;
+    const int GetNumRepeats(const Model_Billsdeposits::Data* item) const;
     const wxString GetRemainingDays(const Model_Billsdeposits::Data* item) const;
 
     wxString BuildPage() const;

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -230,7 +230,7 @@ void Model_Billsdeposits::decode_fields(const Data& q1)
         m_autoExecuteManual = true;
     }
     repeats %= BD_REPEATS_MULTIPLEX_BASE;
-    if ((repeats < Model_Billsdeposits::REPEAT_IN_X_DAYS) || (numRepeats > Model_Billsdeposits::REPEAT_NONE) || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS))
+    if ((numRepeats > 0) || (repeats < Model_Billsdeposits::REPEAT_IN_X_DAYS) || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS))
     {
         m_allowExecution = true;
     }
@@ -351,7 +351,7 @@ void Model_Billsdeposits::completeBDInSeries(int bdID)
         const wxDateTime& due_date_current = NEXTOCCURRENCEDATE(bill);
         const wxDateTime& due_date_update = nextOccurDate(repeats, numRepeats, due_date_current);
 
-        if (numRepeats != REPEAT_TYPE::REPEAT_INACTIVE)
+        if (numRepeats != -1)
         {
             if ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS) || (repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS))
                 numRepeats--;
@@ -371,7 +371,7 @@ void Model_Billsdeposits::completeBDInSeries(int bdID)
         bill->NUMOCCURRENCES = numRepeats;
         save(bill);
 
-        if (bill->NUMOCCURRENCES == REPEAT_TYPE::REPEAT_NONE)
+        if (bill->NUMOCCURRENCES == 0)
         {
             mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bdID);
             remove(bdID);

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -351,7 +351,7 @@ void Model_Billsdeposits::completeBDInSeries(int bdID)
         const wxDateTime& due_date_current = NEXTOCCURRENCEDATE(bill);
         const wxDateTime& due_date_update = nextOccurDate(repeats, numRepeats, due_date_current);
 
-        if (numRepeats != -1)
+        if (numRepeats > 0)
         {
             if ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS) || (repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS))
                 numRepeats--;

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -57,6 +57,10 @@ public:
         REPEAT_MONTHLY_LAST_DAY,
         REPEAT_MONTHLY_LAST_BUSINESS_DAY
     };
+    enum REPEAT_NUM {
+        REPEAT_NUM_INFINITY = -1,
+        REPEAT_NUM_UNKNOWN = 0
+    };
 
     static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
     static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_ENUM_CHOICES;

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -38,7 +38,7 @@ public:
     enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
     enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
     enum REPEAT_TYPE {
-        REPEAT_INACTIVE = -1,
+        REPEAT_INACTIVE = -1,  // not used (can be removed)
         REPEAT_NONE,
         REPEAT_WEEKLY,
         REPEAT_BI_WEEKLY,      // FORTNIGHTLY


### PR DESCRIPTION
Change column `Repetitions` in scheduled transactions (billsdeposits) panel, as proposed in #6827.

Also change the special codes of `NUMOCCURRENCES` from {`REPEAT_INACTIVE`, `REPEAT_NONE`} to the corresponding numeric values {-1, 0}, so they don't interfere with the codes of repeat frequency.  The enum `REPEAT_TYPE` has not been changed; I just added a comment that the case `REPEAT_INACTIVE` can be removed, since it is not used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6829)
<!-- Reviewable:end -->
