### PR TITLE
refactor choices in Model_Asset, Model_Account, Model_Currency, Model_Budget, Model_CustomField

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -129,9 +129,9 @@ void mmNewAcctDialog::CreateControls()
     grid_sizer->Add(new wxStaticText(this, wxID_STATIC, _("Account Type:")), g_flagsH);
 
     wxChoice* itemChoice61 = new wxChoice(this, ID_DIALOG_NEWACCT_COMBO_ACCTTYPE);
-    for (const auto& type : Model_Account::all_type())
+    for (const auto& type : Model_Account::TYPE_STR)
         itemChoice61->Append(wxGetTranslation(type), new wxStringClientData(type));
-    if (Model_Account::all_type().Index(m_account->ACCOUNTTYPE) == wxNOT_FOUND)
+    if (Model_Account::TYPE_STR.Index(m_account->ACCOUNTTYPE) == wxNOT_FOUND)
         itemChoice61->Append(m_account->ACCOUNTTYPE);
     mmToolTip(itemChoice61, _("Specify the type of account to be created."));
     grid_sizer->Add(itemChoice61, g_flagsExpand);
@@ -140,7 +140,7 @@ void mmNewAcctDialog::CreateControls()
     grid_sizer->Add(new wxStaticText(this, wxID_STATIC, _("Account Status:")), g_flagsH);
 
     wxChoice* itemChoice6 = new wxChoice(this, ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS);
-    for (const auto& status : Model_Account::all_status())
+    for (const auto& status : Model_Account::STATUS_STR)
         itemChoice6->Append(wxGetTranslation(status), new wxStringClientData(status));
     mmToolTip(itemChoice6, _("Specify if this account has been closed. Closed accounts are inactive in most calculations, reporting etc."));
     grid_sizer->Add(itemChoice6, g_flagsExpand);
@@ -195,7 +195,7 @@ void mmNewAcctDialog::CreateControls()
     grid_sizer2->AddGrowableCol(1, 1);
     others_sizer->Add(grid_sizer2, g_flagsExpand);
 
-    grid_sizer2->Add(new wxStaticText(others_tab, wxID_STATIC, (Model_Account::type(m_account) == Model_Account::CREDIT_CARD ? _("Card Number:") : _("Account Number:"))), g_flagsH);
+    grid_sizer2->Add(new wxStaticText(others_tab, wxID_STATIC, (Model_Account::type_id(m_account) == Model_Account::TYPE_ID_CREDIT_CARD ? _("Card Number:") : _("Account Number:"))), g_flagsH);
     wxTextCtrl* itemTextCtrl6 = new wxTextCtrl(others_tab, ID_ACCTNUMBER, "", wxDefaultPosition, wxDefaultSize);
     mmToolTip(itemTextCtrl6, _("Enter the Account Number associated with this account."));
     grid_sizer2->Add(itemTextCtrl6, g_flagsExpand);
@@ -326,7 +326,7 @@ void mmNewAcctDialog::fillControls()
     itemAcctType->Enable(false);
 
     wxChoice* choice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS));
-    choice->SetSelection(Model_Account::status(m_account));
+    choice->SetSelection(Model_Account::status_id(m_account));
 
     wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT));
     itemCheckBox->SetValue(Model_Account::FAVORITEACCT(m_account));
@@ -372,7 +372,7 @@ void mmNewAcctDialog::OnAccountStatus()
 {
     wxChoice* choice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS));
     wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT));
-    if (choice->GetSelection() == Model_Account::CLOSED)    // Can only change if account is open
+    if (choice->GetSelection() == Model_Account::STATUS_ID_CLOSED)    // Can only change if account is open
         itemCheckBox->Disable();
     else
         itemCheckBox->Enable();
@@ -544,7 +544,7 @@ void mmNewAcctDialog::OnOk(wxCommandEvent& /*event*/)
     wxTextCtrl* textCtrlContact = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_NEWACCT_TEXTCTRL_CONTACT));
 
     wxChoice* choice = static_cast<wxChoice*>(FindWindow(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS));
-    m_account->STATUS = Model_Account::all_status()[choice->GetSelection()];
+    m_account->STATUS = Model_Account::STATUS_STR[choice->GetSelection()];
 
     wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_NEWACCT_CHKBOX_FAVACCOUNT));
     m_account->FAVORITEACCT = itemCheckBox->IsChecked() ? "TRUE" : "FALSE";

--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -122,9 +122,9 @@ void mmAssetDialog::dataToControls()
 
     m_valueChangeRate->SetValue(m_asset->VALUECHANGERATE, 3);
 
-    m_valueChange->SetSelection(Model_Asset::rate(m_asset));
-    enableDisableRate(Model_Asset::rate(m_asset) != Model_Asset::RATE_NONE);
-    m_assetType->SetSelection(Model_Asset::type(m_asset));
+    m_valueChange->SetSelection(Model_Asset::change_id(m_asset));
+    enableDisableRate(Model_Asset::change_id(m_asset) != Model_Asset::CHANGE_ID_NONE);
+    m_assetType->SetSelection(Model_Asset::type_id(m_asset));
 
     // Set up the transaction if this is the first entry.
     if (translink.empty())
@@ -190,11 +190,11 @@ void mmAssetDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(asset_details_panel, wxID_STATIC, _("Asset Type")), g_flagsH);
 
     m_assetType = new wxChoice(asset_details_panel, wxID_STATIC);
-    for (const auto& a : Model_Asset::all_type())
+    for (const auto& a : Model_Asset::TYPE_STR)
         m_assetType->Append(wxGetTranslation(a), new wxStringClientData(a));
 
     mmToolTip(m_assetType, _("Select type of asset"));
-    m_assetType->SetSelection(Model_Asset::TYPE_PROPERTY);
+    m_assetType->SetSelection(Model_Asset::TYPE_ID_PROPERTY);
     itemFlexGridSizer6->Add(m_assetType, g_flagsExpand);
 
     wxStaticText* v = new wxStaticText(asset_details_panel, wxID_STATIC, _("Value"));
@@ -210,11 +210,11 @@ void mmAssetDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(asset_details_panel, wxID_STATIC, _("Change in Value")), g_flagsH);
 
     m_valueChange = new wxChoice(asset_details_panel, IDC_COMBO_TYPE);
-    for(const auto& a : Model_Asset::all_rate())
+    for(const auto& a : Model_Asset::CHANGE_STR)
         m_valueChange->Append(wxGetTranslation(a));
 
     mmToolTip(m_valueChange, _("Specify if the value of the asset changes over time"));
-    m_valueChange->SetSelection(Model_Asset::RATE_NONE);
+    m_valueChange->SetSelection(Model_Asset::CHANGE_ID_NONE);
     itemFlexGridSizer6->Add(m_valueChange, g_flagsExpand);
 
     m_valueChangeRateLabel = new wxStaticText(asset_details_panel, wxID_STATIC, _("% Rate"));
@@ -301,7 +301,7 @@ void mmAssetDialog::OnChangeAppreciationType(wxCommandEvent& /*event*/)
 {
     int selection = m_valueChange->GetSelection();
     // Disable for "None", Enable for "Appreciates" or "Depreciates"
-    enableDisableRate(selection != Model_Asset::RATE_NONE);
+    enableDisableRate(selection != Model_Asset::CHANGE_ID_NONE);
 }
 
 void mmAssetDialog::enableDisableRate(bool en)
@@ -337,7 +337,7 @@ void mmAssetDialog::OnOk(wxCommandEvent& /*event*/)
     }
 
     int valueChangeType = m_valueChange->GetSelection();
-    if (valueChangeType != Model_Asset::RATE_NONE && !m_valueChangeRate->checkValue(valueChangeRate))
+    if (valueChangeType != Model_Asset::CHANGE_ID_NONE && !m_valueChangeRate->checkValue(valueChangeRate))
     {
         return;
     }
@@ -352,11 +352,11 @@ void mmAssetDialog::OnOk(wxCommandEvent& /*event*/)
     m_asset->STARTDATE        = m_dpc->GetValue().FormatISODate();
     m_asset->NOTES            = m_notes->GetValue().Trim();
     m_asset->ASSETNAME        = name;
-    m_asset->ASSETSTATUS      = Model_Asset::OPEN_STR;
-    m_asset->VALUECHANGEMODE  = Model_Asset::PERCENTAGE_STR;  
+    m_asset->ASSETSTATUS      = Model_Asset::STATUS_STR[Model_Asset::STATUS_ID_OPEN];
+    m_asset->VALUECHANGEMODE  = Model_Asset::CHANGEMODE_STR[Model_Asset::CHANGEMODE_ID_PERCENTAGE];  
     m_asset->CURRENCYID       = -1; 
     m_asset->VALUE            = value;
-    m_asset->VALUECHANGE      = Model_Asset::all_rate()[valueChangeType];
+    m_asset->VALUECHANGE      = Model_Asset::CHANGE_STR[valueChangeType];
     m_asset->VALUECHANGERATE  = valueChangeRate;
     m_asset->ASSETTYPE        = asset_type;
 

--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -414,9 +414,9 @@ void mmAssetDialog::CreateAssetAccount()
 {
     Model_Account::Data* asset_account = Model_Account::instance().create();
     asset_account->ACCOUNTNAME = m_asset->ASSETNAME;
-    asset_account->ACCOUNTTYPE = Model_Account::all_type()[Model_Account::ASSET];
+    asset_account->ACCOUNTTYPE = Model_Account::TYPE_STR_ASSET;
     asset_account->FAVORITEACCT = "TRUE";
-    asset_account->STATUS = Model_Account::all_status()[Model_Account::OPEN];
+    asset_account->STATUS = Model_Account::STATUS_STR_OPEN;
     asset_account->INITIALBAL = 0;
     asset_account->INITIALDATE = wxDate::Today().FormatISODate();
     asset_account->CURRENCYID = Model_Currency::GetBaseCurrency()->CURRENCYID;

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -149,7 +149,7 @@ void mmAssetsListCtrl::OnListItemSelected(wxListEvent& event)
 
 int mmAssetsListCtrl::OnGetItemImage(long item) const
 {
-    return Model_Asset::type(m_panel->m_assets[item]);
+    return Model_Asset::type_id(m_panel->m_assets[item]);
 }
 
 void mmAssetsListCtrl::OnListKeyDown(wxListEvent& event)
@@ -366,7 +366,7 @@ END_EVENT_TABLE()
 
 mmAssetsPanel::mmAssetsPanel(mmGUIFrame* frame, wxWindow *parent, wxWindowID winid, const wxString& name)
     : m_frame(frame)
-    , m_filter_type(Model_Asset::TYPE(-1))
+    , m_filter_type(Model_Asset::TYPE_ID(-1))
     , tips_()
 {
     Create(parent, winid, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, name);
@@ -570,7 +570,7 @@ int mmAssetsPanel::initVirtualListControl(int id, int col, bool asc)
     item.SetImage(asc ? ICON_UPARROW : ICON_DOWNARROW);
     m_listCtrlAssets->SetColumn(col, item);
 
-    if (this->m_filter_type == Model_Asset::TYPE(-1)) // ALL
+    if (this->m_filter_type == Model_Asset::TYPE_ID(-1)) // ALL
         this->m_assets = Model_Asset::instance().all();
     else
         this->m_assets = Model_Asset::instance().find(Model_Asset::ASSETTYPE(m_filter_type));
@@ -661,7 +661,7 @@ void mmAssetsPanel::updateExtraAssetData(int selIndex)
     {
         const Model_Asset::Data& asset = this->m_assets[selIndex];
         enableEditDeleteButtons(true);
-        const auto& change_rate = (Model_Asset::rate(asset) != Model_Asset::RATE_NONE)
+        const auto& change_rate = (Model_Asset::change_id(asset) != Model_Asset::CHANGE_ID_NONE)
             ? wxString::Format("%.2f %%", asset.VALUECHANGERATE) : "";
         const wxString& miniInfo = " " + wxString::Format(_("Change in Value: %1$s %2$s")
             , wxGetTranslation(asset.VALUECHANGE), change_rate);
@@ -704,7 +704,7 @@ void mmAssetsPanel::OnMouseLeftDown (wxCommandEvent& event)
     wxMenu menu;
     menu.Append(++i, wxGetTranslation(wxTRANSLATE("All")));
 
-    for (const auto& type: Model_Asset::all_type())
+    for (const auto& type: Model_Asset::TYPE_STR)
     {
         menu.Append(++i, wxGetTranslation(type));
     }
@@ -721,13 +721,13 @@ void mmAssetsPanel::OnViewPopupSelected(wxCommandEvent& event)
     {
         m_bitmapTransFilter->SetLabel(_("All"));
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
-        this->m_filter_type = Model_Asset::TYPE(-1);
+        this->m_filter_type = Model_Asset::TYPE_ID(-1);
     }
     else
     {
-        this->m_filter_type = Model_Asset::TYPE(evt - 1);
+        this->m_filter_type = Model_Asset::TYPE_ID(evt - 1);
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER_ACTIVE, mmBitmapButtonSize));
-        m_bitmapTransFilter->SetLabel(wxGetTranslation(Model_Asset::all_type()[evt - 1]));
+        m_bitmapTransFilter->SetLabel(wxGetTranslation(Model_Asset::TYPE_STR[evt - 1]));
     }
 
     int trx_id = -1;

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -117,7 +117,7 @@ void mmAssetsListCtrl::OnMouseRightClick(wxMouseEvent& event)
         menu.Enable(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, false);
     }
 
-    const auto& asset_accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::ASSET]));
+    const auto& asset_accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_ASSET));
     menu.Enable(MENU_TREEPOPUP_GOTOACCOUNT, !asset_accounts.empty());
     menu.Enable(MENU_TREEPOPUP_VIEWTRANS, !asset_accounts.empty());
 

--- a/src/assetspanel.h
+++ b/src/assetspanel.h
@@ -101,7 +101,7 @@ public:
     wxString getItem(long item, long column);
 
     Model_Asset::Data_Set m_assets;
-    Model_Asset::TYPE m_filter_type;
+    Model_Asset::TYPE_ID m_filter_type;
     int col_max() { return COL_MAX; }
     int col_sort() { return COL_DATE; }
 

--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -152,7 +152,7 @@ mmBDDialog::mmBDDialog(wxWindow* parent, int bdID, bool duplicate, bool enterOcc
         }
     }
 
-    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TRANSFER_STR);
+    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TYPE_STR_TRANSFER);
 
     int ref_id = m_dup_bill ?  -bdID : (m_new_bill ? 0 : -m_bill_data.BDID);
     m_custom_fields = new mmCustomDataTransaction(this, ref_id, ID_CUSTOMFIELDS);
@@ -206,13 +206,13 @@ void mmBDDialog::dataToControls()
     }
     setRepeatType(Model_Billsdeposits::REPEAT_MONTHLY);
 
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (i == Model_Checking::TRANSFER_STR && Model_Account::instance().all().size() < 2)
+        if (i == Model_Checking::TYPE_STR_TRANSFER && Model_Account::instance().all().size() < 2)
             break;
         m_choice_transaction_type->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
-    m_choice_transaction_type->SetSelection(Model_Checking::WITHDRAWAL);
+    m_choice_transaction_type->SetSelection(Model_Checking::TYPE_ID_WITHDRAWAL);
 
     SetTransferControls();  // hide appropriate fields
     setCategoryLabel();
@@ -221,7 +221,7 @@ void mmBDDialog::dataToControls()
         return;
     }
 
-    m_choice_status->SetSelection(Model_Checking::status(m_bill_data.STATUS));
+    m_choice_status->SetSelection(Model_Checking::status_id(m_bill_data.STATUS));
 
     // Set the date paid
     wxDateTime field_date;
@@ -268,7 +268,7 @@ void mmBDDialog::dataToControls()
     }
     setRepeatDetails();
 
-    m_choice_transaction_type->SetSelection(Model_Checking::type(m_bill_data.TRANSCODE));
+    m_choice_transaction_type->SetSelection(Model_Checking::type_id(m_bill_data.TRANSCODE));
     updateControlsForTransType();
 
     Model_Account::Data* account = Model_Account::instance().get(m_bill_data.ACCOUNTID);
@@ -339,8 +339,8 @@ void mmBDDialog::SetDialogParameters(int trx_id)
     cbAccount_->SetValue(t.ACCOUNTNAME);
 
     m_bill_data.TRANSCODE = t.TRANSCODE;
-    m_choice_transaction_type->SetSelection(Model_Checking::type(t.TRANSCODE));
-    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TRANSFER_STR);
+    m_choice_transaction_type->SetSelection(Model_Checking::type_id(t.TRANSCODE));
+    m_transfer = (m_bill_data.TRANSCODE == Model_Checking::TYPE_STR_TRANSFER);
     updateControlsForTransType();
 
     m_bill_data.TRANSAMOUNT = t.TRANSAMOUNT;
@@ -489,7 +489,7 @@ void mmBDDialog::CreateControls()
     // Status --------------------------------------------
     m_choice_status = new wxChoice(this, ID_DIALOG_TRANS_STATUS);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
     {
         m_choice_status->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
@@ -819,7 +819,7 @@ void mmBDDialog::updateControlsForTransType()
     m_transfer = false;
     switch (m_choice_transaction_type->GetSelection())
     {
-    case Model_Checking::TRANSFER:
+    case Model_Checking::TYPE_ID_TRANSFER:
     {
         m_transfer = true;
         mmToolTip(textAmount_, amountTransferTip_);
@@ -829,7 +829,7 @@ void mmBDDialog::updateControlsForTransType()
         m_bill_data.PAYEEID = -1;
         break;
     }
-    case Model_Checking::WITHDRAWAL:
+    case Model_Checking::TYPE_ID_WITHDRAWAL:
     {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_("Account"));
@@ -842,7 +842,7 @@ void mmBDDialog::updateControlsForTransType()
         OnPayee(evt);
         break;
     }
-    case Model_Checking::DEPOSIT:
+    case Model_Checking::TYPE_ID_DEPOSIT:
     {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_("Account"));
@@ -1052,7 +1052,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         bill->ACCOUNTID = m_bill_data.ACCOUNTID;
         bill->TOACCOUNTID = m_bill_data.TOACCOUNTID;
         bill->PAYEEID = m_bill_data.PAYEEID;
-        bill->TRANSCODE = Model_Checking::all_type()[m_choice_transaction_type->GetSelection()];
+        bill->TRANSCODE = Model_Checking::TYPE_STR[m_choice_transaction_type->GetSelection()];
         bill->TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
         bill->STATUS = m_bill_data.STATUS;
         bill->TRANSACTIONNUMBER = m_bill_data.TRANSACTIONNUMBER;
@@ -1134,7 +1134,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             tran->ACCOUNTID = m_bill_data.ACCOUNTID;
             tran->TOACCOUNTID = m_bill_data.TOACCOUNTID;
             tran->PAYEEID = m_bill_data.PAYEEID;
-            tran->TRANSCODE = Model_Checking::all_type()[m_choice_transaction_type->GetSelection()];
+            tran->TRANSCODE = Model_Checking::TYPE_STR[m_choice_transaction_type->GetSelection()];
             tran->TRANSAMOUNT = m_bill_data.TRANSAMOUNT;
             tran->STATUS = m_bill_data.STATUS;
             tran->TRANSACTIONNUMBER = m_bill_data.TRANSACTIONNUMBER;
@@ -1418,7 +1418,7 @@ void mmBDDialog::activateSplitTransactionsDlg()
         m_bill_data.local_splits = dlg.mmGetResult();
         m_bill_data.TRANSAMOUNT = Model_Splittransaction::get_total(m_bill_data.local_splits);
         m_bill_data.CATEGID = -1;
-        if (m_choice_transaction_type->GetSelection() == Model_Checking::TRANSFER && m_bill_data.TRANSAMOUNT < 0)
+        if (m_choice_transaction_type->GetSelection() == Model_Checking::TYPE_ID_TRANSFER && m_bill_data.TRANSAMOUNT < 0)
         {
             m_bill_data.TRANSAMOUNT = -m_bill_data.TRANSAMOUNT;
         }
@@ -1466,7 +1466,7 @@ void mmBDDialog::setCategoryLabel()
         && Option::instance().TransCategorySelectionTransfer() == Option::LASTUSED)
     {
         Model_Checking::Data_Set transactions = Model_Checking::instance().find(
-            Model_Checking::TRANSCODE(Model_Checking::TRANSFER, EQUAL)
+            Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, EQUAL)
             , Model_Checking::TRANSDATE(wxDateTime(23,59,59,999), LESS_OR_EQUAL));
 
         if (!transactions.empty())

--- a/src/budgetentrydialog.cpp
+++ b/src/budgetentrydialog.cpp
@@ -68,9 +68,9 @@ bool mmBudgetEntryDialog::Create(wxWindow* parent
 void mmBudgetEntryDialog::fillControls()
 {
     double amt = budgetEntry_->AMOUNT;
-    int period = Model_Budget::period(budgetEntry_);
+    int period = Model_Budget::period_id(budgetEntry_);
     m_choiceItem->SetSelection(period);
-    if (period == Model_Budget::NONE && amt == 0.0)
+    if (period == Model_Budget::PERIOD_ID_NONE && amt == 0.0)
         m_choiceItem->SetSelection(DEF_FREQ_MONTHLY);
 
     if (amt <= 0.0)
@@ -128,7 +128,7 @@ void mmBudgetEntryDialog::CreateControls()
     itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, _("Frequency:")), g_flagsH);
 
     m_choiceItem = new wxChoice(itemPanel7, wxID_ANY
-        , wxDefaultPosition, wxDefaultSize, Model_Budget::all_period());
+        , wxDefaultPosition, wxDefaultSize, Model_Budget::period_loc_all());
     itemGridSizer2->Add(m_choiceItem, g_flagsExpand);
     mmToolTip(m_choiceItem, _("Specify the frequency of the expense or deposit"));
     m_choiceItem->Connect(wxID_ANY, wxEVT_CHAR, wxKeyEventHandler(mmBudgetEntryDialog::onChoiceChar), nullptr, this);
@@ -161,13 +161,13 @@ void mmBudgetEntryDialog::CreateControls()
 void mmBudgetEntryDialog::OnOk(wxCommandEvent& event)
 {
     int typeSelection = m_choiceType->GetSelection();    
-    wxString period = Model_Budget::PERIOD_ENUM_CHOICES[m_choiceItem->GetSelection()].second;
+    wxString period = Model_Budget::PERIOD_STR[m_choiceItem->GetSelection()];
     double amt = 0.0;
 
     if (!m_textAmount->checkValue(amt))
         return;
 
-    if (period == Model_Budget::PERIOD_ENUM_CHOICES[Model_Budget::NONE].second && amt > 0) {
+    if (period == Model_Budget::PERIOD_STR[Model_Budget::PERIOD_ID_NONE] && amt > 0) {
         m_choiceItem->SetFocus();
         m_choiceItem->SetSelection(DEF_FREQ_MONTHLY);
         event.Skip();
@@ -175,7 +175,7 @@ void mmBudgetEntryDialog::OnOk(wxCommandEvent& event)
     }
     
     if (amt == 0.0)
-        period = Model_Budget::PERIOD_ENUM_CHOICES[Model_Budget::NONE].second;
+        period = Model_Budget::PERIOD_STR[Model_Budget::PERIOD_ID_NONE];
 
     if (typeSelection == DEF_TYPE_EXPENSE)
         amt = -amt;

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -536,7 +536,7 @@ double mmBudgetingPanel::getEstimate(int category) const
 {
     try
     {
-        Model_Budget::PERIOD_ENUM period = budgetPeriod_.at(category);
+        Model_Budget::PERIOD_ID period = budgetPeriod_.at(category);
         double amt = budgetAmt_.at(category);
         return Model_Budget::getEstimate(monthlyBudget_, period, amt);
     }
@@ -583,7 +583,10 @@ wxString mmBudgetingPanel::getItem(long item, long column)
     case COL_FREQUENCY:
     {
         if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second)
-            return Model_Budget::all_period()[budgetPeriod_[budget_[item].first]];
+        {
+            Model_Budget::PERIOD_ID period = budgetPeriod_[budget_[item].first];
+            return wxGetTranslation(Model_Budget::PERIOD_STR[period]);
+        }
         return wxEmptyString;
     }
     case COL_AMOUNT:

--- a/src/budgetingpanel.h
+++ b/src/budgetingpanel.h
@@ -105,7 +105,7 @@ private:
     std::vector<std::pair<int, int> > budget_;
     std::map<int, std::pair<int, bool > > displayDetails_; //map categid to level of the category, whether category is visible, and whether any subtree is visible 
     std::map<int, std::pair<double, double> > budgetTotals_;
-    std::map<int, Model_Budget::PERIOD_ENUM> budgetPeriod_;
+    std::map<int, Model_Budget::PERIOD_ID> budgetPeriod_;
     std::map<int, double> budgetAmt_;
     std::map<int, wxString> budgetNotes_;
     std::map<int, std::map<int,double> > categoryStats_;

--- a/src/currencydialog.cpp
+++ b/src/currencydialog.cpp
@@ -72,7 +72,7 @@ mmCurrencyDialog::mmCurrencyDialog(wxWindow* parent, const Model_Currency::Data 
         m_currency->SCALE = 100;
         m_currency->DECIMAL_POINT = ".";
         m_currency->GROUP_SEPARATOR = ",";
-        m_currency->CURRENCY_TYPE = Model_Currency::FIAT_STR;
+        m_currency->CURRENCY_TYPE = Model_Currency::TYPE_STR_FIAT;
     }
 
     // Check if locale will be used in preference

--- a/src/customfieldeditdialog.cpp
+++ b/src/customfieldeditdialog.cpp
@@ -75,7 +75,7 @@ void mmCustomFieldEditDialog::dataToControls()
     if (this->m_field)
     {
         m_itemDescription->SetValue(m_field->DESCRIPTION);
-        m_itemType->SetSelection(Model_CustomField::type(m_field));
+        m_itemType->SetSelection(Model_CustomField::type_id(m_field));
         m_itemReference->SetSelection(Model_CustomField::getReference(m_field->REFTYPE));
         m_itemTooltip->SetValue(Model_CustomField::getTooltip(m_field->PROPERTIES));
         m_itemRegEx->SetValue(Model_CustomField::getRegEx(m_field->PROPERTIES));
@@ -95,7 +95,7 @@ void mmCustomFieldEditDialog::dataToControls()
     else
     {
         m_itemReference->SetSelection(Model_CustomField::getReference(m_fieldRefType));
-        m_itemType->SetSelection(Model_CustomField::STRING);
+        m_itemType->SetSelection(Model_CustomField::TYPE_ID_STRING);
         m_itemUDFC->SetSelection(0);
     }
     wxCommandEvent evt;
@@ -140,7 +140,7 @@ void mmCustomFieldEditDialog::CreateControls()
 
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _("Field Type")), g_flagsH);
     m_itemType = new wxChoice(itemPanel5, wxID_HIGHEST);
-    for (const auto& type : Model_CustomField::all_type())
+    for (const auto& type : Model_CustomField::TYPE_STR)
         m_itemType->Append(wxGetTranslation(type), new wxStringClientData(type));
     mmToolTip(m_itemType, _("Select type of custom field"));
     itemFlexGridSizer6->Add(m_itemType, g_flagsExpand);
@@ -215,7 +215,7 @@ void mmCustomFieldEditDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     }
 
     int itemType = m_itemType->GetSelection();
