### PR TITLE
refactor choices in Model_Checking

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -152,7 +152,7 @@ mmBDDialog::mmBDDialog(wxWindow* parent, int bdID, bool duplicate, bool enterOcc
         }
     }
 
-    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TRANSFER_STR);
+    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TYPE_STR_TRANSFER);
 
     int ref_id = m_dup_bill ?  -bdID : (m_new_bill ? 0 : -m_bill_data.BDID);
     m_custom_fields = new mmCustomDataTransaction(this, ref_id, ID_CUSTOMFIELDS);
@@ -206,13 +206,13 @@ void mmBDDialog::dataToControls()
     }
     setRepeatType(Model_Billsdeposits::REPEAT_MONTHLY);
 
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (i == Model_Checking::TRANSFER_STR && Model_Account::instance().all().size() < 2)
+        if (i == Model_Checking::TYPE_STR_TRANSFER && Model_Account::instance().all().size() < 2)
             break;
         m_choice_transaction_type->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
-    m_choice_transaction_type->SetSelection(Model_Checking::WITHDRAWAL);
+    m_choice_transaction_type->SetSelection(Model_Checking::TYPE_ID_WITHDRAWAL);
 
     SetTransferControls();  // hide appropriate fields
     setCategoryLabel();
@@ -221,7 +221,7 @@ void mmBDDialog::dataToControls()
         return;
     }
 
-    m_choice_status->SetSelection(Model_Checking::status(m_bill_data.STATUS));
+    m_choice_status->SetSelection(Model_Checking::status_id(m_bill_data.STATUS));
 
     // Set the date paid
     wxDateTime field_date;
@@ -268,7 +268,7 @@ void mmBDDialog::dataToControls()
     }
     setRepeatDetails();
 
-    m_choice_transaction_type->SetSelection(Model_Checking::type(m_bill_data.TRANSCODE));
+    m_choice_transaction_type->SetSelection(Model_Checking::type_id(m_bill_data.TRANSCODE));
     updateControlsForTransType();
 
     Model_Account::Data* account = Model_Account::instance().get(m_bill_data.ACCOUNTID);
@@ -339,8 +339,8 @@ void mmBDDialog::SetDialogParameters(int trx_id)
     cbAccount_->SetValue(t.ACCOUNTNAME);
 
     m_bill_data.TRANSCODE = t.TRANSCODE;
-    m_choice_transaction_type->SetSelection(Model_Checking::type(t.TRANSCODE));
-    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TRANSFER_STR);
+    m_choice_transaction_type->SetSelection(Model_Checking::type_id(t.TRANSCODE));
+    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TYPE_STR_TRANSFER);
     updateControlsForTransType();
 
     m_bill_data.TRANSAMOUNT = t.TRANSAMOUNT;
@@ -489,7 +489,7 @@ void mmBDDialog::CreateControls()
     // Status --------------------------------------------
     m_choice_status = new wxChoice(this, ID_DIALOG_TRANS_STATUS);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
     {
         m_choice_status->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
@@ -819,7 +819,7 @@ void mmBDDialog::updateControlsForTransType()
     m_transfer = false;
     switch (m_choice_transaction_type->GetSelection())
     {
-    case Model_Checking::TRANSFER:
+    case Model_Checking::TYPE_ID_TRANSFER:
     {
         m_transfer = true;
         mmToolTip(textAmount_, amountTransferTip_);
@@ -829,7 +829,7 @@ void mmBDDialog::updateControlsForTransType()
         m_bill_data.PAYEEID = -1;
         break;
     }
-    case Model_Checking::WITHDRAWAL:
+    case Model_Checking::TYPE_ID_WITHDRAWAL:
     {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_("Account"));
@@ -842,7 +842,7 @@ void mmBDDialog::updateControlsForTransType()
         OnPayee(evt);
         break;
     }
-    case Model_Checking::DEPOSIT:
+    case Model_Checking::TYPE_ID_DEPOSIT:
     {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_("Account"));
@@ -1052,7 +1052,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         bill->ACCOUNTID = m_bill_data.ACCOUNTID;
         bill->TOACCOUNTID = m_bill_data.TOACCOUNTID;
         bill->PAYEEID = m_bill_data.PAYEEID;
-        bill->TRANSCODE = Model_Checking::all_type()[m_choice_transaction_type->GetSelection()];
+        bill->TRANSCODE = Model_Checking::TYPE_STR[m_choice_transaction_type->GetSelection()];
         bill->TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
         bill->STATUS = m_bill_data.STATUS;
         bill->TRANSACTIONNUMBER = m_bill_data.TRANSACTIONNUMBER;
@@ -1134,7 +1134,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             tran->ACCOUNTID = m_bill_data.ACCOUNTID;
             tran->TOACCOUNTID = m_bill_data.TOACCOUNTID;
             tran->PAYEEID = m_bill_data.PAYEEID;
-            tran->TRANSCODE = Model_Checking::all_type()[m_choice_transaction_type->GetSelection()];
+            tran->TRANSCODE = Model_Checking::TYPE_STR[m_choice_transaction_type->GetSelection()];
             tran->TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
             tran->STATUS = m_bill_data.STATUS;
             tran->TRANSACTIONNUMBER = m_bill_data.TRANSACTIONNUMBER;
@@ -1418,7 +1418,7 @@ void mmBDDialog::activateSplitTransactionsDlg()
         m_bill_data.local_splits = dlg.mmGetResult();
         m_bill_data.TRANSAMOUNT = Model_Splittransaction::get_total(m_bill_data.local_splits);
         m_bill_data.CATEGID = -1;
-        if (m_choice_transaction_type->GetSelection() == Model_Checking::TRANSFER && m_bill_data.TRANSAMOUNT < 0)
+        if (m_choice_transaction_type->GetSelection() == Model_Checking::TYPE_ID_TRANSFER && m_bill_data.TRANSAMOUNT < 0)
         {
             m_bill_data.TRANSAMOUNT = -m_bill_data.TRANSAMOUNT;
         }
@@ -1466,7 +1466,7 @@ void mmBDDialog::setCategoryLabel()
         && Option::instance().TransCategorySelectionTransfer() == Option::LASTUSED)
     {
         Model_Checking::Data_Set transactions = Model_Checking::instance().find(
-            Model_Checking::TRANSCODE(Model_Checking::TRANSFER, EQUAL)
+            Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, EQUAL)
             , Model_Checking::TRANSDATE(wxDateTime(23,59,59,999), LESS_OR_EQUAL));
 
         if (!transactions.empty())

--- a/src/dbcheck.cpp
+++ b/src/dbcheck.cpp
@@ -41,7 +41,7 @@ bool dbCheck::checkAccounts()
     // Transactions
     const auto &transactions = Model_Checking::instance().all();
     for (const auto& trx : transactions)
-        if (!Model_Account::instance().get(trx.ACCOUNTID) || (Model_Checking::type(trx) == Model_Checking::TRANSFER && !Model_Account::instance().get(trx.TOACCOUNTID)))
+        if (!Model_Account::instance().get(trx.ACCOUNTID) || (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER && !Model_Account::instance().get(trx.TOACCOUNTID)))
         {
             result = false;
         }
@@ -49,7 +49,7 @@ bool dbCheck::checkAccounts()
     // BillsDeposits
     const auto &bills = Model_Billsdeposits::instance().all();
     for (const auto& bill : bills)
-        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type(bill) == Model_Checking::TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
+        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type_id(bill) == Model_Checking::TYPE_ID_TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
         {
             result = false;
         }

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -1235,7 +1235,7 @@ bool mmFilterTransactionsDialog::mmIsStatusMatches(const wxString& itemStatus) c
     }
     else if ("A" == filterStatus) // All Except Reconciled
     {
-        return "R" != itemStatus;
+        return Model_Checking::STATUS_KEY_RECONCILED != itemStatus;
     }
     return false;
 }
@@ -1243,21 +1243,21 @@ bool mmFilterTransactionsDialog::mmIsStatusMatches(const wxString& itemStatus) c
 bool mmFilterTransactionsDialog::mmIsTypeMaches(const wxString& typeState, int accountid, int toaccountid) const
 {
     bool result = false;
-    if (typeState == Model_Checking::all_type()[Model_Checking::TRANSFER] && cbTypeTransferTo_->GetValue() &&
+    if (typeState == Model_Checking::TYPE_STR_TRANSFER && cbTypeTransferTo_->GetValue() &&
         (!mmIsAccountChecked() || (m_selected_accounts_id.Index(accountid) != wxNOT_FOUND)))
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::TRANSFER] && cbTypeTransferFrom_->GetValue() &&
+    else if (typeState == Model_Checking::TYPE_STR_TRANSFER && cbTypeTransferFrom_->GetValue() &&
              (!mmIsAccountChecked() || (m_selected_accounts_id.Index(toaccountid) != wxNOT_FOUND)))
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::WITHDRAWAL] && cbTypeWithdrawal_->IsChecked())
+    else if (typeState == Model_Checking::TYPE_STR_WITHDRAWAL && cbTypeWithdrawal_->IsChecked())
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::DEPOSIT] && cbTypeDeposit_->IsChecked())
+    else if (typeState == Model_Checking::TYPE_STR_DEPOSIT && cbTypeDeposit_->IsChecked())
     {
         result = true;
     }
