### PR TITLE
fix(#6827): refactoring model checking, bills deposits and cleanup

### DIFF
--- a/src/dbcheck.cpp
+++ b/src/dbcheck.cpp
@@ -49,7 +49,7 @@ bool dbCheck::checkAccounts()
     // BillsDeposits
     const auto &bills = Model_Billsdeposits::instance().all();
     for (const auto& bill : bills)
-        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type(bill) == Model_Billsdeposits::TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
+        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type(bill) == Model_Checking::TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
         {
             result = false;
         }

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -561,7 +561,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
                 }
                 break;
             case COL_STATUS:
-                copyText_ = menuItemText = Model_Checking::STATUS_ENUM_CHOICES[Model_Checking::status(m_trans[row].STATUS)].second;
+                copyText_ = menuItemText = Model_Checking::all_status()[Model_Checking::status(m_trans[row].STATUS)];
                 rightClickFilter_ = "{\n\"STATUS\": \"" + menuItemText + "\"\n}";
                 break;
             case COL_CATEGORY:
@@ -1306,7 +1306,7 @@ void TransactionListCtrl::DeleteTransactionsByStatus(const wxString& status)
     int retainDays = Model_Setting::instance().GetIntSetting("DELETED_TRANS_RETAIN_DAYS", 30);
     wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
     std::set<std::pair<wxString, int>> assetStockAccts;
-    const auto s = Model_Checking::toShortStatus(status);
+    const auto s = Model_Checking::status_key(status);
     Model_Checking::instance().Savepoint();
     Model_Attachment::instance().Savepoint();
     Model_Splittransaction::instance().Savepoint();

--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -315,7 +315,7 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         if (account) accountStr = account->ACCOUNTNAME;
 
         wxString payeeStr = "";
