### PR TITLE
fix(#6827), part 2: inactive billsdeposits; None -> Once

### DIFF
--- a/src/billsdepositsdialog.h
+++ b/src/billsdepositsdialog.h
@@ -146,6 +146,8 @@ private:
     void OnRepeatTypeChanged(wxCommandEvent& event);
     void OnsetPrevOrNextRepeatDate(wxCommandEvent& event);
     void setRepeatDetails();
+    int getRepeatType();
+    void setRepeatType(int repeatType);
     void OnMoreFields(wxCommandEvent& event);
 
     void activateSplitTransactionsDlg();

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -481,10 +481,15 @@ wxString mmBillsDepositsPanel::getItem(long item, long column)
     case COL_FREQUENCY:
         return GetFrequency(&bill);
     case COL_REPEATS:
-        if (bill.NUMOCCURRENCES == -1)
-            return L"\x221E";
+    {
+        int numRepeats = GetNumRepeats(&bill);
+        if (numRepeats > 0)
+            return wxString::Format("%i", numRepeats).Trim();
+        else if (numRepeats == Model_Billsdeposits::REPEAT_NUM_INFINITY)
+            return L"\x221E";  // INFITITY
         else
-            return wxString::Format("%i", bill.NUMOCCURRENCES).Trim();
+            return L"\x2015";  // HORIZONTAL BAR
+    }
     case COL_AUTO:
     {
         int repeats = bill.REPEATS;
@@ -525,6 +530,23 @@ const wxString mmBillsDepositsPanel::GetFrequency(const Model_Billsdeposits::Dat
     if (repeats > 10 && repeats < 15)
         text = wxString::Format(text, wxString::Format("%d", item->NUMOCCURRENCES));
     return text;
+}
+
+const int mmBillsDepositsPanel::GetNumRepeats(const Model_Billsdeposits::Data* item) const
+{
+    int repeats = item->REPEATS % BD_REPEATS_MULTIPLEX_BASE; // DeMultiplex the Auto Executable fields.
+    int numRepeats = item->NUMOCCURRENCES;
+
+    if (repeats == Model_Billsdeposits::REPEAT_NONE)
+        numRepeats = 1;
+    else if (repeats >= Model_Billsdeposits::REPEAT_IN_X_DAYS && repeats <= Model_Billsdeposits::REPEAT_IN_X_MONTHS)
+        numRepeats = numRepeats > 0 ? 2 : Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+    else if (repeats >= Model_Billsdeposits::REPEAT_EVERY_X_DAYS && repeats <= Model_Billsdeposits::REPEAT_EVERY_X_MONTHS)
+        numRepeats = numRepeats > 0 ? Model_Billsdeposits::REPEAT_NUM_INFINITY : Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+    else if (numRepeats < -1)  // this should not happen
+        numRepeats = Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+
+    return numRepeats;
 }
 
 const wxString mmBillsDepositsPanel::GetRemainingDays(const Model_Billsdeposits::Data* item) const
@@ -815,7 +837,17 @@ void mmBillsDepositsPanel::sortTable()
         });
         break;
     case COL_REPEATS:
-        std::stable_sort(bills_.begin(), bills_.end(), SorterByREPEATS());
+        std::stable_sort(bills_.begin(), bills_.end()
+            , [&](const Model_Billsdeposits::Full_Data& x, const Model_Billsdeposits::Full_Data& y)
+        {
+            int xn = this->GetNumRepeats(&x);
+            int yn = this->GetNumRepeats(&y);
+            // the order is: 1, 2, ..., -1 (REPEAT_NUM_INFINITY), 0 (REPEAT_NUM_UNKNOWN)
+            if (xn > 0)
+                return yn > xn || yn == Model_Billsdeposits::REPEAT_NUM_INFINITY || yn == Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+            else
+                return xn == Model_Billsdeposits::REPEAT_NUM_INFINITY && yn == Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+        });
         break;
     case COL_DAYS:
         std::stable_sort(bills_.begin(), bills_.end()

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -47,7 +47,7 @@ enum
 
 const wxString BILLSDEPOSITS_REPEATS[] =
 {
-    wxTRANSLATE("None"),
+    wxTRANSLATE("Once"),
     wxTRANSLATE("Weekly"),
     wxTRANSLATE("Fortnightly"),
     wxTRANSLATE("Monthly"),
@@ -537,14 +537,17 @@ const int mmBillsDepositsPanel::GetNumRepeats(const Model_Billsdeposits::Data* i
     int repeats = item->REPEATS % BD_REPEATS_MULTIPLEX_BASE; // DeMultiplex the Auto Executable fields.
     int numRepeats = item->NUMOCCURRENCES;
 
-    if (repeats == Model_Billsdeposits::REPEAT_NONE)
+    if (repeats == Model_Billsdeposits::REPEAT_ONCE)
         numRepeats = 1;
     else if (repeats >= Model_Billsdeposits::REPEAT_IN_X_DAYS && repeats <= Model_Billsdeposits::REPEAT_IN_X_MONTHS)
         numRepeats = numRepeats > 0 ? 2 : Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
     else if (repeats >= Model_Billsdeposits::REPEAT_EVERY_X_DAYS && repeats <= Model_Billsdeposits::REPEAT_EVERY_X_MONTHS)
         numRepeats = numRepeats > 0 ? Model_Billsdeposits::REPEAT_NUM_INFINITY : Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
-    else if (numRepeats < -1)  // this should not happen
+    else if (numRepeats < -1)
+    {
+        wxFAIL;
         numRepeats = Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
+    }
 
     return numRepeats;
 }

--- a/src/billsdepositspanel.h
+++ b/src/billsdepositspanel.h
@@ -108,6 +108,7 @@ public:
     int col_sort();
 
     const wxString GetFrequency(const Model_Billsdeposits::Data* item) const;
+    const int GetNumRepeats(const Model_Billsdeposits::Data* item) const;
     const wxString GetRemainingDays(const Model_Billsdeposits::Data* item) const;
 
     wxString BuildPage() const;

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -514,7 +514,6 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
     for (const auto& q1 : bills.all())
     {
         bills.decode_fields(q1);
-        const wxDateTime payment_date = bills.TRANSDATE(q1);
         if (bills.autoExecuteManual() && bills.requireExecution())
         {
             if (bills.allowExecution() && bills.AllowTransaction(q1, bal))
@@ -549,6 +548,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 tran->NOTES = q1.NOTES;
                 tran->CATEGID = q1.CATEGID;
                 tran->FOLLOWUPID = q1.FOLLOWUPID;
+                const wxDateTime payment_date = bills.TRANSDATE(q1);
                 tran->TRANSDATE = payment_date.FormatISOCombined();
                 tran->COLOR = q1.COLOR;
                 int transID = Model_Checking::instance().save(tran);

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -230,7 +230,7 @@ void Model_Billsdeposits::decode_fields(const Data& q1)
         m_autoExecuteManual = true;
     }
     repeats %= BD_REPEATS_MULTIPLEX_BASE;
-    if ((repeats < Model_Billsdeposits::REPEAT_IN_X_DAYS) || (numRepeats > Model_Billsdeposits::REPEAT_NONE) || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS))
+    if ((numRepeats > 0) || (repeats < Model_Billsdeposits::REPEAT_IN_X_DAYS) || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS))
     {
         m_allowExecution = true;
     }
@@ -351,7 +351,7 @@ void Model_Billsdeposits::completeBDInSeries(int bdID)
         const wxDateTime& due_date_current = NEXTOCCURRENCEDATE(bill);
         const wxDateTime& due_date_update = nextOccurDate(repeats, numRepeats, due_date_current);
 
-        if (numRepeats != REPEAT_TYPE::REPEAT_INACTIVE)
+        if (numRepeats > 0)
         {
             if ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS) || (repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS))
                 numRepeats--;
@@ -371,7 +371,7 @@ void Model_Billsdeposits::completeBDInSeries(int bdID)
         bill->NUMOCCURRENCES = numRepeats;
         save(bill);
 
-        if (bill->NUMOCCURRENCES == REPEAT_TYPE::REPEAT_NONE)
+        if (bill->NUMOCCURRENCES == 0)
         {
             mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bdID);
             remove(bdID);

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -24,6 +24,7 @@
 #include "Model_Category.h"
 #include "Model_Payee.h"
 #include "Model_Tag.h"
+#include "Model_CustomFieldData.h"
 
  /* TODO: Move attachment management outside of attachmentdialog */
 #include "attachmentdialog.h"
@@ -216,7 +217,7 @@ void Model_Billsdeposits::decode_fields(const Data& q1)
     m_autoExecuteManual = false; // Used when decoding: REPEATS
     m_autoExecuteSilent = false;
     m_requireExecution = false;
-    m_allowExecution = false;
+    m_allowExecution = true;
 
     // DeMultiplex the Auto Executable fields from the db entry: REPEATS
     int repeats = q1.REPEATS;
@@ -230,9 +231,12 @@ void Model_Billsdeposits::decode_fields(const Data& q1)
         m_autoExecuteManual = true;
     }
     repeats %= BD_REPEATS_MULTIPLEX_BASE;