@@ -1840,7 +1840,7 @@ const wxString mmFilterTransactionsDialog::mmGetJsonSetings(bool i18n) const
     // Status
     if (statusCheckBox_->IsChecked())
     {
-        wxArrayString s = Model_Checking::all_status();
+        wxArrayString s = Model_Checking::STATUS_STR;
         s.Add(wxTRANSLATE("All Except Reconciled"));
         int item = choiceStatus_->GetSelection();
         wxString status;

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -75,7 +75,7 @@ const wxString mmExportTransaction::getTransactionCSV(const Model_Checking::Full
         for (const auto &split_entry : full_tran.m_splits)
         {
             double valueSplit = split_entry.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL)
+            if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL)
                 valueSplit = -valueSplit;
             const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
             const wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
@@ -165,7 +165,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
     }
 
     buffer << "D" << mmGetDateForDisplay(full_tran.TRANSDATE, dateMask) << "\n";
-    buffer << "C" << (full_tran.STATUS == "R" ? "R" : "") << "\n";
+    buffer << "C" << (full_tran.STATUS == Model_Checking::STATUS_KEY_RECONCILED ? "R" : "") << "\n";
     double value = Model_Checking::balance(full_tran
         , (reverce ? full_tran.TOACCOUNTID : full_tran.ACCOUNTID));
     const wxString& s = wxString::FromCDouble(value, 2);
@@ -187,7 +187,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
     for (const auto &split_entry : full_tran.m_splits)
     {
         double valueSplit = split_entry.SPLITTRANSAMOUNT;
-        if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL)
+        if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL)
             valueSplit = -valueSplit;
         const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
         wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
@@ -424,7 +424,7 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
         for (const auto &split_entry : full_tran.m_splits)
         {
             double valueSplit = split_entry.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL) {
+            if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL) {
                 valueSplit = -valueSplit;
             }
 

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -472,7 +472,7 @@ void mmQIFExportDialog::mmExportQIF()
     wxArrayInt allCustomFields4Export;
     wxArrayInt allTags4Export;
     const auto transactions = Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL));
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL));
 
     if (exp_transactions && !transactions.empty())
     {
@@ -524,7 +524,7 @@ void mmQIFExportDialog::mmExportQIF()
                 mmExportTransaction::getTransactionJSON(json_writer, full_tran);
                 allAccounts4Export[account_id] = "";
                 if (allPayees4Export.Index(full_tran.PAYEEID) == wxNOT_FOUND
-                    && full_tran.TRANSCODE != Model_Checking::all_type()[Model_Checking::TRANSFER]) {
+                    && full_tran.TRANSCODE != Model_Checking::TYPE_STR_TRANSFER) {
                     allPayees4Export.Add(full_tran.PAYEEID);
                 }
 

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -95,7 +95,7 @@ mmUnivCSVDialog::mmUnivCSVDialog(
     m_account_id(account_id),
     m_file_path(file_path),
     decimal_(Model_Currency::GetBaseCurrency()->DECIMAL_POINT),
-    depositType_(Model_Checking::all_type()[Model_Checking::DEPOSIT])
+    depositType_(Model_Checking::TYPE_STR_DEPOSIT)
 {
     CSVFieldName_[UNIV_CSV_ID] = wxTRANSLATE("ID");
     CSVFieldName_[UNIV_CSV_DATE] = wxTRANSLATE("Date");
@@ -1609,7 +1609,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
 
     for (const auto& pBankTransaction : txns)
     {
-        if (Model_Checking::status(pBankTransaction) == Model_Checking::VOID_ || !pBankTransaction.DELETEDTIME.IsEmpty())
+        if (Model_Checking::status_id(pBankTransaction) == Model_Checking::STATUS_ID_VOID || !pBankTransaction.DELETEDTIME.IsEmpty())
             continue;
 
         Model_Checking::Full_Data tran(pBankTransaction, split, tags);
@@ -1633,7 +1633,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
             Model_Category::Data* category = Model_Category::instance().get(splt.CATEGID);
 
             double amt = splt.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(pBankTransaction) == Model_Checking::WITHDRAWAL
+            if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_WITHDRAWAL
                 && has_split) {
                 amt = -amt;
             }
@@ -1705,7 +1705,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                     itemType = ITransactionsFile::TYPE_NUMBER;
                     break;
                 case UNIV_CSV_TYPE:
-                    entry = Model_Checking::all_type()[Model_Checking::type(pBankTransaction)];
+                    entry = Model_Checking::TYPE_STR[Model_Checking::type_id(pBankTransaction)];
                     break;
                 case UNIV_CSV_ID:
                     entry = wxString::Format("%i", tran.TRANSID);
@@ -1916,7 +1916,7 @@ void mmUnivCSVDialog::update_preview()
             std::stable_sort(txns.begin(), txns.end(), SorterByTRANSDATE());
             for (const auto& pBankTransaction : txns)
             {
-                if (Model_Checking::status(pBankTransaction) == Model_Checking::VOID_ || !pBankTransaction.DELETEDTIME.IsEmpty())
+                if (Model_Checking::status_id(pBankTransaction) == Model_Checking::STATUS_ID_VOID || !pBankTransaction.DELETEDTIME.IsEmpty())
                     continue;
 
                 Model_Checking::Full_Data tran(pBankTransaction, split, tags);
@@ -1948,7 +1948,7 @@ void mmUnivCSVDialog::update_preview()
                     Model_Currency::Data* currency = Model_Account::currency(from_account);
 
                     double amt = splt.SPLITTRANSAMOUNT;
-                    if (Model_Checking::type(pBankTransaction) == Model_Checking::WITHDRAWAL
+                    if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_WITHDRAWAL
                         && has_split) {
                         amt = -amt;
                     }
@@ -2438,7 +2438,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
 
         if (find_if(csvFieldOrder_.begin(), csvFieldOrder_.end(), [](const std::pair<int, int>& element) {return element.first == UNIV_CSV_TYPE; }) == csvFieldOrder_.end()) {
             if ((amount > 0.0 && !m_reverce_sign) || (amount <= 0.0 && m_reverce_sign)) {
-                holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
             }
         }
 
@@ -2551,7 +2551,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = Model_Checking::all_type()[Model_Checking::WITHDRAWAL];
+        holder.Type = Model_Checking::TYPE_STR_WITHDRAWAL;
         break;
 
     case UNIV_CSV_DEPOSIT:
@@ -2569,7 +2569,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+        holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
         break;
 
         // A number of type options are supported to make amount positive 
@@ -2579,7 +2579,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         {
             if (depositType_.CmpNoCase(token) == 0)
             {
-                holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
                 break;
             }
         }
@@ -2587,7 +2587,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         {
             for (const wxString& entry : { "debit", "deposit", "+" }) {
                 if (entry.CmpNoCase(token) == 0) {
-                    holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                    holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
                     break;
                 }
             }

--- a/src/import_export/univcsvdialog.h
+++ b/src/import_export/univcsvdialog.h
@@ -130,7 +130,7 @@ private:
     struct tran_holder
     {
         wxDateTime Date;
-        wxString Type = Model_Checking::all_type()[Model_Checking::WITHDRAWAL];
+        wxString Type = Model_Checking::TYPE_STR_WITHDRAWAL;
         wxString Status = "";
         int ToAccountID = -1;
         double ToAmount = 0.0;

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -60,7 +60,7 @@ wxBEGIN_EVENT_TABLE(mmCheckingPanel, wxPanel)
     EVT_SEARCHCTRL_SEARCH_BTN(wxID_FIND, mmCheckingPanel::OnSearchTxtEntered)
     EVT_MENU_RANGE(wxID_HIGHEST + MENU_VIEW_ALLTRANSACTIONS, wxID_HIGHEST + MENU_VIEW_ALLTRANSACTIONS + menu_labels().size()
         , mmCheckingPanel::OnViewPopupSelected)
-    EVT_MENU_RANGE(Model_Checking::WITHDRAWAL, Model_Checking::TRANSFER, mmCheckingPanel::OnNewTransaction)
+    EVT_MENU_RANGE(Model_Checking::TYPE_ID_WITHDRAWAL, Model_Checking::TYPE_ID_TRANSFER, mmCheckingPanel::OnNewTransaction)
 wxEND_EVENT_TABLE()
 //----------------------------------------------------------------------------
 
@@ -172,9 +172,9 @@ void mmCheckingPanel::filterTable()
         double transaction_amount = Model_Checking::amount(tran, m_AccountID);
         if (tran.DELETEDTIME.IsEmpty())
         {
-            if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_)
+            if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID)
                 m_account_balance += transaction_amount;
-            if (Model_Checking::status(tran.STATUS) == Model_Checking::RECONCILED)
+            if (Model_Checking::status_id(tran.STATUS) == Model_Checking::STATUS_ID_RECONCILED)
                 m_reconciled_balance += transaction_amount;
         }
 
@@ -254,7 +254,7 @@ void mmCheckingPanel::filterTable()
         {
             if (!expandSplits) {
                 m_listCtrlAccount->m_trans.push_back(full_tran);
-                if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_ && tran.DELETEDTIME.IsEmpty())
+                if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID && tran.DELETEDTIME.IsEmpty())
                     m_filteredBalance += transaction_amount;
             }
             else
@@ -285,7 +285,7 @@ void mmCheckingPanel::filterTable()
                         if(!tagnames.IsEmpty())
                             full_tran.TAGNAMES.Append((full_tran.TAGNAMES.IsEmpty() ? "" : ", ") + tagnames.Trim());
                         m_listCtrlAccount->m_trans.push_back(full_tran);
-                        if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_ && tran.DELETEDTIME.IsEmpty())
+                        if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID && tran.DELETEDTIME.IsEmpty())
                             m_filteredBalance += full_tran.AMOUNT;
                     }
                 }