-        if (Model_Billsdeposits::type(entry) == Model_Billsdeposits::TRANSFER)
+        if (Model_Billsdeposits::type(entry) == Model_Checking::TRANSFER)
         {
             const Model_Account::Data *to_account = Model_Account::instance().get(entry.TOACCOUNTID);
             if (to_account) payeeStr = to_account->ACCOUNTNAME;
@@ -325,10 +325,10 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         {
             const Model_Payee::Data* payee = Model_Payee::instance().get(entry.PAYEEID);
             payeeStr = accountStr;
-            payeeStr += (Model_Billsdeposits::type(entry) == Model_Billsdeposits::WITHDRAWAL ? " &rarr; " : " &larr; ");
+            payeeStr += (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? " &rarr; " : " &larr; ");
             if (payee) payeeStr += payee->PAYEENAME;
         }
-        double amount = (Model_Billsdeposits::type(entry) == Model_Billsdeposits::WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
+        double amount = (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
         wxString notes = HTMLEncode(entry.NOTES);
         bd_days.push_back(std::make_tuple(daysPayment, payeeStr, daysRemainingStr, amount, account, notes));
     }

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -29,47 +29,16 @@
  /* TODO: Move attachment management outside of attachmentdialog */
 #include "attachmentdialog.h"
 
-const std::vector<std::pair<Model_Billsdeposits::TYPE, wxString> > Model_Billsdeposits::TYPE_CHOICES =
-{
-    {Model_Billsdeposits::WITHDRAWAL, wxString(wxTRANSLATE("Withdrawal"))}
-    , {Model_Billsdeposits::DEPOSIT, wxString(wxTRANSLATE("Deposit"))}
-    , {Model_Billsdeposits::TRANSFER, wxString(wxTRANSLATE("Transfer"))}
-};
-
-const std::vector<std::pair<Model_Billsdeposits::STATUS_ENUM, wxString> > Model_Billsdeposits::STATUS_ENUM_CHOICES =
-{
-    {Model_Billsdeposits::NONE, wxString(wxTRANSLATE("Unreconciled"))}
-    , {Model_Billsdeposits::RECONCILED, wxString(wxTRANSLATE("Reconciled"))}
-    , {Model_Billsdeposits::VOID_, wxString(wxTRANSLATE("Void"))}
-    , {Model_Billsdeposits::FOLLOWUP, wxString(wxTRANSLATE("Follow Up"))}
-    , {Model_Billsdeposits::DUPLICATE_, wxString(wxTRANSLATE("Duplicate"))}
-};
-
 Model_Billsdeposits::Model_Billsdeposits()
     : Model<DB_Table_BILLSDEPOSITS_V1>()
     , m_autoExecute (REPEAT_AUTO_NONE)
     , m_requireExecution (false)
     , m_allowExecution (false)
-
 {
 }
 
 Model_Billsdeposits::~Model_Billsdeposits()
 {
-}
-
-wxArrayString Model_Billsdeposits::all_type()
-{
-    wxArrayString types;
-    for (const auto& item : TYPE_CHOICES) types.Add(item.second);
-    return types;
-}
-
-wxArrayString Model_Billsdeposits::all_status()
-{
-    wxArrayString status;
-    for (const auto& item : STATUS_ENUM_CHOICES) status.Add(item.second);
-    return status;
 }
 
 /** Return the static instance of Model_Billsdeposits table */
@@ -112,70 +81,22 @@ wxDate Model_Billsdeposits::NEXTOCCURRENCEDATE(const Data& r)
     return Model::to_date(r.NEXTOCCURRENCEDATE);
 }
 
-Model_Billsdeposits::TYPE Model_Billsdeposits::type(const wxString& r)
+Model_Checking::TYPE Model_Billsdeposits::type(const Data& r)
 {
-    static std::unordered_map<wxString, TYPE> cache;
-    const auto it = cache.find(r);
-    if (it != cache.end()) return it->second;
-
-    for (const auto& t : TYPE_CHOICES)
-    {
-        if (r.CmpNoCase(t.second) == 0)
-        {
-            cache.insert(std::make_pair(r, t.first));
-            return t.first;
-        }
-    }
-
-    cache.insert(std::make_pair(r, WITHDRAWAL));
-    return WITHDRAWAL;
+    return Model_Checking::type(r.TRANSCODE);
 }
-Model_Billsdeposits::TYPE Model_Billsdeposits::type(const Data& r)
+Model_Checking::TYPE Model_Billsdeposits::type(const Data* r)
 {
-    return type(r.TRANSCODE);
-}
-Model_Billsdeposits::TYPE Model_Billsdeposits::type(const Data* r)
-{
-    return type(r->TRANSCODE);
-}
-Model_Billsdeposits::STATUS_ENUM Model_Billsdeposits::status(const wxString& r)
-{
-    static std::unordered_map<wxString, STATUS_ENUM> cache;
-    const auto it = cache.find(r);
-    if (it != cache.end()) return it->second;
-
-    for (const auto & s : STATUS_ENUM_CHOICES)
-    {
-        if (r.CmpNoCase(s.second) == 0)
-        {
-            cache.insert(std::make_pair(r, s.first));
-            return s.first;
-        }
-    }
-
-    STATUS_ENUM ret = NONE;
-    if (r.CmpNoCase("R") == 0) ret = RECONCILED;
-    else if (r.CmpNoCase("V") == 0) ret = VOID_;
-    else if (r.CmpNoCase("F") == 0) ret = FOLLOWUP;
-    else if (r.CmpNoCase("D") == 0) ret = DUPLICATE_;
-    cache.insert(std::make_pair(r, ret));
-
-    return ret;
-}
-Model_Billsdeposits::STATUS_ENUM Model_Billsdeposits::status(const Data& r)
-{
-    return status(r.STATUS);
-}
-Model_Billsdeposits::STATUS_ENUM Model_Billsdeposits::status(const Data* r)
-{
-    return status(r->STATUS);
+    return Model_Checking::type(r->TRANSCODE);
 }
 
-wxString Model_Billsdeposits::toShortStatus(const wxString& fullStatus)
+Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data& r)
 {
-    wxString s = fullStatus.Left(1);
-    s.Replace("U", "");
-    return s;
+    return Model_Checking::status(r.STATUS);
+}
+Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data* r)
+{
+    return Model_Checking::status(r->STATUS);
 }
 
 /**
@@ -191,14 +112,14 @@ bool Model_Billsdeposits::remove(int id)
     return this->remove(id, db_);
 }
 
-DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(STATUS_ENUM status, OP op)
+DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(Model_Checking::STATUS_ENUM status, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::STATUS(toShortStatus(all_status()[status]), op);
+    return DB_Table_BILLSDEPOSITS_V1::STATUS(Model_Checking::all_status_key()[status], op);
 }
 
-DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(TYPE type, OP op)
+DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(Model_Checking::TYPE type, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(all_type()[type], op);
+    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(Model_Checking::all_type()[type], op);
 }
 
 const Model_Budgetsplittransaction::Data_Set Model_Billsdeposits::splittransaction(const Data* r)
@@ -427,7 +348,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
 
     PAYEENAME = Model_Payee::get_payee_name(r.PAYEEID);
-    if (Model_Billsdeposits::type(r) == Model_Billsdeposits::TRANSFER)
+    if (Model_Billsdeposits::type(r) == Model_Checking::TRANSFER)
     {
         PAYEENAME = Model_Account::get_account_name(r.TOACCOUNTID);
     }
@@ -436,7 +357,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
 
 wxString Model_Billsdeposits::Full_Data::real_payee_name() const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (Model_Checking::TRANSFER == Model_Checking::type(this->TRANSCODE))
     {
         return ("> " + this->PAYEENAME);
     }

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -22,7 +22,8 @@
 
 #include "Model.h"
 #include "db/DB_Table_Billsdeposits_V1.h"
-#include "model/Model_Splittransaction.h"
+#include "Model_Checking.h"
+#include "Model_Splittransaction.h"
 #include "Model_Budgetsplittransaction.h"
 #include "Model_Taglink.h"
 
@@ -35,11 +36,8 @@ public:
     typedef Model_Budgetsplittransaction::Data_Set Split_Data_Set;
 
 public:
-    enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
-    enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
     enum REPEAT_TYPE {
-        REPEAT_INACTIVE = -1,  // not used (can be removed)
-        REPEAT_ONCE,
+        REPEAT_ONCE = 0,
         REPEAT_WEEKLY,
         REPEAT_BI_WEEKLY,      // FORTNIGHTLY
         REPEAT_MONTHLY,
@@ -67,9 +65,6 @@ public:
         REPEAT_AUTO_SILENT = 2
     };
 
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_ENUM_CHOICES;
-
 public:
     Model_Billsdeposits();
     ~Model_Billsdeposits();
@@ -81,10 +76,10 @@ public:
         int BDID = 0;
         // This relates the 'Date Due' field.
         wxString TRANSDATE = wxDateTime::Now().FormatISOCombined();
-        wxString STATUS = Model_Billsdeposits::all_status()[Model_Billsdeposits::NONE];;
+        wxString STATUS = Model_Checking::all_status()[Model_Checking::NONE];
         int ACCOUNTID = -1;
         int TOACCOUNTID = -1;
-        wxString TRANSCODE = Model_Billsdeposits::all_type()[Model_Billsdeposits::WITHDRAWAL];;
+        wxString TRANSCODE = Model_Checking::WITHDRAWAL_STR;
         int CATEGID = -1;
         double TRANSAMOUNT = 0;
         double TOTRANSAMOUNT = 0;
@@ -116,10 +111,6 @@ public:
     typedef std::vector<Full_Data> Full_Data_Set;
 
 public:
-    static wxArrayString all_type();
-    static wxArrayString all_status();
-
-public:
     /**
     Initialize the global Model_Billsdeposits table on initial call.
     Resets the global table on subsequent calls.
@@ -143,13 +134,10 @@ public:
     static wxDate NEXTOCCURRENCEDATE(const Data* r);
     // This relates the 'Date Paid' field
     static wxDate NEXTOCCURRENCEDATE(const Data& r);
-    static TYPE type(const wxString& r);
-    static TYPE type(const Data* r);
-    static TYPE type(const Data& r);
-    static STATUS_ENUM status(const wxString& r);
-    static STATUS_ENUM status(const Data* r);
-    static STATUS_ENUM status(const Data& r);
-    static wxString toShortStatus(const wxString& fullStatus);
+    static Model_Checking::TYPE type(const Data* r);
+    static Model_Checking::TYPE type(const Data& r);
+    static Model_Checking::STATUS_ENUM status(const Data* r);
+    static Model_Checking::STATUS_ENUM status(const Data& r);
 
     /**
     * Decodes the internal fields and sets the condition of the following parameters:
@@ -160,7 +148,6 @@ public:
     bool autoExecuteSilent();
     bool requireExecution();
     bool allowExecution();
-    // typedef std::map<int, double> AccountBalance;
     bool AllowTransaction(const Data& r);
 
 private:
@@ -175,8 +162,8 @@ public:
     */
     bool remove(int id);
 