-    if ((numRepeats > 0) || (repeats < Model_Billsdeposits::REPEAT_IN_X_DAYS) || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS))
+    if (repeats >= Model_Billsdeposits::REPEAT_IN_X_DAYS && repeats <= Model_Billsdeposits::REPEAT_EVERY_X_MONTHS && numRepeats < 1)
     {
-        m_allowExecution = true;
+        // old inactive entry
+        m_allowExecution = false;
+        m_autoExecuteSilent = false;
+        m_autoExecuteManual = false;
     }
 
     m_requireExecution = (Model_Billsdeposits::NEXTOCCURRENCEDATE(&q1)
@@ -339,44 +343,40 @@ bool Model_Billsdeposits::AllowTransaction(const Data& r, AccountBalance& bal)
 void Model_Billsdeposits::completeBDInSeries(int bdID)
 {
     Data* bill = get(bdID);
-    if (bill)
+    if (!bill) return;
+
+    int repeats = bill->REPEATS % BD_REPEATS_MULTIPLEX_BASE; // DeMultiplex the Auto Executable fields.
+    int numRepeats = bill->NUMOCCURRENCES;
+
+    if ((repeats == REPEAT_TYPE::REPEAT_ONCE) || ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS || repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS) && numRepeats <= 1))
     {
-        int repeats = bill->REPEATS % BD_REPEATS_MULTIPLEX_BASE; // DeMultiplex the Auto Executable fields.
-        int numRepeats = bill->NUMOCCURRENCES;
-        wxDateTime transdate;
-        transdate.ParseDateTime(bill->TRANSDATE) || transdate.ParseDate(bill->TRANSDATE);
-        const wxDateTime& payment_date_current = transdate;
-        const wxDateTime& payment_date_update = nextOccurDate(repeats, numRepeats, payment_date_current);
-
-        const wxDateTime& due_date_current = NEXTOCCURRENCEDATE(bill);
-        const wxDateTime& due_date_update = nextOccurDate(repeats, numRepeats, due_date_current);
-
-        if (numRepeats > 0)
-        {
-            if ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS) || (repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS))
-                numRepeats--;
-        }
-
-        if (repeats == REPEAT_TYPE::REPEAT_NONE)
-            numRepeats = 0;
-        else if ((repeats == REPEAT_TYPE::REPEAT_IN_X_DAYS)
-            || (repeats == REPEAT_TYPE::REPEAT_IN_X_MONTHS))
-        {
-            if (numRepeats != -1) numRepeats = -1;
-        }
-
-        bill->NEXTOCCURRENCEDATE = due_date_update.FormatISODate();
-        bill->TRANSDATE = payment_date_update.FormatISOCombined();
-
-        bill->NUMOCCURRENCES = numRepeats;
-        save(bill);
-
-        if (bill->NUMOCCURRENCES == 0)
-        {
-            mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bdID);
-            remove(bdID);
-        }
+        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bdID);
+        remove(bdID);
+        return;
     }
+
+    wxDateTime transdate;
+    transdate.ParseDateTime(bill->TRANSDATE) || transdate.ParseDate(bill->TRANSDATE);
+    const wxDateTime& payment_date_current = transdate;
+    const wxDateTime& payment_date_update = nextOccurDate(repeats, numRepeats, payment_date_current);
+    bill->TRANSDATE = payment_date_update.FormatISOCombined();
+
+    const wxDateTime& due_date_current = NEXTOCCURRENCEDATE(bill);
+    const wxDateTime& due_date_update = nextOccurDate(repeats, numRepeats, due_date_current);
+    bill->NEXTOCCURRENCEDATE = due_date_update.FormatISODate();
+
+    if (repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS || repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS)
+    {
+        bill->NUMOCCURRENCES = numRepeats-1;
+    }
+    else if (repeats >= REPEAT_TYPE::REPEAT_IN_X_DAYS && repeats <= REPEAT_TYPE::REPEAT_IN_X_MONTHS)
+    {
+        // preserve the Auto Executable fields, change type to REPEAT_ONCE
+        bill->REPEATS += REPEAT_TYPE::REPEAT_ONCE - repeats;
+        bill->NUMOCCURRENCES = -1;
+    }
+
+    save(bill);
 }
 
 const wxDateTime Model_Billsdeposits::nextOccurDate(int repeatsType, int numRepeats, wxDateTime nextOccurDate, bool reverse)

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -38,7 +38,7 @@ public:
     enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
     enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
     enum REPEAT_TYPE {
-        REPEAT_INACTIVE = -1,
+        REPEAT_INACTIVE = -1,  // not used (can be removed)
         REPEAT_NONE,
         REPEAT_WEEKLY,
         REPEAT_BI_WEEKLY,      // FORTNIGHTLY
@@ -56,6 +56,10 @@ public:
         REPEAT_EVERY_X_MONTHS,
         REPEAT_MONTHLY_LAST_DAY,
         REPEAT_MONTHLY_LAST_BUSINESS_DAY
+    };
+    enum REPEAT_NUM {
+        REPEAT_NUM_INFINITY = -1,
+        REPEAT_NUM_UNKNOWN = 0
     };
 
     static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -61,6 +61,11 @@ public:
         REPEAT_NUM_INFINITY = -1,
         REPEAT_NUM_UNKNOWN = 0
     };