@@ -320,9 +320,9 @@ void mmCheckingPanel::OnButtonRightDown(wxMouseEvent& event)
     case wxID_NEW:
     {
         wxMenu menu;
-        menu.Append(Model_Checking::WITHDRAWAL, _("&New Withdrawal..."));
-        menu.Append(Model_Checking::DEPOSIT, _("&New Deposit..."));
-        menu.Append(Model_Checking::TRANSFER, _("&New Transfer..."));
+        menu.Append(Model_Checking::TYPE_ID_WITHDRAWAL, _("&New Withdrawal..."));
+        menu.Append(Model_Checking::TYPE_ID_DEPOSIT, _("&New Deposit..."));
+        menu.Append(Model_Checking::TYPE_ID_TRANSFER, _("&New Transfer..."));
         PopupMenu(&menu);
     }
     default:
@@ -908,7 +908,7 @@ void mmCheckingPanel::OnSearchTxtEntered(wxCommandEvent& event)
 void mmCheckingPanel::DisplaySplitCategories(int transID)
 {
     const Model_Checking::Data* tran = Model_Checking::instance().get(transID);
-    int transType = Model_Checking::type(tran->TRANSCODE);
+    int transType = Model_Checking::type_id(tran->TRANSCODE);
 
     Model_Checking::Data *transaction = Model_Checking::instance().get(transID);
     auto splits = Model_Checking::splittransaction(transaction);

--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -205,8 +205,8 @@ void htmlWidgetTop7Categories::getTopCategoryStats(
     const auto &transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
-        , Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL));
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
+        , Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL));
 
     for (const auto &trx : transactions)
     {
@@ -214,7 +214,7 @@ void htmlWidgetTop7Categories::getTopCategoryStats(
         if (Model_Checking::foreignTransactionAsTransfer(trx) || !trx.DELETEDTIME.IsEmpty())
             continue;
 
-        bool withdrawal = Model_Checking::type(trx) == Model_Checking::WITHDRAWAL;
+        bool withdrawal = Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_WITHDRAWAL;
         const auto it = split.find(trx.TRANSID);
 
         double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
@@ -315,7 +315,7 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         if (account) accountStr = account->ACCOUNTNAME;
 
         wxString payeeStr = "";
-        if (Model_Billsdeposits::type(entry) == Model_Checking::TRANSFER)
+        if (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_TRANSFER)
         {
             const Model_Account::Data *to_account = Model_Account::instance().get(entry.TOACCOUNTID);
             if (to_account) payeeStr = to_account->ACCOUNTNAME;
@@ -325,10 +325,10 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         {
             const Model_Payee::Data* payee = Model_Payee::instance().get(entry.PAYEEID);
             payeeStr = accountStr;
-            payeeStr += (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? " &rarr; " : " &larr; ");
+            payeeStr += (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_WITHDRAWAL ? " &rarr; " : " &larr; ");
             if (payee) payeeStr += payee->PAYEENAME;
         }
-        double amount = (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
+        double amount = (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
         wxString notes = HTMLEncode(entry.NOTES);
         bd_days.push_back(std::make_tuple(daysPayment, payeeStr, daysRemainingStr, amount, account, notes));
     }
@@ -388,8 +388,8 @@ const wxString htmlWidgetIncomeVsExpenses::getHTMLText()
     const auto &transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(date_range.get()->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range.get()->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
-        , Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL)
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
+        , Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL)
     );
 
     for (const auto& pBankTransaction : transactions)
@@ -402,7 +402,7 @@ const wxString htmlWidgetIncomeVsExpenses::getHTMLText()
         double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(pBankTransaction.ACCOUNTID)->CURRENCYID, pBankTransaction.TRANSDATE);
 
         int idx = pBankTransaction.ACCOUNTID;
-        if (Model_Checking::type(pBankTransaction) == Model_Checking::DEPOSIT)
+        if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_DEPOSIT)
             incomeExpensesStats[idx].first += pBankTransaction.TRANSAMOUNT * convRate;
         else
             incomeExpensesStats[idx].second += pBankTransaction.TRANSAMOUNT * convRate;
@@ -493,13 +493,13 @@ const wxString htmlWidgetStatistics::getHTMLText()
         if (Model_Checking::foreignTransactionAsTransfer(trx))
             continue;
 
-        if (Model_Checking::status(trx) == Model_Checking::FOLLOWUP)
+        if (Model_Checking::status_id(trx) == Model_Checking::STATUS_ID_FOLLOWUP)
             countFollowUp++;
 
         accountStats[trx.ACCOUNTID].first += Model_Checking::reconciled(trx, trx.ACCOUNTID);
         accountStats[trx.ACCOUNTID].second += Model_Checking::balance(trx, trx.ACCOUNTID);
 
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER)
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER)
         {
             accountStats[trx.TOACCOUNTID].first += Model_Checking::reconciled(trx, trx.TOACCOUNTID);
             accountStats[trx.TOACCOUNTID].second += Model_Checking::balance(trx, trx.TOACCOUNTID);
@@ -673,7 +673,7 @@ void htmlWidgetAccounts::get_account_stats()
         accountStats_[trx.ACCOUNTID].first += Model_Checking::reconciled(trx, trx.ACCOUNTID);
         accountStats_[trx.ACCOUNTID].second += Model_Checking::balance(trx, trx.ACCOUNTID);
 
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER)
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER)
         {
             accountStats_[trx.TOACCOUNTID].first += Model_Checking::reconciled(trx, trx.TOACCOUNTID);
             accountStats_[trx.TOACCOUNTID].second += Model_Checking::balance(trx, trx.TOACCOUNTID);

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -81,22 +81,22 @@ wxDate Model_Billsdeposits::NEXTOCCURRENCEDATE(const Data& r)
     return Model::to_date(r.NEXTOCCURRENCEDATE);
 }
 
-Model_Checking::TYPE Model_Billsdeposits::type(const Data& r)
+Model_Checking::TYPE_ID Model_Billsdeposits::type_id(const Data& r)
 {
-    return Model_Checking::type(r.TRANSCODE);
+    return Model_Checking::type_id(r.TRANSCODE);
 }
-Model_Checking::TYPE Model_Billsdeposits::type(const Data* r)
+Model_Checking::TYPE_ID Model_Billsdeposits::type_id(const Data* r)
 {
-    return Model_Checking::type(r->TRANSCODE);
+    return Model_Checking::type_id(r->TRANSCODE);
 }
 
-Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data& r)
+Model_Checking::STATUS_ID Model_Billsdeposits::status_id(const Data& r)
 {
-    return Model_Checking::status(r.STATUS);
+    return Model_Checking::status_id(r.STATUS);
 }
-Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data* r)
+Model_Checking::STATUS_ID Model_Billsdeposits::status_id(const Data* r)
 {
-    return Model_Checking::status(r->STATUS);
+    return Model_Checking::status_id(r->STATUS);
 }
 
 /**
@@ -112,14 +112,14 @@ bool Model_Billsdeposits::remove(int id)
     return this->remove(id, db_);
 }
 
-DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(Model_Checking::STATUS_ENUM status, OP op)
+DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(Model_Checking::STATUS_ID status, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::STATUS(Model_Checking::all_status_key()[status], op);
+    return DB_Table_BILLSDEPOSITS_V1::STATUS(Model_Checking::STATUS_KEY[status], op);
 }
 
-DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(Model_Checking::TYPE type, OP op)
+DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(Model_Checking::TYPE_ID type, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(Model_Checking::all_type()[type], op);
+    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(Model_Checking::TYPE_STR[type], op);
 }
 
 const Model_Budgetsplittransaction::Data_Set Model_Billsdeposits::splittransaction(const Data* r)
@@ -173,9 +173,9 @@ bool Model_Billsdeposits::allowExecution()
 
 bool Model_Billsdeposits::AllowTransaction(const Data& r)
 {
-    if (r.STATUS == "V")
+    if (r.STATUS == Model_Checking::STATUS_KEY_VOID)
         return true;
-    if (r.TRANSCODE != Model_Checking::WITHDRAWAL_STR && r.TRANSCODE != Model_Checking::TRANSFER_STR)
+    if (r.TRANSCODE != Model_Checking::TYPE_STR_WITHDRAWAL && r.TRANSCODE != Model_Checking::TYPE_STR_TRANSFER)
         return true;
 
     const int acct_id = r.ACCOUNTID;
@@ -348,7 +348,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
 
     PAYEENAME = Model_Payee::get_payee_name(r.PAYEEID);
-    if (Model_Billsdeposits::type(r) == Model_Checking::TRANSFER)
+    if (Model_Billsdeposits::type_id(r) == Model_Checking::TYPE_ID_TRANSFER)
     {
         PAYEENAME = Model_Account::get_account_name(r.TOACCOUNTID);
     }
@@ -357,7 +357,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
 
 wxString Model_Billsdeposits::Full_Data::real_payee_name() const
 {
-    if (Model_Checking::TRANSFER == Model_Checking::type(this->TRANSCODE))
+    if (Model_Checking::TYPE_ID_TRANSFER == Model_Checking::type_id(this->TRANSCODE))
     {
         return ("> " + this->PAYEENAME);
     }

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -76,10 +76,10 @@ public:
         int BDID = 0;
         // This relates the 'Date Due' field.
         wxString TRANSDATE = wxDateTime::Now().FormatISOCombined();
-        wxString STATUS = Model_Checking::all_status()[Model_Checking::NONE];
+        wxString STATUS = Model_Checking::STATUS_STR_NONE;
         int ACCOUNTID = -1;
         int TOACCOUNTID = -1;
-        wxString TRANSCODE = Model_Checking::WITHDRAWAL_STR;
+        wxString TRANSCODE = Model_Checking::TYPE_STR_WITHDRAWAL;
         int CATEGID = -1;
         double TRANSAMOUNT = 0;
         double TOTRANSAMOUNT = 0;
@@ -134,10 +134,10 @@ public:
     static wxDate NEXTOCCURRENCEDATE(const Data* r);
     // This relates the 'Date Paid' field
     static wxDate NEXTOCCURRENCEDATE(const Data& r);
-    static Model_Checking::TYPE type(const Data* r);
-    static Model_Checking::TYPE type(const Data& r);
-    static Model_Checking::STATUS_ENUM status(const Data* r);
-    static Model_Checking::STATUS_ENUM status(const Data& r);
+    static Model_Checking::TYPE_ID type_id(const Data* r);
+    static Model_Checking::TYPE_ID type_id(const Data& r);
+    static Model_Checking::STATUS_ID status_id(const Data* r);
+    static Model_Checking::STATUS_ID status_id(const Data& r);
 
     /**
     * Decodes the internal fields and sets the condition of the following parameters:
@@ -162,8 +162,8 @@ public:
     */
     bool remove(int id);
 
