### PR TITLE
fix(#6827): mmBDDialog::OnOk

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -903,12 +903,6 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     m_bill_data.ACCOUNTID = cbAccount_->mmGetId();
     Model_Account::Data* acc = Model_Account::instance().get(m_bill_data.ACCOUNTID);
 
-    Model_Billsdeposits::Data bill_data;
-    bill_data.ACCOUNTID = m_bill_data.ACCOUNTID;
-    bill_data.TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
-    bill_data.TRANSCODE = m_bill_data.TRANSCODE;
-
-    if (!Model_Billsdeposits::instance().AllowTransaction(bill_data)) return;
     if (!textAmount_->checkValue(m_bill_data.TRANSAMOUNT)) return;
 
     m_bill_data.TOTRANSAMOUNT = m_bill_data.TRANSAMOUNT;
@@ -1130,6 +1124,12 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             || (repeats > Model_Billsdeposits::REPEAT_EVERY_X_MONTHS)
             || (m_bill_data.NUMOCCURRENCES > 0))
         {
+            Model_Billsdeposits::Data bill_data;
+            bill_data.ACCOUNTID = m_bill_data.ACCOUNTID;
+            bill_data.TRANSCODE = m_bill_data.TRANSCODE;
+            bill_data.TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
+            if (!Model_Billsdeposits::instance().AllowTransaction(bill_data)) return;
+
             Model_Checking::Data* tran = Model_Checking::instance().create();
             tran->ACCOUNTID = m_bill_data.ACCOUNTID;
             tran->TOACCOUNTID = m_bill_data.TOACCOUNTID;


### PR DESCRIPTION
`mmBDDialog::OnOk()` calls `Model_Billsdeposits::.AllowTransaction()` in order to check if the execution of a scheduled transaction would exceed an account limit.

## Problems
- The check is performed before `m_bill_data.TRANSAMOUNT` is updated. If the user changed the amount in the dialog form and then immediately pressed OK (without changing focus in between), the old amount in the dialog form is checked.
- This check makes sense only when the scheduled transaction is executed, i.e., only if the dialog form was created by the Enter button. For all other actions (New, Edit, Duplicate), a scheduled transaction is just created/updated in the `BILLSDEPOSITS_V1` table, but it is not executed, therefore no check is needed. Actually a premature check is misleading, e.g., the scheduled transaction may exceed an account limit if executed now, but not if executed as scheduled.

## Change
- Move the check of account limits just before the schedule transaction is executed. Do not check the account limits in other actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6843)
<!-- Reviewable:end -->