-    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(STATUS_ENUM status, OP op = EQUAL);
-    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(TYPE type, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(Model_Checking::STATUS_ENUM status, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(Model_Checking::TYPE type, OP op = EQUAL);
 
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data* r);
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data& r);

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -36,7 +36,7 @@ const std::vector<std::pair<Model_Checking::TYPE, wxString> > Model_Checking::TY
     , {Model_Checking::TRANSFER, wxString(wxTRANSLATE("Transfer"))}
 };
 
-const std::vector<std::pair<Model_Checking::STATUS_ENUM, wxString> > Model_Checking::STATUS_ENUM_CHOICES =
+const std::vector<std::pair<Model_Checking::STATUS_ENUM, wxString> > Model_Checking::STATUS_CHOICES =
 {
     {Model_Checking::NONE, wxTRANSLATE("Unreconciled")}
     , {Model_Checking::RECONCILED, wxString(wxTRANSLATE("Reconciled"))}
@@ -45,9 +45,9 @@ const std::vector<std::pair<Model_Checking::STATUS_ENUM, wxString> > Model_Check
     , {Model_Checking::DUPLICATE_, wxString(wxTRANSLATE("Duplicate"))}
 };
 
-const wxString Model_Checking::TRANSFER_STR = all_type()[TRANSFER];
-const wxString Model_Checking::DEPOSIT_STR = all_type()[DEPOSIT];
 const wxString Model_Checking::WITHDRAWAL_STR = all_type()[WITHDRAWAL];