-    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(Model_Checking::STATUS_ENUM status, OP op = EQUAL);
-    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(Model_Checking::TYPE type, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(Model_Checking::STATUS_ID status, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(Model_Checking::TYPE_ID type, OP op = EQUAL);
 
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data* r);
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data& r);

--- a/src/model/Model_Category.cpp
+++ b/src/model/Model_Category.cpp
@@ -232,28 +232,28 @@ bool Model_Category::has_income(int id)
     {
         if (!tran.DELETEDTIME.IsEmpty()) continue;
 
-        switch (Model_Checking::type(tran))
+        switch (Model_Checking::type_id(tran))
         {
-        case Model_Checking::WITHDRAWAL:
+        case Model_Checking::TYPE_ID_WITHDRAWAL:
             sum -= tran.TRANSAMOUNT;
             break;
-        case Model_Checking::DEPOSIT:
+        case Model_Checking::TYPE_ID_DEPOSIT:
             sum += tran.TRANSAMOUNT;
-        case Model_Checking::TRANSFER:
+        case Model_Checking::TYPE_ID_TRANSFER:
         default:
             break;
         }
 
         for (const auto& split: splits[tran.id()])
         {
-            switch (Model_Checking::type(tran))
+            switch (Model_Checking::type_id(tran))
             {
-            case Model_Checking::WITHDRAWAL:
+            case Model_Checking::TYPE_ID_WITHDRAWAL:
                 sum -= split.SPLITTRANSAMOUNT;
                 break;
-            case Model_Checking::DEPOSIT:
+            case Model_Checking::TYPE_ID_DEPOSIT:
                 sum += split.SPLITTRANSAMOUNT;
-            case Model_Checking::TRANSFER:
+            case Model_Checking::TYPE_ID_TRANSFER:
             default:
                 break;
             }
@@ -298,7 +298,7 @@ void Model_Category::getCategoryStats(
     //Calculations
     auto splits = Model_Splittransaction::instance().get_all();
     for (const auto& transaction : Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
         , Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)))
     {
@@ -328,7 +328,7 @@ void Model_Category::getCategoryStats(
 
         if (categID > -1)
         {
-            if (Model_Checking::type(transaction) != Model_Checking::TRANSFER)
+            if (Model_Checking::type_id(transaction) != Model_Checking::TYPE_ID_TRANSFER)
             {
                 // Do not include asset or stock transfers in income expense calculations.
                 if (Model_Checking::foreignTransactionAsTransfer(transaction))
@@ -349,7 +349,7 @@ void Model_Category::getCategoryStats(
             for (const auto& entry : splits[transaction.id()])
             {
                 categoryStats[entry.CATEGID][month] += entry.SPLITTRANSAMOUNT
-                    * convRate * ((Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL) ? -1 : 1);
+                    * convRate * ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL) ? -1 : 1);
             }
         }
     }

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -29,25 +29,40 @@
 #include "attachmentdialog.h"
 #include "util.h"
 
-const std::vector<std::pair<Model_Checking::TYPE, wxString> > Model_Checking::TYPE_CHOICES =
+const std::vector<std::pair<Model_Checking::TYPE_ID, wxString> > Model_Checking::TYPE_CHOICES =
 {
-    {Model_Checking::WITHDRAWAL, wxString(wxTRANSLATE("Withdrawal"))}
-    , {Model_Checking::DEPOSIT, wxString(wxTRANSLATE("Deposit"))}
-    , {Model_Checking::TRANSFER, wxString(wxTRANSLATE("Transfer"))}
+    { Model_Checking::TYPE_ID_WITHDRAWAL, wxString(wxTRANSLATE("Withdrawal")) },
+    { Model_Checking::TYPE_ID_DEPOSIT,    wxString(wxTRANSLATE("Deposit")) },
+    { Model_Checking::TYPE_ID_TRANSFER,   wxString(wxTRANSLATE("Transfer")) }
 };
 
-const std::vector<std::pair<Model_Checking::STATUS_ENUM, wxString> > Model_Checking::STATUS_CHOICES =
+const std::vector<std::tuple<Model_Checking::STATUS_ID, wxString, wxString> > Model_Checking::STATUS_CHOICES =
 {
-    {Model_Checking::NONE, wxTRANSLATE("Unreconciled")}
-    , {Model_Checking::RECONCILED, wxString(wxTRANSLATE("Reconciled"))}
-    , {Model_Checking::VOID_, wxString(wxTRANSLATE("Void"))}
-    , {Model_Checking::FOLLOWUP, wxString(wxTRANSLATE("Follow Up"))}
-    , {Model_Checking::DUPLICATE_, wxString(wxTRANSLATE("Duplicate"))}
+    { Model_Checking::STATUS_ID_NONE,       wxString(""),  wxString(wxTRANSLATE("Unreconciled")) },
+    { Model_Checking::STATUS_ID_RECONCILED, wxString("R"), wxString(wxTRANSLATE("Reconciled")) },
+    { Model_Checking::STATUS_ID_VOID,       wxString("V"), wxString(wxTRANSLATE("Void")) },
+    { Model_Checking::STATUS_ID_FOLLOWUP,   wxString("F"), wxString(wxTRANSLATE("Follow Up")) },
+    { Model_Checking::STATUS_ID_DUPLICATE,  wxString("D"), wxString(wxTRANSLATE("Duplicate")) }
 };
 
-const wxString Model_Checking::WITHDRAWAL_STR = all_type()[WITHDRAWAL];
-const wxString Model_Checking::DEPOSIT_STR = all_type()[DEPOSIT];
-const wxString Model_Checking::TRANSFER_STR = all_type()[TRANSFER];
+wxArrayString Model_Checking::TYPE_STR = type_str_all();
+const wxString Model_Checking::TYPE_STR_WITHDRAWAL = TYPE_STR[TYPE_ID_WITHDRAWAL];
+const wxString Model_Checking::TYPE_STR_DEPOSIT    = TYPE_STR[TYPE_ID_DEPOSIT];
+const wxString Model_Checking::TYPE_STR_TRANSFER   = TYPE_STR[TYPE_ID_TRANSFER];
+
+wxArrayString Model_Checking::STATUS_KEY = status_key_all();
+const wxString Model_Checking::STATUS_KEY_NONE       = STATUS_KEY[STATUS_ID_NONE];
+const wxString Model_Checking::STATUS_KEY_RECONCILED = STATUS_KEY[STATUS_ID_RECONCILED];
+const wxString Model_Checking::STATUS_KEY_VOID       = STATUS_KEY[STATUS_ID_VOID];
+const wxString Model_Checking::STATUS_KEY_FOLLOWUP   = STATUS_KEY[STATUS_ID_FOLLOWUP];
+const wxString Model_Checking::STATUS_KEY_DUPLICATE  = STATUS_KEY[STATUS_ID_DUPLICATE];
+
+wxArrayString Model_Checking::STATUS_STR = status_str_all();
+const wxString Model_Checking::STATUS_STR_NONE       = STATUS_STR[STATUS_ID_NONE];
+const wxString Model_Checking::STATUS_STR_RECONCILED = STATUS_STR[STATUS_ID_RECONCILED];
+const wxString Model_Checking::STATUS_STR_VOID       = STATUS_STR[STATUS_ID_VOID];
+const wxString Model_Checking::STATUS_STR_FOLLOWUP   = STATUS_STR[STATUS_ID_FOLLOWUP];
+const wxString Model_Checking::STATUS_STR_DUPLICATE  = STATUS_STR[STATUS_ID_DUPLICATE];
 
 Model_Checking::Model_Checking() : Model<DB_Table_CHECKINGACCOUNT_V1>()
 {
@@ -57,24 +72,39 @@ Model_Checking::~Model_Checking()
 {
 }
 
-wxArrayString Model_Checking::all_type()
+wxArrayString Model_Checking::type_str_all()
 {
     wxArrayString types;
-    for (const auto& r : TYPE_CHOICES) types.Add(r.second);
+    int i = 0;
+    for (const auto& r : TYPE_CHOICES)
+    {
+        wxASSERT_MSG(r.first == i++, "Wrong order in Model_Checking::TYPE_CHOICES");
+        types.Add(r.second);
+    }
     return types;
 }
 
-wxArrayString Model_Checking::all_status()
+wxArrayString Model_Checking::status_key_all()
 {
     wxArrayString status;
-    for (const auto& r : STATUS_CHOICES) status.Add(r.second);
+    int i = 0;
+    for (const auto& r : STATUS_CHOICES)
+    {
+        wxASSERT_MSG(std::get<0>(r) == i++, "Wrong order in Model_Checking::STATUS_CHOICES");
+        status.Add(std::get<1>(r));
+    }
     return status;
 }
 
-wxArrayString Model_Checking::all_status_key()
+wxArrayString Model_Checking::status_str_all()
 {
     wxArrayString status;
-    for (const auto& r : STATUS_CHOICES) status.Add(status_key(r.second));
+    int i = 0;
+    for (const auto& r : STATUS_CHOICES)
+    {
+        wxASSERT_MSG(std::get<0>(r) == i++, "Wrong order in Model_Checking::STATUS_CHOICES");
+        status.Add(std::get<2>(r));
+    }
     return status;
 }
 
@@ -162,14 +192,14 @@ const Model_Splittransaction::Data_Set Model_Checking::splittransaction(const Da
     return Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(r.TRANSID));
 }
 
-DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ENUM status, OP op)
+DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ID status, OP op)
 {
-    return DB_Table_CHECKINGACCOUNT_V1::STATUS(all_status_key()[status], op);
+    return DB_Table_CHECKINGACCOUNT_V1::STATUS(STATUS_KEY[status], op);
 }
 