+    enum REPEAT_AUTO {
+        REPEAT_AUTO_NONE = 0,
+        REPEAT_AUTO_MANUAL = 1,
+        REPEAT_AUTO_SILENT = 2
+    };
 
     static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
     static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_ENUM_CHOICES;
@@ -159,8 +164,7 @@ public:
     bool AllowTransaction(const Data& r, AccountBalance& bal);
 
 private:
-    bool m_autoExecuteManual;
-    bool m_autoExecuteSilent;
+    int m_autoExecute;
     bool m_requireExecution;
     bool m_allowExecution;
 

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -39,7 +39,7 @@ public:
     enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
     enum REPEAT_TYPE {
         REPEAT_INACTIVE = -1,  // not used (can be removed)
-        REPEAT_NONE,
+        REPEAT_ONCE,
         REPEAT_WEEKLY,
         REPEAT_BI_WEEKLY,      // FORTNIGHTLY
         REPEAT_MONTHLY,


### PR DESCRIPTION
Change billsdeposits model as proposed in #6827

- Change `None` to `Once` and `REPEAT_NONE` to `REPEAT_ONCE`.
- An empty `Period` in the edit form for type `REPEAT_IN_*` or `REPEAT_EVERY_*`, means `1`.
- After the first execution, `REPEAT_IN_*` entries are converted to `REPEAT_ONCE`.
- All entries created by the edit form (with new/edit/duplicate) are active.

## Backwards compatibility

The old inactive entries (of type `REPEAT_IN_*`, `REPEAT_EVERY_*` and with `NUMOCCURRENCES == -1`) are handled as follows:

- They are not executed automatically.
- If they are executed manually (by pressing the `Enter` button), they are converted to `REPEAT_ONCE`, therefore they are removed after execution. (In MMEX 1.8.0 they can be executed manually, as described in #6827, probably due to a bug.)
- If they are edited, they are converted to `REPEAT_ONCE`. The user can change the type again in the edit form, but the new entry is always active.
- If they are duplicated, they are converted to `REPEAT_ONCE`.
- In the Scheduled Transactions panel, only the old inactive entries have `Repetitions` equal to `-` (horizontal bar). All new/updated entries have `Repetitions` equal to a positive number or infinity. 

## User's perspective

Apart from the old inactive entries (which are converted to active at the first chance), all entries in the Scheduled Transactions are active. If the user wants to have a dummy entry as a template, it can be added as type `Once` (or any other type) with a paid/due date in the far future (so it does not appear in the reports of the following years).

The type `REPEAT_IN_*` can be used in order to schedule two transactions. It can also be used to schedule a sequence of transactions with unpredictable paid/due dates, as follows: the user inserts a scheduled transaction of type `REPEAT_IN_*` with the known date of the first transaction, and with a period  according to the expected next paid/due date. After the first execution and before the second date, the user may edit the entry (which is now of type `REPEAT_ONCE`) and change it again to type `REPEAT_IN_*`, with a period according to the third expected paid/due date. This method is anyway of limited value; the user can simply duplicate a previous transaction in the Transactions panel.

The behavior of `REPEAT_IN_*` entries in MMEX 1.8.0 is not clear. If they are meant to be executed only once, then they are no different than `REPEAT_ONCE` entries (which replaces the misleading term `REPEAT_NONE`). Their manual execution is quite strange, since they move backwards in time.

## Additional changes

In `src/billsdepositsdialog.cpp`, the enum in the beginning of the file has been removed and the enum values have been replaced by the corresponding `Model_Billsdeposits::REPEAT_*` values. The old enum was redundant and error-prone (if e.g., by mistake the order of the symbols becomes inconsistent with the order in `Model_Billsdeposits::REPEAT_*`).

The order of repeat types in the gui (defined in `mmBDDialog::BILLSDEPOSITS_REPEATS`), is the same as the order in `Model_Billsdeposits ::REPEAT_*`, however a different order is also supported.

## Branching

This PR (part 2) is a follow-up based on #6829 (part 1). If needed, I can rebase after part 1 is merged. I think that it is easier to review/merge smaller and self-contained parts separately, instead of one big chunk. I plan to submit one more part for the same issue, based on parts 1 and 2.

## New translation strings

> Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

There are a few new translation strings (e.g., "Once"), but I don't know how to register them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6836)
<!-- Reviewable:end -->