+const wxString Model_Checking::DEPOSIT_STR = all_type()[DEPOSIT];
+const wxString Model_Checking::TRANSFER_STR = all_type()[TRANSFER];
 
 Model_Checking::Model_Checking() : Model<DB_Table_CHECKINGACCOUNT_V1>()
 {
@@ -61,15 +61,20 @@ wxArrayString Model_Checking::all_type()
 {
     wxArrayString types;
     for (const auto& r : TYPE_CHOICES) types.Add(r.second);
-
     return types;
 }
 
 wxArrayString Model_Checking::all_status()
 {
     wxArrayString status;
-    for (const auto& r : STATUS_ENUM_CHOICES) status.Add(r.second);
+    for (const auto& r : STATUS_CHOICES) status.Add(r.second);
+    return status;
+}
 
+wxArrayString Model_Checking::all_status_key()
+{
+    wxArrayString status;
+    for (const auto& r : STATUS_CHOICES) status.Add(status_key(r.second));
     return status;
 }
 
@@ -159,7 +164,7 @@ const Model_Splittransaction::Data_Set Model_Checking::splittransaction(const Da
 
 DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ENUM status, OP op)
 {
-    return DB_Table_CHECKINGACCOUNT_V1::STATUS(toShortStatus(all_status()[status]), op);
+    return DB_Table_CHECKINGACCOUNT_V1::STATUS(all_status_key()[status], op);
 }
 
 DB_Table_CHECKINGACCOUNT_V1::TRANSCODE Model_Checking::TRANSCODE(TYPE type, OP op)
@@ -233,7 +238,7 @@ Model_Checking::STATUS_ENUM Model_Checking::status(const wxString& r)
     const auto it = cache.find(r);
     if (it != cache.end()) return it->second;
 
-    for (const auto & s : STATUS_ENUM_CHOICES)
+    for (const auto & s : STATUS_CHOICES)
     {
         if (r.CmpNoCase(s.second) == 0)
         {
@@ -368,7 +373,7 @@ bool Model_Checking::is_deposit(const Data* r)
     return is_deposit(r->TRANSCODE);
 }
 
-wxString Model_Checking::toShortStatus(const wxString& fullStatus)
+wxString Model_Checking::status_key(const wxString& fullStatus)
 {
     wxString s = fullStatus.Left(1);
     s.Replace("U", "");
@@ -605,7 +610,7 @@ void Model_Checking::getEmptyTransaction(Data &data, int accountID)
 
     data.TRANSDATE = max_trx_date;
     data.ACCOUNTID = accountID;
-    data.STATUS = toShortStatus(all_status()[Option::instance().TransStatusReconciled()]);
+    data.STATUS = all_status_key()[Option::instance().TransStatusReconciled()];
     data.TRANSCODE = all_type()[WITHDRAWAL];
     data.CATEGID = -1;
     data.FOLLOWUPID = -1;

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -34,10 +34,10 @@ public:
 
 public:
     enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
-    enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_};
+    enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
 
     static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_ENUM_CHOICES;
+    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_CHOICES;
 
 public:
     struct Full_Data: public Data
@@ -148,6 +148,7 @@ public:
 public:
     static wxArrayString all_type();
     static wxArrayString all_status();
+    static wxArrayString all_status_key();
     static const wxString TRANSFER_STR;
     static const wxString WITHDRAWAL_STR;
     static const wxString DEPOSIT_STR;
@@ -209,7 +210,7 @@ public:
     static bool is_transfer(const Data* r);
     static bool is_deposit(const wxString& r);
     static bool is_deposit(const Data* r);
-    static wxString toShortStatus(const wxString& fullStatus);
+    static wxString status_key(const wxString& fullStatus);
     static void getFrequentUsedNotes(std::vector<wxString> &frequentNotes, int accountID = -1);
     static void getEmptyTransaction(Data &data, int accountID);
     static bool getTransactionData(Data &data, const Data* r);

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -131,7 +131,7 @@ void mmReportCashFlow::getTransactions()
     }
 
     // Now we gather the recurring transaction list
-    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Billsdeposits::VOID_, NOT_EQUAL)))
+    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
     {
         wxDateTime nextOccurDate = Model_Billsdeposits::NEXTOCCURRENCEDATE(entry);
         if (nextOccurDate > endDate) continue;

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -313,7 +313,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         wxStringClientData* status_obj = static_cast<wxStringClientData*>(m_status_choice->GetClientObject(m_status_choice->GetSelection()));
         if (status_obj)
-            status = Model_Checking::toShortStatus(status_obj->GetData());
+            status = Model_Checking::status_key(status_obj->GetData());
         else
             return;
     }

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -1178,7 +1178,7 @@ void mmTransDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     wxStringClientData* status_obj = static_cast<wxStringClientData*>(choiceStatus_->GetClientObject(choiceStatus_->GetSelection()));
     if (status_obj)
     {
-        m_status = Model_Checking::toShortStatus(status_obj->GetData());
+        m_status = Model_Checking::status_key(status_obj->GetData());
         m_trx_data.STATUS = m_status;
     }
 


### PR DESCRIPTION
## Remove redundant definitions

The following definitions in `Model_Billsdeposits` are identical to the corresponding definitions in `Model_Checking`.
- enum `TYPE`
- vector `TYPE_CHOICES`
- `all_type()`
- `type(const wxString& r)`
- enum `STATUS_ENUM`
- vector `STATUS_ENUM_CHOICES` (rename to `STATUS_CHOICES`)
- `all_status()`
- `status(const wxString& r)`
- `toShortStatus(const wxString& fullStatus)`

The references to all `Model_Billsdeposits` definitions above have been replaced with references to `Model_Checking`.

## Remove unused definitions

- in enum `Model_Billsdeposits::REPEAT_TYPE`: `REPEAT_INACTIVE`
- in `Model_Billsdeposits`: typedef `AccountBalance` (was commented out)

## Rename

- in `Model_Checking`: `toShortStatus()` -> `status_key()`

## Add

- `Model_Checking::all_status_key()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6846)
<!-- Reviewable:end -->