-DB_Table_CHECKINGACCOUNT_V1::TRANSCODE Model_Checking::TRANSCODE(TYPE type, OP op)
+DB_Table_CHECKINGACCOUNT_V1::TRANSCODE Model_Checking::TRANSCODE(TYPE_ID type, OP op)
 {
-    return DB_Table_CHECKINGACCOUNT_V1::TRANSCODE(all_type()[type], op);
+    return DB_Table_CHECKINGACCOUNT_V1::TRANSCODE(TYPE_STR[type], op);
 }
 
 DB_Table_CHECKINGACCOUNT_V1::TRANSACTIONNUMBER Model_Checking::TRANSACTIONNUMBER(const wxString& num, OP op)
@@ -204,10 +234,10 @@ wxDateTime Model_Checking::TRANSDATE(const Data& r)
     return Model::to_date(r.TRANSDATE);
 }
 
-Model_Checking::TYPE Model_Checking::type(const wxString& r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const wxString& r)
 {
-    if (r.empty()) return TYPE::WITHDRAWAL;
-    static std::unordered_map<wxString, TYPE> cache;
+    if (r.empty()) return TYPE_ID_WITHDRAWAL;
+    static std::unordered_map<wxString, TYPE_ID> cache;
     const auto it = cache.find(r);
     if (it != cache.end()) return it->second;
 
@@ -220,63 +250,59 @@ Model_Checking::TYPE Model_Checking::type(const wxString& r)
         }
     }
 
-    cache.insert(std::make_pair(r, TYPE::WITHDRAWAL));
-    return TYPE::WITHDRAWAL;
+    cache.insert(std::make_pair(r, TYPE_ID_WITHDRAWAL));
+    return TYPE_ID_WITHDRAWAL;
 }
-Model_Checking::TYPE Model_Checking::type(const Data& r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const Data& r)
 {
-    return type(r.TRANSCODE);
+    return type_id(r.TRANSCODE);
 }
-Model_Checking::TYPE Model_Checking::type(const Data* r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const Data* r)
 {
-    return type(r->TRANSCODE);
+    return type_id(r->TRANSCODE);
 }
 
-Model_Checking::STATUS_ENUM Model_Checking::status(const wxString& r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const wxString& r)
 {
-    static std::unordered_map<wxString, STATUS_ENUM> cache;
+    static std::unordered_map<wxString, STATUS_ID> cache;
     const auto it = cache.find(r);
     if (it != cache.end()) return it->second;
 
     for (const auto & s : STATUS_CHOICES)
     {
-        if (r.CmpNoCase(s.second) == 0)
+        if (r.CmpNoCase(std::get<1>(s)) == 0 || r.CmpNoCase(std::get<2>(s)) == 0)
         {
-            cache.insert(std::make_pair(r, s.first));
-            return s.first;
+            STATUS_ID ret = std::get<0>(s);
+            cache.insert(std::make_pair(r, ret));
+            return ret;
         }
     }
 
-    STATUS_ENUM ret = NONE;
-    if (r.CmpNoCase("R") == 0) ret = RECONCILED;
-    else if (r.CmpNoCase("V") == 0) ret = VOID_;
-    else if (r.CmpNoCase("F") == 0) ret = FOLLOWUP;
-    else if (r.CmpNoCase("D") == 0) ret = DUPLICATE_;
+    STATUS_ID ret = STATUS_ID_NONE;
     cache.insert(std::make_pair(r, ret));
-
     return ret;
 }
-Model_Checking::STATUS_ENUM Model_Checking::status(const Data& r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const Data& r)
 {
-    return status(r.STATUS);
+    return status_id(r.STATUS);
 }