-    if (ArrChoices.IsEmpty() && (itemType == Model_CustomField::SINGLECHOICE || itemType == Model_CustomField::MULTICHOICE))
+    if (ArrChoices.IsEmpty() && (itemType == Model_CustomField::TYPE_ID_SINGLECHOICE || itemType == Model_CustomField::TYPE_ID_MULTICHOICE))
     {
         return mmErrorDialogs::ToolTip4Object(m_itemChoices, _("Empty value"), _("Choices"));
     }
@@ -224,7 +224,7 @@ void mmCustomFieldEditDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         this->m_field = Model_CustomField::instance().create();
     }
-    else if (m_field->TYPE != Model_CustomField::fieldtype_desc(m_itemType->GetSelection()))
+    else if (m_field->TYPE != Model_CustomField::TYPE_STR[m_itemType->GetSelection()])
     {
         auto DataSet = Model_CustomFieldData::instance().find(Model_CustomFieldData::FIELDID(m_field->FIELDID));
         if (DataSet.size() > 0)
@@ -280,7 +280,7 @@ void mmCustomFieldEditDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
     m_field->REFTYPE = m_fieldRefType;
     m_field->DESCRIPTION = name;
-    m_field->TYPE = Model_CustomField::fieldtype_desc(m_itemType->GetSelection());
+    m_field->TYPE = Model_CustomField::TYPE_STR[m_itemType->GetSelection()];
     m_field->PROPERTIES = Model_CustomField::formatProperties(
         m_itemTooltip->GetValue(),
         regexp,
@@ -333,31 +333,31 @@ void mmCustomFieldEditDialog::OnChangeType(wxCommandEvent& WXUNUSED(event), bool
     //Enable specific fields
     switch (m_itemType->GetSelection())
     {
-    case Model_CustomField::STRING:
+    case Model_CustomField::TYPE_ID_STRING:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);
         m_itemAutocomplete->Enable(true);
         break;
     }
-    case Model_CustomField::SINGLECHOICE:
+    case Model_CustomField::TYPE_ID_SINGLECHOICE:
     {
         m_itemChoices->Enable(true);
         m_itemDefault->Enable(true);
         break;
     }
-    case Model_CustomField::MULTICHOICE:
+    case Model_CustomField::TYPE_ID_MULTICHOICE:
     {
         m_itemChoices->Enable(true);
         break;
     }
-    case Model_CustomField::INTEGER:
+    case Model_CustomField::TYPE_ID_INTEGER:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);
         break;
     }
-    case Model_CustomField::DECIMAL:
+    case Model_CustomField::TYPE_ID_DECIMAL:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);

--- a/src/dbcheck.cpp
+++ b/src/dbcheck.cpp
@@ -41,7 +41,7 @@ bool dbCheck::checkAccounts()
     // Transactions
     const auto &transactions = Model_Checking::instance().all();
     for (const auto& trx : transactions)
-        if (!Model_Account::instance().get(trx.ACCOUNTID) || (Model_Checking::type(trx) == Model_Checking::TRANSFER && !Model_Account::instance().get(trx.TOACCOUNTID)))
+        if (!Model_Account::instance().get(trx.ACCOUNTID) || (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER && !Model_Account::instance().get(trx.TOACCOUNTID)))
         {
             result = false;
         }
@@ -49,7 +49,7 @@ bool dbCheck::checkAccounts()
     // BillsDeposits
     const auto &bills = Model_Billsdeposits::instance().all();
     for (const auto& bill : bills)
-        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type(bill) == Model_Checking::TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
+        if (!Model_Account::instance().get(bill.ACCOUNTID) || (Model_Billsdeposits::type_id(bill) == Model_Checking::TYPE_ID_TRANSFER && !Model_Account::instance().get(bill.TOACCOUNTID)))
         {
             result = false;
         }

--- a/src/dbcheck.cpp
+++ b/src/dbcheck.cpp
@@ -57,7 +57,7 @@ bool dbCheck::checkAccounts()
     // Stocks
     const auto &stocks = Model_Stock::instance().all();
     for (const auto& stock : stocks)
-        if (!Model_Account::instance().get(stock.HELDAT) || (Model_Account::type(Model_Account::instance().get(stock.HELDAT)) != Model_Account::INVESTMENT))
+        if (!Model_Account::instance().get(stock.HELDAT) || (Model_Account::type_id(Model_Account::instance().get(stock.HELDAT)) != Model_Account::TYPE_ID_INVESTMENT))
         {
             result = false;
         }

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -1235,7 +1235,7 @@ bool mmFilterTransactionsDialog::mmIsStatusMatches(const wxString& itemStatus) c
     }
     else if ("A" == filterStatus) // All Except Reconciled
     {
-        return "R" != itemStatus;
+        return Model_Checking::STATUS_KEY_RECONCILED != itemStatus;
     }
     return false;
 }
@@ -1243,21 +1243,21 @@ bool mmFilterTransactionsDialog::mmIsStatusMatches(const wxString& itemStatus) c
 bool mmFilterTransactionsDialog::mmIsTypeMaches(const wxString& typeState, int accountid, int toaccountid) const
 {
     bool result = false;
-    if (typeState == Model_Checking::all_type()[Model_Checking::TRANSFER] && cbTypeTransferTo_->GetValue() &&
+    if (typeState == Model_Checking::TYPE_STR_TRANSFER && cbTypeTransferTo_->GetValue() &&
         (!mmIsAccountChecked() || (m_selected_accounts_id.Index(accountid) != wxNOT_FOUND)))
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::TRANSFER] && cbTypeTransferFrom_->GetValue() &&
+    else if (typeState == Model_Checking::TYPE_STR_TRANSFER && cbTypeTransferFrom_->GetValue() &&
              (!mmIsAccountChecked() || (m_selected_accounts_id.Index(toaccountid) != wxNOT_FOUND)))
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::WITHDRAWAL] && cbTypeWithdrawal_->IsChecked())
+    else if (typeState == Model_Checking::TYPE_STR_WITHDRAWAL && cbTypeWithdrawal_->IsChecked())
     {
         result = true;
     }
-    else if (typeState == Model_Checking::all_type()[Model_Checking::DEPOSIT] && cbTypeDeposit_->IsChecked())
+    else if (typeState == Model_Checking::TYPE_STR_DEPOSIT && cbTypeDeposit_->IsChecked())
     {
         result = true;
     }
@@ -1840,7 +1840,7 @@ const wxString mmFilterTransactionsDialog::mmGetJsonSetings(bool i18n) const
     // Status
     if (statusCheckBox_->IsChecked())
     {
-        wxArrayString s = Model_Checking::all_status();
+        wxArrayString s = Model_Checking::STATUS_STR;
         s.Add(wxTRANSLATE("All Except Reconciled"));
         int item = choiceStatus_->GetSelection();
         wxString status;

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -136,7 +136,8 @@ void mmFilterTransactionsDialog::mmDoInitVariables()
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmSinseCurrentFinancialYear()));
 
     m_accounts_name.clear();
-    const auto accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], NOT_EQUAL));
+    const auto accounts = Model_Account::instance().find(
+        Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, NOT_EQUAL));
     for (const auto& acc : accounts)
     {
         m_accounts_name.push_back(acc.ACCOUNTNAME);

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -75,7 +75,7 @@ const wxString mmExportTransaction::getTransactionCSV(const Model_Checking::Full
         for (const auto &split_entry : full_tran.m_splits)
         {
             double valueSplit = split_entry.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL)
+            if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL)
                 valueSplit = -valueSplit;
             const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
             const wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
@@ -165,7 +165,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
     }
 
     buffer << "D" << mmGetDateForDisplay(full_tran.TRANSDATE, dateMask) << "\n";
-    buffer << "C" << (full_tran.STATUS == "R" ? "R" : "") << "\n";
+    buffer << "C" << (full_tran.STATUS == Model_Checking::STATUS_KEY_RECONCILED ? "R" : "") << "\n";
     double value = Model_Checking::balance(full_tran
         , (reverce ? full_tran.TOACCOUNTID : full_tran.ACCOUNTID));
     const wxString& s = wxString::FromCDouble(value, 2);
@@ -187,7 +187,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
     for (const auto &split_entry : full_tran.m_splits)
     {
         double valueSplit = split_entry.SPLITTRANSAMOUNT;
-        if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL)
+        if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL)
             valueSplit = -valueSplit;
         const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
         wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
@@ -424,7 +424,7 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
         for (const auto &split_entry : full_tran.m_splits)
         {
             double valueSplit = split_entry.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(full_tran) == Model_Checking::WITHDRAWAL) {
+            if (Model_Checking::type_id(full_tran) == Model_Checking::TYPE_ID_WITHDRAWAL) {
                 valueSplit = -valueSplit;
             }
 

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -262,17 +262,17 @@ const wxString mmExportTransaction::getCategoriesQIF()
     return buffer_qif;
 }
 
-//map Quicken !Account type strings to Model_Account::TYPE
+//map Quicken !Account type strings to Model_Account::TYPE_ID
 // (not sure whether these need to be translated)
 const std::unordered_map<wxString, int> mmExportTransaction::m_QIFaccountTypes =
 {
-    std::make_pair(wxString("Cash"), Model_Account::CASH), //Cash Flow: Cash Account
-    std::make_pair(wxString("Bank"), Model_Account::CHECKING), //Cash Flow: Checking Account
-    std::make_pair(wxString("CCard"), Model_Account::CREDIT_CARD), //Cash Flow: Credit Card Account
-    std::make_pair(wxString("Invst"), Model_Account::INVESTMENT), //Investing: Investment Account
-    std::make_pair(wxString("Oth A"), Model_Account::CHECKING), //Property & Debt: Asset
-    std::make_pair(wxString("Oth L"), Model_Account::CHECKING), //Property & Debt: Liability
-    std::make_pair(wxString("Invoice"), Model_Account::CHECKING), //Invoice (Quicken for Business only)
+    std::make_pair(wxString("Cash"), Model_Account::TYPE_ID_CASH), //Cash Flow: Cash Account
+    std::make_pair(wxString("Bank"), Model_Account::TYPE_ID_CHECKING), //Cash Flow: Checking Account
+    std::make_pair(wxString("CCard"), Model_Account::TYPE_ID_CREDIT_CARD), //Cash Flow: Credit Card Account
+    std::make_pair(wxString("Invst"), Model_Account::TYPE_ID_INVESTMENT), //Investing: Investment Account
+    std::make_pair(wxString("Oth A"), Model_Account::TYPE_ID_CHECKING), //Property & Debt: Asset
+    std::make_pair(wxString("Oth L"), Model_Account::TYPE_ID_CHECKING), //Property & Debt: Liability
+    std::make_pair(wxString("Invoice"), Model_Account::TYPE_ID_CHECKING), //Invoice (Quicken for Business only)
 };
 
 const wxString mmExportTransaction::qif_acc_type(const wxString& mmex_type)
@@ -280,7 +280,7 @@ const wxString mmExportTransaction::qif_acc_type(const wxString& mmex_type)
     wxString qif_acc_type = m_QIFaccountTypes.begin()->first;
     for (const auto &item : m_QIFaccountTypes)
     {
-        if (item.second == Model_Account::all_type().Index(mmex_type))
+        if (item.second == Model_Account::TYPE_STR.Index(mmex_type))
         {
             qif_acc_type = item.first;
             break;
@@ -291,12 +291,12 @@ const wxString mmExportTransaction::qif_acc_type(const wxString& mmex_type)
 
 const wxString mmExportTransaction::mm_acc_type(const wxString& qif_type)
 {
-    wxString mm_acc_type = Model_Account::all_type()[Model_Account::CASH];
+    wxString mm_acc_type = Model_Account::TYPE_STR_CASH;
     for (const auto &item : m_QIFaccountTypes)
     {
         if (item.first == qif_type)
         {
-            mm_acc_type = Model_Account::all_type()[(item.second)];
+            mm_acc_type = Model_Account::TYPE_STR[item.second];
             break;
         }
     }

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -472,7 +472,7 @@ void mmQIFExportDialog::mmExportQIF()
     wxArrayInt allCustomFields4Export;
     wxArrayInt allTags4Export;
     const auto transactions = Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL));
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL));
 
     if (exp_transactions && !transactions.empty())
     {
@@ -524,7 +524,7 @@ void mmQIFExportDialog::mmExportQIF()
                 mmExportTransaction::getTransactionJSON(json_writer, full_tran);
                 allAccounts4Export[account_id] = "";
                 if (allPayees4Export.Index(full_tran.PAYEEID) == wxNOT_FOUND
-                    && full_tran.TRANSCODE != Model_Checking::all_type()[Model_Checking::TRANSFER]) {
+                    && full_tran.TRANSCODE != Model_Checking::TYPE_STR_TRANSFER) {
                     allPayees4Export.Add(full_tran.PAYEEID);
                 }
 

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -80,7 +80,7 @@ void mmQIFExportDialog::fillControls()
     accounts_id_.clear();
 
     Model_Account::Data_Set all_accounts = Model_Account::instance().find(
-            Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], NOT_EQUAL)
+            Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, NOT_EQUAL)
     );
 
     for (const auto& a : all_accounts)
@@ -261,7 +261,7 @@ void mmQIFExportDialog::OnAccountsButton(wxCommandEvent& WXUNUSED(event))
     int i = 0;
     wxArrayInt s;
     Model_Account::Data_Set all_accounts = Model_Account::instance().find(
-        Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], NOT_EQUAL)
+        Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, NOT_EQUAL)
     );
 
     for (const auto& a : all_accounts)

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1563,11 +1563,11 @@ int mmQIFImportDialog::getOrCreateAccounts()
             Model_Account::Data *account = Model_Account::instance().create();
 
             account->FAVORITEACCT = "TRUE";
-            account->STATUS = Model_Account::all_status()[Model_Account::OPEN];
+            account->STATUS = Model_Account::STATUS_STR_OPEN;
 
             const auto type = item.second.find(AccountType) != item.second.end() ? item.second.at(AccountType) : "";
             account->ACCOUNTTYPE = mmExportTransaction::mm_acc_type(type);
