### PR TITLE
fix(#6827): Model_Billsdeposits::AllowTransaction

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -908,9 +908,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     bill_data.TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
     bill_data.TRANSCODE = m_bill_data.TRANSCODE;
 
-    Model_Billsdeposits::AccountBalance bal;
-
-    if (!Model_Billsdeposits::instance().AllowTransaction(bill_data, bal)) return;
+    if (!Model_Billsdeposits::instance().AllowTransaction(bill_data)) return;
     if (!textAmount_->checkValue(m_bill_data.TRANSAMOUNT)) return;
 
     m_bill_data.TOTRANSAMOUNT = m_bill_data.TRANSAMOUNT;

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -509,14 +509,13 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
     //Auto scheduled transaction
     bool continueExecution = false;
 
-    Model_Billsdeposits::AccountBalance bal;
     Model_Billsdeposits& bills = Model_Billsdeposits::instance();
     for (const auto& q1 : bills.all())
     {
         bills.decode_fields(q1);
         if (bills.autoExecuteManual() && bills.requireExecution())
         {
-            if (bills.allowExecution() && bills.AllowTransaction(q1, bal))
+            if (bills.allowExecution() && bills.AllowTransaction(q1))
             {
                 continueExecution = true;
                 mmBDDialog repeatTransactionsDlg(this, q1.BDID, false, true);
@@ -532,7 +531,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
 
         if (bills.autoExecuteSilent() && bills.requireExecution())
         {
-            if (bills.allowExecution() && bills.AllowTransaction(q1, bal))
+            if (bills.allowExecution() && bills.AllowTransaction(q1))
             {
                 continueExecution = true;
                 Model_Checking::Data* tran = Model_Checking::instance().create();

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -160,8 +160,8 @@ public:
     bool autoExecuteSilent();
     bool requireExecution();
     bool allowExecution();
-    typedef std::map<int, double> AccountBalance;
-    bool AllowTransaction(const Data& r, AccountBalance& bal);
+    // typedef std::map<int, double> AccountBalance;
+    bool AllowTransaction(const Data& r);
 
 private:
     int m_autoExecute;

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -758,23 +758,17 @@ bool mmTransDialog::ValidateData()
     //Checking account does not exceed limits
     if (m_new_trx || m_duplicate)
     {
-        if ((m_trx_data.TRANSCODE == Model_Checking::WITHDRAWAL_STR) ||
-            (m_trx_data.TRANSCODE == Model_Checking::TRANSFER_STR))
+        if (m_trx_data.STATUS != "V" &&
+            (m_trx_data.TRANSCODE == Model_Checking::WITHDRAWAL_STR ||
+             m_trx_data.TRANSCODE == Model_Checking::TRANSFER_STR) &&
+            (account->MINIMUMBALANCE != 0 || account->CREDITLIMIT != 0))
         {
             const double fromAccountBalance = Model_Account::balance(account);
             const double new_value = fromAccountBalance - m_trx_data.TRANSAMOUNT;
 
-            bool abort_transaction = false;
-
-            if ((account->MINIMUMBALANCE != 0) && (new_value < account->MINIMUMBALANCE))
-            {
-                abort_transaction = true;
-            }
-
-            if ((account->CREDITLIMIT != 0) && (new_value < (account->CREDITLIMIT * -1)))
-            {
-                abort_transaction = true;
-            }
+            bool abort_transaction =
+                (account->MINIMUMBALANCE != 0 && new_value < account->MINIMUMBALANCE) ||
+                (account->CREDITLIMIT != 0 && new_value < -(account->CREDITLIMIT));
 
             if (abort_transaction && wxMessageBox(_(
                 "This transaction will exceed your account limit.\n\n"


### PR DESCRIPTION
## Current status

`Model_Account::balance(a)`, which calculates the balance of account `a`, has the following properties:
- Transactions with `STATUS == VOID` or with non-empty `DELETEDTIME` are ignored.
- `TRANSAMOUNT` is added to the balance of `ACCOUNTID` if `TRANSCODE == DEPOSIT`.
- `TRANSAMOUNT` is subtracted from the balance of `ACCOUNTID` if `TRANSCODE == WITHDRAWAL` or `TRANSCODE == TRANSFER`.
- `TOTRANSAMOUNT` is added to the balance of `TOACCOUNTID` if `TRANSCODE == TRANSFER`.

`htmlWidgetAccounts::get_account_stats()`, which calculates and stores the sum of transactions per account, is consistent with `Model_Account::balance()`.

## Problems

`mmTransDialog::ValidateData()`, which checks the limits of new or duplicated transactions, is inconsistent with `Model_Account::balance()`:
- It aborts transactions with `STATUS == VOID`, although these transactions do not affect the account balance.

`Model_Billsdeposits::AllowTransaction()`, which maintains a cache of the balance per account, is highly inconsistent with `Model_Account::balance()`:
- It updates the balance also for transaction with `STATUS == VOID`.
- It adds `TRANSAMOUNT` to the balance of `ACCOUNTID` with the wrong sign if `TRANSCODE == TRANSFER`.
- It does not add `TOTRANSAMOUNT` to the balance of `TOACCOUNTID` if `TRANSCODE == TRANSFER`.

Additional (minor) problems in `Model_Billsdeposits::AllowTransaction()`:
- If an account has both a `MINIMUMBALANCE` and a `CREDITLIMIT` (normally this does not happen), the abort message may wrongly show the `CREDITLIMIT` as the exceeded limit.
- If an account has negative `MINIMUMBALANCE` and `CREDITLIMIT` (normally this does not happen), the abort message does not show the exceeded limit.
- It is not a pure function, as implied by its name. Its main functionality is mostly to update the balance cache; in addition it indicates if an account limit is exceeded.

The balance cache avoids repeated calls to `Model_Account::balance()`, which can be expensive for accounts with too many transactions. However it is quite tedious to make it consistent with `Model_Account::balance`. E.g., `Model_Billsdeposits::AllowTransaction()` is called by `mmGUIFrame::OnAutoRepeatTransactionsTimer()` for a sequence of auto executed transactions, either in manual or in silent mode. In manual mode the user can change the amount before pressing OK. Therefore, the balance cache is updated based on the amount in the original scheduled transaction, but the actual transaction may exceed the account limit (without warning), and a change in the amount invalidates the balance cache.

## Changes

In `mmTransDialog::ValidateData()`:
- Do not abort transactions with `STATUS == VOID`.
- As an optimization, `Model_Account::balance()` is called only for accounts with limit.

In `Model_Billsdeposits::AllowTransaction()`:
- Do not cache the accounts balance (this also makes the function pure).
- As an optimization, `Model_Account::balance()` is called only for accounts with limit.
- The calculation of `new_balance` is fully consistent with `Model_Account::balance()`.

## User's perspective

The overhead of repeated calls to `Model_Account::balance()` in `Model_Billsdeposits::AllowTransaction()` is typically small. Usually only a few scheduled transactions are executed in the same batch. The source code is greatly simplified without the balance cache, and consistency with `Model_Account::balance()` is much more important than a minor optimization.

If nevertheless `Model_Account::balance()` becomes very expensive and it is highly desirable to avoid it, the user can disable the limits in accounts with too many transactions, at the cost of missing warnings on exceeded limits for these accounts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6841)
<!-- Reviewable:end -->