-Model_Checking::STATUS_ENUM Model_Checking::status(const Data* r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const Data* r)
 {
-    return status(r->STATUS);
+    return status_id(r->STATUS);
 }
 
 double Model_Checking::amount(const Data* r, int account_id)
 {
     double sum = 0;
-    switch (type(r->TRANSCODE))
+    switch (type_id(r->TRANSCODE))
     {
-    case WITHDRAWAL:
+    case TYPE_ID_WITHDRAWAL:
         sum -= r->TRANSAMOUNT;
         break;
-    case DEPOSIT:
+    case TYPE_ID_DEPOSIT:
         sum += r->TRANSAMOUNT;
         break;
-    case TRANSFER:
+    case TYPE_ID_TRANSFER:
         if (account_id == r->ACCOUNTID)
             sum -= r->TRANSAMOUNT;
         else
@@ -295,7 +321,7 @@ double Model_Checking::amount(const Data&r, int account_id)
 
 double Model_Checking::balance(const Data* r, int account_id)
 {
-    if (Model_Checking::status(r->STATUS) == Model_Checking::VOID_ || !r->DELETEDTIME.IsEmpty()) return 0;
+    if (Model_Checking::status_id(r->STATUS) == Model_Checking::STATUS_ID_VOID || !r->DELETEDTIME.IsEmpty()) return 0;
     return amount(r, account_id);
 }
 
@@ -328,7 +354,7 @@ double Model_Checking::deposit(const Data& r, int account_id)
 
 double Model_Checking::reconciled(const Data* r, int account_id)
 {
-    return (Model_Checking::status(r->STATUS) == Model_Checking::RECONCILED) ? balance(r, account_id) : 0;
+    return (Model_Checking::status_id(r->STATUS) == Model_Checking::STATUS_ID_RECONCILED) ? balance(r, account_id) : 0;
 }
 
 double Model_Checking::reconciled(const Data& r, int account_id)
@@ -358,7 +384,7 @@ bool Model_Checking::is_locked(const Data* r)
 
 bool Model_Checking::is_transfer(const wxString& r)
 {
-    return type(r) == Model_Checking::TRANSFER;
+    return type_id(r) == Model_Checking::TYPE_ID_TRANSFER;
 }
 bool Model_Checking::is_transfer(const Data* r)
 {
@@ -366,18 +392,16 @@ bool Model_Checking::is_transfer(const Data* r)
 }
 bool Model_Checking::is_deposit(const wxString& r)
 {
-    return type(r) == Model_Checking::DEPOSIT;
+    return type_id(r) == Model_Checking::TYPE_ID_DEPOSIT;
 }
 bool Model_Checking::is_deposit(const Data* r)
 {
     return is_deposit(r->TRANSCODE);
 }
 
-wxString Model_Checking::status_key(const wxString& fullStatus)
+wxString Model_Checking::status_key(const wxString& r)
 {
-    wxString s = fullStatus.Left(1);
-    s.Replace("U", "");
-    return s;
+    return STATUS_KEY[status_id(r)];
 }
 
 Model_Checking::Full_Data::Full_Data()
@@ -397,7 +421,7 @@ Model_Checking::Full_Data::Full_Data(const Data& r) : Data(r), BALANCE(0), AMOUN
 {
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
     displayID = wxString::Format("%i", r.TRANSID);
-    if (Model_Checking::type(r) == Model_Checking::TRANSFER) {
+    if (Model_Checking::type_id(r) == Model_Checking::TYPE_ID_TRANSFER) {
         TOACCOUNTNAME = Model_Account::get_account_name(r.TOACCOUNTID);
         PAYEENAME = TOACCOUNTNAME;
     }
@@ -440,7 +464,7 @@ Model_Checking::Full_Data::Full_Data(const Data& r
 
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
     displayID = wxString::Format("%i", r.TRANSID);
-    if (Model_Checking::type(r) == Model_Checking::TRANSFER)
+    if (Model_Checking::type_id(r) == Model_Checking::TYPE_ID_TRANSFER)
     {
         TOACCOUNTNAME = Model_Account::get_account_name(r.TOACCOUNTID);
         PAYEENAME = TOACCOUNTNAME;
@@ -480,7 +504,7 @@ Model_Checking::Full_Data::~Full_Data()
 
 wxString Model_Checking::Full_Data::real_payee_name(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id < 0)
             return ("> " + this->TOACCOUNTNAME);
@@ -493,7 +517,7 @@ wxString Model_Checking::Full_Data::real_payee_name(int account_id) const
 
 const wxString Model_Checking::Full_Data::get_currency_code(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id == -1)
             account_id = this->ACCOUNTID;
@@ -509,7 +533,7 @@ const wxString Model_Checking::Full_Data::get_currency_code(int account_id) cons
 
 const wxString Model_Checking::Full_Data::get_account_name(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id == -1) {
             return this->ACCOUNTNAME;
@@ -525,7 +549,7 @@ const wxString Model_Checking::Full_Data::get_account_name(int account_id) const
 
 bool Model_Checking::Full_Data::is_foreign() const
 {
-    return (this->TOACCOUNTID > 0) && ((this->TRANSCODE == all_type()[DEPOSIT]) || (this->TRANSCODE == all_type()[WITHDRAWAL]));
+    return (this->TOACCOUNTID > 0) && (this->TRANSCODE == TYPE_STR_DEPOSIT || this->TRANSCODE == TYPE_STR_WITHDRAWAL);
 }
 
 bool Model_Checking::Full_Data::is_foreign_transfer() const
@@ -610,8 +634,8 @@ void Model_Checking::getEmptyTransaction(Data &data, int accountID)
 
     data.TRANSDATE = max_trx_date;
     data.ACCOUNTID = accountID;
-    data.STATUS = all_status_key()[Option::instance().TransStatusReconciled()];
-    data.TRANSCODE = all_type()[WITHDRAWAL];
+    data.STATUS = STATUS_KEY[Option::instance().TransStatusReconciled()];
+    data.TRANSCODE = TYPE_STR_WITHDRAWAL;
     data.CATEGID = -1;
     data.FOLLOWUPID = -1;
     data.TRANSAMOUNT = 0;
@@ -723,7 +747,7 @@ const wxString Model_Checking::Full_Data::to_json()
 
 bool Model_Checking::foreignTransaction(const Data& data)
 {
-    return (data.TOACCOUNTID > 0) && ((data.TRANSCODE == all_type()[DEPOSIT]) || (data.TRANSCODE == all_type()[WITHDRAWAL]));
+    return (data.TOACCOUNTID > 0) && (data.TRANSCODE == TYPE_STR_DEPOSIT || data.TRANSCODE == TYPE_STR_WITHDRAWAL);
 }
 
 bool Model_Checking::foreignTransactionAsTransfer(const Data& data)

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -33,11 +33,43 @@ public:
     typedef Model_Splittransaction::Data_Set Split_Data_Set;
 
 public:
-    enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
-    enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
+    enum TYPE_ID
+    {
+        TYPE_ID_WITHDRAWAL = 0,
+        TYPE_ID_DEPOSIT,
+        TYPE_ID_TRANSFER
+    };
+    enum STATUS_ID
+    {
+        STATUS_ID_NONE = 0,
+        STATUS_ID_RECONCILED,
+        STATUS_ID_VOID,
+        STATUS_ID_FOLLOWUP,
+        STATUS_ID_DUPLICATE
+    };
+    static wxArrayString TYPE_STR;
+    static const wxString TYPE_STR_WITHDRAWAL;
+    static const wxString TYPE_STR_DEPOSIT;
+    static const wxString TYPE_STR_TRANSFER;
+    static wxArrayString STATUS_KEY;
+    static const wxString STATUS_KEY_NONE;
+    static const wxString STATUS_KEY_RECONCILED;
+    static const wxString STATUS_KEY_VOID;
+    static const wxString STATUS_KEY_FOLLOWUP;
+    static const wxString STATUS_KEY_DUPLICATE;
+    static wxArrayString STATUS_STR;
+    static const wxString STATUS_STR_NONE;
+    static const wxString STATUS_STR_RECONCILED;
+    static const wxString STATUS_STR_VOID;
+    static const wxString STATUS_STR_FOLLOWUP;
+    static const wxString STATUS_STR_DUPLICATE;
 
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_CHOICES;
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const std::vector<std::tuple<STATUS_ID, wxString, wxString> > STATUS_CHOICES;
+    static wxArrayString type_str_all();
+    static wxArrayString status_key_all();
+    static wxArrayString status_str_all();
 
 public:
     struct Full_Data: public Data
@@ -91,7 +123,7 @@ public:
     typedef std::vector<Full_Data> Full_Data_Set;
 
     struct SorterByBALANCE
-    { 
+    {
         template<class DATA>
         bool operator()(const DATA& x, const DATA& y)
         {
@@ -146,14 +178,6 @@ public:
     ~Model_Checking();
 
 public:
-    static wxArrayString all_type();
-    static wxArrayString all_status();
-    static wxArrayString all_status_key();
-    static const wxString TRANSFER_STR;
-    static const wxString WITHDRAWAL_STR;
-    static const wxString DEPOSIT_STR;
-
-public:
     /**
     Initialize the global Model_Checking table on initial call.
     Resets the global table on subsequent calls.
@@ -182,19 +206,20 @@ public:
     static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxDateTime& date, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::DELETEDTIME DELETEDTIME(const wxString& date, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxString& date_iso_str, OP op = EQUAL);
-    static DB_Table_CHECKINGACCOUNT_V1::STATUS STATUS(STATUS_ENUM status, OP op = EQUAL);
-    static DB_Table_CHECKINGACCOUNT_V1::TRANSCODE TRANSCODE(TYPE type, OP op = EQUAL);
+    static DB_Table_CHECKINGACCOUNT_V1::STATUS STATUS(STATUS_ID status, OP op = EQUAL);
+    static DB_Table_CHECKINGACCOUNT_V1::TRANSCODE TRANSCODE(TYPE_ID type, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::TRANSACTIONNUMBER TRANSACTIONNUMBER(const wxString& num, OP op = EQUAL);
 
 public:
     static wxDate TRANSDATE(const Data* r);
     static wxDate TRANSDATE(const Data& r);
-    static TYPE type(const wxString& r);
-    static TYPE type(const Data* r);
-    static TYPE type(const Data& r);
-    static STATUS_ENUM status(const wxString& r);
-    static STATUS_ENUM status(const Data* r);
-    static STATUS_ENUM status(const Data& r);
+    static TYPE_ID type_id(const wxString& r);
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static wxString status_key(const wxString& r);
+    static STATUS_ID status_id(const wxString& r);
+    static STATUS_ID status_id(const Data* r);
+    static STATUS_ID status_id(const Data& r);
     static double amount(const Data* r, int account_id = -1);
     static double amount(const Data&r, int account_id = -1);
     static double balance(const Data* r, int account_id = -1);
@@ -210,7 +235,6 @@ public:
     static bool is_transfer(const Data* r);
     static bool is_deposit(const wxString& r);
     static bool is_deposit(const Data* r);
-    static wxString status_key(const wxString& fullStatus);
     static void getFrequentUsedNotes(std::vector<wxString> &frequentNotes, int accountID = -1);
     static void getEmptyTransaction(Data &data, int accountID);
     static bool getTransactionData(Data &data, const Data* r);

--- a/src/model/Model_Translink.cpp
+++ b/src/model/Model_Translink.cpp
@@ -171,7 +171,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     for (const auto &trans : trans_list)
     {
         Model_Checking::Data* checking_entry = Model_Checking::instance().get(trans.CHECKINGACCOUNTID);
-        if (checking_entry && checking_entry->DELETEDTIME.IsEmpty() && Model_Checking::status(checking_entry->STATUS) != Model_Checking::VOID_) checking_list.push_back(*checking_entry);
+        if (checking_entry && checking_entry->DELETEDTIME.IsEmpty() && Model_Checking::status_id(checking_entry->STATUS) != Model_Checking::STATUS_ID_VOID) checking_list.push_back(*checking_entry);
     }
     std::stable_sort(checking_list.begin(), checking_list.end(), SorterByTRANSDATE());
     for (const auto &trans : checking_list)
@@ -222,12 +222,12 @@ void Model_Translink::UpdateAssetValue(Model_Asset::Data* asset_entry)
     for (const auto &trans : trans_list)
     {
         Model_Checking::Data* asset_trans = Model_Checking::instance().get(trans.CHECKINGACCOUNTID);
-        if (asset_trans && asset_trans->DELETEDTIME.IsEmpty() && Model_Checking::status(asset_trans->STATUS) != Model_Checking::VOID_)
+        if (asset_trans && asset_trans->DELETEDTIME.IsEmpty() && Model_Checking::status_id(asset_trans->STATUS) != Model_Checking::STATUS_ID_VOID)
         {
             Model_Currency::Data* asset_currency = Model_Account::currency(Model_Account::instance().get(asset_trans->ACCOUNTID));
             const double conv_rate = Model_CurrencyHistory::getDayRate(asset_currency->CURRENCYID, asset_trans->TRANSDATE);
 
-            if (asset_trans->TRANSCODE == Model_Checking::all_type()[Model_Checking::DEPOSIT])
+            if (asset_trans->TRANSCODE == Model_Checking::TYPE_STR_DEPOSIT)
             {
                 new_value -= asset_trans->TRANSAMOUNT * conv_rate; // Withdrawal from asset value
             }

--- a/src/optionsettingsmisc.cpp
+++ b/src/optionsettingsmisc.cpp
@@ -133,7 +133,7 @@ void OptionSettingsMisc::Create()
     wxChoice* default_status = new wxChoice(misc_panel
         , ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
         default_status->Append(wxGetTranslation(i), new wxStringClientData(i));
 
     default_status->SetSelection(Option::instance().TransStatusReconciled());

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -47,14 +47,14 @@ double mmReportCashFlow::trueAmount(const Model_Checking::Data& trx)
     if (!(isAccountFound && isToAccountFound))
     {
         const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
-        switch (Model_Checking::type(trx.TRANSCODE)) {
-        case Model_Checking::WITHDRAWAL:
+        switch (Model_Checking::type_id(trx.TRANSCODE)) {
+        case Model_Checking::TYPE_ID_WITHDRAWAL:
             amount = -trx.TRANSAMOUNT * convRate;
             break;
-        case Model_Checking::DEPOSIT:
+        case Model_Checking::TYPE_ID_DEPOSIT:
             amount = +trx.TRANSAMOUNT * convRate;
             break;
-        case Model_Checking::TRANSFER:
+        case Model_Checking::TYPE_ID_TRANSFER:
             if (isAccountFound)
                 amount = -trx.TRANSAMOUNT * convRate;
             else
@@ -105,7 +105,7 @@ void mmReportCashFlow::getTransactions()
     Model_Checking::Data_Set transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(m_today, GREATER),
         Model_Checking::TRANSDATE(endDate, LESS),
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL));
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL));
     for (auto& trx : transactions)
     {
         if (!trx.DELETEDTIME.IsEmpty()) continue;
@@ -131,7 +131,7 @@ void mmReportCashFlow::getTransactions()
     }
 
     // Now we gather the recurring transaction list
-    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         wxDateTime nextOccurDate = Model_Billsdeposits::NEXTOCCURRENCEDATE(entry);
         if (nextOccurDate > endDate) continue;

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -52,7 +52,7 @@ wxString mmReportForecast::getHTMLText()
 
     for (const auto & trx : all_trans)
     {
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER || Model_Checking::foreignTransactionAsTransfer(trx))
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER || Model_Checking::foreignTransactionAsTransfer(trx))
             continue;
         const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
         amount_by_day[trx.TRANSDATE].first += Model_Checking::withdrawal(trx, -1) * convRate;

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -48,7 +48,7 @@ wxString mmReportIncomeExpenses::getHTMLText()
     for (const auto& transaction : Model_Checking::instance().find(
         Model_Checking::TRANSDATE(m_date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(m_date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         // Do not include asset or stock transfers or deleted transactions in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(transaction) || !transaction.DELETEDTIME.IsEmpty())
@@ -64,9 +64,9 @@ wxString mmReportIncomeExpenses::getHTMLText()
         // We got this far, get the currency conversion rate for this account
         if (account) convRate = Model_CurrencyHistory::getDayRate(Model_Account::currency(account)->CURRENCYID,transaction.TRANSDATE);
 
-        if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT)
+        if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_DEPOSIT)
             income_expenses_pair.first += transaction.TRANSAMOUNT * convRate;
-        else if (Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL)
+        else if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL)
             income_expenses_pair.second += transaction.TRANSAMOUNT * convRate;
     }
 
@@ -148,7 +148,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
     for (const auto& transaction : Model_Checking::instance().find(
         Model_Checking::TRANSDATE(start_date, GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(m_date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         // Do not include asset or stock transfers or deleted transactions in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(transaction) || !transaction.DELETEDTIME.IsEmpty())
@@ -167,10 +167,10 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
 
         int idx = year * 100 + Model_Checking::TRANSDATE(transaction).GetMonth();
 
-        if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT) {
+        if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_DEPOSIT) {
             incomeExpensesStats[idx].first += transaction.TRANSAMOUNT * convRate;
         }
-        else if (Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL) {
+        else if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL) {
             incomeExpensesStats[idx].second += transaction.TRANSAMOUNT * convRate;
         }
     }

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -185,13 +185,13 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
 {
 // FIXME: do not ignore ignoreFuture param
     const auto &transactions = Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
         , Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL));
     const auto all_splits = Model_Splittransaction::instance().get_all();
     for (const auto& trx: transactions)
     {
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER || !trx.DELETEDTIME.IsEmpty()) continue;
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER || !trx.DELETEDTIME.IsEmpty()) continue;
 
         // Do not include asset or stock transfers in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(trx))
@@ -203,7 +203,7 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
         if (all_splits.count(trx.id())) splits = all_splits.at(trx.id());
         if (splits.empty())
         {
-            if (Model_Checking::type(trx) == Model_Checking::DEPOSIT)
+            if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_DEPOSIT)
                 payeeStats[trx.PAYEEID].first += trx.TRANSAMOUNT * convRate;
             else
                 payeeStats[trx.PAYEEID].second -= trx.TRANSAMOUNT * convRate;
@@ -212,7 +212,7 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
         {
             for (const auto& entry : splits)
             {
-                if (Model_Checking::type(trx) == Model_Checking::DEPOSIT)
+                if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_DEPOSIT)
                 {
                     if (entry.SPLITTRANSAMOUNT >= 0)
                         payeeStats[trx.PAYEEID].first += entry.SPLITTRANSAMOUNT * convRate;

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -257,7 +257,7 @@ table {
         // If a transfer between two accounts in the list of accounts being reported then we
         // should report both the transfer in and transfer out, i.e. two transactions
         int noOfTrans = 1;
-        if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER) &&
+        if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER) &&
             (allAccounts ||
                 ((selected_accounts.Index(transaction.ACCOUNTID) != wxNOT_FOUND)
                     && (selected_accounts.Index(transaction.TOACCOUNTID) != wxNOT_FOUND))))
@@ -271,7 +271,7 @@ table {
         {
             hb.startTableRow();
             {
-                /*  if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER)
+                /*  if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER)
                     && m_transDialog->getTypeCheckBox() && */
                 if (showColumnById(mmFilterTransactionsDialog::COL_ID))
                 {
@@ -323,7 +323,7 @@ table {
                         amount = -amount;
                     const double convRate = Model_CurrencyHistory::getDayRate(curr->CURRENCYID, transaction.TRANSDATE);
                     if (showColumnById(mmFilterTransactionsDialog::COL_AMOUNT))
-                        if (Model_Checking::status(transaction.STATUS) == Model_Checking::VOID_)
+                        if (Model_Checking::status_id(transaction.STATUS) == Model_Checking::STATUS_ID_VOID)
                             hb.addCurrencyCell(Model_Checking::amount(transaction, acc->ACCOUNTID), curr, -1, true);                            
                         else if (transaction.DELETEDTIME.IsEmpty())
                             hb.addCurrencyCell(amount, curr);
@@ -331,7 +331,7 @@ table {
                     grand_total[curr->CURRENCYID] += amount;
                     total_in_base_curr[curr->CURRENCYID] += amount * convRate;
                     grand_total_in_base_curr[curr->CURRENCYID] += amount * convRate;
-                    if (Model_Checking::type(transaction) != Model_Checking::TRANSFER)
+                    if (Model_Checking::type_id(transaction) != Model_Checking::TYPE_ID_TRANSFER)
                     {
                         grand_total_extrans[curr->CURRENCYID] += amount;
                         grand_total_in_base_curr_extrans[curr->CURRENCYID] += amount * convRate;
@@ -351,7 +351,7 @@ table {
                 // Exchange Rate
                 if (showColumnById(mmFilterTransactionsDialog::COL_RATE))
                 {
-                    if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER)
+                    if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER)
                         && (transaction.TRANSAMOUNT != transaction.TOTRANSAMOUNT))
                         hb.addMoneyCell(transaction.TOTRANSAMOUNT / transaction.TRANSAMOUNT);
                     else

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -46,7 +46,7 @@ wxEND_EVENT_TABLE()
 
 double ShareTransactionDialog::GetAmount(double shares, double price, double commision)
 {
-    if (m_transaction_panel->TransactionType() == Model_Checking::DEPOSIT)
+    if (m_transaction_panel->TransactionType() == Model_Checking::TYPE_ID_DEPOSIT)
         return (shares * price - commision);
     else
         return (shares * price + commision);
@@ -149,7 +149,7 @@ void ShareTransactionDialog::DataToControls()
                     m_transaction_panel->SetTransactionValue(GetAmount(std::abs(m_share_entry->SHARENUMBER)
                         , m_share_entry->SHAREPRICE, m_share_entry->SHARECOMMISSION), true);
                     m_transaction_panel->SetTransactionAccount(Model_Account::get_account_name(checking_entry->ACCOUNTID));
-                    m_transaction_panel->SetTransactionStatus(Model_Checking::status(checking_entry));
+                    m_transaction_panel->SetTransactionStatus(Model_Checking::status_id(checking_entry));
                     m_transaction_panel->SetTransactionPayee(checking_entry->PAYEEID);
                     m_transaction_panel->SetTransactionCategory(checking_entry->CATEGID);
                     if (!checking_entry->DELETEDTIME.IsEmpty()) {
@@ -380,7 +380,7 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     if (m_transaction_panel->ValidCheckingAccountEntry())
     {
         // addition or removal shares
-        if ((num_shares > 0) && (m_transaction_panel->TransactionType() == Model_Checking::DEPOSIT))
+        if ((num_shares > 0) && (m_transaction_panel->TransactionType() == Model_Checking::TYPE_ID_DEPOSIT))
         {
             // we need to subtract the number of shares for a sale
             num_shares = num_shares * -1;

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -150,7 +150,7 @@ void transactionsUpdateDialog::CreateControls()
 
     m_status_choice = new wxChoice(this, wxID_ANY
         , wxDefaultPosition, wxDefaultSize);
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
         m_status_choice->Append(wxGetTranslation(i), new wxStringClientData(i));
 
     m_status_choice->Enable(false);
@@ -165,9 +165,9 @@ void transactionsUpdateDialog::CreateControls()
 
     m_type_choice = new wxChoice(this, ID_TRANS_TYPE
         , wxDefaultPosition, wxDefaultSize);
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (!(m_hasSplits && (Model_Checking::TRANSFER_STR == i)))
+        if (!(m_hasSplits && (Model_Checking::TYPE_STR_TRANSFER == i)))
             m_type_choice->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
     m_type_choice->Enable(false);
@@ -323,7 +323,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         wxStringClientData* type_obj = static_cast<wxStringClientData*>(m_type_choice->GetClientObject(m_type_choice->GetSelection()));
         type = type_obj->GetData();
-        if (Model_Checking::TRANSFER_STR == type)
+        if (Model_Checking::TYPE_STR_TRANSFER == type)
         {
             if  (m_hasNonTransfers && !m_transferAcc_checkbox->IsChecked())
                 return mmErrorDialogs::InvalidAccount(m_transferAcc_checkbox, true);
@@ -547,7 +547,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void transactionsUpdateDialog::SetPayeeTransferControls()
 {
     wxStringClientData* trans_obj = static_cast<wxStringClientData*>(m_type_choice->GetClientObject(m_type_choice->GetSelection()));
-    bool transfer = (Model_Checking::TRANSFER_STR == trans_obj->GetData());
+    bool transfer = (Model_Checking::TYPE_STR_TRANSFER == trans_obj->GetData());
 
     m_payee_checkbox->Enable(!transfer);
     m_transferAcc_checkbox->Enable(transfer);

--- a/src/transdialog.h
+++ b/src/transdialog.h
@@ -49,7 +49,7 @@ public:
         , int transaction_id
         , double current_balance
         , bool duplicate = false
-        , int type = Model_Checking::WITHDRAWAL);
+        , int type = Model_Checking::TYPE_ID_WITHDRAWAL);
 
     bool Create(wxWindow* parent
         , wxWindowID id = wxID_ANY

--- a/src/usertransactionpanel.cpp
+++ b/src/usertransactionpanel.cpp
@@ -94,13 +94,13 @@ void UserTransactionPanel::Create()
 
     // Type --------------------------------------------
     m_type_selector = new wxChoice(this, wxID_VIEW_DETAILS, wxDefaultPosition, std_half_size);
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (i != Model_Checking::all_type()[Model_Checking::TRANSFER])
+        if (i != Model_Checking::TYPE_STR_TRANSFER)
             m_type_selector->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
 
-    m_type_selector->SetSelection(Model_Checking::WITHDRAWAL);
+    m_type_selector->SetSelection(Model_Checking::TYPE_ID_WITHDRAWAL);
     mmToolTip(m_type_selector, _("Withdraw funds from or deposit funds to this Account."));
 
     m_transfer = new wxCheckBox(this, ID_TRANS_TRANSFER, _("&Transfer")
@@ -142,7 +142,7 @@ void UserTransactionPanel::Create()
     m_status_selector = new wxChoice(this, ID_TRANS_STATUS_SELECTOR
         , wxDefaultPosition, std_half_size);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
     {
         m_status_selector->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
@@ -215,7 +215,7 @@ void UserTransactionPanel::DataToControls()
     m_transaction_id = m_checking_entry->TRANSID;
     m_account_id = m_checking_entry->ACCOUNTID;
     m_account->SetLabelText(Model_Account::get_account_name(m_account_id));
-    m_type_selector->SetSelection(Model_Checking::type(m_checking_entry->TRANSCODE));
+    m_type_selector->SetSelection(Model_Checking::type_id(m_checking_entry->TRANSCODE));
 
     if (m_account_id > 0)
     {
@@ -225,7 +225,7 @@ void UserTransactionPanel::DataToControls()
     }
 
     SetTransactionValue(m_checking_entry->TRANSAMOUNT);
-    m_status_selector->SetSelection(Model_Checking::status(m_checking_entry->STATUS));
+    m_status_selector->SetSelection(Model_Checking::status_id(m_checking_entry->STATUS));
 
     m_payee_id = m_checking_entry->PAYEEID;
     m_payee->SetLabelText(Model_Payee::get_payee_name(m_payee_id));
@@ -258,7 +258,7 @@ void UserTransactionPanel::SetLastPayeeAndCategory(const int account_id)
 {
     if (Option::instance().TransPayeeSelection() == Option::LASTUSED)
     {
-        Model_Checking::Data_Set trans_list = Model_Checking::instance().find(Model_Checking::ACCOUNTID(account_id), Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL));
+        Model_Checking::Data_Set trans_list = Model_Checking::instance().find(Model_Checking::ACCOUNTID(account_id), Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL));
         if (!trans_list.empty())
         {
             int last_trans_pos = trans_list.size() - 1;
@@ -460,7 +460,7 @@ int UserTransactionPanel::SaveChecking()
     m_checking_entry->TOACCOUNTID = CheckingType();
 
     m_checking_entry->PAYEEID = m_payee_id;
-    m_checking_entry->TRANSCODE = Model_Checking::instance().all_type()[TransactionType()];
+    m_checking_entry->TRANSCODE = Model_Checking::TYPE_STR[TransactionType()];
     m_checking_entry->TRANSAMOUNT = initial_amount;
     m_checking_entry->STATUS = m_status_selector->GetStringSelection().Mid(0, 1);
     m_checking_entry->TRANSACTIONNUMBER = m_entered_number->GetValue();

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -476,7 +476,7 @@ int mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     }
     else
     {
-        TrStatus = "F";
+        TrStatus = Model_Checking::STATUS_KEY_FOLLOWUP;
         wxString FistAccountName;
 
         //Search first bank account


### PR DESCRIPTION
This PR improves a few design weaknesses in `TYPE` and `STATUS` choices in `Model_Checking`. If accepted, other PRs will implement similar improvements in other model choices.

## Design weaknesses

- The order of the entries in vector `TYPE_CHOICES` and `STATUS_CHOICES` is not checked. If the order is wrong (by mistake) and this becomes unnoticed, the database may be corrupted, since the choice values presented by the gui are different than the choice values processed by the program.

- The cases in enum `TYPE` and `STATUS_ENUM` pollute the `Model_Checking` class namespace, especially if they have a common short name like `VOID`. Since they are not prefixed, they are sometimes confusing when used outside of `Model_Checking`.

- The single-letter keys of `STATUS` appear as raw values in several places, i.e., their values are not encapsulated.

- `status_key` (previously called `toShortStatus`) may generate an invalid status key (single-letter code), if its input argument is wrong (by mistake).


## Changes

- Rename enum `TYPE` -> `TYPE_ID`, `STATUS_ENUM` -> `STATUS_ID`.

- Add prefix `TYPE_ID_` in the cases of `TYPE_ID`. Similar for `STATUS_ID`.

- Add the status keys (single-letter) in `STATUS_CHOICES`, together with the long names for each case.

- At initialization phase (only once), create wxArrayString `TYPE_STR`, `STATUS_KEY`, `STATUS_STR`, and at the same time check the order of `TYPE_CHOICES`, `STATUS_CHOICES`.

- At initialization phase, create wxString `TYPE_STR_*`, `STATUS_KEY_*`, `STATUS_STR_*` for all cases in `TYPE_ID`, `STATUS_ID`. These symbols simplify the code outside of `Model_Checking`.

- Rename `all_type()` -> `type_str_all()` and make it private. Similar for `all_status()` -> `status_str_all()` and `all_status_key()` -> `status_key_all()`.

- Rename `type()` -> `type_id()`, in order to clarify that this function returns a `TYPE_ID`. Similar for `status()` -> `status_id()`.

- `status_key()` (previously called `toShortStatus`) converts a long name to a key (single-letter). Do not rely on the first letter of the input argument (it may be wrong by mistake). Instead, convert the long name to `STATUS_ID` using `status_id()` and then to key using wxArrayString `STATUS_KEY`.

- Replace all raw values of status keys to `Model_Checking::STATUS_KEY_*`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6848)
<!-- Reviewable:end -->