-            //Model_Account::all_type()[Model_Account::CHECKING];
+            //Model_Account::TYPE_STR_CHECKING;
             account->ACCOUNTNAME = item.first;
             account->INITIALBAL = 0;
             account->INITIALDATE = wxDate::Today().FormatISODate();

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -95,7 +95,7 @@ mmUnivCSVDialog::mmUnivCSVDialog(
     m_account_id(account_id),
     m_file_path(file_path),
     decimal_(Model_Currency::GetBaseCurrency()->DECIMAL_POINT),
-    depositType_(Model_Checking::all_type()[Model_Checking::DEPOSIT])
+    depositType_(Model_Checking::TYPE_STR_DEPOSIT)
 {
     CSVFieldName_[UNIV_CSV_ID] = wxTRANSLATE("ID");
     CSVFieldName_[UNIV_CSV_DATE] = wxTRANSLATE("Date");
@@ -1609,7 +1609,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
 
     for (const auto& pBankTransaction : txns)
     {
-        if (Model_Checking::status(pBankTransaction) == Model_Checking::VOID_ || !pBankTransaction.DELETEDTIME.IsEmpty())
+        if (Model_Checking::status_id(pBankTransaction) == Model_Checking::STATUS_ID_VOID || !pBankTransaction.DELETEDTIME.IsEmpty())
             continue;
 
         Model_Checking::Full_Data tran(pBankTransaction, split, tags);
@@ -1633,7 +1633,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
             Model_Category::Data* category = Model_Category::instance().get(splt.CATEGID);
 
             double amt = splt.SPLITTRANSAMOUNT;
-            if (Model_Checking::type(pBankTransaction) == Model_Checking::WITHDRAWAL
+            if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_WITHDRAWAL
                 && has_split) {
                 amt = -amt;
             }
@@ -1705,7 +1705,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                     itemType = ITransactionsFile::TYPE_NUMBER;
                     break;
                 case UNIV_CSV_TYPE:
-                    entry = Model_Checking::all_type()[Model_Checking::type(pBankTransaction)];
+                    entry = Model_Checking::TYPE_STR[Model_Checking::type_id(pBankTransaction)];
                     break;
                 case UNIV_CSV_ID:
                     entry = wxString::Format("%i", tran.TRANSID);
@@ -1916,7 +1916,7 @@ void mmUnivCSVDialog::update_preview()
             std::stable_sort(txns.begin(), txns.end(), SorterByTRANSDATE());
             for (const auto& pBankTransaction : txns)
             {
-                if (Model_Checking::status(pBankTransaction) == Model_Checking::VOID_ || !pBankTransaction.DELETEDTIME.IsEmpty())
+                if (Model_Checking::status_id(pBankTransaction) == Model_Checking::STATUS_ID_VOID || !pBankTransaction.DELETEDTIME.IsEmpty())
                     continue;
 
                 Model_Checking::Full_Data tran(pBankTransaction, split, tags);
@@ -1948,7 +1948,7 @@ void mmUnivCSVDialog::update_preview()
                     Model_Currency::Data* currency = Model_Account::currency(from_account);
 
                     double amt = splt.SPLITTRANSAMOUNT;
-                    if (Model_Checking::type(pBankTransaction) == Model_Checking::WITHDRAWAL
+                    if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_WITHDRAWAL
                         && has_split) {
                         amt = -amt;
                     }
@@ -2438,7 +2438,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
 
         if (find_if(csvFieldOrder_.begin(), csvFieldOrder_.end(), [](const std::pair<int, int>& element) {return element.first == UNIV_CSV_TYPE; }) == csvFieldOrder_.end()) {
             if ((amount > 0.0 && !m_reverce_sign) || (amount <= 0.0 && m_reverce_sign)) {
-                holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
             }
         }
 
@@ -2551,7 +2551,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = Model_Checking::all_type()[Model_Checking::WITHDRAWAL];
+        holder.Type = Model_Checking::TYPE_STR_WITHDRAWAL;
         break;
 
     case UNIV_CSV_DEPOSIT:
@@ -2569,7 +2569,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+        holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
         break;
 
         // A number of type options are supported to make amount positive 
@@ -2579,7 +2579,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         {
             if (depositType_.CmpNoCase(token) == 0)
             {
-                holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
                 break;
             }
         }
@@ -2587,7 +2587,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         {
             for (const wxString& entry : { "debit", "deposit", "+" }) {
                 if (entry.CmpNoCase(token) == 0) {
-                    holder.Type = Model_Checking::all_type()[Model_Checking::DEPOSIT];
+                    holder.Type = Model_Checking::TYPE_STR_DEPOSIT;
                     break;
                 }
             }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1718,7 +1718,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                         if (data)
                         {
                             // format date fields
-                            if (Model_CustomField::type(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::DATE)
+                            if (Model_CustomField::type_id(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::TYPE_ID_DATE)
                                 entry = mmGetDateForDisplay(data->CONTENT, date_format_);
                             else
                                 entry = data->CONTENT;
@@ -2030,7 +2030,7 @@ void mmUnivCSVDialog::update_preview()
                                 if (data)
                                 {
                                     // Format date fields
-                                    if (Model_CustomField::type(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::DATE)
+                                    if (Model_CustomField::type_id(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::TYPE_ID_DATE)
                                         text << inQuotes(mmGetDateForDisplay(data->CONTENT, date_format_), delimit);
                                     else
                                         text << inQuotes(data->CONTENT, delimit);
@@ -2799,11 +2799,11 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
     if (!value.IsEmpty())
     {
         const Model_CustomField::Data* data = Model_CustomField::instance().get(fieldId);
-        wxString type_string = Model_CustomField::fieldtype_desc(Model_CustomField::type(data));
-        switch (Model_CustomField::type(data))
+        wxString type_string = Model_CustomField::TYPE_STR[Model_CustomField::type_id(data)];
+        switch (Model_CustomField::type_id(data))
         {
             // Check if string can be read as an integer. Will fail if passed a double.
-        case Model_CustomField::INTEGER:
+        case Model_CustomField::TYPE_ID_INTEGER:
             value = cleanseNumberString(value, true);
             if (!value.ToCLong(&int_val))
             {
@@ -2814,7 +2814,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Check if string can be read as a double
-        case Model_CustomField::DECIMAL:
+        case Model_CustomField::TYPE_ID_DECIMAL:
             value = cleanseNumberString(value, true);
             if (!value.ToCDouble(&double_val))
             {
@@ -2830,7 +2830,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Check if string can be interpreted as "True" or "False" (case insensitive)    
-        case Model_CustomField::BOOLEAN:
+        case Model_CustomField::TYPE_ID_BOOLEAN:
             if (bool_true_array.Index(value, false) == wxNOT_FOUND)
                 if (bool_false_array.Index(value, false) == wxNOT_FOUND)
                 {
@@ -2842,7 +2842,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Check if string is a valid choice (case insensitive)
-        case Model_CustomField::SINGLECHOICE:
+        case Model_CustomField::TYPE_ID_SINGLECHOICE:
             choices = Model_CustomField::getChoices(data->PROPERTIES);
             index = choices.Index(value, false);
             if (index == wxNOT_FOUND)
@@ -2854,7 +2854,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Check if all of the ';' delimited strings are valid choices (case insensitive)
-        case Model_CustomField::MULTICHOICE:
+        case Model_CustomField::TYPE_ID_MULTICHOICE:
             choices = Model_CustomField::getChoices(data->PROPERTIES);
             tokenizer = wxStringTokenizer(value, ";");
             value.Clear();
@@ -2875,7 +2875,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Parse the date using the user specified format. Convert to ISO date
-        case Model_CustomField::DATE:
+        case Model_CustomField::TYPE_ID_DATE:
             if (!mmParseDisplayStringToDate(date, value, date_format_))
             {
                 message << " " << wxString::Format(_("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string) <<
@@ -2886,7 +2886,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int fieldId, wxString& value, wxSt
             break;
 
             // Parse the time. Convert to ISO Format
-        case Model_CustomField::TIME:
+        case Model_CustomField::TYPE_ID_TIME:
             if (!time.ParseTime(value))
             {
                 message << " " << wxString::Format(_("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string);

--- a/src/import_export/univcsvdialog.h
+++ b/src/import_export/univcsvdialog.h
@@ -130,7 +130,7 @@ private:
     struct tran_holder
     {
         wxDateTime Date;
-        wxString Type = Model_Checking::all_type()[Model_Checking::WITHDRAWAL];
+        wxString Type = Model_Checking::TYPE_STR_WITHDRAWAL;
         wxString Status = "";
         int ToAccountID = -1;
         double ToAmount = 0.0;

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -1451,14 +1451,14 @@ bool TransactionListCtrl::CheckForClosedAccounts()
         Model_Checking::Data* transaction = Model_Checking::instance().get(i);
         Model_Account::Data* account = Model_Account::instance().get(transaction->ACCOUNTID);
         if (account)
-            if (Model_Account::CLOSED == Model_Account::status(account))
+            if (Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account))
             {
                 closedTrx++;
                 continue;
             }
         Model_Account::Data* to_account = Model_Account::instance().get(transaction->TOACCOUNTID);
         if (to_account) {
-            if (Model_Account::CLOSED == Model_Account::status(account))
+            if (Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account))
                 closedTrx++;
         }
     }

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -91,7 +91,7 @@ TransactionListCtrl::EColumn TransactionListCtrl::toEColumn(const unsigned long 
 void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
 {
     const auto& ref_type = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
-    Model_CustomField::FIELDTYPE type;
+    Model_CustomField::TYPE_ID type;
 
     switch (m_real_columns[sortcol])
     {
@@ -157,7 +157,7 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         break;
     case TransactionListCtrl::COL_UDFC01:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC01");
-        if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC01_val)
                   : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC01_val);
         else
@@ -166,7 +166,7 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         break;
     case TransactionListCtrl::COL_UDFC02:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC02");
-        if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC02_val)
                   : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC02_val);
         else
@@ -175,7 +175,7 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         break;
     case TransactionListCtrl::COL_UDFC03:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC03");
-        if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC03_val)
                   : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC03_val);
         else
@@ -184,7 +184,7 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         break;
     case TransactionListCtrl::COL_UDFC04:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC04");
-        if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC04_val)
                   : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC04_val);
         else
@@ -193,7 +193,7 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         break;
     case TransactionListCtrl::COL_UDFC05:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC05");
-        if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC05_val)
                   : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC05_val);
         else
@@ -340,9 +340,9 @@ void TransactionListCtrl::resetColumns()
         {
             const auto& type = Model_CustomField::getUDFCType(ref_type, udfc_entry);
             int align;
-            if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+            if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
                 align = wxLIST_FORMAT_RIGHT;
-            else if (type == Model_CustomField::FIELDTYPE::BOOLEAN)
+            else if (type == Model_CustomField::TYPE_ID_BOOLEAN)
                 align = wxLIST_FORMAT_CENTER;
             else
                 align = wxLIST_FORMAT_LEFT;
@@ -1918,17 +1918,17 @@ void TransactionListCtrl::doSearchText(const wxString& value)
     EnsureVisible(selectedItem);
 }
 
-wxString UDFCFormatHelper(Model_CustomField::FIELDTYPE type, wxString data)
+wxString UDFCFormatHelper(Model_CustomField::TYPE_ID type, wxString data)
 {
     wxString formattedData = data;
     bool v = false;
     if (!data.empty())
     {
         switch (type) {
-        case Model_CustomField::FIELDTYPE::DATE:
+        case Model_CustomField::TYPE_ID_DATE:
             formattedData = mmGetDateForDisplay(data);
             break;
-        case Model_CustomField::FIELDTYPE::BOOLEAN:
+        case Model_CustomField::TYPE_ID_BOOLEAN:
             v = wxString("TRUE|true|1").Contains(data);
             formattedData = (v) ? L"\u2713" : L"\u2717";
             break;

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -60,7 +60,7 @@ wxBEGIN_EVENT_TABLE(mmCheckingPanel, wxPanel)
     EVT_SEARCHCTRL_SEARCH_BTN(wxID_FIND, mmCheckingPanel::OnSearchTxtEntered)
     EVT_MENU_RANGE(wxID_HIGHEST + MENU_VIEW_ALLTRANSACTIONS, wxID_HIGHEST + MENU_VIEW_ALLTRANSACTIONS + menu_labels().size()
         , mmCheckingPanel::OnViewPopupSelected)
-    EVT_MENU_RANGE(Model_Checking::WITHDRAWAL, Model_Checking::TRANSFER, mmCheckingPanel::OnNewTransaction)
+    EVT_MENU_RANGE(Model_Checking::TYPE_ID_WITHDRAWAL, Model_Checking::TYPE_ID_TRANSFER, mmCheckingPanel::OnNewTransaction)
 wxEND_EVENT_TABLE()
 //----------------------------------------------------------------------------
 
@@ -172,9 +172,9 @@ void mmCheckingPanel::filterTable()
         double transaction_amount = Model_Checking::amount(tran, m_AccountID);
         if (tran.DELETEDTIME.IsEmpty())
         {
-            if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_)
+            if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID)
                 m_account_balance += transaction_amount;
-            if (Model_Checking::status(tran.STATUS) == Model_Checking::RECONCILED)
+            if (Model_Checking::status_id(tran.STATUS) == Model_Checking::STATUS_ID_RECONCILED)
                 m_reconciled_balance += transaction_amount;
         }
 
@@ -254,7 +254,7 @@ void mmCheckingPanel::filterTable()
         {
             if (!expandSplits) {
                 m_listCtrlAccount->m_trans.push_back(full_tran);
-                if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_ && tran.DELETEDTIME.IsEmpty())
+                if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID && tran.DELETEDTIME.IsEmpty())
                     m_filteredBalance += transaction_amount;
             }
             else
@@ -285,7 +285,7 @@ void mmCheckingPanel::filterTable()
                         if(!tagnames.IsEmpty())
                             full_tran.TAGNAMES.Append((full_tran.TAGNAMES.IsEmpty() ? "" : ", ") + tagnames.Trim());
                         m_listCtrlAccount->m_trans.push_back(full_tran);
-                        if (Model_Checking::status(tran.STATUS) != Model_Checking::VOID_ && tran.DELETEDTIME.IsEmpty())
+                        if (Model_Checking::status_id(tran.STATUS) != Model_Checking::STATUS_ID_VOID && tran.DELETEDTIME.IsEmpty())
                             m_filteredBalance += full_tran.AMOUNT;
                     }
                 }
@@ -320,9 +320,9 @@ void mmCheckingPanel::OnButtonRightDown(wxMouseEvent& event)
     case wxID_NEW:
     {
         wxMenu menu;
-        menu.Append(Model_Checking::WITHDRAWAL, _("&New Withdrawal..."));
-        menu.Append(Model_Checking::DEPOSIT, _("&New Deposit..."));
-        menu.Append(Model_Checking::TRANSFER, _("&New Transfer..."));
+        menu.Append(Model_Checking::TYPE_ID_WITHDRAWAL, _("&New Withdrawal..."));
+        menu.Append(Model_Checking::TYPE_ID_DEPOSIT, _("&New Deposit..."));
+        menu.Append(Model_Checking::TYPE_ID_TRANSFER, _("&New Transfer..."));
         PopupMenu(&menu);
     }
     default:
@@ -908,7 +908,7 @@ void mmCheckingPanel::OnSearchTxtEntered(wxCommandEvent& event)
 void mmCheckingPanel::DisplaySplitCategories(int transID)
 {
     const Model_Checking::Data* tran = Model_Checking::instance().get(transID);
-    int transType = Model_Checking::type(tran->TRANSCODE);
+    int transType = Model_Checking::type_id(tran->TRANSCODE);
 
     Model_Checking::Data *transaction = Model_Checking::instance().get(transID);
     auto splits = Model_Checking::splittransaction(transaction);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -134,11 +134,11 @@ void mmCheckingPanel::filterTable()
     
     const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
     const wxString splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
-    Model_CustomField::FIELDTYPE UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
-    Model_CustomField::FIELDTYPE UDFC02_Type = Model_CustomField::getUDFCType(RefType, "UDFC02");
-    Model_CustomField::FIELDTYPE UDFC03_Type = Model_CustomField::getUDFCType(RefType, "UDFC03");
-    Model_CustomField::FIELDTYPE UDFC04_Type = Model_CustomField::getUDFCType(RefType, "UDFC04");
-    Model_CustomField::FIELDTYPE UDFC05_Type = Model_CustomField::getUDFCType(RefType, "UDFC05");
+    Model_CustomField::TYPE_ID UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
+    Model_CustomField::TYPE_ID UDFC02_Type = Model_CustomField::getUDFCType(RefType, "UDFC02");
+    Model_CustomField::TYPE_ID UDFC03_Type = Model_CustomField::getUDFCType(RefType, "UDFC03");
+    Model_CustomField::TYPE_ID UDFC04_Type = Model_CustomField::getUDFCType(RefType, "UDFC04");
+    Model_CustomField::TYPE_ID UDFC05_Type = Model_CustomField::getUDFCType(RefType, "UDFC05");
     int UDFC01_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC01"));
     int UDFC02_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC02"));
     int UDFC03_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC03"));
@@ -209,11 +209,11 @@ void mmCheckingPanel::filterTable()
             }
         }
 
-        full_tran.UDFC01_Type = Model_CustomField::FIELDTYPE::UNKNOWN;
-        full_tran.UDFC02_Type = Model_CustomField::FIELDTYPE::UNKNOWN;
-        full_tran.UDFC03_Type = Model_CustomField::FIELDTYPE::UNKNOWN;
-        full_tran.UDFC04_Type = Model_CustomField::FIELDTYPE::UNKNOWN;
-        full_tran.UDFC05_Type = Model_CustomField::FIELDTYPE::UNKNOWN;
+        full_tran.UDFC01_Type = Model_CustomField::TYPE_ID_UNKNOWN;
+        full_tran.UDFC02_Type = Model_CustomField::TYPE_ID_UNKNOWN;
+        full_tran.UDFC03_Type = Model_CustomField::TYPE_ID_UNKNOWN;
+        full_tran.UDFC04_Type = Model_CustomField::TYPE_ID_UNKNOWN;
+        full_tran.UDFC05_Type = Model_CustomField::TYPE_ID_UNKNOWN;
         full_tran.UDFC01_val = -DBL_MAX;
         full_tran.UDFC02_val = -DBL_MAX;
         full_tran.UDFC03_val = -DBL_MAX;

--- a/src/mmcustomdata.cpp
+++ b/src/mmcustomdata.cpp
@@ -100,9 +100,9 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 
         grid_sizer_custom->Add(Description, g_flagsH);
 
-        switch (Model_CustomField::type(field))
+        switch (Model_CustomField::type_id(field))
         {
-        case Model_CustomField::STRING:
+        case Model_CustomField::TYPE_ID_STRING:
         {
             const auto& data = fieldData->CONTENT;
             wxTextCtrl* CustomString = new wxTextCtrl(scrolled_window, controlID, data, wxDefaultPosition, wxDefaultSize);
@@ -122,8 +122,8 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
             CustomString->Connect(controlID, wxEVT_TEXT, wxCommandEventHandler(mmCustomData::OnStringChanged), nullptr, this);
             break;
         }
-        case Model_CustomField::INTEGER:
-        case Model_CustomField::DECIMAL:
+        case Model_CustomField::TYPE_ID_INTEGER:
+        case Model_CustomField::TYPE_ID_DECIMAL:
         {
             int digitScale = Model_CustomField::getDigitScale(field.PROPERTIES);
             wxString content = cleanseNumberString(fieldData->CONTENT, digitScale > 0);
@@ -150,7 +150,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case Model_CustomField::BOOLEAN:
+        case Model_CustomField::TYPE_ID_BOOLEAN:
         {
             wxRadioButton* CustomBooleanF = new wxRadioButton(scrolled_window, controlID
                 , _("False"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
@@ -177,7 +177,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case Model_CustomField::DATE:
+        case Model_CustomField::TYPE_ID_DATE:
         {
             wxDate value;
             if (!value.ParseDate(fieldData->CONTENT)) {
@@ -196,7 +196,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case Model_CustomField::TIME:
+        case Model_CustomField::TYPE_ID_TIME:
         {
             wxDateTime value;
             if (!value.ParseTime(fieldData->CONTENT)) {
@@ -216,7 +216,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case Model_CustomField::SINGLECHOICE:
+        case Model_CustomField::TYPE_ID_SINGLECHOICE:
         {
             wxArrayString Choices = Model_CustomField::getChoices(field.PROPERTIES);
             Choices.Sort();
@@ -241,7 +241,7 @@ bool mmCustomData::FillCustomFields(wxBoxSizer* box_sizer)
             CustomChoice->Connect(controlID, wxEVT_CHOICE, wxCommandEventHandler(mmCustomData::OnSingleChoice), nullptr, this);
             break;
         }
-        case Model_CustomField::MULTICHOICE:
+        case Model_CustomField::TYPE_ID_MULTICHOICE:
         {
             const auto& content = fieldData->CONTENT;
             const auto& name = field.DESCRIPTION;
@@ -285,7 +285,7 @@ void mmCustomData::OnMultiChoice(wxCommandEvent& event)
     }
 
     const auto& name = button->GetName();
-    const wxString& type = Model_CustomField::FIELDTYPE_CHOICES[Model_CustomField::MULTICHOICE].second;
+    const wxString& type = Model_CustomField::TYPE_STR[Model_CustomField::TYPE_ID_MULTICHOICE];
 
     Model_CustomField::Data_Set fields = Model_CustomField::instance()
         .find(Model_CustomField::REFTYPE(m_ref_type)
@@ -489,7 +489,7 @@ bool mmCustomData::SaveCustomValues(int ref_id)
             fieldData->CONTENT = data;
             wxLogDebug("Control:%i Type:%s Value:%s"
                 , controlID
-                , Model_CustomField::all_type()[Model_CustomField::type(field)]
+                , Model_CustomField::TYPE_STR[Model_CustomField::type_id(field)]
                 , data);
 
             if (!fieldData->equals(&oldData)) updateTimestamp = true;
@@ -633,7 +633,7 @@ int mmCustomData::GetWidgetType(wxWindowID controlID) const
     {
         if (entry.FIELDID == control_id)
         {
-            return Model_CustomField::type(entry);
+            return Model_CustomField::type_id(entry);
         }
     }
     wxFAIL_MSG("unknown custom field type");
@@ -765,8 +765,8 @@ bool mmCustomData::ValidateCustomValues(int ref_id)
         if (!cb || !cb->GetValue())
             continue;
 
-        if (GetWidgetType(controlID) == Model_CustomField::DECIMAL 
-                || GetWidgetType(controlID) == Model_CustomField::INTEGER)
+        if (GetWidgetType(controlID) == Model_CustomField::TYPE_ID_DECIMAL 
+                || GetWidgetType(controlID) == Model_CustomField::TYPE_ID_INTEGER)
         {
             wxWindow* w = FindWindowById(controlID, m_dialog);
             if (w)

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -857,9 +857,9 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
 
         for (const auto& account : Model_Account::instance().all(Model_Account::COL_ACCOUNTNAME))
         {
-            if ((m_temp_view == VIEW_ACCOUNTS_OPEN_STR) && (Model_Account::status(account) != Model_Account::OPEN))
+            if ((m_temp_view == VIEW_ACCOUNTS_OPEN_STR) && (Model_Account::status_id(account) != Model_Account::STATUS_ID_OPEN))
                 continue;
-            else if (m_temp_view == VIEW_ACCOUNTS_CLOSED_STR && (Model_Account::status(account) == Model_Account::OPEN))
+            else if (m_temp_view == VIEW_ACCOUNTS_CLOSED_STR && (Model_Account::status_id(account) == Model_Account::STATUS_ID_OPEN))
                 continue;
             else if (m_temp_view == VIEW_ACCOUNTS_FAVORITES_STR && !Model_Account::FAVORITEACCT(account))
                 continue;
@@ -867,11 +867,11 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
             int selectedImage = Option::instance().AccountImageId(account.ACCOUNTID, false);
 
             wxTreeItemId tacct;
-            Model_Account::TYPE account_type = Model_Account::type(account);
-            if (Model_Account::FAVORITEACCT(account) && (Model_Account::status(account) == Model_Account::OPEN))
+            Model_Account::TYPE_ID account_type = Model_Account::type_id(account);
+            if (Model_Account::FAVORITEACCT(account) && (Model_Account::status_id(account) == Model_Account::STATUS_ID_OPEN))
             {
-                if (Model_Account::type(account) != Model_Account::INVESTMENT &&
-                    (account_type != Model_Account::SHARES || !hideShareAccounts))
+                if (Model_Account::type_id(account) != Model_Account::TYPE_ID_INVESTMENT &&
+                    (account_type != Model_Account::TYPE_ID_SHARES || !hideShareAccounts))
                 {
                     tacct = m_nav_tree_ctrl->AppendItem(favorites, account.ACCOUNTNAME, selectedImage, selectedImage);
                     m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
@@ -880,7 +880,7 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
 
             switch (account_type)
             {
-            case Model_Account::INVESTMENT:
+            case Model_Account::TYPE_ID_INVESTMENT:
             {
                 tacct = m_nav_tree_ctrl->AppendItem(stocks, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::STOCK, account.ACCOUNTID));
@@ -902,34 +902,34 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
                 }
                 break;
             }
-            case Model_Account::CHECKING:
+            case Model_Account::TYPE_ID_CHECKING:
                 tacct = m_nav_tree_ctrl->AppendItem(accounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
-            case Model_Account::SHARES:
+            case Model_Account::TYPE_ID_SHARES:
                 if (!hideShareAccounts)
                 {
                     tacct = m_nav_tree_ctrl->AppendItem(shareAccounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                     m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 }
                 break;
-            case Model_Account::ASSET:
+            case Model_Account::TYPE_ID_ASSET:
                 tacct = m_nav_tree_ctrl->AppendItem(assets, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
-            case Model_Account::TERM:
+            case Model_Account::TYPE_ID_TERM:
                 tacct = m_nav_tree_ctrl->AppendItem(termAccounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
-            case Model_Account::CREDIT_CARD:
+            case Model_Account::TYPE_ID_CREDIT_CARD:
                 tacct = m_nav_tree_ctrl->AppendItem(cardAccounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
-            case Model_Account::CASH:
+            case Model_Account::TYPE_ID_CASH:
                 tacct = m_nav_tree_ctrl->AppendItem(cashAccounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
-            case Model_Account::LOAN:
+            case Model_Account::TYPE_ID_LOAN:
                 tacct = m_nav_tree_ctrl->AppendItem(loanAccounts, account.ACCOUNTNAME, selectedImage, selectedImage);
                 m_nav_tree_ctrl->SetItemData(tacct, new mmTreeItemData(mmTreeItemData::ACCOUNT, account.ACCOUNTID));
                 break;
@@ -1392,7 +1392,7 @@ void mmGUIFrame::OnPopupDeleteAccount(wxCommandEvent& /*event*/)
         if (account)
         {
             wxString warning_msg = _("Do you really want to delete the account?");
-            if (account->ACCOUNTTYPE == Model_Account::all_type()[Model_Account::INVESTMENT] || account->ACCOUNTTYPE == Model_Account::all_type()[Model_Account::SHARES])
+            if (account->ACCOUNTTYPE == Model_Account::TYPE_STR_INVESTMENT || account->ACCOUNTTYPE == Model_Account::TYPE_STR_SHARES)
             {
                 warning_msg += "\n\nThis will also delete any associated Shares.";
             }
@@ -1517,7 +1517,7 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
             menu.Append(MENU_TREEPOPUP_LAUNCHWEBSITE, _("&Launch Account Website"));
             menu.Append(MENU_TREEPOPUP_ACCOUNTATTACHMENTS, _("&Attachment Manager..."));
             menu.Enable(MENU_TREEPOPUP_LAUNCHWEBSITE, !account->WEBSITE.IsEmpty());
-            menu.Enable(MENU_TREEPOPUP_REALLOCATE, account->ACCOUNTTYPE != Model_Account::all_type()[Model_Account::SHARES]);
+            menu.Enable(MENU_TREEPOPUP_REALLOCATE, account->ACCOUNTTYPE != Model_Account::TYPE_STR_SHARES);
             menu.AppendSeparator();
             AppendImportMenu(menu);
             PopupMenu(&menu, pt);
@@ -2705,7 +2705,7 @@ void mmGUIFrame::OnNewAccount(wxCommandEvent& /*event*/)
         Model_Account::Data* account = Model_Account::instance().get(wizard->acctID_);
         mmNewAcctDialog dlg(account, this);
         dlg.ShowModal();
-        if (account->ACCOUNTTYPE == Model_Account::all_type()[Model_Account::ASSET])
+        if (account->ACCOUNTTYPE == Model_Account::TYPE_STR_ASSET)
         {
             wxMessageBox(_(
                 "Asset Accounts hold Asset transactions\n\n"
@@ -2715,7 +2715,7 @@ void mmGUIFrame::OnNewAccount(wxCommandEvent& /*event*/)
             ), _("Asset Account Creation"));
         }
 
-        if (account->ACCOUNTTYPE == Model_Account::all_type()[Model_Account::SHARES])
+        if (account->ACCOUNTTYPE == Model_Account::TYPE_STR_SHARES)
         {
             wxMessageBox(wxGetTranslation(wxString::FromUTF8(wxTRANSLATE(
                 "Share Accounts hold Share transactions\n\n"
@@ -3461,7 +3461,7 @@ void mmGUIFrame::OnGotoAccount(wxCommandEvent& WXUNUSED(event))
     bool proper_type = false;
     Model_Account::Data *acc = Model_Account::instance().get(gotoAccountID_);
     if (acc)
-        proper_type = Model_Account::type(acc) != Model_Account::INVESTMENT;
+        proper_type = Model_Account::type_id(acc) != Model_Account::TYPE_ID_INVESTMENT;
     if (proper_type)
         createCheckingAccountPage(gotoAccountID_);
     m_nav_tree_ctrl->Refresh();
@@ -3472,7 +3472,7 @@ void mmGUIFrame::OnGotoStocksAccount(wxCommandEvent& WXUNUSED(event))
     bool proper_type = false;
     Model_Account::Data *acc = Model_Account::instance().get(gotoAccountID_);
     if (acc)
-        proper_type = Model_Account::type(acc) == Model_Account::INVESTMENT;
+        proper_type = Model_Account::type_id(acc) == Model_Account::TYPE_ID_INVESTMENT;
     if (proper_type)
         createStocksAccountPage(gotoAccountID_);
     m_nav_tree_ctrl->Refresh();
@@ -3655,8 +3655,8 @@ void mmGUIFrame::ReallocateAccount(int accountID)
 {
     Model_Account::Data* account = Model_Account::instance().get(accountID);
 
-    wxArrayString types = Model_Account::instance().all_type();
-    types.Remove(Model_Account::all_type()[Model_Account::INVESTMENT]);
+    wxArrayString types = Model_Account::TYPE_STR;
+    types.Remove(Model_Account::TYPE_STR_INVESTMENT);
     types.Remove(account->ACCOUNTTYPE);
     wxArrayString t;
     for (const auto &entry : types)

--- a/src/mmframereport.cpp
+++ b/src/mmframereport.cpp
@@ -222,7 +222,7 @@ void mmGUIFrame::DoUpdateReportNavigation(wxTreeItemId& parent_item)
 
     ///////////////////////////////////////////////////////////////////
 
-    Model_Account::Data_Set investments_account = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], EQUAL));
+    Model_Account::Data_Set investments_account = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, EQUAL));
     if (!investments_account.empty())
     {
         if (hidden_reports.Index("Stocks Report") == wxNOT_FOUND)

--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -205,8 +205,8 @@ void htmlWidgetTop7Categories::getTopCategoryStats(
     const auto &transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
-        , Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL));
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
+        , Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL));
 
     for (const auto &trx : transactions)
     {
@@ -214,7 +214,7 @@ void htmlWidgetTop7Categories::getTopCategoryStats(
         if (Model_Checking::foreignTransactionAsTransfer(trx) || !trx.DELETEDTIME.IsEmpty())
             continue;
 
-        bool withdrawal = Model_Checking::type(trx) == Model_Checking::WITHDRAWAL;
+        bool withdrawal = Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_WITHDRAWAL;
         const auto it = split.find(trx.TRANSID);
 
         double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
@@ -315,7 +315,7 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         if (account) accountStr = account->ACCOUNTNAME;
 
         wxString payeeStr = "";
-        if (Model_Billsdeposits::type(entry) == Model_Checking::TRANSFER)
+        if (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_TRANSFER)
         {
             const Model_Account::Data *to_account = Model_Account::instance().get(entry.TOACCOUNTID);
             if (to_account) payeeStr = to_account->ACCOUNTNAME;
@@ -325,10 +325,10 @@ const wxString htmlWidgetBillsAndDeposits::getHTMLText()
         {
             const Model_Payee::Data* payee = Model_Payee::instance().get(entry.PAYEEID);
             payeeStr = accountStr;
-            payeeStr += (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? " &rarr; " : " &larr; ");
+            payeeStr += (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_WITHDRAWAL ? " &rarr; " : " &larr; ");
             if (payee) payeeStr += payee->PAYEENAME;
         }
-        double amount = (Model_Billsdeposits::type(entry) == Model_Checking::WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
+        double amount = (Model_Billsdeposits::type_id(entry) == Model_Checking::TYPE_ID_WITHDRAWAL ? -entry.TRANSAMOUNT : entry.TRANSAMOUNT);
         wxString notes = HTMLEncode(entry.NOTES);
         bd_days.push_back(std::make_tuple(daysPayment, payeeStr, daysRemainingStr, amount, account, notes));
     }
@@ -388,8 +388,8 @@ const wxString htmlWidgetIncomeVsExpenses::getHTMLText()
     const auto &transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(date_range.get()->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range.get()->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
-        , Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL)
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
+        , Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL)
     );
 
     for (const auto& pBankTransaction : transactions)
@@ -402,7 +402,7 @@ const wxString htmlWidgetIncomeVsExpenses::getHTMLText()
         double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(pBankTransaction.ACCOUNTID)->CURRENCYID, pBankTransaction.TRANSDATE);
 
         int idx = pBankTransaction.ACCOUNTID;
-        if (Model_Checking::type(pBankTransaction) == Model_Checking::DEPOSIT)
+        if (Model_Checking::type_id(pBankTransaction) == Model_Checking::TYPE_ID_DEPOSIT)
             incomeExpensesStats[idx].first += pBankTransaction.TRANSAMOUNT * convRate;
         else
             incomeExpensesStats[idx].second += pBankTransaction.TRANSAMOUNT * convRate;
@@ -493,13 +493,13 @@ const wxString htmlWidgetStatistics::getHTMLText()
         if (Model_Checking::foreignTransactionAsTransfer(trx))
             continue;
 
-        if (Model_Checking::status(trx) == Model_Checking::FOLLOWUP)
+        if (Model_Checking::status_id(trx) == Model_Checking::STATUS_ID_FOLLOWUP)
             countFollowUp++;
 
         accountStats[trx.ACCOUNTID].first += Model_Checking::reconciled(trx, trx.ACCOUNTID);
         accountStats[trx.ACCOUNTID].second += Model_Checking::balance(trx, trx.ACCOUNTID);
 
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER)
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER)
         {
             accountStats[trx.TOACCOUNTID].first += Model_Checking::reconciled(trx, trx.TOACCOUNTID);
             accountStats[trx.TOACCOUNTID].second += Model_Checking::balance(trx, trx.TOACCOUNTID);
@@ -673,7 +673,7 @@ void htmlWidgetAccounts::get_account_stats()
         accountStats_[trx.ACCOUNTID].first += Model_Checking::reconciled(trx, trx.ACCOUNTID);
         accountStats_[trx.ACCOUNTID].second += Model_Checking::balance(trx, trx.ACCOUNTID);
 
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER)
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER)
         {
             accountStats_[trx.TOACCOUNTID].first += Model_Checking::reconciled(trx, trx.TOACCOUNTID);
             accountStats_[trx.TOACCOUNTID].second += Model_Checking::balance(trx, trx.TOACCOUNTID);

--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -87,8 +87,8 @@ const wxString htmlWidgetStocks::getHTMLText()
         wxString body = "";
         for (const auto& account : accounts)
         {
-            if (Model_Account::type(account) != Model_Account::INVESTMENT) continue;
-            if (Model_Account::status(account) != Model_Account::OPEN) continue;
+            if (Model_Account::type_id(account) != Model_Account::TYPE_ID_INVESTMENT) continue;
+            if (Model_Account::status_id(account) != Model_Account::STATUS_ID_OPEN) continue;
             body += "<tr>";
             body += wxString::Format("<td sorttable_customkey='*%s*'><a href='stock:%i' oncontextmenu='return false;' target='_blank'>%s</a>%s</td>\n"
                 , account.ACCOUNTNAME, account.ACCOUNTID, account.ACCOUNTNAME,
@@ -682,7 +682,7 @@ void htmlWidgetAccounts::get_account_stats()
 
 }
 
-const wxString htmlWidgetAccounts::displayAccounts(double& tBalance, double& tReconciled, int type = Model_Account::CHECKING)
+const wxString htmlWidgetAccounts::displayAccounts(double& tBalance, double& tReconciled, int type = Model_Account::TYPE_ID_CHECKING)
 {
     static const std::vector < std::pair <wxString, wxString> > typeStr
     {
@@ -713,8 +713,8 @@ const wxString htmlWidgetAccounts::displayAccounts(double& tBalance, double& tRe
     const wxDate today = wxDate::Today();
     wxString vAccts = Model_Setting::instance().GetViewAccounts();
     auto accounts = Model_Account::instance().find(
-        Model_Account::ACCOUNTTYPE(Model_Account::all_type()[type])
-        , Model_Account::STATUS(Model_Account::CLOSED, NOT_EQUAL));
+        Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR[type])
+        , Model_Account::STATUS(Model_Account::STATUS_ID_CLOSED, NOT_EQUAL));
     std::stable_sort(accounts.begin(), accounts.end(), SorterByACCOUNTNAME());
     for (const auto& account : accounts)
     {
@@ -727,7 +727,7 @@ const wxString htmlWidgetAccounts::displayAccounts(double& tBalance, double& tRe
         tReconciled += reconciledBal * currency_rate;
 
         // show the actual amount in that account
-        if (((vAccts == VIEW_ACCOUNTS_OPEN_STR && Model_Account::status(account) == Model_Account::OPEN) ||
+        if (((vAccts == VIEW_ACCOUNTS_OPEN_STR && Model_Account::status_id(account) == Model_Account::STATUS_ID_OPEN) ||
             (vAccts == VIEW_ACCOUNTS_FAVORITES_STR && Model_Account::FAVORITEACCT(account)) ||
             (vAccts == VIEW_ACCOUNTS_ALL_STR)))
         {

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -140,29 +140,29 @@ void mmHomePagePanel::insertDataIntoTemplate()
     double assetBalance = 0.0, assetReconciled = 0.0;
 
     htmlWidgetAccounts account_stats;
-    m_frames["ACCOUNTS_INFO"] = account_stats.displayAccounts(tBalance, tReconciled, Model_Account::CHECKING);
-    m_frames["CARD_ACCOUNTS_INFO"] = account_stats.displayAccounts(cardBalance, cardReconciled, Model_Account::CREDIT_CARD);
+    m_frames["ACCOUNTS_INFO"] = account_stats.displayAccounts(tBalance, tReconciled, Model_Account::TYPE_ID_CHECKING);
+    m_frames["CARD_ACCOUNTS_INFO"] = account_stats.displayAccounts(cardBalance, cardReconciled, Model_Account::TYPE_ID_CREDIT_CARD);
     tBalance += cardBalance;
     tReconciled += cardReconciled;
 
     // Accounts
-    m_frames["CASH_ACCOUNTS_INFO"] = account_stats.displayAccounts(cashBalance, cashReconciled, Model_Account::CASH);
+    m_frames["CASH_ACCOUNTS_INFO"] = account_stats.displayAccounts(cashBalance, cashReconciled, Model_Account::TYPE_ID_CASH);
     tBalance += cashBalance;
     tReconciled += cashReconciled;
 
-    m_frames["LOAN_ACCOUNTS_INFO"] = account_stats.displayAccounts(loanBalance, loanReconciled, Model_Account::LOAN);
+    m_frames["LOAN_ACCOUNTS_INFO"] = account_stats.displayAccounts(loanBalance, loanReconciled, Model_Account::TYPE_ID_LOAN);
     tBalance += loanBalance;
     tReconciled += loanReconciled;
 
-    m_frames["TERM_ACCOUNTS_INFO"] = account_stats.displayAccounts(termBalance, termReconciled, Model_Account::TERM);
+    m_frames["TERM_ACCOUNTS_INFO"] = account_stats.displayAccounts(termBalance, termReconciled, Model_Account::TYPE_ID_TERM);
     tBalance += termBalance;
     tReconciled += termReconciled;
 
-    account_stats.displayAccounts(assetBalance, assetReconciled, Model_Account::ASSET);
+    account_stats.displayAccounts(assetBalance, assetReconciled, Model_Account::TYPE_ID_ASSET);
     tBalance += assetBalance;
     tReconciled += assetReconciled;
 
-    account_stats.displayAccounts(shareBalance, shareReconciled, Model_Account::SHARES);
+    account_stats.displayAccounts(shareBalance, shareReconciled, Model_Account::TYPE_ID_SHARES);
     tBalance += shareBalance;
     tReconciled += shareReconciled;
 

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -356,9 +356,9 @@ void mmReportsPanel::CreateControls()
             m_accounts = new wxChoice(itemPanel3, ID_CHOICE_ACCOUNTS);
             m_accounts->Append(_("All Accounts:"));
             m_accounts->Append(_("Specific Accounts:"));
-            for (const auto& e : Model_Account::instance().TYPE_CHOICES)
+            for (const auto& e : Model_Account::TYPE_CHOICES)
             {
-                if (e.first != Model_Account::INVESTMENT) {
+                if (e.first != Model_Account::TYPE_ID_INVESTMENT) {
                     m_accounts->Append(wxGetTranslation(e.second), new wxStringClientData(e.second));
                 }
             }

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -122,7 +122,7 @@ public:
     Args: One or more Specialised Parameters creating SQL statement conditions used after the WHERE statement.
     Specialised Parameters: Table_Column_Name(content)[, Table_Column_Name(content)[, ...]]
     Example:
-    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_JEWELLERY)
+    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_ID_JEWELLERY)
     produces SQL statement condition: ASSETID = 2 AND ASSETTYPE = "Jewellery"
     * Returns a Data_Set containing the addresses of the items found.
     * The Data_Set is empty when nothing found.
@@ -138,7 +138,7 @@ public:
     Args: One or more Specialised Parameters creating SQL statement conditions used after the WHERE statement.
     Specialised Parameters: Table_Column_Name(content)[, Table_Column_Name(content)[, ...]]
     Example:
-    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_JEWELLERY)
+    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_ID_JEWELLERY)
     produces SQL statement condition: ASSETID = 2 OR ASSETTYPE = "Jewellery"
     * Returns a Data_Set containing the addresses of the items found.
     * The Data_Set is empty when nothing found.

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -22,23 +22,37 @@
 #include "Model_Translink.h"
 #include "Model_Shareinfo.h"
 
-const std::vector<std::pair<Model_Account::STATUS_ENUM, wxString> > Model_Account::STATUS_CHOICES =
+const std::vector<std::pair<Model_Account::TYPE_ID, wxString> > Model_Account::TYPE_CHOICES =
 {
-    {Model_Account::OPEN, wxString(wxTRANSLATE("Open"))},
-    {Model_Account::CLOSED, wxString(wxTRANSLATE("Closed"))}
+    { Model_Account::TYPE_ID_CASH,        wxString(wxTRANSLATE("Cash")) },
+    { Model_Account::TYPE_ID_CHECKING,    wxString(wxTRANSLATE("Checking")) },
+    { Model_Account::TYPE_ID_CREDIT_CARD, wxString(wxTRANSLATE("Credit Card")) },
+    { Model_Account::TYPE_ID_LOAN,        wxString(wxTRANSLATE("Loan")) },
+    { Model_Account::TYPE_ID_TERM,        wxString(wxTRANSLATE("Term")) },
+    { Model_Account::TYPE_ID_INVESTMENT,  wxString(wxTRANSLATE("Investment")) },
+    { Model_Account::TYPE_ID_ASSET,       wxString(wxTRANSLATE("Asset")) },
+    { Model_Account::TYPE_ID_SHARES,      wxString(wxTRANSLATE("Shares")) },
 };
 
-const std::vector<std::pair<Model_Account::TYPE, wxString> > Model_Account::TYPE_CHOICES =
+const std::vector<std::pair<Model_Account::STATUS_ID, wxString> > Model_Account::STATUS_CHOICES =
 {
-    {Model_Account::CASH, wxString(wxTRANSLATE("Cash"))},
-    {Model_Account::CHECKING, wxString(wxTRANSLATE("Checking"))},
-    {Model_Account::CREDIT_CARD, wxString(wxTRANSLATE("Credit Card"))},
-    {Model_Account::LOAN, wxString(wxTRANSLATE("Loan"))},
-    {Model_Account::TERM, wxString(wxTRANSLATE("Term"))},
-    {Model_Account::INVESTMENT, wxString(wxTRANSLATE("Investment"))},
-    {Model_Account::ASSET, wxString(wxTRANSLATE("Asset"))},
-    {Model_Account::SHARES, wxString(wxTRANSLATE("Shares"))},
+    { Model_Account::STATUS_ID_OPEN,   wxString(wxTRANSLATE("Open")) },
+    { Model_Account::STATUS_ID_CLOSED, wxString(wxTRANSLATE("Closed")) }
 };
+
+wxArrayString Model_Account::TYPE_STR = type_str_all();
+const wxString Model_Account::TYPE_STR_CASH        = TYPE_STR[TYPE_ID_CASH];
+const wxString Model_Account::TYPE_STR_CHECKING    = TYPE_STR[TYPE_ID_CHECKING];
+const wxString Model_Account::TYPE_STR_CREDIT_CARD = TYPE_STR[TYPE_ID_CREDIT_CARD];
+const wxString Model_Account::TYPE_STR_LOAN        = TYPE_STR[TYPE_ID_LOAN];
+const wxString Model_Account::TYPE_STR_TERM        = TYPE_STR[TYPE_ID_TERM];
+const wxString Model_Account::TYPE_STR_INVESTMENT  = TYPE_STR[TYPE_ID_INVESTMENT];
+const wxString Model_Account::TYPE_STR_ASSET       = TYPE_STR[TYPE_ID_ASSET];
+const wxString Model_Account::TYPE_STR_SHARES      = TYPE_STR[TYPE_ID_SHARES];
+
+wxArrayString Model_Account::STATUS_STR = status_str_all();
+const wxString Model_Account::STATUS_STR_OPEN   = STATUS_STR[STATUS_ID_OPEN];
+const wxString Model_Account::STATUS_STR_CLOSED = STATUS_STR[STATUS_ID_CLOSED];
 
 Model_Account::Model_Account()
 : Model<DB_Table_ACCOUNTLIST_V1>()
@@ -75,9 +89,9 @@ wxArrayString Model_Account::all_checking_account_names(bool skip_closed)
     wxArrayString accounts;
     for (const auto &account : this->all(COL_ACCOUNTNAME))
     {
-        if (skip_closed && status(account) == CLOSED)
+        if (skip_closed && status_id(account) == STATUS_ID_CLOSED)
             continue;
-        if (type(account) == INVESTMENT)
+        if (type_id(account) == TYPE_ID_INVESTMENT)
             continue;
         if (account.ACCOUNTNAME.empty())
             continue;
@@ -91,9 +105,9 @@ const std::map<wxString, int> Model_Account::all_accounts(bool skip_closed)
     std::map<wxString, int> accounts;
     for (const auto& account : this->all(COL_ACCOUNTNAME))
     {
-        if (skip_closed && status(account) == CLOSED)
+        if (skip_closed && status_id(account) == STATUS_ID_CLOSED)
             continue;
-        if (type(account) == INVESTMENT)
+        if (type_id(account) == TYPE_ID_INVESTMENT)
             continue;
         if (account.ACCOUNTNAME.empty())
             continue;
@@ -102,18 +116,28 @@ const std::map<wxString, int> Model_Account::all_accounts(bool skip_closed)
     return accounts;
 }
 
-wxArrayString Model_Account::all_status()
-{
-    wxArrayString status;
-    for (const auto& item : STATUS_CHOICES) status.Add(item.second);
-    return status;
-}
-
-wxArrayString Model_Account::all_type()
+wxArrayString Model_Account::type_str_all()
 {
     wxArrayString type;
-    for (const auto& item : TYPE_CHOICES) type.Add(item.second);
+    int i = 0;
+    for (const auto& item : TYPE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Account::TYPE_CHOICES");
+        type.Add(item.second);
+    }
     return type;
+}
+
+wxArrayString Model_Account::status_str_all()
+{
+    wxArrayString status;
+    int i = 0;
+    for (const auto& item : STATUS_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Account::STATUS_CHOICES");
+        status.Add(item.second);
+    }
+    return status;
 }
 
 /** Get the Data record instance in memory. */
@@ -262,26 +286,26 @@ wxString Model_Account::toString(double value, const Data& r, int precision)
     return toString(value, &r, precision);
 }
 
-Model_Account::STATUS_ENUM Model_Account::status(const Data* account)
+Model_Account::STATUS_ID Model_Account::status_id(const Data* account)
 {
-    if (account->STATUS.CmpNoCase(all_status()[OPEN]) == 0)
-        return OPEN;
-    return CLOSED;
+    if (account->STATUS.CmpNoCase(status_str_all()[STATUS_ID_OPEN]) == 0)
+        return STATUS_ID_OPEN;
+    return STATUS_ID_CLOSED;
 }
 
-Model_Account::STATUS_ENUM Model_Account::status(const Data& account)
+Model_Account::STATUS_ID Model_Account::status_id(const Data& account)
 {
-    return status(&account);
+    return status_id(&account);
 }
 
-DB_Table_ACCOUNTLIST_V1::STATUS Model_Account::STATUS(STATUS_ENUM status, OP op)
+DB_Table_ACCOUNTLIST_V1::STATUS Model_Account::STATUS(STATUS_ID status, OP op)
 {
-    return DB_Table_ACCOUNTLIST_V1::STATUS(all_status()[status], op);
+    return DB_Table_ACCOUNTLIST_V1::STATUS(status_str_all()[status], op);
 }
 
-Model_Account::TYPE Model_Account::type(const Data* account)
+Model_Account::TYPE_ID Model_Account::type_id(const Data* account)
 {
-    static std::unordered_map<wxString, TYPE> cache;
+    static std::unordered_map<wxString, TYPE_ID> cache;
     const auto it = cache.find(account->ACCOUNTTYPE);
     if (it != cache.end()) return it->second;
 
@@ -294,13 +318,13 @@ Model_Account::TYPE Model_Account::type(const Data* account)
         }
     }
 
-    cache.insert(std::make_pair(account->ACCOUNTTYPE, TYPE::CHECKING));
-    return TYPE::CHECKING;
+    cache.insert(std::make_pair(account->ACCOUNTTYPE, TYPE_ID_CHECKING));
+    return TYPE_ID_CHECKING;
 }
 
-Model_Account::TYPE Model_Account::type(const Data& account)
+Model_Account::TYPE_ID Model_Account::type_id(const Data& account)
 {
-    return type(&account);
+    return type_id(&account);
 }
 
 bool Model_Account::FAVORITEACCT(const Data* r)
@@ -316,7 +340,9 @@ bool Model_Account::FAVORITEACCT(const Data& r)
 bool Model_Account::is_used(const Model_Currency::Data* c)
 {
     if (!c) return false;
-    const auto &accounts = Model_Account::instance().find(CURRENCYID(c->CURRENCYID) , STATUS(CLOSED, NOT_EQUAL));
+    const auto &accounts = Model_Account::instance().find(
+        CURRENCYID(c->CURRENCYID),
+        STATUS(STATUS_ID_CLOSED, NOT_EQUAL));
     return !accounts.empty();
 }
 
@@ -328,13 +354,13 @@ bool Model_Account::is_used(const Model_Currency::Data& c)
 int Model_Account::money_accounts_num()
 {
     return
-        Model_Account::instance().find(ACCOUNTTYPE(all_type()[CASH])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[CHECKING])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[CREDIT_CARD])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[LOAN])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[TERM])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[ASSET])).size()
-        + Model_Account::instance().find(ACCOUNTTYPE(all_type()[SHARES])).size();
+        Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_CASH)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_CHECKING)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_CREDIT_CARD)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_LOAN)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_TERM)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_ASSET)).size()
+        + Model_Account::instance().find(ACCOUNTTYPE(TYPE_STR_SHARES)).size();
 }
 
 bool Model_Account::Exist(const wxString& account_name)
@@ -359,9 +385,9 @@ const Model_Account::Data_Set Model_Account::FilterAccounts(const wxString& acco
     Data_Set accounts;
     for (auto &account : this->all(Model_Account::COL_ACCOUNTNAME))
     {
-        if (skip_closed && status(account) == CLOSED)
+        if (skip_closed && status_id(account) == STATUS_ID_CLOSED)
             continue;
-        if (type(account) == INVESTMENT)
+        if (type_id(account) == TYPE_ID_INVESTMENT)
             continue;
         if (account.ACCOUNTNAME.Lower().Matches(account_pattern.Lower().Append("*")))
             accounts.push_back(account);

--- a/src/model/Model_Account.h
+++ b/src/model/Model_Account.h
@@ -32,11 +32,43 @@ public:
     using Model<DB_Table_ACCOUNTLIST_V1>::remove;
     using Model<DB_Table_ACCOUNTLIST_V1>::get;
 
-    enum STATUS_ENUM { OPEN = 0, CLOSED };
-    enum TYPE { CASH = 0, CHECKING, CREDIT_CARD, LOAN, TERM, INVESTMENT, ASSET, SHARES, MAX};
+    enum TYPE_ID
+    {
+        TYPE_ID_CASH = 0,
+        TYPE_ID_CHECKING,
+        TYPE_ID_CREDIT_CARD,
+        TYPE_ID_LOAN,
+        TYPE_ID_TERM,
+        TYPE_ID_INVESTMENT,
+        TYPE_ID_ASSET,
+        TYPE_ID_SHARES,
+        TYPE_ID_MAX
+    };
+    enum STATUS_ID
+    {
+        STATUS_ID_OPEN = 0,
+        STATUS_ID_CLOSED
+    };
+    static wxArrayString TYPE_STR;
+    static const wxString TYPE_STR_CASH;
+    static const wxString TYPE_STR_CHECKING;
+    static const wxString TYPE_STR_CREDIT_CARD;
+    static const wxString TYPE_STR_LOAN;
+    static const wxString TYPE_STR_TERM;
+    static const wxString TYPE_STR_INVESTMENT;
+    static const wxString TYPE_STR_ASSET;
+    static const wxString TYPE_STR_SHARES;
+    static wxArrayString STATUS_STR;
+    static const wxString STATUS_STR_OPEN;
+    static const wxString STATUS_STR_CLOSED;
 
-    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_CHOICES;
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
+public:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const std::vector<std::pair<STATUS_ID, wxString> > STATUS_CHOICES;
+
+private:
+    static wxArrayString type_str_all();
+    static wxArrayString status_str_all();
 
 public:
     Model_Account();
@@ -73,9 +105,6 @@ public:
     wxArrayString all_checking_account_names(bool skip_closed = false);
     const std::map<wxString, int> all_accounts(bool skip_closed = false);
 
-    static wxArrayString all_status();
-    static wxArrayString all_type();
-
     static Model_Currency::Data* currency(const Data* r);
     static Model_Currency::Data* currency(const Data& r);
 
@@ -95,12 +124,12 @@ public:
     static wxString toString(double value, const Data* r, int precision = 2);
     static wxString toString(double value, const Data& r, int precision = 2);
 
-    static STATUS_ENUM status(const Data* account);
-    static STATUS_ENUM status(const Data& account);
-    static DB_Table_ACCOUNTLIST_V1::STATUS STATUS(STATUS_ENUM status, OP op = EQUAL);
+    static STATUS_ID status_id(const Data* account);
+    static STATUS_ID status_id(const Data& account);
+    static DB_Table_ACCOUNTLIST_V1::STATUS STATUS(STATUS_ID status, OP op = EQUAL);
 
-    static TYPE type(const Data* account);
-    static TYPE type(const Data& account);
+    static TYPE_ID type_id(const Data* account);
+    static TYPE_ID type_id(const Data& account);
 
     static bool FAVORITEACCT(const Data* r);
     static bool FAVORITEACCT(const Data& r);

--- a/src/model/Model_Asset.cpp
+++ b/src/model/Model_Asset.cpp
@@ -21,41 +21,40 @@
 #include "Model_Translink.h"
 #include "Model_CurrencyHistory.h"
 
-const std::vector<std::pair<Model_Asset::RATE, wxString> > Model_Asset::RATE_CHOICES = 
+const std::vector<std::pair<Model_Asset::TYPE_ID, wxString> > Model_Asset::TYPE_CHOICES = 
 {
-    {Model_Asset::RATE_NONE, wxString(wxTRANSLATE("None"))}
-    , {Model_Asset::RATE_APPRECIATE, wxString(wxTRANSLATE("Appreciates"))}
-    , {Model_Asset::RATE_DEPRECIATE, wxString(wxTRANSLATE("Depreciates"))}
+    { Model_Asset::TYPE_ID_PROPERTY,  wxString(wxTRANSLATE("Property")) },
+    { Model_Asset::TYPE_ID_AUTO,      wxString(wxTRANSLATE("Automobile")) },
+    { Model_Asset::TYPE_ID_HOUSE,     wxString(wxTRANSLATE("Household Object")) },
+    { Model_Asset::TYPE_ID_ART,       wxString(wxTRANSLATE("Art")) },
+    { Model_Asset::TYPE_ID_JEWELLERY, wxString(wxTRANSLATE("Jewellery")) },
+    { Model_Asset::TYPE_ID_CASH,      wxString(wxTRANSLATE("Cash")) },
+    { Model_Asset::TYPE_ID_OTHER,     wxString(wxTRANSLATE("Other")) }
 };
 
-const std::vector<std::pair<Model_Asset::RATEMODE, wxString> > Model_Asset::RATEMODE_CHOICES = 
+const std::vector<std::pair<Model_Asset::STATUS_ID, wxString> > Model_Asset::STATUS_CHOICES = 
 {
-    {Model_Asset::PERCENTAGE, wxString(wxTRANSLATE("Percentage"))}
-    , {Model_Asset::LINEAR, wxString(wxTRANSLATE("Linear"))}
+    { Model_Asset::STATUS_ID_CLOSED, wxString(wxTRANSLATE("Closed")) },
+    { Model_Asset::STATUS_ID_OPEN,   wxString(wxTRANSLATE("Open")) }
 };
 
-const wxString Model_Asset::PERCENTAGE_STR = all_ratemode()[PERCENTAGE];
-const wxString Model_Asset::LINEAR_STR = all_ratemode()[LINEAR];
-
-const std::vector<std::pair<Model_Asset::TYPE, wxString> > Model_Asset::TYPE_CHOICES = 
+const std::vector<std::pair<Model_Asset::CHANGE_ID, wxString> > Model_Asset::CHANGE_CHOICES = 
 {
-    {Model_Asset::TYPE_PROPERTY, wxString(wxTRANSLATE("Property"))}
-    , {Model_Asset::TYPE_AUTO, wxString(wxTRANSLATE("Automobile"))}
-    , {Model_Asset::TYPE_HOUSE, wxString(wxTRANSLATE("Household Object"))}
-    , {Model_Asset::TYPE_ART, wxString(wxTRANSLATE("Art"))}
-    , {Model_Asset::TYPE_JEWELLERY, wxString(wxTRANSLATE("Jewellery"))}
-    , {Model_Asset::TYPE_CASH, wxString(wxTRANSLATE("Cash"))}
-    , {Model_Asset::TYPE_OTHER, wxString(wxTRANSLATE("Other"))}
+    { Model_Asset::CHANGE_ID_NONE,       wxString(wxTRANSLATE("None")) },
+    { Model_Asset::CHANGE_ID_APPRECIATE, wxString(wxTRANSLATE("Appreciates")) },
+    { Model_Asset::CHANGE_ID_DEPRECIATE, wxString(wxTRANSLATE("Depreciates")) }
 };
 
-const std::vector<std::pair<Model_Asset::STATUS, wxString> > Model_Asset::STATUS_CHOICES = 
+const std::vector<std::pair<Model_Asset::CHANGEMODE_ID, wxString> > Model_Asset::CHANGEMODE_CHOICES = 
 {
-    {Model_Asset::STATUS_CLOSED, wxString(wxTRANSLATE("Closed"))}
-    , {Model_Asset::STATUS_OPEN, wxString(wxTRANSLATE("Open"))}
+    { Model_Asset::CHANGEMODE_ID_PERCENTAGE, wxString(wxTRANSLATE("Percentage")) },
+    { Model_Asset::CHANGEMODE_ID_LINEAR,     wxString(wxTRANSLATE("Linear")) }
 };
 
-const wxString Model_Asset::OPEN_STR = all_status()[STATUS_OPEN];
-const wxString Model_Asset::CLOSED_STR = all_status()[STATUS_CLOSED];
+wxArrayString Model_Asset::TYPE_STR = type_str_all();
+wxArrayString Model_Asset::STATUS_STR = status_str_all();
+wxArrayString Model_Asset::CHANGE_STR = change_str_all();
+wxArrayString Model_Asset::CHANGEMODE_STR = changemode_str_all();
 
 Model_Asset::Model_Asset()
 : Model<DB_Table_ASSETS_V1>()
@@ -95,32 +94,52 @@ wxString Model_Asset::get_asset_name(int asset_id)
         return _("Asset Error");
 }
 
-wxArrayString Model_Asset::all_rate()
-{
-    wxArrayString rates;
-    for (const auto& item: RATE_CHOICES) rates.Add(item.second);
-    return rates;
-}
-
-wxArrayString Model_Asset::all_ratemode()
-{
-    wxArrayString ratemodes;
-    for (const auto& item: RATEMODE_CHOICES) ratemodes.Add(item.second);
-    return ratemodes;
-}
-
-wxArrayString Model_Asset::all_type()
+wxArrayString Model_Asset::type_str_all()
 {
     wxArrayString types;
-    for (const auto& item: TYPE_CHOICES) types.Add(item.second);
+    int i = 0;
+    for (const auto& item: TYPE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::TYPE_CHOICES");
+        types.Add(item.second);
+    }
     return types;
 }
 
-wxArrayString Model_Asset::all_status()
+wxArrayString Model_Asset::status_str_all()
 {
     wxArrayString statusList;
-    for (const auto& item: STATUS_CHOICES) statusList.Add(item.second);
+    int i = 0;
+    for (const auto& item: STATUS_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::STATUS_CHOICES");
+        statusList.Add(item.second);
+    }
     return statusList;
+}
+
+wxArrayString Model_Asset::change_str_all()
+{
+    wxArrayString rates;
+    int i = 0;
+    for (const auto& item: CHANGE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::CHANGE_CHOICES");
+        rates.Add(item.second);
+    }
+    return rates;
+}
+
+wxArrayString Model_Asset::changemode_str_all()
+{
+    wxArrayString changemodes;
+    int i = 0;
+    for (const auto& item: CHANGEMODE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::CHANGEMODE_CHOICES");
+        changemodes.Add(item.second);
+    }
+    return changemodes;
 }
 
 double Model_Asset::balance()
@@ -133,9 +152,9 @@ double Model_Asset::balance()
     return balance;
 }
 
-DB_Table_ASSETS_V1::ASSETTYPE Model_Asset::ASSETTYPE(TYPE type, OP op)
+DB_Table_ASSETS_V1::ASSETTYPE Model_Asset::ASSETTYPE(TYPE_ID type, OP op)
 {
-    return DB_Table_ASSETS_V1::ASSETTYPE(all_type()[type], op);
+    return DB_Table_ASSETS_V1::ASSETTYPE(TYPE_STR[type], op);
 }
 
 DB_Table_ASSETS_V1::STARTDATE Model_Asset::STARTDATE(const wxDate& date, OP op)
@@ -153,49 +172,48 @@ wxDate Model_Asset::STARTDATE(const Data& r)
     return Model::to_date(r.STARTDATE);
 }
 
-Model_Asset::TYPE Model_Asset::type(const Data* r)
+Model_Asset::TYPE_ID Model_Asset::type_id(const Data* r)
 {
-    for (const auto& item : TYPE_CHOICES) if (item.second.CmpNoCase(r->ASSETTYPE) == 0) return item.first;
-
-    return TYPE(-1);
+    for (const auto& item : TYPE_CHOICES)
+        if (item.second.CmpNoCase(r->ASSETTYPE) == 0) return item.first;
+    return TYPE_ID(-1);
+}
+Model_Asset::TYPE_ID Model_Asset::type_id(const Data& r)
+{
+    return type_id(&r);
 }
 
-Model_Asset::TYPE Model_Asset::type(const Data& r)
+Model_Asset::STATUS_ID Model_Asset::status_id(const Data* r)
 {
-    return type(&r);
+    for (const auto & item : STATUS_CHOICES)
+        if (item.second.CmpNoCase(r->ASSETSTATUS) == 0) return item.first;
+    return STATUS_ID(-1);
+}
+Model_Asset::STATUS_ID Model_Asset::status_id(const Data& r)
+{
+    return status_id(&r);
 }
 
-Model_Asset::RATE Model_Asset::rate(const Data* r)
+Model_Asset::CHANGE_ID Model_Asset::change_id(const Data* r)
 {
-    for (const auto & item : RATE_CHOICES) if (item.second.CmpNoCase(r->VALUECHANGE) == 0) return item.first;
-    return RATE(-1);
+    for (const auto & item : CHANGE_CHOICES)
+        if (item.second.CmpNoCase(r->VALUECHANGE) == 0) return item.first;
+    return CHANGE_ID(-1);
+}
+Model_Asset::CHANGE_ID Model_Asset::change_id(const Data& r)
+{
+    return change_id(&r);
 }
 
-Model_Asset::RATE Model_Asset::rate(const Data& r)
+Model_Asset::CHANGEMODE_ID Model_Asset::changemode_id(const Data* r)
 {
-    return rate(&r);
+    for (const auto & item : CHANGEMODE_CHOICES)
+        if (item.second.CmpNoCase(r->VALUECHANGEMODE) == 0) return item.first;
+    return CHANGEMODE_ID(-1);
 }
-
-Model_Asset::RATEMODE Model_Asset::ratemode(const Data* r)
+Model_Asset::CHANGEMODE_ID Model_Asset::changemode_id(const Data& r)
 {
-    for (const auto & item : RATEMODE_CHOICES) if (item.second.CmpNoCase(r->VALUECHANGEMODE) == 0) return item.first;
-    return RATEMODE(-1);
-}
-
-Model_Asset::RATEMODE Model_Asset::ratemode(const Data& r)
-{
-    return ratemode(&r);
-}
-
-Model_Asset::STATUS Model_Asset::status(const Data* r)
-{
-    for (const auto & item : STATUS_CHOICES) if (item.second.CmpNoCase(r->ASSETSTATUS) == 0) return item.first;
-    return STATUS(-1);
-}
-
-Model_Asset::STATUS Model_Asset::status(const Data& r)
-{
-    return status(&r);
+    return changemode_id(&r);
 }
 
 Model_Currency::Data* Model_Asset::currency(const Data* /* r */)
@@ -231,14 +249,14 @@ double Model_Asset::valueAtDate(const Data* r, const wxDate date)
                     wxTimeSpan diff_time = date - tranDate;
                     double diff_time_in_days = static_cast<double>(diff_time.GetDays());
 
-                    switch (rate(r))
+                    switch (change_id(r))
                     {
-                    case RATE_NONE:
+                    case CHANGE_ID_NONE:
                         break;
-                    case RATE_APPRECIATE:
+                    case CHANGE_ID_APPRECIATE:
                         amount *= pow(1.0 + (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                         break;
-                    case RATE_DEPRECIATE:
+                    case CHANGE_ID_DEPRECIATE:
                         amount *= pow(1.0 - (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                         break;
                     default:
@@ -254,14 +272,14 @@ double Model_Asset::valueAtDate(const Data* r, const wxDate date)
             wxTimeSpan diff_time = date - STARTDATE(r);
             double diff_time_in_days = static_cast<double>(diff_time.GetDays());
 
-            switch (rate(r))
+            switch (change_id(r))
             {
-            case RATE_NONE:
+            case CHANGE_ID_NONE:
                 break;
-            case RATE_APPRECIATE:
+            case CHANGE_ID_APPRECIATE:
                 balance *= pow(1.0 + (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                 break;
-            case RATE_DEPRECIATE:
+            case CHANGE_ID_DEPRECIATE:
                 balance *= pow(1.0 - (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                 break;
             default:

--- a/src/model/Model_Asset.h
+++ b/src/model/Model_Asset.h
@@ -27,23 +27,44 @@
 class Model_Asset : public Model<DB_Table_ASSETS_V1>
 {
 public:
-    enum RATE { RATE_NONE = 0, RATE_APPRECIATE, RATE_DEPRECIATE };
+    enum TYPE_ID
+    {
+        TYPE_ID_PROPERTY = 0,
+        TYPE_ID_AUTO,
+        TYPE_ID_HOUSE,
+        TYPE_ID_ART,
+        TYPE_ID_JEWELLERY,
+        TYPE_ID_CASH,
+        TYPE_ID_OTHER
+    };
+    enum STATUS_ID {
+        STATUS_ID_CLOSED = 0,
+        STATUS_ID_OPEN
+    };
+    enum CHANGE_ID
+    {
+        CHANGE_ID_NONE = 0,
+        CHANGE_ID_APPRECIATE,
+        CHANGE_ID_DEPRECIATE
+    };
+    enum CHANGEMODE_ID {
+        CHANGEMODE_ID_PERCENTAGE = 0,
+        CHANGEMODE_ID_LINEAR
+    };
+    static wxArrayString TYPE_STR;
+    static wxArrayString STATUS_STR;
+    static wxArrayString CHANGE_STR;
+    static wxArrayString CHANGEMODE_STR;
 
-    enum RATEMODE { PERCENTAGE = 0, LINEAR };
-    static const wxString PERCENTAGE_STR;
-    static const wxString LINEAR_STR;
-
-    enum TYPE { TYPE_PROPERTY = 0, TYPE_AUTO, TYPE_HOUSE, TYPE_ART, TYPE_JEWELLERY, TYPE_CASH, TYPE_OTHER };
-
-    enum STATUS { STATUS_CLOSED = 0, STATUS_OPEN };
-    static const wxString OPEN_STR;
-    static const wxString CLOSED_STR;
-
-public:
-    static const std::vector<std::pair<RATE, wxString> > RATE_CHOICES;
-    static const std::vector<std::pair<RATEMODE, wxString> > RATEMODE_CHOICES;
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS, wxString> > STATUS_CHOICES;
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const std::vector<std::pair<STATUS_ID, wxString> > STATUS_CHOICES;
+    static const std::vector<std::pair<CHANGE_ID, wxString> > CHANGE_CHOICES;
+    static const std::vector<std::pair<CHANGEMODE_ID, wxString> > CHANGEMODE_CHOICES;
+    static wxArrayString type_str_all();
+    static wxArrayString status_str_all();
+    static wxArrayString change_str_all();
+    static wxArrayString changemode_str_all();
 
 public:
     Model_Asset();
@@ -65,27 +86,23 @@ public:
     static Model_Asset& instance();
 
 public:
-    static DB_Table_ASSETS_V1::ASSETTYPE ASSETTYPE(TYPE type, OP op = EQUAL);
+    static DB_Table_ASSETS_V1::ASSETTYPE ASSETTYPE(TYPE_ID type, OP op = EQUAL);
     static DB_Table_ASSETS_V1::STARTDATE STARTDATE(const wxDate& date, OP op = EQUAL);
     
 public:
     static wxString get_asset_name(int asset_id);
-    static wxArrayString all_rate();
-    static wxArrayString all_ratemode();
-    static wxArrayString all_type();
-    static wxArrayString all_status();
     double balance();
     static wxDate STARTDATE(const Data* r);
     static wxDate STARTDATE(const Data& r);
 
-    static TYPE type(const Data* r);
-    static TYPE type(const Data& r);
-    static RATE rate(const Data* r);
-    static RATE rate(const Data& r);
-    static RATEMODE ratemode(const Data* r);
-    static RATEMODE ratemode(const Data& r);
-    static STATUS status(const Data* r);
-    static STATUS status(const Data& r);
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static STATUS_ID status_id(const Data* r);
+    static STATUS_ID status_id(const Data& r);
+    static CHANGE_ID change_id(const Data* r);
+    static CHANGE_ID change_id(const Data& r);
+    static CHANGEMODE_ID changemode_id(const Data* r);
+    static CHANGEMODE_ID changemode_id(const Data& r);
 
     /** Returns the base currency Data record pointer*/
     static Model_Currency::Data* currency(const Data* /* r */);

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -81,22 +81,22 @@ wxDate Model_Billsdeposits::NEXTOCCURRENCEDATE(const Data& r)
     return Model::to_date(r.NEXTOCCURRENCEDATE);
 }
 
-Model_Checking::TYPE Model_Billsdeposits::type(const Data& r)
+Model_Checking::TYPE_ID Model_Billsdeposits::type_id(const Data& r)
 {
-    return Model_Checking::type(r.TRANSCODE);
+    return Model_Checking::type_id(r.TRANSCODE);
 }
-Model_Checking::TYPE Model_Billsdeposits::type(const Data* r)
+Model_Checking::TYPE_ID Model_Billsdeposits::type_id(const Data* r)
 {
-    return Model_Checking::type(r->TRANSCODE);
+    return Model_Checking::type_id(r->TRANSCODE);
 }
 
-Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data& r)
+Model_Checking::STATUS_ID Model_Billsdeposits::status_id(const Data& r)
 {
-    return Model_Checking::status(r.STATUS);
+    return Model_Checking::status_id(r.STATUS);
 }
-Model_Checking::STATUS_ENUM Model_Billsdeposits::status(const Data* r)
+Model_Checking::STATUS_ID Model_Billsdeposits::status_id(const Data* r)
 {
-    return Model_Checking::status(r->STATUS);
+    return Model_Checking::status_id(r->STATUS);
 }
 
 /**
@@ -112,14 +112,14 @@ bool Model_Billsdeposits::remove(int id)
     return this->remove(id, db_);
 }
 
-DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(Model_Checking::STATUS_ENUM status, OP op)
+DB_Table_BILLSDEPOSITS_V1::STATUS Model_Billsdeposits::STATUS(Model_Checking::STATUS_ID status, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::STATUS(Model_Checking::all_status_key()[status], op);
+    return DB_Table_BILLSDEPOSITS_V1::STATUS(Model_Checking::STATUS_KEY[status], op);
 }
 
-DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(Model_Checking::TYPE type, OP op)
+DB_Table_BILLSDEPOSITS_V1::TRANSCODE Model_Billsdeposits::TRANSCODE(Model_Checking::TYPE_ID type, OP op)
 {
-    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(Model_Checking::all_type()[type], op);
+    return DB_Table_BILLSDEPOSITS_V1::TRANSCODE(Model_Checking::TYPE_STR[type], op);
 }
 
 const Model_Budgetsplittransaction::Data_Set Model_Billsdeposits::splittransaction(const Data* r)
@@ -173,9 +173,9 @@ bool Model_Billsdeposits::allowExecution()
 
 bool Model_Billsdeposits::AllowTransaction(const Data& r)
 {
-    if (r.STATUS == "V")
+    if (r.STATUS == Model_Checking::STATUS_KEY_VOID)
         return true;
-    if (r.TRANSCODE != Model_Checking::WITHDRAWAL_STR && r.TRANSCODE != Model_Checking::TRANSFER_STR)
+    if (r.TRANSCODE != Model_Checking::TYPE_STR_WITHDRAWAL && r.TRANSCODE != Model_Checking::TYPE_STR_TRANSFER)
         return true;
 
     const int acct_id = r.ACCOUNTID;
@@ -348,7 +348,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
 
     PAYEENAME = Model_Payee::get_payee_name(r.PAYEEID);
-    if (Model_Billsdeposits::type(r) == Model_Checking::TRANSFER)
+    if (Model_Billsdeposits::type_id(r) == Model_Checking::TYPE_ID_TRANSFER)
     {
         PAYEENAME = Model_Account::get_account_name(r.TOACCOUNTID);
     }
@@ -357,7 +357,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) : Data(r)
 
 wxString Model_Billsdeposits::Full_Data::real_payee_name() const
 {
-    if (Model_Checking::TRANSFER == Model_Checking::type(this->TRANSCODE))
+    if (Model_Checking::TYPE_ID_TRANSFER == Model_Checking::type_id(this->TRANSCODE))
     {
         return ("> " + this->PAYEENAME);
     }

--- a/src/model/Model_Billsdeposits.h
+++ b/src/model/Model_Billsdeposits.h
@@ -76,10 +76,10 @@ public:
         int BDID = 0;
         // This relates the 'Date Due' field.
         wxString TRANSDATE = wxDateTime::Now().FormatISOCombined();
-        wxString STATUS = Model_Checking::all_status()[Model_Checking::NONE];
+        wxString STATUS = Model_Checking::STATUS_STR_NONE;
         int ACCOUNTID = -1;
         int TOACCOUNTID = -1;
-        wxString TRANSCODE = Model_Checking::WITHDRAWAL_STR;
+        wxString TRANSCODE = Model_Checking::TYPE_STR_WITHDRAWAL;
         int CATEGID = -1;
         double TRANSAMOUNT = 0;
         double TOTRANSAMOUNT = 0;
@@ -134,10 +134,10 @@ public:
     static wxDate NEXTOCCURRENCEDATE(const Data* r);
     // This relates the 'Date Paid' field
     static wxDate NEXTOCCURRENCEDATE(const Data& r);
-    static Model_Checking::TYPE type(const Data* r);
-    static Model_Checking::TYPE type(const Data& r);
-    static Model_Checking::STATUS_ENUM status(const Data* r);
-    static Model_Checking::STATUS_ENUM status(const Data& r);
+    static Model_Checking::TYPE_ID type_id(const Data* r);
+    static Model_Checking::TYPE_ID type_id(const Data& r);
+    static Model_Checking::STATUS_ID status_id(const Data* r);
+    static Model_Checking::STATUS_ID status_id(const Data& r);
 
     /**
     * Decodes the internal fields and sets the condition of the following parameters:
@@ -162,8 +162,8 @@ public:
     */
     bool remove(int id);
 
-    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(Model_Checking::STATUS_ENUM status, OP op = EQUAL);
-    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(Model_Checking::TYPE type, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::STATUS STATUS(Model_Checking::STATUS_ID status, OP op = EQUAL);
+    static DB_Table_BILLSDEPOSITS_V1::TRANSCODE TRANSCODE(Model_Checking::TYPE_ID type, OP op = EQUAL);
 
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data* r);
     static const Model_Budgetsplittransaction::Data_Set splittransaction(const Data& r);

--- a/src/model/Model_Budget.cpp
+++ b/src/model/Model_Budget.cpp
@@ -106,7 +106,7 @@ Model_Budget::PERIOD_ID Model_Budget::period_id(const Data& r)
 
 DB_Table_BUDGETTABLE_V1::PERIOD Model_Budget::PERIOD(PERIOD_ID period, OP op)
 {
-    return DB_Table_BUDGETTABLE_V1::PERIOD(period_loc_all()[period], op);
+    return DB_Table_BUDGETTABLE_V1::PERIOD(PERIOD_STR[period], op);
 }
 
 void Model_Budget::getBudgetEntry(int budgetYearID

--- a/src/model/Model_Budget.cpp
+++ b/src/model/Model_Budget.cpp
@@ -24,6 +24,21 @@
 #include "db/DB_Table_Budgettable_V1.h"
 #include "option.h"
 
+const std::vector<std::pair<Model_Budget::PERIOD_ID, wxString> > Model_Budget::PERIOD_CHOICES =
+{
+    { Model_Budget::PERIOD_ID_NONE,       wxString(wxTRANSLATE("None")) },
+    { Model_Budget::PERIOD_ID_WEEKLY,     wxString(wxTRANSLATE("Weekly")) },
+    { Model_Budget::PERIOD_ID_BIWEEKLY,   wxString(wxTRANSLATE("Fortnightly")) },
+    { Model_Budget::PERIOD_ID_MONTHLY,    wxString(wxTRANSLATE("Monthly")) },
+    { Model_Budget::PERIOD_ID_BIMONTHLY,  wxString(wxTRANSLATE("Every 2 Months")) },
+    { Model_Budget::PERIOD_ID_QUARTERLY,  wxString(wxTRANSLATE("Quarterly")) },
+    { Model_Budget::PERIOD_ID_HALFYEARLY, wxString(wxTRANSLATE("Half-Yearly")) },
+    { Model_Budget::PERIOD_ID_YEARLY,     wxString(wxTRANSLATE("Yearly")) },
+    { Model_Budget::PERIOD_ID_DAILY,      wxString(wxTRANSLATE("Daily")) }
+};
+
+wxArrayString Model_Budget::PERIOD_STR = period_str_all();
+
 Model_Budget::Model_Budget()
     : Model<DB_Table_BUDGETTABLE_V1>()
 {
@@ -53,47 +68,49 @@ Model_Budget& Model_Budget::instance()
     return Singleton<Model_Budget>::instance();
 }
 
-const std::vector<std::pair<Model_Budget::PERIOD_ENUM, wxString> > Model_Budget::PERIOD_ENUM_CHOICES =
-{
-    {Model_Budget::NONE, wxString(wxTRANSLATE("None"))}
-    , {Model_Budget::WEEKLY, wxString(wxTRANSLATE("Weekly"))}
-    , {Model_Budget::BIWEEKLY, wxString(wxTRANSLATE("Fortnightly"))}
-    , {Model_Budget::MONTHLY, wxString(wxTRANSLATE("Monthly"))}
-    , {Model_Budget::BIMONTHLY, wxString(wxTRANSLATE("Every 2 Months"))}
-    , {Model_Budget::QUARTERLY, wxString(wxTRANSLATE("Quarterly"))}
-    , {Model_Budget::HALFYEARLY, wxString(wxTRANSLATE("Half-Yearly"))}
-    , {Model_Budget::YEARLY, wxString(wxTRANSLATE("Yearly"))}
-    , {Model_Budget::DAILY, wxString(wxTRANSLATE("Daily"))}
-};
-
-wxArrayString Model_Budget::all_period()
+wxArrayString Model_Budget::period_str_all()
 {
     wxArrayString period;
-    for (const auto& item : PERIOD_ENUM_CHOICES) period.Add(wxGetTranslation(item.second));
+    int i = 0;
+    for (const auto& item : PERIOD_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Budget::PERIOD_CHOICES");
+        period.Add(item.second);
+    }
     return period;
 }
 
-Model_Budget::PERIOD_ENUM Model_Budget::period(const Data* r)
+wxArrayString Model_Budget::period_loc_all()
 {
-    for (const auto &entry : PERIOD_ENUM_CHOICES)
+    wxArrayString period;
+    for (const auto& item : PERIOD_CHOICES)
+    {
+        period.Add(wxGetTranslation(item.second));
+    }
+    return period;
+}
+
+Model_Budget::PERIOD_ID Model_Budget::period_id(const Data* r)
+{
+    for (const auto &entry : PERIOD_CHOICES)
     {
         if (r->PERIOD.CmpNoCase(entry.second) == 0) return entry.first;
     }
-    return NONE;
+    return PERIOD_ID_NONE;
 }
 
-Model_Budget::PERIOD_ENUM Model_Budget::period(const Data& r)
+Model_Budget::PERIOD_ID Model_Budget::period_id(const Data& r)
 {
-    return period(&r);
+    return period_id(&r);
 }
 
-DB_Table_BUDGETTABLE_V1::PERIOD Model_Budget::PERIOD(PERIOD_ENUM period, OP op)
+DB_Table_BUDGETTABLE_V1::PERIOD Model_Budget::PERIOD(PERIOD_ID period, OP op)
 {
-    return DB_Table_BUDGETTABLE_V1::PERIOD(all_period()[period], op);
+    return DB_Table_BUDGETTABLE_V1::PERIOD(period_loc_all()[period], op);
 }
 
 void Model_Budget::getBudgetEntry(int budgetYearID
-    , std::map<int, PERIOD_ENUM> &budgetPeriod
+    , std::map<int, PERIOD_ID> &budgetPeriod
     , std::map<int, double> &budgetAmt
     , std::map<int, wxString> &budgetNotes)
 {
@@ -101,14 +118,14 @@ void Model_Budget::getBudgetEntry(int budgetYearID
     double value = 0;
     for (const auto& category : Model_Category::instance().all())
     {
-        budgetPeriod[category.CATEGID] = NONE;
+        budgetPeriod[category.CATEGID] = PERIOD_ID_NONE;
         budgetAmt[category.CATEGID] = value;
 
     }
 
     for (const auto& budget : instance().find(BUDGETYEARID(budgetYearID)))
     {
-        budgetPeriod[budget.CATEGID] = period(budget);
+        budgetPeriod[budget.CATEGID] = period_id(budget);
         budgetAmt[budget.CATEGID] = budget.AMOUNT;
         budgetNotes[budget.CATEGID] = budget.NOTES;
     }
@@ -142,9 +159,9 @@ void Model_Budget::getBudgetStats(
     for (const auto& budget : instance().find(BUDGETYEARID(budgetYearID)))
     {
         // Determine the monhly budgeted amounts
-        monthlyBudgetValue[budget.CATEGID] = getEstimate(true, period(budget), budget.AMOUNT);
+        monthlyBudgetValue[budget.CATEGID] = getEstimate(true, period_id(budget), budget.AMOUNT);
         // Determine the yearly budgeted amounts
-        yearlyBudgetValue[budget.CATEGID] = getEstimate(false, period(budget), budget.AMOUNT);
+        yearlyBudgetValue[budget.CATEGID] = getEstimate(false, period_id(budget), budget.AMOUNT);
         // Store the yearly budget to use in reporting. Monthly budgets are stored in index 0-11, so use index 12 for year
         budgetStats[budget.CATEGID][12] = yearlyBudgetValue[budget.CATEGID];
     }
@@ -164,7 +181,7 @@ void Model_Budget::getBudgetStats(
                 isBudgeted[month_categ] = true;
                 budgetedMonths[budget.CATEGID]++;
             }
-            budgetStats[budget.CATEGID][month] = getEstimate(true, period(budget), budget.AMOUNT);
+            budgetStats[budget.CATEGID][month] = getEstimate(true, period_id(budget), budget.AMOUNT);
             yearDeduction[budget.CATEGID] += budgetStats[budget.CATEGID][month];
         }
     }
@@ -233,7 +250,7 @@ void Model_Budget::copyBudgetYear(int newYearID, int baseYearID)
             //calculate deduction
             for (const auto& budget : monthlyBudgetData)
             {
-                yearDeduction[budget.CATEGID] += getEstimate(true, period(budget), budget.AMOUNT);
+                yearDeduction[budget.CATEGID] += getEstimate(true, period_id(budget), budget.AMOUNT);
             }
         }
     }
@@ -242,10 +259,10 @@ void Model_Budget::copyBudgetYear(int newYearID, int baseYearID)
     {
         Data* budgetEntry = instance().clone(&data);
         budgetEntry->BUDGETYEARID = newYearID;
-        double yearAmount = getEstimate(false, period(data), data.AMOUNT);
+        double yearAmount = getEstimate(false, period_id(data), data.AMOUNT);
         if (optionDeductMonthly && budgetedMonths > 0)
         {
-            budgetEntry->PERIOD = PERIOD_ENUM_CHOICES[MONTHLY].second;
+            budgetEntry->PERIOD = PERIOD_CHOICES[PERIOD_ID_MONTHLY].second;
             if (yearDeduction[budgetEntry->CATEGID] / yearAmount < 1)
                 budgetEntry->AMOUNT = (yearAmount - yearDeduction[budgetEntry->CATEGID]) / (12 - budgetedMonths);
             else budgetEntry->AMOUNT = 0;
@@ -254,9 +271,9 @@ void Model_Budget::copyBudgetYear(int newYearID, int baseYearID)
     }
 }
 
-double Model_Budget::getEstimate(bool is_monthly, const PERIOD_ENUM period, const double amount)
+double Model_Budget::getEstimate(bool is_monthly, const PERIOD_ID period, const double amount)
 {
-    int p[MAX] = { 0, 52, 26, 12, 6, 4, 2, 1, 365 };
+    int p[PERIOD_ID_MAX] = { 0, 52, 26, 12, 6, 4, 2, 1, 365 };
     double estimated = amount * p[period];
     if (is_monthly) estimated = estimated / 12;
     return estimated;

--- a/src/model/Model_Budget.h
+++ b/src/model/Model_Budget.h
@@ -47,16 +47,33 @@ public:
     static Model_Budget& instance();
 
 public:
-    enum PERIOD_ENUM { NONE = 0, WEEKLY, BIWEEKLY, MONTHLY, BIMONTHLY, QUARTERLY, HALFYEARLY, YEARLY, DAILY, MAX };
-    static const std::vector<std::pair<PERIOD_ENUM, wxString> > PERIOD_ENUM_CHOICES;
+    enum PERIOD_ID
+    {
+        PERIOD_ID_NONE = 0,
+        PERIOD_ID_WEEKLY,
+        PERIOD_ID_BIWEEKLY,
+        PERIOD_ID_MONTHLY,
+        PERIOD_ID_BIMONTHLY,
+        PERIOD_ID_QUARTERLY,
+        PERIOD_ID_HALFYEARLY,
+        PERIOD_ID_YEARLY,
+        PERIOD_ID_DAILY,
+        PERIOD_ID_MAX
+    };
+    static wxArrayString PERIOD_STR;
 
-    static wxArrayString all_period();
-    static PERIOD_ENUM period(const Data* r);
-    static PERIOD_ENUM period(const Data& r);
-    static DB_Table_BUDGETTABLE_V1::PERIOD PERIOD(PERIOD_ENUM period, OP op = EQUAL);
+private:
+    static const std::vector<std::pair<PERIOD_ID, wxString> > PERIOD_CHOICES;
+    static wxArrayString period_str_all();
 
-    static void getBudgetEntry(int budgetYearID, std::map<int,
-       PERIOD_ENUM> &budgetPeriod,
+public:
+    static wxArrayString period_loc_all();
+    static PERIOD_ID period_id(const Data* r);
+    static PERIOD_ID period_id(const Data& r);
+    static DB_Table_BUDGETTABLE_V1::PERIOD PERIOD(PERIOD_ID period, OP op = EQUAL);
+
+    static void getBudgetEntry(int budgetYearID,
+        std::map<int, PERIOD_ID> &budgetPeriod,
         std::map<int, double> &budgetAmt,
         std::map<int, wxString> &budgetNotes);
     static void getBudgetStats(
@@ -64,7 +81,7 @@ public:
         , mmDateRange* date_range
         , bool groupByMonth);
     static void copyBudgetYear(int newYearID, int baseYearID);
-    static double getEstimate(bool is_monthly, const PERIOD_ENUM period, const double amount);
+    static double getEstimate(bool is_monthly, const PERIOD_ID period, const double amount);
 };
 
 #endif // 

--- a/src/model/Model_Category.cpp
+++ b/src/model/Model_Category.cpp
@@ -232,28 +232,28 @@ bool Model_Category::has_income(int id)
     {
         if (!tran.DELETEDTIME.IsEmpty()) continue;
 
-        switch (Model_Checking::type(tran))
+        switch (Model_Checking::type_id(tran))
         {
-        case Model_Checking::WITHDRAWAL:
+        case Model_Checking::TYPE_ID_WITHDRAWAL:
             sum -= tran.TRANSAMOUNT;
             break;
-        case Model_Checking::DEPOSIT:
+        case Model_Checking::TYPE_ID_DEPOSIT:
             sum += tran.TRANSAMOUNT;
-        case Model_Checking::TRANSFER:
+        case Model_Checking::TYPE_ID_TRANSFER:
         default:
             break;
         }
 
         for (const auto& split: splits[tran.id()])
         {
-            switch (Model_Checking::type(tran))
+            switch (Model_Checking::type_id(tran))
             {
-            case Model_Checking::WITHDRAWAL:
+            case Model_Checking::TYPE_ID_WITHDRAWAL:
                 sum -= split.SPLITTRANSAMOUNT;
                 break;
-            case Model_Checking::DEPOSIT:
+            case Model_Checking::TYPE_ID_DEPOSIT:
                 sum += split.SPLITTRANSAMOUNT;
-            case Model_Checking::TRANSFER:
+            case Model_Checking::TYPE_ID_TRANSFER:
             default:
                 break;
             }
@@ -298,7 +298,7 @@ void Model_Category::getCategoryStats(
     //Calculations
     auto splits = Model_Splittransaction::instance().get_all();
     for (const auto& transaction : Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
         , Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)))
     {
@@ -328,7 +328,7 @@ void Model_Category::getCategoryStats(
 
         if (categID > -1)
         {
-            if (Model_Checking::type(transaction) != Model_Checking::TRANSFER)
+            if (Model_Checking::type_id(transaction) != Model_Checking::TYPE_ID_TRANSFER)
             {
                 // Do not include asset or stock transfers in income expense calculations.
                 if (Model_Checking::foreignTransactionAsTransfer(transaction))
@@ -349,7 +349,7 @@ void Model_Category::getCategoryStats(
             for (const auto& entry : splits[transaction.id()])
             {
                 categoryStats[entry.CATEGID][month] += entry.SPLITTRANSAMOUNT
-                    * convRate * ((Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL) ? -1 : 1);
+                    * convRate * ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL) ? -1 : 1);
             }
         }
     }

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -407,11 +407,11 @@ wxString Model_Checking::status_key(const wxString& r)
 Model_Checking::Full_Data::Full_Data()
     : Data(0), BALANCE(0), AMOUNT(0), TAGNAMES(""),
     UDFC01(""), UDFC02(""), UDFC03(""), UDFC04(""), UDFC05(""),
-    UDFC01_Type(Model_CustomField::FIELDTYPE::UNKNOWN),
-    UDFC02_Type(Model_CustomField::FIELDTYPE::UNKNOWN),
-    UDFC03_Type(Model_CustomField::FIELDTYPE::UNKNOWN),
-    UDFC04_Type(Model_CustomField::FIELDTYPE::UNKNOWN),
-    UDFC05_Type(Model_CustomField::FIELDTYPE::UNKNOWN)
+    UDFC01_Type(Model_CustomField::TYPE_ID_UNKNOWN),
+    UDFC02_Type(Model_CustomField::TYPE_ID_UNKNOWN),
+    UDFC03_Type(Model_CustomField::TYPE_ID_UNKNOWN),
+    UDFC04_Type(Model_CustomField::TYPE_ID_UNKNOWN),
+    UDFC05_Type(Model_CustomField::TYPE_ID_UNKNOWN)
 {
 }
 

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -29,25 +29,40 @@
 #include "attachmentdialog.h"
 #include "util.h"
 
-const std::vector<std::pair<Model_Checking::TYPE, wxString> > Model_Checking::TYPE_CHOICES =
+const std::vector<std::pair<Model_Checking::TYPE_ID, wxString> > Model_Checking::TYPE_CHOICES =
 {
-    {Model_Checking::WITHDRAWAL, wxString(wxTRANSLATE("Withdrawal"))}
-    , {Model_Checking::DEPOSIT, wxString(wxTRANSLATE("Deposit"))}
-    , {Model_Checking::TRANSFER, wxString(wxTRANSLATE("Transfer"))}
+    { Model_Checking::TYPE_ID_WITHDRAWAL, wxString(wxTRANSLATE("Withdrawal")) },
+    { Model_Checking::TYPE_ID_DEPOSIT,    wxString(wxTRANSLATE("Deposit")) },
+    { Model_Checking::TYPE_ID_TRANSFER,   wxString(wxTRANSLATE("Transfer")) }
 };
 
-const std::vector<std::pair<Model_Checking::STATUS_ENUM, wxString> > Model_Checking::STATUS_CHOICES =
+const std::vector<std::tuple<Model_Checking::STATUS_ID, wxString, wxString> > Model_Checking::STATUS_CHOICES =
 {
-    {Model_Checking::NONE, wxTRANSLATE("Unreconciled")}
-    , {Model_Checking::RECONCILED, wxString(wxTRANSLATE("Reconciled"))}
-    , {Model_Checking::VOID_, wxString(wxTRANSLATE("Void"))}
-    , {Model_Checking::FOLLOWUP, wxString(wxTRANSLATE("Follow Up"))}
-    , {Model_Checking::DUPLICATE_, wxString(wxTRANSLATE("Duplicate"))}
+    { Model_Checking::STATUS_ID_NONE,       wxString(""),  wxString(wxTRANSLATE("Unreconciled")) },
+    { Model_Checking::STATUS_ID_RECONCILED, wxString("R"), wxString(wxTRANSLATE("Reconciled")) },
+    { Model_Checking::STATUS_ID_VOID,       wxString("V"), wxString(wxTRANSLATE("Void")) },
+    { Model_Checking::STATUS_ID_FOLLOWUP,   wxString("F"), wxString(wxTRANSLATE("Follow Up")) },
+    { Model_Checking::STATUS_ID_DUPLICATE,  wxString("D"), wxString(wxTRANSLATE("Duplicate")) }
 };
 
-const wxString Model_Checking::WITHDRAWAL_STR = all_type()[WITHDRAWAL];
-const wxString Model_Checking::DEPOSIT_STR = all_type()[DEPOSIT];
-const wxString Model_Checking::TRANSFER_STR = all_type()[TRANSFER];
+wxArrayString Model_Checking::TYPE_STR = type_str_all();
+const wxString Model_Checking::TYPE_STR_WITHDRAWAL = TYPE_STR[TYPE_ID_WITHDRAWAL];
+const wxString Model_Checking::TYPE_STR_DEPOSIT    = TYPE_STR[TYPE_ID_DEPOSIT];
+const wxString Model_Checking::TYPE_STR_TRANSFER   = TYPE_STR[TYPE_ID_TRANSFER];
+
+wxArrayString Model_Checking::STATUS_KEY = status_key_all();
+const wxString Model_Checking::STATUS_KEY_NONE       = STATUS_KEY[STATUS_ID_NONE];
+const wxString Model_Checking::STATUS_KEY_RECONCILED = STATUS_KEY[STATUS_ID_RECONCILED];
+const wxString Model_Checking::STATUS_KEY_VOID       = STATUS_KEY[STATUS_ID_VOID];
+const wxString Model_Checking::STATUS_KEY_FOLLOWUP   = STATUS_KEY[STATUS_ID_FOLLOWUP];
+const wxString Model_Checking::STATUS_KEY_DUPLICATE  = STATUS_KEY[STATUS_ID_DUPLICATE];
+
+wxArrayString Model_Checking::STATUS_STR = status_str_all();
+const wxString Model_Checking::STATUS_STR_NONE       = STATUS_STR[STATUS_ID_NONE];
+const wxString Model_Checking::STATUS_STR_RECONCILED = STATUS_STR[STATUS_ID_RECONCILED];
+const wxString Model_Checking::STATUS_STR_VOID       = STATUS_STR[STATUS_ID_VOID];
+const wxString Model_Checking::STATUS_STR_FOLLOWUP   = STATUS_STR[STATUS_ID_FOLLOWUP];
+const wxString Model_Checking::STATUS_STR_DUPLICATE  = STATUS_STR[STATUS_ID_DUPLICATE];
 
 Model_Checking::Model_Checking() : Model<DB_Table_CHECKINGACCOUNT_V1>()
 {
@@ -57,24 +72,39 @@ Model_Checking::~Model_Checking()
 {
 }
 
-wxArrayString Model_Checking::all_type()
+wxArrayString Model_Checking::type_str_all()
 {
     wxArrayString types;
-    for (const auto& r : TYPE_CHOICES) types.Add(r.second);
+    int i = 0;
+    for (const auto& r : TYPE_CHOICES)
+    {
+        wxASSERT_MSG(r.first == i++, "Wrong order in Model_Checking::TYPE_CHOICES");
+        types.Add(r.second);
+    }
     return types;
 }
 
-wxArrayString Model_Checking::all_status()
+wxArrayString Model_Checking::status_key_all()
 {
     wxArrayString status;
-    for (const auto& r : STATUS_CHOICES) status.Add(r.second);
+    int i = 0;
+    for (const auto& r : STATUS_CHOICES)
+    {
+        wxASSERT_MSG(std::get<0>(r) == i++, "Wrong order in Model_Checking::STATUS_CHOICES");
+        status.Add(std::get<1>(r));
+    }
     return status;
 }
 
-wxArrayString Model_Checking::all_status_key()
+wxArrayString Model_Checking::status_str_all()
 {
     wxArrayString status;
-    for (const auto& r : STATUS_CHOICES) status.Add(status_key(r.second));
+    int i = 0;
+    for (const auto& r : STATUS_CHOICES)
+    {
+        wxASSERT_MSG(std::get<0>(r) == i++, "Wrong order in Model_Checking::STATUS_CHOICES");
+        status.Add(std::get<2>(r));
+    }
     return status;
 }
 
@@ -162,14 +192,14 @@ const Model_Splittransaction::Data_Set Model_Checking::splittransaction(const Da
     return Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(r.TRANSID));
 }
 
-DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ENUM status, OP op)
+DB_Table_CHECKINGACCOUNT_V1::STATUS Model_Checking::STATUS(STATUS_ID status, OP op)
 {
-    return DB_Table_CHECKINGACCOUNT_V1::STATUS(all_status_key()[status], op);
+    return DB_Table_CHECKINGACCOUNT_V1::STATUS(STATUS_KEY[status], op);
 }
 
-DB_Table_CHECKINGACCOUNT_V1::TRANSCODE Model_Checking::TRANSCODE(TYPE type, OP op)
+DB_Table_CHECKINGACCOUNT_V1::TRANSCODE Model_Checking::TRANSCODE(TYPE_ID type, OP op)
 {
-    return DB_Table_CHECKINGACCOUNT_V1::TRANSCODE(all_type()[type], op);
+    return DB_Table_CHECKINGACCOUNT_V1::TRANSCODE(TYPE_STR[type], op);
 }
 
 DB_Table_CHECKINGACCOUNT_V1::TRANSACTIONNUMBER Model_Checking::TRANSACTIONNUMBER(const wxString& num, OP op)
@@ -204,10 +234,10 @@ wxDateTime Model_Checking::TRANSDATE(const Data& r)
     return Model::to_date(r.TRANSDATE);
 }
 
-Model_Checking::TYPE Model_Checking::type(const wxString& r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const wxString& r)
 {
-    if (r.empty()) return TYPE::WITHDRAWAL;
-    static std::unordered_map<wxString, TYPE> cache;
+    if (r.empty()) return TYPE_ID_WITHDRAWAL;
+    static std::unordered_map<wxString, TYPE_ID> cache;
     const auto it = cache.find(r);
     if (it != cache.end()) return it->second;
 
@@ -220,63 +250,59 @@ Model_Checking::TYPE Model_Checking::type(const wxString& r)
         }
     }
 
-    cache.insert(std::make_pair(r, TYPE::WITHDRAWAL));
-    return TYPE::WITHDRAWAL;
+    cache.insert(std::make_pair(r, TYPE_ID_WITHDRAWAL));
+    return TYPE_ID_WITHDRAWAL;
 }
-Model_Checking::TYPE Model_Checking::type(const Data& r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const Data& r)
 {
-    return type(r.TRANSCODE);
+    return type_id(r.TRANSCODE);
 }
-Model_Checking::TYPE Model_Checking::type(const Data* r)
+Model_Checking::TYPE_ID Model_Checking::type_id(const Data* r)
 {
-    return type(r->TRANSCODE);
+    return type_id(r->TRANSCODE);
 }
 
-Model_Checking::STATUS_ENUM Model_Checking::status(const wxString& r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const wxString& r)
 {
-    static std::unordered_map<wxString, STATUS_ENUM> cache;
+    static std::unordered_map<wxString, STATUS_ID> cache;
     const auto it = cache.find(r);
     if (it != cache.end()) return it->second;
 
     for (const auto & s : STATUS_CHOICES)
     {
-        if (r.CmpNoCase(s.second) == 0)
+        if (r.CmpNoCase(std::get<1>(s)) == 0 || r.CmpNoCase(std::get<2>(s)) == 0)
         {
-            cache.insert(std::make_pair(r, s.first));
-            return s.first;
+            STATUS_ID ret = std::get<0>(s);
+            cache.insert(std::make_pair(r, ret));
+            return ret;
         }
     }
 
-    STATUS_ENUM ret = NONE;
-    if (r.CmpNoCase("R") == 0) ret = RECONCILED;
-    else if (r.CmpNoCase("V") == 0) ret = VOID_;
-    else if (r.CmpNoCase("F") == 0) ret = FOLLOWUP;
-    else if (r.CmpNoCase("D") == 0) ret = DUPLICATE_;
+    STATUS_ID ret = STATUS_ID_NONE;
     cache.insert(std::make_pair(r, ret));
-
     return ret;
 }
-Model_Checking::STATUS_ENUM Model_Checking::status(const Data& r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const Data& r)
 {
-    return status(r.STATUS);
+    return status_id(r.STATUS);
 }
-Model_Checking::STATUS_ENUM Model_Checking::status(const Data* r)
+Model_Checking::STATUS_ID Model_Checking::status_id(const Data* r)
 {
-    return status(r->STATUS);
+    return status_id(r->STATUS);
 }
 
 double Model_Checking::amount(const Data* r, int account_id)
 {
     double sum = 0;
-    switch (type(r->TRANSCODE))
+    switch (type_id(r->TRANSCODE))
     {
-    case WITHDRAWAL:
+    case TYPE_ID_WITHDRAWAL:
         sum -= r->TRANSAMOUNT;
         break;
-    case DEPOSIT:
+    case TYPE_ID_DEPOSIT:
         sum += r->TRANSAMOUNT;
         break;
-    case TRANSFER:
+    case TYPE_ID_TRANSFER:
         if (account_id == r->ACCOUNTID)
             sum -= r->TRANSAMOUNT;
         else
@@ -295,7 +321,7 @@ double Model_Checking::amount(const Data&r, int account_id)
 
 double Model_Checking::balance(const Data* r, int account_id)
 {
-    if (Model_Checking::status(r->STATUS) == Model_Checking::VOID_ || !r->DELETEDTIME.IsEmpty()) return 0;
+    if (Model_Checking::status_id(r->STATUS) == Model_Checking::STATUS_ID_VOID || !r->DELETEDTIME.IsEmpty()) return 0;
     return amount(r, account_id);
 }
 
@@ -328,7 +354,7 @@ double Model_Checking::deposit(const Data& r, int account_id)
 
 double Model_Checking::reconciled(const Data* r, int account_id)
 {
-    return (Model_Checking::status(r->STATUS) == Model_Checking::RECONCILED) ? balance(r, account_id) : 0;
+    return (Model_Checking::status_id(r->STATUS) == Model_Checking::STATUS_ID_RECONCILED) ? balance(r, account_id) : 0;
 }
 
 double Model_Checking::reconciled(const Data& r, int account_id)
@@ -358,7 +384,7 @@ bool Model_Checking::is_locked(const Data* r)
 
 bool Model_Checking::is_transfer(const wxString& r)
 {
-    return type(r) == Model_Checking::TRANSFER;
+    return type_id(r) == Model_Checking::TYPE_ID_TRANSFER;
 }
 bool Model_Checking::is_transfer(const Data* r)
 {
@@ -366,18 +392,16 @@ bool Model_Checking::is_transfer(const Data* r)
 }
 bool Model_Checking::is_deposit(const wxString& r)
 {
-    return type(r) == Model_Checking::DEPOSIT;
+    return type_id(r) == Model_Checking::TYPE_ID_DEPOSIT;
 }
 bool Model_Checking::is_deposit(const Data* r)
 {
     return is_deposit(r->TRANSCODE);
 }
 
-wxString Model_Checking::status_key(const wxString& fullStatus)
+wxString Model_Checking::status_key(const wxString& r)
 {
-    wxString s = fullStatus.Left(1);
-    s.Replace("U", "");
-    return s;
+    return STATUS_KEY[status_id(r)];
 }
 
 Model_Checking::Full_Data::Full_Data()
@@ -397,7 +421,7 @@ Model_Checking::Full_Data::Full_Data(const Data& r) : Data(r), BALANCE(0), AMOUN
 {
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
     displayID = wxString::Format("%i", r.TRANSID);
-    if (Model_Checking::type(r) == Model_Checking::TRANSFER) {
+    if (Model_Checking::type_id(r) == Model_Checking::TYPE_ID_TRANSFER) {
         TOACCOUNTNAME = Model_Account::get_account_name(r.TOACCOUNTID);
         PAYEENAME = TOACCOUNTNAME;
     }
@@ -440,7 +464,7 @@ Model_Checking::Full_Data::Full_Data(const Data& r
 
     ACCOUNTNAME = Model_Account::get_account_name(r.ACCOUNTID);
     displayID = wxString::Format("%i", r.TRANSID);
-    if (Model_Checking::type(r) == Model_Checking::TRANSFER)
+    if (Model_Checking::type_id(r) == Model_Checking::TYPE_ID_TRANSFER)
     {
         TOACCOUNTNAME = Model_Account::get_account_name(r.TOACCOUNTID);
         PAYEENAME = TOACCOUNTNAME;
@@ -480,7 +504,7 @@ Model_Checking::Full_Data::~Full_Data()
 
 wxString Model_Checking::Full_Data::real_payee_name(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id < 0)
             return ("> " + this->TOACCOUNTNAME);
@@ -493,7 +517,7 @@ wxString Model_Checking::Full_Data::real_payee_name(int account_id) const
 
 const wxString Model_Checking::Full_Data::get_currency_code(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id == -1)
             account_id = this->ACCOUNTID;
@@ -509,7 +533,7 @@ const wxString Model_Checking::Full_Data::get_currency_code(int account_id) cons
 
 const wxString Model_Checking::Full_Data::get_account_name(int account_id) const
 {
-    if (TYPE::TRANSFER == type(this->TRANSCODE))
+    if (TYPE_ID_TRANSFER == type_id(this->TRANSCODE))
     {
         if (this->ACCOUNTID == account_id || account_id == -1) {
             return this->ACCOUNTNAME;
@@ -525,7 +549,7 @@ const wxString Model_Checking::Full_Data::get_account_name(int account_id) const
 
 bool Model_Checking::Full_Data::is_foreign() const
 {
-    return (this->TOACCOUNTID > 0) && ((this->TRANSCODE == all_type()[DEPOSIT]) || (this->TRANSCODE == all_type()[WITHDRAWAL]));
+    return (this->TOACCOUNTID > 0) && (this->TRANSCODE == TYPE_STR_DEPOSIT || this->TRANSCODE == TYPE_STR_WITHDRAWAL);
 }
 
 bool Model_Checking::Full_Data::is_foreign_transfer() const
@@ -610,8 +634,8 @@ void Model_Checking::getEmptyTransaction(Data &data, int accountID)
 
     data.TRANSDATE = max_trx_date;
     data.ACCOUNTID = accountID;
-    data.STATUS = all_status_key()[Option::instance().TransStatusReconciled()];
-    data.TRANSCODE = all_type()[WITHDRAWAL];
+    data.STATUS = STATUS_KEY[Option::instance().TransStatusReconciled()];
+    data.TRANSCODE = TYPE_STR_WITHDRAWAL;
     data.CATEGID = -1;
     data.FOLLOWUPID = -1;
     data.TRANSAMOUNT = 0;
@@ -723,7 +747,7 @@ const wxString Model_Checking::Full_Data::to_json()
 
 bool Model_Checking::foreignTransaction(const Data& data)
 {
-    return (data.TOACCOUNTID > 0) && ((data.TRANSCODE == all_type()[DEPOSIT]) || (data.TRANSCODE == all_type()[WITHDRAWAL]));
+    return (data.TOACCOUNTID > 0) && (data.TRANSCODE == TYPE_STR_DEPOSIT || data.TRANSCODE == TYPE_STR_WITHDRAWAL);
 }
 
 bool Model_Checking::foreignTransactionAsTransfer(const Data& data)

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -33,11 +33,43 @@ public:
     typedef Model_Splittransaction::Data_Set Split_Data_Set;
 
 public:
-    enum TYPE { WITHDRAWAL = 0, DEPOSIT, TRANSFER };
-    enum STATUS_ENUM { NONE = 0, RECONCILED, VOID_, FOLLOWUP, DUPLICATE_ };
+    enum TYPE_ID
+    {
+        TYPE_ID_WITHDRAWAL = 0,
+        TYPE_ID_DEPOSIT,
+        TYPE_ID_TRANSFER
+    };
+    enum STATUS_ID
+    {
+        STATUS_ID_NONE = 0,
+        STATUS_ID_RECONCILED,
+        STATUS_ID_VOID,
+        STATUS_ID_FOLLOWUP,
+        STATUS_ID_DUPLICATE
+    };
+    static wxArrayString TYPE_STR;
+    static const wxString TYPE_STR_WITHDRAWAL;
+    static const wxString TYPE_STR_DEPOSIT;
+    static const wxString TYPE_STR_TRANSFER;
+    static wxArrayString STATUS_KEY;
+    static const wxString STATUS_KEY_NONE;
+    static const wxString STATUS_KEY_RECONCILED;
+    static const wxString STATUS_KEY_VOID;
+    static const wxString STATUS_KEY_FOLLOWUP;
+    static const wxString STATUS_KEY_DUPLICATE;
+    static wxArrayString STATUS_STR;
+    static const wxString STATUS_STR_NONE;
+    static const wxString STATUS_STR_RECONCILED;
+    static const wxString STATUS_STR_VOID;
+    static const wxString STATUS_STR_FOLLOWUP;
+    static const wxString STATUS_STR_DUPLICATE;
 
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS_ENUM, wxString> > STATUS_CHOICES;
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const std::vector<std::tuple<STATUS_ID, wxString, wxString> > STATUS_CHOICES;
+    static wxArrayString type_str_all();
+    static wxArrayString status_key_all();
+    static wxArrayString status_str_all();
 
 public:
     struct Full_Data: public Data
@@ -91,7 +123,7 @@ public:
     typedef std::vector<Full_Data> Full_Data_Set;
 
     struct SorterByBALANCE
-    { 
+    {
         template<class DATA>
         bool operator()(const DATA& x, const DATA& y)
         {
@@ -146,14 +178,6 @@ public:
     ~Model_Checking();
 
 public:
-    static wxArrayString all_type();
-    static wxArrayString all_status();
-    static wxArrayString all_status_key();
-    static const wxString TRANSFER_STR;
-    static const wxString WITHDRAWAL_STR;
-    static const wxString DEPOSIT_STR;
-
-public:
     /**
     Initialize the global Model_Checking table on initial call.
     Resets the global table on subsequent calls.
@@ -182,19 +206,20 @@ public:
     static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxDateTime& date, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::DELETEDTIME DELETEDTIME(const wxString& date, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::TRANSDATE TRANSDATE(const wxString& date_iso_str, OP op = EQUAL);
-    static DB_Table_CHECKINGACCOUNT_V1::STATUS STATUS(STATUS_ENUM status, OP op = EQUAL);
-    static DB_Table_CHECKINGACCOUNT_V1::TRANSCODE TRANSCODE(TYPE type, OP op = EQUAL);
+    static DB_Table_CHECKINGACCOUNT_V1::STATUS STATUS(STATUS_ID status, OP op = EQUAL);
+    static DB_Table_CHECKINGACCOUNT_V1::TRANSCODE TRANSCODE(TYPE_ID type, OP op = EQUAL);
     static DB_Table_CHECKINGACCOUNT_V1::TRANSACTIONNUMBER TRANSACTIONNUMBER(const wxString& num, OP op = EQUAL);
 
 public:
     static wxDate TRANSDATE(const Data* r);
     static wxDate TRANSDATE(const Data& r);
-    static TYPE type(const wxString& r);
-    static TYPE type(const Data* r);
-    static TYPE type(const Data& r);
-    static STATUS_ENUM status(const wxString& r);
-    static STATUS_ENUM status(const Data* r);
-    static STATUS_ENUM status(const Data& r);
+    static TYPE_ID type_id(const wxString& r);
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static wxString status_key(const wxString& r);
+    static STATUS_ID status_id(const wxString& r);
+    static STATUS_ID status_id(const Data* r);
+    static STATUS_ID status_id(const Data& r);
     static double amount(const Data* r, int account_id = -1);
     static double amount(const Data&r, int account_id = -1);
     static double balance(const Data* r, int account_id = -1);
@@ -210,7 +235,6 @@ public:
     static bool is_transfer(const Data* r);
     static bool is_deposit(const wxString& r);
     static bool is_deposit(const Data* r);
-    static wxString status_key(const wxString& fullStatus);
     static void getFrequentUsedNotes(std::vector<wxString> &frequentNotes, int accountID = -1);
     static void getEmptyTransaction(Data &data, int accountID);
     static bool getTransactionData(Data &data, const Data* r);

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -106,19 +106,19 @@ public:
         // Reserved string variables for custom data
         wxString UDFC01;
         double UDFC01_val;
-        Model_CustomField::FIELDTYPE UDFC01_Type;
+        Model_CustomField::TYPE_ID UDFC01_Type;
         wxString UDFC02;
         double UDFC02_val;
-        Model_CustomField::FIELDTYPE UDFC02_Type;
+        Model_CustomField::TYPE_ID UDFC02_Type;
         wxString UDFC03;
         double UDFC03_val;
-        Model_CustomField::FIELDTYPE UDFC03_Type;
+        Model_CustomField::TYPE_ID UDFC03_Type;
         wxString UDFC04;
         double UDFC04_val;
-        Model_CustomField::FIELDTYPE UDFC04_Type;
+        Model_CustomField::TYPE_ID UDFC04_Type;
         wxString UDFC05;
         double UDFC05_val;
-        Model_CustomField::FIELDTYPE UDFC05_Type;
+        Model_CustomField::TYPE_ID UDFC05_Type;
     };
     typedef std::vector<Full_Data> Full_Data_Set;
 

--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -33,6 +33,16 @@ constexpr auto LIMIT = 1e-10;
 static wxString s_locale;
 static wxString s_use_locale;
 
+const std::vector<std::pair<Model_Currency::TYPE_ID, wxString> > Model_Currency::TYPE_CHOICES =
+{
+    { Model_Currency::TYPE_ID_FIAT,   wxString(wxTRANSLATE("Fiat")) },
+    { Model_Currency::TYPE_ID_CRYPTO, wxString(wxTRANSLATE("Crypto")) }
+};
+
+wxArrayString Model_Currency::TYPE_STR = type_str_all();
+const wxString Model_Currency::TYPE_STR_FIAT   = TYPE_STR[TYPE_ID_FIAT];
+const wxString Model_Currency::TYPE_STR_CRYPTO = TYPE_STR[TYPE_ID_CRYPTO];
+
 Model_Currency::Model_Currency()
     : Model<DB_Table_CURRENCYFORMATS_V1>()
 {
@@ -64,39 +74,35 @@ Model_Currency& Model_Currency::instance()
     return Singleton<Model_Currency>::instance();
 }
 
-const std::vector<std::pair<Model_Currency::CURRENCYTYPE, wxString> > Model_Currency::CURRENCYTYPE_CHOICES =
-{
-    {Model_Currency::FIAT, wxString(wxTRANSLATE("Fiat"))}
-    , {Model_Currency::CRYPTO, wxString(wxTRANSLATE("Crypto"))}
-};
-
-const wxString Model_Currency::FIAT_STR = all_currencytype()[FIAT];
-const wxString Model_Currency::CRYPTO_STR = all_currencytype()[CRYPTO];
-
-wxArrayString Model_Currency::all_currencytype()
+wxArrayString Model_Currency::type_str_all()
 {
     wxArrayString types;
-    for (const auto& item : CURRENCYTYPE_CHOICES) types.Add(wxGetTranslation(item.second));
+    int i = 0;
+    for (const auto& item : TYPE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Currency::TYPE_CHOICES");
+        types.Add(wxGetTranslation(item.second));
+    }
     return types;
 }
 
-Model_Currency::CURRENCYTYPE Model_Currency::currencytype(const Data* r)
+Model_Currency::TYPE_ID Model_Currency::type_id(const Data* r)
 {
-    for (const auto &entry : CURRENCYTYPE_CHOICES)
+    for (const auto &entry : TYPE_CHOICES)
     {
         if (r->CURRENCY_TYPE.CmpNoCase(entry.second) == 0) return entry.first;
     }
-    return FIAT;
+    return TYPE_ID_FIAT;
 }
 
-Model_Currency::CURRENCYTYPE Model_Currency::currencytype(const Data& r)
+Model_Currency::TYPE_ID Model_Currency::type_id(const Data& r)
 {
-    return currencytype(&r);
+    return type_id(&r);
 }
 
-DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE Model_Currency::CURRENCY_TYPE(CURRENCYTYPE currencytype, OP op)
+DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE Model_Currency::CURRENCY_TYPE(TYPE_ID currencytype, OP op)
 {
-    return DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE(all_currencytype()[currencytype], op);
+    return DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE(Model_Currency::TYPE_STR[currencytype], op);
 }
 
 const wxArrayString Model_Currency::all_currency_names()

--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -81,7 +81,7 @@ wxArrayString Model_Currency::type_str_all()
     for (const auto& item : TYPE_CHOICES)
     {
         wxASSERT_MSG(item.first == i++, "Wrong order in Model_Currency::TYPE_CHOICES");
-        types.Add(wxGetTranslation(item.second));
+        types.Add(item.second);
     }
     return types;
 }

--- a/src/model/Model_Currency.cpp
+++ b/src/model/Model_Currency.cpp
@@ -174,7 +174,7 @@ std::map<wxDateTime, int> Model_Currency::DateUsed(int CurrencyID)
     const auto &accounts = Model_Account::instance().find(CURRENCYID(CurrencyID));
     for (const auto &account : accounts)
     {
-        if (Model_Account::type(account) == Model_Account::TYPE::INVESTMENT)
+        if (Model_Account::type_id(account) == Model_Account::TYPE_ID_INVESTMENT)
         {
             for (const auto trans : Model_Stock::instance().find(Model_Stock::HELDAT(account.ACCOUNTID)))
             {

--- a/src/model/Model_Currency.h
+++ b/src/model/Model_Currency.h
@@ -48,14 +48,23 @@ public:
     static Model_Currency& instance();
 
 public:
-    enum CURRENCYTYPE { FIAT = 0, CRYPTO };
-    static const std::vector<std::pair<CURRENCYTYPE, wxString> > CURRENCYTYPE_CHOICES;
-    static wxArrayString all_currencytype();
-    static const wxString FIAT_STR;
-    static const wxString CRYPTO_STR;
-    static CURRENCYTYPE currencytype(const Data* r);
-    static CURRENCYTYPE currencytype(const Data& r);
-    static DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE CURRENCY_TYPE(CURRENCYTYPE currencytype, OP op = EQUAL);
+    enum TYPE_ID
+    {
+        TYPE_ID_FIAT = 0,
+        TYPE_ID_CRYPTO
+    };
+    static wxArrayString TYPE_STR;
+    static const wxString TYPE_STR_FIAT;
+    static const wxString TYPE_STR_CRYPTO;
+
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static wxArrayString type_str_all();
+
+public:
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE CURRENCY_TYPE(TYPE_ID currencytype, OP op = EQUAL);
 
     const wxArrayString all_currency_names();
     const std::map<wxString, int>  all_currency();

--- a/src/model/Model_CustomField.cpp
+++ b/src/model/Model_CustomField.cpp
@@ -20,17 +20,19 @@
 #include "Model_CustomFieldData.h"
 #include <wx/string.h>
 
-const std::vector<std::pair<Model_CustomField::FIELDTYPE, wxString> > Model_CustomField::FIELDTYPE_CHOICES =
+const std::vector<std::pair<Model_CustomField::TYPE_ID, wxString> > Model_CustomField::TYPE_CHOICES =
 {
-    {Model_CustomField::STRING, wxString(wxTRANSLATE("String"))},
-    {Model_CustomField::INTEGER, wxString(wxTRANSLATE("Integer"))},
-    {Model_CustomField::DECIMAL, wxString(wxTRANSLATE("Decimal"))},
-    {Model_CustomField::BOOLEAN, wxString(wxTRANSLATE("Boolean"))},
-    {Model_CustomField::DATE, wxString(wxTRANSLATE("Date"))},
-    {Model_CustomField::TIME, wxString(wxTRANSLATE("Time"))},
-    {Model_CustomField::SINGLECHOICE, wxString(wxTRANSLATE("SingleChoice"))},
-    {Model_CustomField::MULTICHOICE, wxString(wxTRANSLATE("MultiChoice"))}
+    { Model_CustomField::TYPE_ID_STRING,       wxString(wxTRANSLATE("String")) },
+    { Model_CustomField::TYPE_ID_INTEGER,      wxString(wxTRANSLATE("Integer")) },
+    { Model_CustomField::TYPE_ID_DECIMAL,      wxString(wxTRANSLATE("Decimal")) },
+    { Model_CustomField::TYPE_ID_BOOLEAN,      wxString(wxTRANSLATE("Boolean")) },
+    { Model_CustomField::TYPE_ID_DATE,         wxString(wxTRANSLATE("Date")) },
+    { Model_CustomField::TYPE_ID_TIME,         wxString(wxTRANSLATE("Time")) },
+    { Model_CustomField::TYPE_ID_SINGLECHOICE, wxString(wxTRANSLATE("SingleChoice")) },
+    { Model_CustomField::TYPE_ID_MULTICHOICE,  wxString(wxTRANSLATE("MultiChoice")) }
 };
+
+wxArrayString Model_CustomField::TYPE_STR = type_str_all();
 
 Model_CustomField::Model_CustomField()
     : Model<DB_Table_CUSTOMFIELD_V1>()
@@ -83,41 +85,34 @@ bool Model_CustomField::Delete(const int& FieldID)
     return this->remove(FieldID, db_);
 }
 
-const wxString Model_CustomField::fieldtype_desc(const int FieldTypeEnum)
+Model_CustomField::TYPE_ID Model_CustomField::type_id(const wxString& value)
 {
-    const auto& item = FIELDTYPE_CHOICES[FieldTypeEnum];
-    const wxString reftype_desc = item.second;
-    return reftype_desc;
-}
-
-Model_CustomField::FIELDTYPE Model_CustomField::type(const wxString& value)
-{
-    for (const auto& item : FIELDTYPE_CHOICES)
+    for (const auto& item : TYPE_CHOICES)
     {
         if (item.second.CmpNoCase(value) == 0)
             return item.first;
     }
-
-    return UNKNOWN;
+    return TYPE_ID_UNKNOWN;
 }
 
-Model_CustomField::FIELDTYPE Model_CustomField::type(const Data* r)
+Model_CustomField::TYPE_ID Model_CustomField::type_id(const Data* r)
 {
-    return type(r->TYPE);
+    return type_id(r->TYPE);
 }
 
-Model_CustomField::FIELDTYPE Model_CustomField::type(const Data& r)
+Model_CustomField::TYPE_ID Model_CustomField::type_id(const Data& r)
 {
-    return type(&r);
+    return type_id(&r);
 }
 
-const wxArrayString Model_CustomField::all_type()
+const wxArrayString Model_CustomField::type_str_all()
 {
-    static wxArrayString types;
-    if (types.empty())
+    wxArrayString types;
+    int i = 0;
+    for (const auto& item : TYPE_CHOICES)
     {
-        for (const auto& item : FIELDTYPE_CHOICES)
-            types.Add(item.second);
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_CustomField::TYPE_CHOICES");
+        types.Add(item.second);
     }
     return types;
 }
@@ -266,7 +261,7 @@ const wxString Model_CustomField::getUDFCName(const wxString& ref_type, const wx
     return wxEmptyString;
 }
 
-Model_CustomField::FIELDTYPE Model_CustomField::getUDFCType(const wxString& ref_type, const wxString& name)
+Model_CustomField::TYPE_ID Model_CustomField::getUDFCType(const wxString& ref_type, const wxString& name)
 {
     Document json_doc;
     const auto& a = Model_CustomField::instance().find(REFTYPE(ref_type));
@@ -279,12 +274,12 @@ Model_CustomField::FIELDTYPE Model_CustomField::getUDFCType(const wxString& ref_
                 Value& s = json_doc["UDFC"];
                 const wxString& desc = s.GetString();
                 if (desc == name) {
-                    return type(item.TYPE);
+                    return type_id(item.TYPE);
                 }
             }
         }
     }
-    return Model_CustomField::FIELDTYPE::UNKNOWN;
+    return Model_CustomField::TYPE_ID_UNKNOWN;
 }
 
 const wxString Model_CustomField::getUDFCProperties(const wxString& ref_type, const wxString& name)

--- a/src/model/Model_CustomField.h
+++ b/src/model/Model_CustomField.h
@@ -26,8 +26,23 @@ class Model_CustomField : public Model<DB_Table_CUSTOMFIELD_V1>
 public:
     using Model<DB_Table_CUSTOMFIELD_V1>::get;
 
-    enum FIELDTYPE { STRING = 0, INTEGER, DECIMAL, BOOLEAN, DATE, TIME, SINGLECHOICE, MULTICHOICE, UNKNOWN = -1 };
-    static const std::vector<std::pair<FIELDTYPE, wxString> > FIELDTYPE_CHOICES;
+    enum TYPE_ID
+    {
+        TYPE_ID_STRING = 0,
+        TYPE_ID_INTEGER,
+        TYPE_ID_DECIMAL,
+        TYPE_ID_BOOLEAN,
+        TYPE_ID_DATE,
+        TYPE_ID_TIME,
+        TYPE_ID_SINGLECHOICE,
+        TYPE_ID_MULTICHOICE,
+        TYPE_ID_UNKNOWN = -1
+    };
+    static wxArrayString TYPE_STR;
+
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const wxArrayString type_str_all();
 
 public:
     Model_CustomField();
@@ -50,11 +65,9 @@ public:
 
 public:
     bool Delete(const int& FieldID);
-    static const wxString fieldtype_desc(const int FieldTypeEnum);
-    static FIELDTYPE type(const Data* r);
-    static FIELDTYPE type(const Data& r);
-    static FIELDTYPE type(const wxString& value);
-    static const wxArrayString all_type();
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static TYPE_ID type_id(const wxString& value);
     static const wxString getRegEx(const wxString& Properties);
     static const wxString getTooltip(const wxString& Properties);
     static int getReference(const wxString& Properties);
@@ -64,7 +77,7 @@ public:
     static const wxArrayString getUDFCList(DB_Table_CUSTOMFIELD_V1::Data* r);
     static const wxString getUDFC(const wxString& Properties);
     static const wxString getUDFCName(const wxString& ref_type, const wxString& name);
-    static FIELDTYPE getUDFCType(const wxString& ref_type, const wxString& name);
+    static TYPE_ID getUDFCType(const wxString& ref_type, const wxString& name);
     static const wxString getUDFCProperties(const wxString& ref_type, const wxString& name);
     static int getUDFCID(const wxString& ref_type, const wxString& name);
     static const std::map<wxString, int> getMatrix(Model_Attachment::REFTYPE reftype);

--- a/src/model/Model_Stock.cpp
+++ b/src/model/Model_Stock.cpp
@@ -177,7 +177,7 @@ double Model_Stock::getDailyBalanceAt(const Model_Account::Data *account, const 
                 precValueDate = stock.PURCHASEDATE;
             }
             //  if next not found and the accoung is open, takes previous date
-            if (nextValue == 0.0 && Model_Account::status(account) == Model_Account::OPEN)
+            if (nextValue == 0.0 && Model_Account::status_id(account) == Model_Account::STATUS_ID_OPEN)
             {
                 nextValue = precValue;
                 nextValueDate = precValueDate;

--- a/src/model/Model_Translink.cpp
+++ b/src/model/Model_Translink.cpp
@@ -171,7 +171,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
     for (const auto &trans : trans_list)
     {
         Model_Checking::Data* checking_entry = Model_Checking::instance().get(trans.CHECKINGACCOUNTID);
-        if (checking_entry && checking_entry->DELETEDTIME.IsEmpty() && Model_Checking::status(checking_entry->STATUS) != Model_Checking::VOID_) checking_list.push_back(*checking_entry);
+        if (checking_entry && checking_entry->DELETEDTIME.IsEmpty() && Model_Checking::status_id(checking_entry->STATUS) != Model_Checking::STATUS_ID_VOID) checking_list.push_back(*checking_entry);
     }
     std::stable_sort(checking_list.begin(), checking_list.end(), SorterByTRANSDATE());
     for (const auto &trans : checking_list)
@@ -222,12 +222,12 @@ void Model_Translink::UpdateAssetValue(Model_Asset::Data* asset_entry)
     for (const auto &trans : trans_list)
     {
         Model_Checking::Data* asset_trans = Model_Checking::instance().get(trans.CHECKINGACCOUNTID);
-        if (asset_trans && asset_trans->DELETEDTIME.IsEmpty() && Model_Checking::status(asset_trans->STATUS) != Model_Checking::VOID_)
+        if (asset_trans && asset_trans->DELETEDTIME.IsEmpty() && Model_Checking::status_id(asset_trans->STATUS) != Model_Checking::STATUS_ID_VOID)
         {
             Model_Currency::Data* asset_currency = Model_Account::currency(Model_Account::instance().get(asset_trans->ACCOUNTID));
             const double conv_rate = Model_CurrencyHistory::getDayRate(asset_currency->CURRENCYID, asset_trans->TRANSDATE);
 
-            if (asset_trans->TRANSCODE == Model_Checking::all_type()[Model_Checking::DEPOSIT])
+            if (asset_trans->TRANSCODE == Model_Checking::TYPE_STR_DEPOSIT)
             {
                 new_value -= asset_trans->TRANSAMOUNT * conv_rate; // Withdrawal from asset value
             }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -464,13 +464,13 @@ void Option::setHomePageIncExpRange(const int value)
 int Option::AccountImageId(const int account_id, const bool def, const bool ignoreClosure)
 {
     wxString acctStatus = VIEW_ACCOUNTS_OPEN_STR;
-    Model_Account::TYPE acctType = Model_Account::CHECKING;
+    Model_Account::TYPE_ID acctType = Model_Account::TYPE_ID_CHECKING;
     int selectedImage = img::SAVINGS_ACC_NORMAL_PNG; //Default value
 
     Model_Account::Data* account = Model_Account::instance().get(account_id);
     if (account)
     {
-        acctType = Model_Account::type(account);
+        acctType = Model_Account::type_id(account);
         acctStatus = account->STATUS;
     }
 
@@ -486,28 +486,28 @@ int Option::AccountImageId(const int account_id, const bool def, const bool igno
 
     switch (acctType)
     {
-    case (Model_Account::CHECKING) :
+    case (Model_Account::TYPE_ID_CHECKING) :
         selectedImage = img::SAVINGS_ACC_NORMAL_PNG;
         break;
-    case (Model_Account::TERM) :
+    case (Model_Account::TYPE_ID_TERM) :
         selectedImage = img::TERMACCOUNT_NORMAL_PNG;
         break;
-    case (Model_Account::INVESTMENT) :
+    case (Model_Account::TYPE_ID_INVESTMENT) :
         selectedImage = img::STOCK_ACC_NORMAL_PNG;
         break;
-    case (Model_Account::CREDIT_CARD) :
+    case (Model_Account::TYPE_ID_CREDIT_CARD) :
         selectedImage = img::CARD_ACC_NORMAL_PNG;
         break;
-    case (Model_Account::CASH) :
+    case (Model_Account::TYPE_ID_CASH) :
         selectedImage = img::CASH_ACC_NORMAL_PNG;
         break;
-    case (Model_Account::LOAN) :
+    case (Model_Account::TYPE_ID_LOAN) :
         selectedImage = img::LOAN_ACC_NORMAL_PNG;
         break;
-    case (Model_Account::ASSET) :
+    case (Model_Account::TYPE_ID_ASSET) :
         selectedImage = img::ASSET_NORMAL_PNG;
         break;
-    case (Model_Account::SHARES) :
+    case (Model_Account::TYPE_ID_SHARES) :
         selectedImage = img::LOAN_ACC_NORMAL_PNG;
         break;
     default:

--- a/src/optionsettingsmisc.cpp
+++ b/src/optionsettingsmisc.cpp
@@ -133,7 +133,7 @@ void OptionSettingsMisc::Create()
     wxChoice* default_status = new wxChoice(misc_panel
         , ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
         default_status->Append(wxGetTranslation(i), new wxStringClientData(i));
 
     default_status->SetSelection(Option::instance().TransStatusReconciled());

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -102,7 +102,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
         evaluateTransfer = true;
     }
     //Get statistics
-    std::map<int, Model_Budget::PERIOD_ENUM> budgetPeriod;
+    std::map<int, Model_Budget::PERIOD_ID> budgetPeriod;
     std::map<int, double> budgetAmt;
     std::map<int, wxString> budgetNotes;
     Model_Budget::instance().getBudgetEntry(m_date_selection, budgetPeriod, budgetAmt, budgetNotes);

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -84,7 +84,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
         evaluateTransfer = true;
     }
     //Get statistics
-    std::map<int, Model_Budget::PERIOD_ENUM> budgetPeriod;
+    std::map<int, Model_Budget::PERIOD_ID> budgetPeriod;
     std::map<int, double> budgetAmt;
     std::map<int, wxString> budgetNotes;
     Model_Budget::instance().getBudgetEntry(m_date_selection, budgetPeriod, budgetAmt, budgetNotes);

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -78,8 +78,8 @@ void mmReportCashFlow::getTransactions()
 
     // Get initial Balance as of today
     for (const auto& account : Model_Account::instance().find(
-        Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], NOT_EQUAL)
-        , Model_Account::STATUS(Model_Account::CLOSED, NOT_EQUAL)))
+        Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, NOT_EQUAL)
+        , Model_Account::STATUS(Model_Account::STATUS_ID_CLOSED, NOT_EQUAL)))
     {
         if (accountArray_ && accountArray_->Index(account.ACCOUNTNAME) == wxNOT_FOUND) {
             continue;

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -47,14 +47,14 @@ double mmReportCashFlow::trueAmount(const Model_Checking::Data& trx)
     if (!(isAccountFound && isToAccountFound))
     {
         const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
-        switch (Model_Checking::type(trx.TRANSCODE)) {
-        case Model_Checking::WITHDRAWAL:
+        switch (Model_Checking::type_id(trx.TRANSCODE)) {
+        case Model_Checking::TYPE_ID_WITHDRAWAL:
             amount = -trx.TRANSAMOUNT * convRate;
             break;
-        case Model_Checking::DEPOSIT:
+        case Model_Checking::TYPE_ID_DEPOSIT:
             amount = +trx.TRANSAMOUNT * convRate;
             break;
-        case Model_Checking::TRANSFER:
+        case Model_Checking::TYPE_ID_TRANSFER:
             if (isAccountFound)
                 amount = -trx.TRANSAMOUNT * convRate;
             else
@@ -105,7 +105,7 @@ void mmReportCashFlow::getTransactions()
     Model_Checking::Data_Set transactions = Model_Checking::instance().find(
         Model_Checking::TRANSDATE(m_today, GREATER),
         Model_Checking::TRANSDATE(endDate, LESS),
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL));
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL));
     for (auto& trx : transactions)
     {
         if (!trx.DELETEDTIME.IsEmpty()) continue;
@@ -131,7 +131,7 @@ void mmReportCashFlow::getTransactions()
     }
 
     // Now we gather the recurring transaction list
-    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+    for (const auto& entry : Model_Billsdeposits::instance().find(Model_Billsdeposits::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         wxDateTime nextOccurDate = Model_Billsdeposits::NEXTOCCURRENCEDATE(entry);
         if (nextOccurDate > endDate) continue;

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -52,7 +52,7 @@ wxString mmReportForecast::getHTMLText()
 
     for (const auto & trx : all_trans)
     {
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER || Model_Checking::foreignTransactionAsTransfer(trx))
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER || Model_Checking::foreignTransactionAsTransfer(trx))
             continue;
         const double convRate = Model_CurrencyHistory::getDayRate(Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID, trx.TRANSDATE);
         amount_by_day[trx.TRANSDATE].first += Model_Checking::withdrawal(trx, -1) * convRate;

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -48,7 +48,7 @@ wxString mmReportIncomeExpenses::getHTMLText()
     for (const auto& transaction : Model_Checking::instance().find(
         Model_Checking::TRANSDATE(m_date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(m_date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         // Do not include asset or stock transfers or deleted transactions in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(transaction) || !transaction.DELETEDTIME.IsEmpty())
@@ -64,9 +64,9 @@ wxString mmReportIncomeExpenses::getHTMLText()
         // We got this far, get the currency conversion rate for this account
         if (account) convRate = Model_CurrencyHistory::getDayRate(Model_Account::currency(account)->CURRENCYID,transaction.TRANSDATE);
 
-        if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT)
+        if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_DEPOSIT)
             income_expenses_pair.first += transaction.TRANSAMOUNT * convRate;
-        else if (Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL)
+        else if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL)
             income_expenses_pair.second += transaction.TRANSAMOUNT * convRate;
     }
 
@@ -148,7 +148,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
     for (const auto& transaction : Model_Checking::instance().find(
         Model_Checking::TRANSDATE(start_date, GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(m_date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL)
-        , Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)))
+        , Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)))
     {
         // Do not include asset or stock transfers or deleted transactions in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(transaction) || !transaction.DELETEDTIME.IsEmpty())
@@ -167,10 +167,10 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
 
         int idx = year * 100 + Model_Checking::TRANSDATE(transaction).GetMonth();
 
-        if (Model_Checking::type(transaction) == Model_Checking::DEPOSIT) {
+        if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_DEPOSIT) {
             incomeExpensesStats[idx].first += transaction.TRANSAMOUNT * convRate;
         }
-        else if (Model_Checking::type(transaction) == Model_Checking::WITHDRAWAL) {
+        else if (Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_WITHDRAWAL) {
             incomeExpensesStats[idx].second += transaction.TRANSAMOUNT * convRate;
         }
     }

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -185,13 +185,13 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
 {
 // FIXME: do not ignore ignoreFuture param
     const auto &transactions = Model_Checking::instance().find(
-        Model_Checking::STATUS(Model_Checking::VOID_, NOT_EQUAL)
+        Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
         , Model_Checking::TRANSDATE(date_range->start_date(), GREATER_OR_EQUAL)
         , Model_Checking::TRANSDATE(date_range->end_date().FormatISOCombined(), LESS_OR_EQUAL));
     const auto all_splits = Model_Splittransaction::instance().get_all();
     for (const auto& trx: transactions)
     {
-        if (Model_Checking::type(trx) == Model_Checking::TRANSFER || !trx.DELETEDTIME.IsEmpty()) continue;
+        if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_TRANSFER || !trx.DELETEDTIME.IsEmpty()) continue;
 
         // Do not include asset or stock transfers in income expense calculations.
         if (Model_Checking::foreignTransactionAsTransfer(trx))
@@ -203,7 +203,7 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
         if (all_splits.count(trx.id())) splits = all_splits.at(trx.id());
         if (splits.empty())
         {
-            if (Model_Checking::type(trx) == Model_Checking::DEPOSIT)
+            if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_DEPOSIT)
                 payeeStats[trx.PAYEEID].first += trx.TRANSAMOUNT * convRate;
             else
                 payeeStats[trx.PAYEEID].second -= trx.TRANSAMOUNT * convRate;
@@ -212,7 +212,7 @@ void mmReportPayeeExpenses::getPayeeStats(std::map<int, std::pair<double, double
         {
             for (const auto& entry : splits)
             {
-                if (Model_Checking::type(trx) == Model_Checking::DEPOSIT)
+                if (Model_Checking::type_id(trx) == Model_Checking::TYPE_ID_DEPOSIT)
                 {
                     if (entry.SPLITTRANSAMOUNT >= 0)
                         payeeStats[trx.PAYEEID].first += entry.SPLITTRANSAMOUNT * convRate;

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -156,9 +156,9 @@ void mmPrintableBase::restoreReportSettings()
     int selection = 0;
     if (j_doc.HasMember("ACCOUNTSELECTION") && j_doc["ACCOUNTSELECTION"].IsInt()) {
         selection = j_doc["ACCOUNTSELECTION"].GetInt();
-        if (selection > (Model_Account::all_type().Count() + 2)) selection = 0;
+        if (selection > (Model_Account::TYPE_STR.Count() + 2)) selection = 0;
     }
-    if (selection > (Model_Account::all_type().Count() + 2))
+    if (selection > (Model_Account::TYPE_STR.Count() + 2))
         selection = 0;
 
     accountArray_ = selectedAccountArray_ = nullptr;
@@ -174,7 +174,7 @@ void mmPrintableBase::restoreReportSettings()
         }
         accountArray_ = selectedAccountArray_ = accountSelections;
     } else if (selection > 1)
-        setAccounts(selection, Model_Account::all_type()[selection - 2]);
+        setAccounts(selection, Model_Account::TYPE_STR[selection - 2]);
 
     m_account_selection = selection;
 }
@@ -220,10 +220,11 @@ void mmPrintableBase::setAccounts(int selection, const wxString& name)
         case 1: // Select Accounts
         {
             wxArrayString accounts;
-            auto a = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT], NOT_EQUAL));
+            auto a = Model_Account::instance().find(
+                Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT, NOT_EQUAL));
             std::stable_sort(a.begin(), a.end(), SorterByACCOUNTNAME());
             for (const auto& item : a) {
-                if (m_only_active && item.STATUS != Model_Account::all_status()[Model_Account::OPEN])
+                if (m_only_active && item.STATUS != Model_Account::STATUS_STR_OPEN)
                     continue;
                 accounts.Add(item.ACCOUNTNAME);
             }
@@ -258,7 +259,7 @@ void mmPrintableBase::setAccounts(int selection, const wxString& name)
         {
             wxArrayString* accountSelections = new wxArrayString();
             auto accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(name)
-                , Model_Account::STATUS(Model_Account::CLOSED, NOT_EQUAL));
+                , Model_Account::STATUS(Model_Account::STATUS_ID_CLOSED, NOT_EQUAL));
             for (const auto &i : accounts) {
                 accountSelections->Add(i.ACCOUNTNAME);
             }

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -84,7 +84,7 @@ double mmReportSummaryByDate::getDailyBalanceAt(const Model_Account::Data* accou
     if (date.FormatISODate() < account->INITIALDATE)
         return 0.0;
 
-    if (Model_Account::type(account) == Model_Account::INVESTMENT)
+    if (Model_Account::type_id(account) == Model_Account::TYPE_ID_INVESTMENT)
     {
         return getInvestingDailyBalanceAt(account, date);
     }
@@ -112,7 +112,7 @@ double mmReportSummaryByDate::getDayRate(int currencyid, const wxDate& date)
 
 wxString mmReportSummaryByDate::getHTMLText()
 {
-    double balancePerDay[Model_Account::MAX];
+    double balancePerDay[Model_Account::TYPE_ID_MAX];
     mmHTMLBuilder   hb;
     wxDate dateStart = wxDate::Today();
     wxDate dateEnd = wxDate::Today();
@@ -125,7 +125,7 @@ wxString mmReportSummaryByDate::getHTMLText()
     std::vector<BalanceEntry> totBalanceData;
 
     GraphData gd;
-    GraphSeries gs_data[Model_Account::MAX + 2];    // +2 as we add assets and balance to the end
+    GraphSeries gs_data[Model_Account::TYPE_ID_MAX + 2];    // +2 as we add assets and balance to the end
 
     std::vector<wxDate> arDates;
 
@@ -143,7 +143,7 @@ wxString mmReportSummaryByDate::getHTMLText()
         const wxDate accountOpeningDate = Model_Account::get_date_by_string(account.INITIALDATE);
         if (accountOpeningDate.IsEarlierThan(dateStart))
             dateStart = accountOpeningDate;
-        if (Model_Account::type(account) == Model_Account::INVESTMENT)
+        if (Model_Account::type_id(account) == Model_Account::TYPE_ID_INVESTMENT)
         {
             Model_Stock::Data_Set stocks = Model_Stock::instance().find(Model_Stock::HELDAT(account.id()));
             for (const auto& stock : stocks)
@@ -212,30 +212,30 @@ wxString mmReportSummaryByDate::getHTMLText()
 
         for (const auto& account : Model_Account::instance().all())
         {
-            balancePerDay[Model_Account::type(account)] += getDailyBalanceAt(&account, end_date) * getDayRate(account.CURRENCYID, end_date);
+            balancePerDay[Model_Account::type_id(account)] += getDailyBalanceAt(&account, end_date) * getDayRate(account.CURRENCYID, end_date);
         }
 
         for (const auto& asset : Model_Asset::instance().all()) {
             assetBalance += Model_Asset::instance().valueAtDate(&asset, end_date) * getDayRate(asset.CURRENCYID, end_date);
         }
 
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::CASH]);
-        gs_data[0].values.push_back(balancePerDay[Model_Account::CASH]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::CHECKING]);
-        gs_data[1].values.push_back(balancePerDay[Model_Account::CHECKING]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::CREDIT_CARD]);
-        gs_data[2].values.push_back(balancePerDay[Model_Account::CREDIT_CARD]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::LOAN]);
-        gs_data[3].values.push_back(balancePerDay[Model_Account::LOAN]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TERM]);
-        gs_data[4].values.push_back(balancePerDay[Model_Account::TERM]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::ASSET]);
-        gs_data[5].values.push_back(balancePerDay[Model_Account::ASSET]);
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::SHARES]);
-        gs_data[6].values.push_back(balancePerDay[Model_Account::SHARES]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_CASH]);
+        gs_data[0].values.push_back(balancePerDay[Model_Account::TYPE_ID_CASH]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_CHECKING]);
+        gs_data[1].values.push_back(balancePerDay[Model_Account::TYPE_ID_CHECKING]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_CREDIT_CARD]);
+        gs_data[2].values.push_back(balancePerDay[Model_Account::TYPE_ID_CREDIT_CARD]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_LOAN]);
+        gs_data[3].values.push_back(balancePerDay[Model_Account::TYPE_ID_LOAN]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_TERM]);
+        gs_data[4].values.push_back(balancePerDay[Model_Account::TYPE_ID_TERM]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_ASSET]);
+        gs_data[5].values.push_back(balancePerDay[Model_Account::TYPE_ID_ASSET]);
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_SHARES]);
+        gs_data[6].values.push_back(balancePerDay[Model_Account::TYPE_ID_SHARES]);
 
-        for (int i = 0; i < Model_Account::MAX; i++) {
-            if (i != Model_Account::INVESTMENT)
+        for (int i = 0; i < Model_Account::TYPE_ID_MAX; i++) {
+            if (i != Model_Account::TYPE_ID_INVESTMENT)
                 total += balancePerDay[i];
         }
 
@@ -243,9 +243,9 @@ wxString mmReportSummaryByDate::getHTMLText()
         totBalanceEntry.values.push_back(assetBalance);
         gs_data[7].values.push_back(assetBalance);
         total += assetBalance;
-        totBalanceEntry.values.push_back(balancePerDay[Model_Account::INVESTMENT]);
-        gs_data[8].values.push_back(balancePerDay[Model_Account::INVESTMENT]);
-        total += balancePerDay[Model_Account::INVESTMENT];
+        totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_INVESTMENT]);
+        gs_data[8].values.push_back(balancePerDay[Model_Account::TYPE_ID_INVESTMENT]);
+        total += balancePerDay[Model_Account::TYPE_ID_INVESTMENT];
         totBalanceEntry.values.push_back(total);
         gs_data[9].values.push_back(total);
         totBalanceData.push_back(totBalanceEntry);

--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -53,8 +53,8 @@ void  mmReportSummaryStocks::RefreshData()
 
     for (const auto& a : Model_Account::instance().all(Model_Account::COL_ACCOUNTNAME))
     {
-        if (Model_Account::type(a) != Model_Account::INVESTMENT) continue;
-        if (Model_Account::status(a) != Model_Account::OPEN) continue;
+        if (Model_Account::type_id(a) != Model_Account::TYPE_ID_INVESTMENT) continue;
+        if (Model_Account::status_id(a) != Model_Account::STATUS_ID_OPEN) continue;
 
         account.id = a.id();
         account.name = a.ACCOUNTNAME;
@@ -265,7 +265,7 @@ wxString mmReportChartStocks::getHTMLText()
     for (const auto& stock : Model_Stock::instance().all(Model_Stock::COL_SYMBOL))
     {
         Model_Account::Data* account = Model_Account::instance().get(stock.HELDAT);
-        if (Model_Account::status(account) != Model_Account::OPEN) continue;
+        if (Model_Account::status_id(account) != Model_Account::STATUS_ID_OPEN) continue;
         if (symbols.Index(stock.SYMBOL) != wxNOT_FOUND) continue;
 
         symbols.Add(stock.SYMBOL);

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -64,18 +64,18 @@ void mmReportTransactions::displayTotals(std::map<int, double> total, std::map<i
     hb.addTotalRow(_("Grand Total:"), noOfCols, v);
 }
 
-void mmReportTransactions::UDFCFormatHelper(Model_CustomField::FIELDTYPE type, int ref, wxString data, double val, int scale)
+void mmReportTransactions::UDFCFormatHelper(Model_CustomField::TYPE_ID type, int ref, wxString data, double val, int scale)
 {
-    if (type == Model_CustomField::FIELDTYPE::DECIMAL || type == Model_CustomField::FIELDTYPE::INTEGER)
+    if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
         hb.addMoneyCell(val, scale);
     else if (ref != -1)
     {
-        if (type == Model_CustomField::FIELDTYPE::BOOLEAN && !data.empty())
+        if (type == Model_CustomField::TYPE_ID_BOOLEAN && !data.empty())
         {
             bool v = wxString("TRUE|true|1").Contains(data);
             hb.addTableCell(v ? "&check;" : "&cross;", false, true);
         } else
-            hb.addTableCell(type == Model_CustomField::FIELDTYPE::DATE && !data.empty() ? mmGetDateForDisplay(data) : data);
+            hb.addTableCell(type == Model_CustomField::TYPE_ID_DATE && !data.empty() ? mmGetDateForDisplay(data) : data);
     }
 }
 
@@ -140,11 +140,11 @@ table {
     std::map<wxString, double> values_chart; // Store grouped values for chart
 
     const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
-    Model_CustomField::FIELDTYPE UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
-    Model_CustomField::FIELDTYPE UDFC02_Type = Model_CustomField::getUDFCType(RefType, "UDFC02");
-    Model_CustomField::FIELDTYPE UDFC03_Type = Model_CustomField::getUDFCType(RefType, "UDFC03");
-    Model_CustomField::FIELDTYPE UDFC04_Type = Model_CustomField::getUDFCType(RefType, "UDFC04");
-    Model_CustomField::FIELDTYPE UDFC05_Type = Model_CustomField::getUDFCType(RefType, "UDFC05");
+    Model_CustomField::TYPE_ID UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
+    Model_CustomField::TYPE_ID UDFC02_Type = Model_CustomField::getUDFCType(RefType, "UDFC02");
+    Model_CustomField::TYPE_ID UDFC03_Type = Model_CustomField::getUDFCType(RefType, "UDFC03");
+    Model_CustomField::TYPE_ID UDFC04_Type = Model_CustomField::getUDFCType(RefType, "UDFC04");
+    Model_CustomField::TYPE_ID UDFC05_Type = Model_CustomField::getUDFCType(RefType, "UDFC05");
     int UDFC01_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC01"));
     int UDFC02_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC02"));
     int UDFC03_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(RefType, "UDFC03"));
@@ -237,11 +237,11 @@ table {
                 {
                     wxString nameCSS = name;
                     switch (Model_CustomField::getUDFCType(ref_type, udfc_entry)) {
-                    case Model_CustomField::FIELDTYPE::DECIMAL:
-                    case Model_CustomField::FIELDTYPE::INTEGER:
+                    case Model_CustomField::TYPE_ID_DECIMAL:
+                    case Model_CustomField::TYPE_ID_INTEGER:
                         nameCSS.Append(" text-right");
                         break;
-                    case Model_CustomField::FIELDTYPE::BOOLEAN:
+                    case Model_CustomField::TYPE_ID_BOOLEAN:
                         nameCSS.Append(" text-center");
                         break;
                     }

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -257,7 +257,7 @@ table {
         // If a transfer between two accounts in the list of accounts being reported then we
         // should report both the transfer in and transfer out, i.e. two transactions
         int noOfTrans = 1;
-        if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER) &&
+        if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER) &&
             (allAccounts ||
                 ((selected_accounts.Index(transaction.ACCOUNTID) != wxNOT_FOUND)
                     && (selected_accounts.Index(transaction.TOACCOUNTID) != wxNOT_FOUND))))
@@ -271,7 +271,7 @@ table {
         {
             hb.startTableRow();
             {
-                /*  if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER)
+                /*  if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER)
                     && m_transDialog->getTypeCheckBox() && */
                 if (showColumnById(mmFilterTransactionsDialog::COL_ID))
                 {
@@ -323,7 +323,7 @@ table {
                         amount = -amount;
                     const double convRate = Model_CurrencyHistory::getDayRate(curr->CURRENCYID, transaction.TRANSDATE);
                     if (showColumnById(mmFilterTransactionsDialog::COL_AMOUNT))
-                        if (Model_Checking::status(transaction.STATUS) == Model_Checking::VOID_)
+                        if (Model_Checking::status_id(transaction.STATUS) == Model_Checking::STATUS_ID_VOID)
                             hb.addCurrencyCell(Model_Checking::amount(transaction, acc->ACCOUNTID), curr, -1, true);                            
                         else if (transaction.DELETEDTIME.IsEmpty())
                             hb.addCurrencyCell(amount, curr);
@@ -331,7 +331,7 @@ table {
                     grand_total[curr->CURRENCYID] += amount;
                     total_in_base_curr[curr->CURRENCYID] += amount * convRate;
                     grand_total_in_base_curr[curr->CURRENCYID] += amount * convRate;
-                    if (Model_Checking::type(transaction) != Model_Checking::TRANSFER)
+                    if (Model_Checking::type_id(transaction) != Model_Checking::TYPE_ID_TRANSFER)
                     {
                         grand_total_extrans[curr->CURRENCYID] += amount;
                         grand_total_in_base_curr_extrans[curr->CURRENCYID] += amount * convRate;
@@ -351,7 +351,7 @@ table {
                 // Exchange Rate
                 if (showColumnById(mmFilterTransactionsDialog::COL_RATE))
                 {
-                    if ((Model_Checking::type(transaction) == Model_Checking::TRANSFER)
+                    if ((Model_Checking::type_id(transaction) == Model_Checking::TYPE_ID_TRANSFER)
                         && (transaction.TRANSAMOUNT != transaction.TOTRANSAMOUNT))
                         hb.addMoneyCell(transaction.TOTRANSAMOUNT / transaction.TRANSAMOUNT);
                     else

--- a/src/reports/transactions.h
+++ b/src/reports/transactions.h
@@ -39,7 +39,7 @@ private:
     wxSharedPtr<mmFilterTransactionsDialog> m_transDialog;
     bool showColumnById(int num);
     void displayTotals(std::map<int, double> total, std::map<int, double> total_in_base_curr, int noOfCols);
-    void UDFCFormatHelper(Model_CustomField::FIELDTYPE type, int ref, wxString data, double val, int scale);
+    void UDFCFormatHelper(Model_CustomField::TYPE_ID type, int ref, wxString data, double val, int scale);
 
     mmHTMLBuilder hb;
     int m_noOfCols;

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -46,7 +46,7 @@ wxEND_EVENT_TABLE()
 
 double ShareTransactionDialog::GetAmount(double shares, double price, double commision)
 {
-    if (m_transaction_panel->TransactionType() == Model_Checking::DEPOSIT)
+    if (m_transaction_panel->TransactionType() == Model_Checking::TYPE_ID_DEPOSIT)
         return (shares * price - commision);
     else
         return (shares * price + commision);
@@ -149,7 +149,7 @@ void ShareTransactionDialog::DataToControls()
                     m_transaction_panel->SetTransactionValue(GetAmount(std::abs(m_share_entry->SHARENUMBER)
                         , m_share_entry->SHAREPRICE, m_share_entry->SHARECOMMISSION), true);
                     m_transaction_panel->SetTransactionAccount(Model_Account::get_account_name(checking_entry->ACCOUNTID));
-                    m_transaction_panel->SetTransactionStatus(Model_Checking::status(checking_entry));
+                    m_transaction_panel->SetTransactionStatus(Model_Checking::status_id(checking_entry));
                     m_transaction_panel->SetTransactionPayee(checking_entry->PAYEEID);
                     m_transaction_panel->SetTransactionCategory(checking_entry->CATEGID);
                     if (!checking_entry->DELETEDTIME.IsEmpty()) {
@@ -380,7 +380,7 @@ void ShareTransactionDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     if (m_transaction_panel->ValidCheckingAccountEntry())
     {
         // addition or removal shares
-        if ((num_shares > 0) && (m_transaction_panel->TransactionType() == Model_Checking::DEPOSIT))
+        if ((num_shares > 0) && (m_transaction_panel->TransactionType() == Model_Checking::TYPE_ID_DEPOSIT))
         {
             // we need to subtract the number of shares for a sale
             num_shares = num_shares * -1;

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -505,10 +505,10 @@ void mmStockDialog::CreateShareAccount(Model_Account::Data* stock_account, const
     if (name.empty()) return;
     Model_Account::Data* share_account = Model_Account::instance().create();
     share_account->ACCOUNTNAME = name;
-    share_account->ACCOUNTTYPE = Model_Account::all_type()[Model_Account::SHARES];
+    share_account->ACCOUNTTYPE = Model_Account::TYPE_STR_SHARES;
 
     share_account->FAVORITEACCT = "TRUE";
-    share_account->STATUS = Model_Account::all_status()[Model_Account::OPEN];
+    share_account->STATUS = Model_Account::STATUS_STR_OPEN;
     share_account->INITIALBAL = 0;
     share_account->INITIALDATE = openingDate;
     share_account->CURRENCYID = stock_account->CURRENCYID;

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -292,7 +292,8 @@ void StocksListCtrl::OnMoveStocks(wxCommandEvent& /*event*/)
 {
     if (m_selected_row == -1) return;
     
-    const auto& accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::all_type()[Model_Account::INVESTMENT]));
+    const auto& accounts = Model_Account::instance().find(
+        Model_Account::ACCOUNTTYPE(Model_Account::TYPE_STR_INVESTMENT));
     if (accounts.empty()) return;
 
     const Model_Account::Data* from_account = Model_Account::instance().get(m_stock_panel->m_account_id);

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -150,7 +150,7 @@ void transactionsUpdateDialog::CreateControls()
 
     m_status_choice = new wxChoice(this, wxID_ANY
         , wxDefaultPosition, wxDefaultSize);
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
         m_status_choice->Append(wxGetTranslation(i), new wxStringClientData(i));
 
     m_status_choice->Enable(false);
@@ -165,9 +165,9 @@ void transactionsUpdateDialog::CreateControls()
 
     m_type_choice = new wxChoice(this, ID_TRANS_TYPE
         , wxDefaultPosition, wxDefaultSize);
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (!(m_hasSplits && (Model_Checking::TRANSFER_STR == i)))
+        if (!(m_hasSplits && (Model_Checking::TYPE_STR_TRANSFER == i)))
             m_type_choice->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
     m_type_choice->Enable(false);
@@ -323,7 +323,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     {
         wxStringClientData* type_obj = static_cast<wxStringClientData*>(m_type_choice->GetClientObject(m_type_choice->GetSelection()));
         type = type_obj->GetData();
-        if (Model_Checking::TRANSFER_STR == type)
+        if (Model_Checking::TYPE_STR_TRANSFER == type)
         {
             if  (m_hasNonTransfers && !m_transferAcc_checkbox->IsChecked())
                 return mmErrorDialogs::InvalidAccount(m_transferAcc_checkbox, true);
@@ -547,7 +547,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void transactionsUpdateDialog::SetPayeeTransferControls()
 {
     wxStringClientData* trans_obj = static_cast<wxStringClientData*>(m_type_choice->GetClientObject(m_type_choice->GetSelection()));
-    bool transfer = (Model_Checking::TRANSFER_STR == trans_obj->GetData());
+    bool transfer = (Model_Checking::TYPE_STR_TRANSFER == trans_obj->GetData());
 
     m_payee_checkbox->Enable(!transfer);
     m_transferAcc_checkbox->Enable(transfer);

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -718,7 +718,7 @@ bool mmTransDialog::ValidateData()
         const Model_Account::Data *to_account = Model_Account::instance().get(cbToAccount_->GetValue());
 
         if (!to_account || to_account->ACCOUNTID == m_trx_data.ACCOUNTID
-            || Model_Account::type(to_account) == Model_Account::INVESTMENT)
+            || Model_Account::type_id(to_account) == Model_Account::TYPE_ID_INVESTMENT)
         {
             mmErrorDialogs::InvalidAccount(cbToAccount_, true);
             return false;

--- a/src/transdialog.h
+++ b/src/transdialog.h
@@ -49,7 +49,7 @@ public:
         , int transaction_id
         , double current_balance
         , bool duplicate = false
-        , int type = Model_Checking::WITHDRAWAL);
+        , int type = Model_Checking::TYPE_ID_WITHDRAWAL);
 
     bool Create(wxWindow* parent
         , wxWindowID id = wxID_ANY

--- a/src/usertransactionpanel.cpp
+++ b/src/usertransactionpanel.cpp
@@ -94,13 +94,13 @@ void UserTransactionPanel::Create()
 
     // Type --------------------------------------------
     m_type_selector = new wxChoice(this, wxID_VIEW_DETAILS, wxDefaultPosition, std_half_size);
-    for (const auto& i : Model_Checking::all_type())
+    for (const auto& i : Model_Checking::TYPE_STR)
     {
-        if (i != Model_Checking::all_type()[Model_Checking::TRANSFER])
+        if (i != Model_Checking::TYPE_STR_TRANSFER)
             m_type_selector->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
 
-    m_type_selector->SetSelection(Model_Checking::WITHDRAWAL);
+    m_type_selector->SetSelection(Model_Checking::TYPE_ID_WITHDRAWAL);
     mmToolTip(m_type_selector, _("Withdraw funds from or deposit funds to this Account."));
 
     m_transfer = new wxCheckBox(this, ID_TRANS_TRANSFER, _("&Transfer")
@@ -142,7 +142,7 @@ void UserTransactionPanel::Create()
     m_status_selector = new wxChoice(this, ID_TRANS_STATUS_SELECTOR
         , wxDefaultPosition, std_half_size);
 
-    for (const auto& i : Model_Checking::all_status())
+    for (const auto& i : Model_Checking::STATUS_STR)
     {
         m_status_selector->Append(wxGetTranslation(i), new wxStringClientData(i));
     }
@@ -215,7 +215,7 @@ void UserTransactionPanel::DataToControls()
     m_transaction_id = m_checking_entry->TRANSID;
     m_account_id = m_checking_entry->ACCOUNTID;
     m_account->SetLabelText(Model_Account::get_account_name(m_account_id));
-    m_type_selector->SetSelection(Model_Checking::type(m_checking_entry->TRANSCODE));
+    m_type_selector->SetSelection(Model_Checking::type_id(m_checking_entry->TRANSCODE));
 
     if (m_account_id > 0)
     {
@@ -225,7 +225,7 @@ void UserTransactionPanel::DataToControls()
     }
 
     SetTransactionValue(m_checking_entry->TRANSAMOUNT);
-    m_status_selector->SetSelection(Model_Checking::status(m_checking_entry->STATUS));
+    m_status_selector->SetSelection(Model_Checking::status_id(m_checking_entry->STATUS));
 
     m_payee_id = m_checking_entry->PAYEEID;
     m_payee->SetLabelText(Model_Payee::get_payee_name(m_payee_id));
@@ -258,7 +258,7 @@ void UserTransactionPanel::SetLastPayeeAndCategory(const int account_id)
 {
     if (Option::instance().TransPayeeSelection() == Option::LASTUSED)
     {
-        Model_Checking::Data_Set trans_list = Model_Checking::instance().find(Model_Checking::ACCOUNTID(account_id), Model_Checking::TRANSCODE(Model_Checking::TRANSFER, NOT_EQUAL));
+        Model_Checking::Data_Set trans_list = Model_Checking::instance().find(Model_Checking::ACCOUNTID(account_id), Model_Checking::TRANSCODE(Model_Checking::TYPE_ID_TRANSFER, NOT_EQUAL));
         if (!trans_list.empty())
         {
             int last_trans_pos = trans_list.size() - 1;
@@ -460,7 +460,7 @@ int UserTransactionPanel::SaveChecking()
     m_checking_entry->TOACCOUNTID = CheckingType();
 
     m_checking_entry->PAYEEID = m_payee_id;
-    m_checking_entry->TRANSCODE = Model_Checking::instance().all_type()[TransactionType()];
+    m_checking_entry->TRANSCODE = Model_Checking::TYPE_STR[TransactionType()];
     m_checking_entry->TRANSAMOUNT = initial_amount;
     m_checking_entry->STATUS = m_status_selector->GetStringSelection().Mid(0, 1);
     m_checking_entry->TRANSACTIONNUMBER = m_entered_number->GetValue();

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -476,7 +476,7 @@ int mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     }
     else
     {
-        TrStatus = "F";
+        TrStatus = Model_Checking::STATUS_KEY_FOLLOWUP;
         wxString FistAccountName;
 
         //Search first bank account

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -178,7 +178,7 @@ bool mmWebApp::WebApp_UpdateAccount()
 
     for (const auto &account : Model_Account::instance().all(Model_Account::COL_ACCOUNTNAME))
     {
-        if (Model_Account::type(account) != Model_Account::INVESTMENT && Model_Account::status(account) != Model_Account::CLOSED)
+        if (Model_Account::type_id(account) != Model_Account::TYPE_ID_INVESTMENT && Model_Account::status_id(account) != Model_Account::STATUS_ID_CLOSED)
         {
             json_writer.StartObject();
             json_writer.Key("AccountName");
@@ -482,7 +482,7 @@ int mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
         //Search first bank account
         for (const auto &FirstAccount : Model_Account::instance().all(Model_Account::COL_ACCOUNTNAME))
         {
-            if (Model_Account::type(FirstAccount) != Model_Account::INVESTMENT && Model_Account::type(FirstAccount) != Model_Account::TERM)
+            if (Model_Account::type_id(FirstAccount) != Model_Account::TYPE_ID_INVESTMENT && Model_Account::type_id(FirstAccount) != Model_Account::TYPE_ID_TERM)
             {
                 accountName = FirstAccount.ACCOUNTNAME;
                 AccountID = FirstAccount.ACCOUNTID;

--- a/src/wizard_newaccount.cpp
+++ b/src/wizard_newaccount.cpp
@@ -63,8 +63,8 @@ void mmAddAccountWizard::RunIt()
         Model_Account::Data* account = Model_Account::instance().create();
 
         account->FAVORITEACCT = "TRUE";
-        account->STATUS = Model_Account::all_status()[Model_Account::OPEN];
-        account->ACCOUNTTYPE = Model_Account::all_type()[accountType_];
+        account->STATUS = Model_Account::STATUS_STR_OPEN;
+        account->ACCOUNTTYPE = Model_Account::TYPE_STR[accountType_];
         account->ACCOUNTNAME = accountName_;
         account->INITIALBAL = 0;
         account->INITIALDATE = wxDate::Today().FormatISODate();
@@ -123,10 +123,10 @@ mmAddAccountTypePage::mmAddAccountTypePage(mmAddAccountWizard *parent)
     , parent_(parent)
 {
     itemChoiceType_ = new wxChoice(this, wxID_ANY);
-    for (const auto& type: Model_Account::all_type())
+    for (const auto& type: Model_Account::TYPE_STR)
         itemChoiceType_->Append(wxGetTranslation(type), new wxStringClientData(type));
     mmToolTip(itemChoiceType_, _("Specify the type of account to be created."));
-    itemChoiceType_->SetSelection(Model_Account::CHECKING);
+    itemChoiceType_->SetSelection(Model_Account::TYPE_ID_CHECKING);
 
     wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
 


### PR DESCRIPTION
This PR is a continuation of #6848.

For easier review, there is a separate commit for each class, in the order listed below.

Latent (non-observable) bugs in the choices of `Model_Currency`, `Model_Budget` are also fixed in this PR, in separate commits.

## Changes in `Model_Asset`

- Rename enum `TYPE` -> `TYPE_ID`, `STATUS` -> `STATUS_ID`, `RATE` -> `CHANGE_ID`, `RATEMODE` -> `CHANGEMODE_ID`.
- Add prefix into enum cases: `TYPE_ID_`, `STATUS_ID_`, `CHANGE_ID_`, `CHANGEMODE_ID_`.
- Rename `RATE_CHOICES` -> `CHANGE_CHOICES`, `RATEMODE_CHOICES` -> `CHANGEMODE_CHOICES`
- Create static wxArrayString `TYPE_STR`, `STATUS_STR`, `CHANGE_STR`, `CHANGEMODE_STR`.
- Rename `all_type()` -> `type_str_all()`, `all_status()` -> `status_str_all()`, all_rate()` -> `change_str_all()`, all_ratemode()` -> `changemode_str_all()`
- Rename `type()` -> `type_id()`, `status()` -> `status_id()`, `rate()` -> `change_id`, `ratemode()` -> `changemode_id`

No static wxString with prefix `TYPE_STR_`, `STATUS_STR_`, `CHANGE_STR_`, `CHANGEMODE_STR_` are created for `Model_Asset`, because such strings are used only in two places. If needed, they can be created in the future, similar to #6848.

## Changes in `Model_Account`

- Rename enum `TYPE` -> `TYPE_ID`, `STATUS_ENUM` -> `STATUS_ID`.
- Add prefix into enum cases: `TYPE_ID_`, `STATUS_ID_`.
- Create static wxArrayString `TYPE_STR`, `STATUS_STR`.
- Create static wxString `TYPE_STR_*`, `STATUS_STR_*`.
- Rename `all_type()` -> `type_str_all()`, `all_status()` -> `status_str_all()`.
- Rename `type()` -> `type_id()`, `status()` -> `status_id()`.

## Changes in `Model_Currency`

- Rename enum `CURRENCYTYPE` -> `TYPE_ID`.
- Add prefix `TYPE_ID_` into enum cases.
- Rename `CURRENCYTYPE_CHOICES` -> `TYPE_CHOICES`
- Create static wxArrayString `TYPE_STR`.
- Rename static wxString `*_STR` -> `TYPE_STR_*`.
- Rename `all_currencytype()` -> `type_str_all()`.
- Rename `currencytype()` -> `type_id()`.

## Changes in `Model_Budget`

- Rename enum `PERIOD_ENUM` -> `PERIOD_ID`.
- Add prefix `PERIOD_ID_` into enum cases.
- Rename `PERIOD_ENUM_CHOICES` -> `PERIOD_CHOICES`.
- Create static wxArrayString `PERIOD_STR`.
- Create `period_str_all()`.
- Rename `period()` -> `period_id()`.
- Rename `all_period()` -> `period_loc_all()`.

## Changes in `Model_CustomField`

- Rename enum `FIELDTYPE` -> `TYPE_ID`.
- Add prefix`TYPE_ID_` into enum cases.
- Rename `FIELDTYPE_CHOICES` -> `TYPE_CHOICES`.
- Create static wxArrayString `TYPE_STR`.
- Rename `all_type()` -> `type_str_all()`.
- Rename `type()` -> `type_id()`.
- Remove `fieldtype_desc()`; replace with `TYPE_STR[]`.

## Latent bug in `Model_Currency`

`mmCurrencyDialog::mmCurrencyDialog` creates a new currency with `CURRENCY_TYPE` set to localized `Fiat`. Luckily, `Fiat` is translated to itself in all languages under `po`. Except in `mmCurrencyDialog::mmCurrencyDialog`, the `CURRENCY_TYPE` field is not shown and not modified in currency dialog forms.

`Model_Currency::CURRENCY_TYPE()` calls `DB_Table_CURRENCYFORMATS_V1::CURRENCY_TYPE()` with localized currency type string. `Model_Currency::CURRENCY_TYPE()` is not used.

Fix:

- Remove localization in `type_str_all()` (formerly called `all_currencytype`).

`type_str_all()` is a private function. It is used only at initialization phase, in order to create wxArrayString `TYPE_STR`, which (after this bug fix) contains the strings of `TYPE_CHOICES` without translation.

Code outside of `Model_Currency` uses `TYPE_STR` in order to convert a `TYPE_ID` to a string (without translation). A translation, if needed, can be pefrormed where it is needed.

## Latent bug in `Model_Budget`

`Model_Budget::PERIOD()` calls `DB_Table_BUDGETTABLE_V1::PERIOD()` with localized period string. `Model_Budget::PERIOD()` is not used.

Fix:

- Call `DB_Table_BUDGETTABLE_V1::PERIOD()` with the period string, instead of the localized period string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6853)
<!-- Reviewable:end -->
