### PR TITLE
Attempt to correctly display localized `<description>` tags at Flathub

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,74 +1,116 @@
-﻿-[English]------------------------------------------------------------------------
-Money Manager Ex is a free, open-source, cross-platform, easy-to-use personal 
-finance software. It primarily helps organize one's finances and keeps track 
-of where, when and how the money goes.
+de Deutsch
+==========
 
-MMEX includes all the basic features that 90% of users would want to see in a
-personal finance application. The design goals are to concentrate on simplicity
-and user-friendliness - something one can use everyday.
+Money Manager Ex (MMEX) ist eine kostenlose, quelloffene,
+plattformübergreifende, einfach zu bedienende persönliche
+Finanzsoftware. Sie hilft in erster Linie dabei, die eigenen Finanzen
+zu organisieren und den Überblick wo, wann und wie das Geld ausgegeben
+wird.
+
+MMEX enthält alle grundlegenden Funktionen, die sich 90% der Benutzer
+von einer Anwendung für persönliche Finanzen wünschen. Die Design-Ziele
+sind die Konzentration auf Einfachheit und Benutzerfreundlichkeit –
+etwas, das man jeden Tag benutzen kann.
 
 https://moneymanagerex.org/
 
--[Russian]-----------------------------------------------------------------------
-Money Manager Ex - бесплатная, с открытым исходным кодом,
+
+en-US English
+=============
+
+Money Manager Ex (MMEX) is a free, open-source, cross-platform,
+easy-to-use personal finance software. It primarily helps organize one’s
+finances and keeps track of where, when and how the money goes.
+
+MMEX includes all the basic features that 90% of users would want to see
+in a personal finance application. The design goals are to concentrate
+on simplicity and user-friendliness – something one can use everyday.
+
+https://moneymanagerex.org/
+
+
+fr Français
+===========
+
+Money Manager Ex (MMEX) est un logiciel de finances personnelles
+gratuit, open-source, multiplateforme et facile à utiliser, logiciel de
+finances personnelles. Il aide principalement à organiser les finances
+d'une personne et à garder la trace où, quand et comment va l'argent.
+
+MMEX comprend toutes les fonctionnalités de base que 90 % des
+utilisateurs souhaiteraient voir dans une application de finances
+personnelles. Les objectifs de la conception sont de se concentrer sur
+la simplicité et la convivialité – quelque chose que l'on peut utiliser
+tous les jours.
+
+https://moneymanagerex.org/
+
+
+hu magyar
+=========
+
+A Money Manager Ex (MMEX) személyes pénzügyek és pénzkezelés egy
+ingyenes, nyílt forráskódú, többplatformos, könnyen használható
+személyes pénzügyi szoftver. Elsősorban a pénzügyek rendezésében segít,
+és nyomon követi, hogy hova, mikor és hogyan megy el a pénz.
+
+Az MMEX tartalmazza mindazokat az alapvető funkciókat, amelyeket a
+felhasználók 90%-a látni szeretne egy személyes pénzügyi alkalmazásban.
+A tervezési célok az egyszerűségre és a felhasználóbarátságra való
+összpontosítás – amit az ember mindennap használhat.
+
+https://moneymanagerex.org/
+
+
+it Italiano
+===========
+
+Money Manager Ex (MMEX) и un programma di gestione finanziaria personale
+gratuito, open-source, multi-piattaforma e facile da usare. Aiuta
+principalmente ad organizzare le proprie finanze e a tenere traccia di
+come, dove e quando si spende il denaro.
+
+MMEX include tutte le caratteristiche di base che il 90% degli utenti
+avrebbe voluto vedere in un programma di gestione finanaziaria.
+L'obiettivo principale della progettazione si и concentrato sulla
+facilitа e semplicitа d'utilizzo, qualcosa che chiunque potesse
+utilizzare ogni giorno.
+
+https://moneymanagerex.org/
+
+
+pl polski
+=========
+
+Money Manager Ex (MMEX) to program rozwijany jako open source służący do
+zarządzania domowym budżetem i finansami osobistymi. 
+
+Aplikacja doskonale nadaje się do obliczania osobistego budżetu, wszyscy
+użytkownicy którzy posiadają konta bankowe, lokaty, udziały w
+funduszach, kredyty, będą mogli bez problemu zarządzać własnymi
+finansami.
+
+Wydatki oraz przychody można podzielić według kategorii dzięki czemu
+zarządzanie nimi jest zdecydowanie łatwiejsze. W ten sposób można
+zaplanować własny budżet na cały rok. Program posiada moduł
+rozbudowanych raportów które określają w jaki sposób użytkownik zarządza
+finansami i w jaki sposób wydaje pieniądze. 
+
+MMEX posiada polski interfejs oraz daje możliwość wyboru polskiej
+waluty.
+
+https://moneymanagerex.org/
+
+
+ru Русский
+==========
+
+Money Manager Ex (MMEX) - бесплатная, с открытым исходным кодом,
 мультиплатформенная программа для персонального учёта финансов. 
 Она поможет Вам знать, когда, сколько и на что были потрачены деньги.
 
 MMEX включает функции, которые 90% пользователей хотят видеть 
-в программе учёта финансов. Принципы реализации - легковесность, 
+в программе учёта финансов. Принципы реализации – легковесность, 
 простота выполнения операций, дружелюбность к пользователю.
-
-https://moneymanagerex.org/
-
--[Italian]-----------------------------------------------------------------------
-Money Manager Ex и un programma di gestione finanziaria personale gratuito, 
-open-source, multi-piattaforma e facile da usare. Aiuta principalmente ad 
-organizzare le proprie finanze e a tenere traccia di come, dove e quando si 
-spende il denaro.
-
-MMEX include tutte le caratteristiche di base che il 90% degli utenti avrebbe 
-voluto vedere in un programma di gestione finanaziaria. L'obiettivo principale 
-della progettazione si и concentrato sulla facilitа e semplicitа d'utilizzo, 
-qualcosa che chiunque potesse utilizzare ogni giorno.
-
-https://moneymanagerex.org/
-
--[Polish]-----------------------------------------------------------------------
-Money Manager Ex to program rozwijany jako open source służący do zarządzania
-domowym budżetem i finansami osobistymi. 
-
-Aplikacja doskonale nadaje się do obliczania osobistego budżetu,
-wszyscy użytkownicy którzy posiadają konta bankowe, lokaty,
-udziały w funduszach, kredyty, będą mogli bez problemu zarządzać własnymi finansami. 
-
-Wydatki oraz przychody można podzielić według kategorii dzięki czemu zarządzanie
-nimi jest zdecydowanie łatwiejsze. W ten sposób można zaplanować własny budżet na cały rok.
-Program posiada moduł rozbudowanych raportów które określają w jaki sposób użytkownik
-zarządza finansami i w jaki sposób wydaje pieniądze. 
-
-Money Manager Ex posiada polski interfejs oraz daje możliwość wyboru polskiej waluty.
-
-https://moneymanagerex.org/
-
--[Deutsch]------------------------------------------------------------------------
-Money Manager Ex ist eine kostenlose, quelloffene, plattformübergreifende, einfach zu bedienende persönliche 
-Finanzsoftware. Sie hilft in erster Linie dabei, die eigenen Finanzen zu organisieren
-und den Überblick wo, wann und wie das Geld ausgegeben wird.
-
-MMEX enthält alle grundlegenden Funktionen, die sich 90% der Benutzer von einer Anwendung
-für persönliche Finanzen wünschen. 
-Die Design-Ziele sind die Konzentration auf Einfachheit und Benutzerfreundlichkeit
- - etwas, das man jeden Tag benutzen kann.
-
-https://moneymanagerex.org/
-
--[Francais]------------------------------------------------------------------------
-Money Manager Ex est un logiciel de finances personnelles gratuit, open-source, multiplateforme et facile à utiliser. 
-logiciel de finances personnelles. Il aide principalement à organiser les finances d'une personne et à garder la trace 
-où, quand et comment va l'argent.
-
-MMEX comprend toutes les fonctionnalités de base que 90 % des utilisateurs souhaiteraient voir dans une
-application de finances personnelles. Les objectifs de la conception sont de se concentrer sur la simplicité
-et la convivialité - quelque chose que l'on peut utiliser tous les jours.
 
 https://moneymanagerex.org/

--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -142,7 +142,17 @@
   </description>
   <description xml:lang="de">
     <p>
-      Persönliche Finanz- und Geldverwaltungssoftware.
+      Money Manager Ex (MMEX) ist eine kostenlose, quelloffene,
+      plattformübergreifende, einfach zu bedienende persönliche
+      Finanzsoftware. Sie hilft in erster Linie dabei, die eigenen Finanzen
+      zu organisieren und den Überblick wo, wann und wie das Geld ausgegeben
+      wird.
+    </p>
+    <p>
+      MMEX enthält alle grundlegenden Funktionen, die sich 90% der Benutzer
+      von einer Anwendung für persönliche Finanzen wünschen. Die Design-Ziele
+      sind die Konzentration auf Einfachheit und Benutzerfreundlichkeit –
+      etwas, das man jeden Tag benutzen kann.
     </p>
   </description>
   <description xml:lang="el">

--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -114,172 +114,214 @@
       application. The design goals are to concentrate on simplicity and user-friendliness – an 
       application that can be used everyday.
     </p>
-
-    <p xml:lang="ar">
+  </description>
+  <description xml:lang="ar">
+    <p>
       .برامج إدارة الأموال والأموال الشخصية
     </p>
-    
-    <p xml:lang="be">
+  </description>
+  <description xml:lang="be">
+    <p>
       Праграмнае забеспячэнне для кіравання асабістымі фінансамі і грашыма.
     </p>
-    
-    <p xml:lang="bg">
+  </description>
+  <description xml:lang="bg">
+    <p>
       Софтуер за лични финанси и управление на пари.
     </p>
-    
-    <p xml:lang="ca">
+  </description>
+  <description xml:lang="ca">
+    <p>
       Programari personal de gestió financera i financera.
     </p>
-    
-    <p xml:lang="cs">
+  </description>
+  <description xml:lang="cs">
+    <p>
       Software pro správu osobních financí a peněz.
     </p>
-    
-    <p xml:lang="de">
+  </description>
+  <description xml:lang="de">
+    <p>
       Persönliche Finanz- und Geldverwaltungssoftware.
     </p>
-    
-    <p xml:lang="el">
+  </description>
+  <description xml:lang="el">
+    <p>
       Λογισμικό προσωπικής διαχείρισης οικονομικών και χρημάτων.
     </p>
-    
-    <p xml:lang="en_AU">
+  </description>
+  <description xml:lang="en_AU">
+    <p>
       Personal financial and money management software.
     </p>
-    
-    <p xml:lang="en_GB">
+  </description>
+  <description xml:lang="en_GB">
+    <p>
       Personal financial and money management software.
     </p>
-    
-    <p xml:lang="en">
+  </description>
+  <description xml:lang="en">
+    <p>
       Personal financial and money management software.
     </p>
-    
-    <p xml:lang="es">
+  </description>
+  <description xml:lang="es">
+    <p>
       Software de administración de dinero y finanzas personales.
     </p>
-    
-    <p xml:lang="fi">
+  </description>
+  <description xml:lang="fi">
+    <p>
       Henkilökohtainen talous- ja rahanhallintaohjelmisto.
     </p>
-    
-    <p xml:lang="fr">
+  </description>
+  <description xml:lang="fr">
+    <p>
       Logiciel de finances personnelles et de gestion de l'argent.
     </p>
-    
-    <p xml:lang="he">
+  </description>
+  <description xml:lang="he">
+    <p>
       .תוכנה אישית לניהול כספים וכספים
     </p>
-    
-    <p xml:lang="hr">
+  </description>
+  <description xml:lang="hr">
+    <p>
       Softver za upravljanje osobnim financijama i novcem.
     </p>
-    
-    <p xml:lang="hu">
+  </description>
+  <description xml:lang="hu">
+    <p>
       Személyes pénzügyi és pénzkezelési szoftver.
     </p>
-    
-    <p xml:lang="id">
+  </description>
+  <description xml:lang="id">
+    <p>
       Perangkat lunak manajemen keuangan dan uang pribadi.
     </p>
-    
-    <p xml:lang="is">
+  </description>
+  <description xml:lang="is">
+    <p>
       Hugbúnaður fyrir persónulegan fjármála- og peningastjórnun.
     </p>
-    
-    <p xml:lang="it">
+  </description>
+  <description xml:lang="it">
+    <p>
       Software personale finanziario e di gestione del denaro.
     </p>
-    
-    <p xml:lang="ja">
+  </description>
+  <description xml:lang="ja">
+    <p>
       個人の財務および資金管理ソフトウェア。
     </p>
-    
-    <p xml:lang="kn">
+  </description>
+  <description xml:lang="kn">
+    <p>
       ವೈಯಕ್ತಿಕ ಹಣಕಾಸು ಮತ್ತು ಹಣ ನಿರ್ವಹಣೆ ಸಾಫ್ಟ್‌ವೇರ್.
     </p>
-    
-    <p xml:lang="ko">
+  </description>
+  <description xml:lang="ko">
+    <p>
       개인 금융 및 자금 관리 소프트웨어.
     </p>
-    
-    <p xml:lang="lt">
+  </description>
+  <description xml:lang="lt">
+    <p>
       Asmeninių finansų ir pinigų valdymo programinė įranga.
     </p>
-    
-    <p xml:lang="lv">
+  </description>
+  <description xml:lang="lv">
+    <p>
       Personīgo finanšu un naudas pārvaldības programmatūra.
     </p>
-    
-    <p xml:lang="nl">
+  </description>
+  <description xml:lang="nl">
+    <p>
       Software voor persoonlijk financieel en geldbeheer.
     </p>
-    
-    <p xml:lang="no_NY">
+  </description>
+  <description xml:lang="no_NY">
+    <p>
       Software voor persoonlijk financieel en geldbeheer.
     </p>
-    
-    <p xml:lang="pl">
+  </description>
+  <description xml:lang="pl">
+    <p>
       Oprogramowanie do zarządzania finansami osobistymi i pieniędzmi.
     </p>
-    
-    <p xml:lang="pt_BR">
+  </description>
+  <description xml:lang="pt_BR">
+    <p>
       Software de gestão financeira e financeira pessoal.
     </p>
-    
-    <p xml:lang="pt">
+  </description>
+  <description xml:lang="pt">
+    <p>
       Software de gestão financeira e financeira pessoal.
     </p>
-    
-    <p xml:lang="ro">
+  </description>
+  <description xml:lang="ro">
+    <p>
       Software financiar personal și software de gestionare a banilor.
     </p>
-    
-    <p xml:lang="ru">
+  </description>
+  <description xml:lang="ru">
+    <p>
       Программное обеспечение для управления личными финансами и деньгами.
     </p>
-    
-    <p xml:lang="sk">
+  </description>
+  <description xml:lang="sk">
+    <p>
       Softvér na správu osobných financií a peňazí.
     </p>
-    
-    <p xml:lang="sl">
+  </description>
+  <description xml:lang="sl">
+    <p>
       Programska oprema za upravljanje osebnih financ in denarja.
     </p>
-    
-    <p xml:lang="sq">
+  </description>
+  <description xml:lang="sq">
+    <p>
       Softuer personal financiar dhe i menaxhimit të parave.
     </p>
-    
-    <p xml:lang="sr">
+  </description>
+  <description xml:lang="sr">
+    <p>
       Лични софтвер за управљање финансијама и новцем.
     </p>
-    
-    <p xml:lang="sv_SE">
+  </description>
+  <description xml:lang="sv_SE">
+    <p>
       Programvara för personlig ekonomi och pengarhantering.
     </p>
-    
-    <p xml:lang="ta">
+  </description>
+  <description xml:lang="ta">
+    <p>
       தனிப்பட்ட நிதி மற்றும் பண மேலாண்மை மென்பொருள்.
     </p>
-    
-    <p xml:lang="tr">
+  </description>
+  <description xml:lang="tr">
+    <p>
       Kişisel finans ve para yönetimi yazılımı.
     </p>
-    
-    <p xml:lang="uk">
+  </description>
+  <description xml:lang="uk">
+    <p>
       Програмне забезпечення для управління особистими фінансами та грошима.
     </p>
-    
-    <p xml:lang="vi">
+  </description>
+  <description xml:lang="vi">
+    <p>
       Phần mềm quản lý tiền và tài chính cá nhân.
     </p>
-    
-    <p xml:lang="zh_CN">
+  </description>
+  <description xml:lang="zh_CN">
+    <p>
       个人财务和资金管理软件。
     </p>
-    
-    <p xml:lang="zh_TW">
+  </description>
+  <description xml:lang="zh_TW">
+    <p>
       個人財務和資金管理軟件。
     </p>
   </description>

--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -162,17 +162,35 @@
   </description>
   <description xml:lang="en_AU">
     <p>
-      Personal financial and money management software.
+      Money Manager Ex (MMEX) is a free/libre, open-source, cross-platform, easy-to-use personal financial 
+      and money management software. It helps organise finances and track cash flow.
+    </p>
+    <p>
+      MMEX includes all the basic features that 90% of users would want to see in a personal finance 
+      application. The design goals are to concentrate on simplicity and user-friendliness – an 
+      application that can be used everyday.
     </p>
   </description>
   <description xml:lang="en_GB">
     <p>
-      Personal financial and money management software.
+      Money Manager Ex (MMEX) is a free/libre, open-source, cross-platform, easy-to-use personal financial 
+      and money management software. It helps organise finances and track cash flow.
+    </p>
+    <p>
+      MMEX includes all the basic features that 90% of users would want to see in a personal finance 
+      application. The design goals are to concentrate on simplicity and user-friendliness – an 
+      application that can be used everyday.
     </p>
   </description>
   <description xml:lang="en">
     <p>
-      Personal financial and money management software.
+      Money Manager Ex (MMEX) is a free/libre, open-source, cross-platform, easy-to-use personal financial 
+      and money management software. It helps organize finances and track cash flow.
+    </p>
+    <p>
+      MMEX includes all the basic features that 90% of users would want to see in a personal finance 
+      application. The design goals are to concentrate on simplicity and user-friendliness – an 
+      application that can be used everyday.
     </p>
   </description>
   <description xml:lang="es">
@@ -187,7 +205,17 @@
   </description>
   <description xml:lang="fr">
     <p>
-      Logiciel de finances personnelles et de gestion de l'argent.
+      Money Manager Ex (MMEX) est un logiciel de finances personnelles
+      gratuit, open-source, multiplateforme et facile à utiliser, logiciel de
+      finances personnelles. Il aide principalement à organiser les finances
+      d'une personne et à garder la trace où, quand et comment va l'argent.
+    </p>
+    <p>
+      MMEX comprend toutes les fonctionnalités de base que 90 % des
+      utilisateurs souhaiteraient voir dans une application de finances
+      personnelles. Les objectifs de la conception sont de se concentrer sur
+      la simplicité et la convivialité – quelque chose que l'on peut utiliser
+      tous les jours.
     </p>
   </description>
   <description xml:lang="he">
@@ -202,7 +230,16 @@
   </description>
   <description xml:lang="hu">
     <p>
-      Személyes pénzügyi és pénzkezelési szoftver.
+      A Money Manager Ex (MMEX) személyes pénzügyek és pénzkezelés egy
+      ingyenes, nyílt forráskódú, többplatformos, könnyen használható
+      személyes pénzügyi szoftver. Elsősorban a pénzügyek rendezésében segít,
+      és nyomon követi, hogy hova, mikor és hogyan megy el a pénz.
+    </p>
+    <p>
+      Az MMEX tartalmazza mindazokat az alapvető funkciókat, amelyeket a
+      felhasználók 90%-a látni szeretne egy személyes pénzügyi alkalmazásban.
+      A tervezési célok az egyszerűségre és a felhasználóbarátságra való
+      összpontosítás – amit az ember mindennap használhat.
     </p>
   </description>
   <description xml:lang="id">
@@ -217,7 +254,17 @@
   </description>
   <description xml:lang="it">
     <p>
-      Software personale finanziario e di gestione del denaro.
+      Money Manager Ex (MMEX) и un programma di gestione finanziaria personale
+      gratuito, open-source, multi-piattaforma e facile da usare. Aiuta
+      principalmente ad organizzare le proprie finanze e a tenere traccia di
+      come, dove e quando si spende il denaro.
+    </p>
+    <p>
+      MMEX include tutte le caratteristiche di base che il 90% degli utenti
+      avrebbe voluto vedere in un programma di gestione finanaziaria.
+      L'obiettivo principale della progettazione si и concentrato sulla
+      facilitа e semplicitа d'utilizzo, qualcosa che chiunque potesse
+      utilizzare ogni giorno.
     </p>
   </description>
   <description xml:lang="ja">
@@ -257,7 +304,25 @@
   </description>
   <description xml:lang="pl">
     <p>
-      Oprogramowanie do zarządzania finansami osobistymi i pieniędzmi.
+      Money Manager Ex (MMEX) to program rozwijany jako open source służący do
+      zarządzania domowym budżetem i finansami osobistymi. 
+    </p>
+    <p>
+      Aplikacja doskonale nadaje się do obliczania osobistego budżetu, wszyscy
+      użytkownicy którzy posiadają konta bankowe, lokaty, udziały w
+      funduszach, kredyty, będą mogli bez problemu zarządzać własnymi
+      finansami.
+    </p>
+    <p>
+      Wydatki oraz przychody można podzielić według kategorii dzięki czemu
+      zarządzanie nimi jest zdecydowanie łatwiejsze. W ten sposób można
+      zaplanować własny budżet na cały rok. Program posiada moduł
+      rozbudowanych raportów które określają w jaki sposób użytkownik zarządza
+      finansami i w jaki sposób wydaje pieniądze. 
+    </p>
+    <p>
+      MMEX posiada polski interfejs oraz daje możliwość wyboru polskiej
+      waluty.
     </p>
   </description>
   <description xml:lang="pt_BR">
@@ -277,7 +342,14 @@
   </description>
   <description xml:lang="ru">
     <p>
-      Программное обеспечение для управления личными финансами и деньгами.
+      Money Manager Ex (MMEX) - бесплатная, с открытым исходным кодом,
+      мультиплатформенная программа для персонального учёта финансов. 
+      Она поможет Вам знать, когда, сколько и на что были потрачены деньги.
+    </p>
+    <p>
+      MMEX включает функции, которые 90% пользователей хотят видеть 
+      в программе учёта финансов. Принципы реализации – легковесность, 
+      простота выполнения операций, дружелюбность к пользователю.
     </p>
   </description>
   <description xml:lang="sk">

--- a/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
+++ b/resources/dist/linux/share/metainfo/org.moneymanagerex.MMEX.metainfo.xml.in
@@ -117,27 +117,42 @@
   </description>
   <description xml:lang="ar">
     <p>
-      .برامج إدارة الأموال والأموال الشخصية
+      يعد Money Manager Ex (MMEX) برنامجًا مجانيًا/حرًا لإدارة الأموال والتمويل الشخصي، مفتوح المصدر، ومتعدد المنصات، وسهل الاستخدام. يساعد في تنظيم الشؤون المالية وتتبع التدفق النقدي.
+    </p>
+    <p>
+      يتضمن MMEX جميع الميزات الأساسية التي يرغب 90% من المستخدمين في رؤيتها في تطبيق مالي شخصي. وتتمثل أهداف التصميم في التركيز على البساطة وسهولة الاستخدام - وهو تطبيق يمكن استخدامه يوميًا.
     </p>
   </description>
   <description xml:lang="be">
     <p>
-      Праграмнае забеспячэнне для кіравання асабістымі фінансамі і грашыма.
+      Money Manager Ex (MMEX) - гэта бясплатнае/бясплатнае праграмнае забеспячэнне з адкрытым зыходным кодам, кросплатформеннае, простае ў выкарыстанні праграмнае забеспячэнне для асабістых фінансаў і кіравання грашыма. Гэта дапамагае арганізаваць фінансы і адсочваць грашовыя патокі.
+    </p>
+    <p>
+      MMEX уключае ўсе асноўныя функцыі, якія 90% карыстальнікаў хацелі б бачыць у дадатку асабістых фінансаў. Мэта дызайну - засяродзіцца на прастаце і зручнасці для карыстальніка - дадатку, якім можна карыстацца кожны дзень.
     </p>
   </description>
   <description xml:lang="bg">
     <p>
-      Софтуер за лични финанси и управление на пари.
+      Money Manager Ex (MMEX) е безплатен/безплатен, с отворен код, междуплатформен, лесен за използване софтуер за лични финанси и управление на пари. Помага за организиране на финанси и проследяване на паричния поток.
+    </p>
+    <p>
+      MMEX включва всички основни функции, които 90% от потребителите биха искали да видят в приложение за лични финанси. Целите на дизайна са да се концентрира върху простотата и удобството за потребителя – приложение, което може да се използва всеки ден.
     </p>
   </description>
   <description xml:lang="ca">
     <p>
-      Programari personal de gestió financera i financera.
+      Money Manager Ex (MMEX) és un programari de gestió financera i financera personal, de codi obert, multiplataforma i fàcil d'utilitzar. Ajuda a organitzar les finances i fer un seguiment del flux d'efectiu.
+    </p>
+    <p>
+      MMEX inclou totes les funcions bàsiques que el 90% dels usuaris voldrien veure en una aplicació de finances personals. Els objectius de disseny són centrar-se en la simplicitat i la facilitat d'ús, una aplicació que es pot utilitzar cada dia.
     </p>
   </description>
   <description xml:lang="cs">
     <p>
-      Software pro správu osobních financí a peněz.
+      Money Manager Ex (MMEX) je bezplatný, open-source, multiplatformní, snadno použitelný software pro správu osobních financí a peněz. Pomáhá organizovat finance a sledovat cash flow.
+    </p>
+    <p>
+      MMEX obsahuje všechny základní funkce, které by 90 % uživatelů chtělo vidět v aplikaci pro osobní finance. Cílem návrhu je soustředit se na jednoduchost a uživatelskou přívětivost – aplikaci, kterou lze používat každý den.
     </p>
   </description>
   <description xml:lang="de">
@@ -157,7 +172,10 @@
   </description>
   <description xml:lang="el">
     <p>
-      Λογισμικό προσωπικής διαχείρισης οικονομικών και χρημάτων.
+      Το Money Manager Ex (MMEX) είναι ένα δωρεάν/ελεύθερο, ανοιχτού κώδικα, πολλαπλών πλατφορμών, εύχρηστο λογισμικό προσωπικής οικονομικής και διαχείρισης χρημάτων. Βοηθά στην οργάνωση των οικονομικών και στην παρακολούθηση των ταμειακών ροών.
+    </p>
+    <p>
+      Το MMEX περιλαμβάνει όλα τα βασικά χαρακτηριστικά που το 90% των χρηστών θα ήθελε να δει σε μια εφαρμογή προσωπικής χρηματοδότησης. Οι στόχοι του σχεδιασμού είναι να επικεντρωθούν στην απλότητα και τη φιλικότητα προς τον χρήστη – μια εφαρμογή που μπορεί να χρησιμοποιηθεί καθημερινά.
     </p>
   </description>
   <description xml:lang="en_AU">
@@ -195,12 +213,18 @@
   </description>
   <description xml:lang="es">
     <p>
-      Software de administración de dinero y finanzas personales.
+      Money Manager Ex (MMEX) es un software de gestión financiera y financiera personal gratuito, de código abierto, multiplataforma y fácil de usar. Ayuda a organizar las finanzas y a realizar un seguimiento del flujo de efectivo.
+    </p>
+    <p>
+      MMEX incluye todas las funciones básicas que el 90 % de los usuarios desearían ver en una aplicación de finanzas personales. Los objetivos de diseño son concentrarse en la simplicidad y la facilidad de uso: una aplicación que se pueda usar todos los días.
     </p>
   </description>
   <description xml:lang="fi">
     <p>
-      Henkilökohtainen talous- ja rahanhallintaohjelmisto.
+      Money Manager Ex (MMEX) on ilmainen / ilmainen, avoimen lähdekoodin, monialustainen, helppokäyttöinen henkilökohtainen talous- ja rahanhallintaohjelmisto. Se auttaa järjestämään taloutta ja seuraamaan kassavirtaa.
+    </p>
+    <p>
+      MMEX sisältää kaikki perusominaisuudet, jotka 90 % käyttäjistä haluaisi nähdä henkilökohtaisessa rahoitussovelluksessa. Suunnittelun tavoitteina on keskittyä yksinkertaisuuteen ja käyttäjäystävällisyyteen – jokapäiväiseen käyttöön.
     </p>
   </description>
   <description xml:lang="fr">
@@ -220,12 +244,18 @@
   </description>
   <description xml:lang="he">
     <p>
-      .תוכנה אישית לניהול כספים וכספים
+      Money Manager Ex (MMEX) היא תוכנה חינמית/חופשית, קוד פתוח, חוצת פלטפורמות, קלה לשימוש אישי פיננסי וניהול כסף. זה עוזר לארגן את הכספים ולעקוב אחר תזרים המזומנים.
+    </p>
+    <p>
+      MMEX כולל את כל התכונות הבסיסיות ש-90% מהמשתמשים היו רוצים לראות באפליקציה למימון אישי. מטרות העיצוב הן להתרכז בפשטות וידידותיות למשתמש - אפליקציה שניתן להשתמש בה מדי יום.
     </p>
   </description>
   <description xml:lang="hr">
     <p>
-      Softver za upravljanje osobnim financijama i novcem.
+      Money Manager Ex (MMEX) je besplatan/besplatan softver otvorenog koda, više platformi, jednostavan za korištenje, osobni financijski softver i softver za upravljanje novcem. Pomaže organizirati financije i pratiti novčani tok.
+    </p>
+    <p>
+      MMEX uključuje sve osnovne značajke koje bi 90% korisnika željelo vidjeti u aplikaciji za osobne financije. Ciljevi dizajna su usredotočiti se na jednostavnost i prilagođenost korisniku – aplikaciju koja se može koristiti svakodnevno.
     </p>
   </description>
   <description xml:lang="hu">
@@ -244,12 +274,18 @@
   </description>
   <description xml:lang="id">
     <p>
-      Perangkat lunak manajemen keuangan dan uang pribadi.
+      Money Manager Ex (MMEX) adalah perangkat lunak manajemen keuangan dan keuangan pribadi yang gratis/bebas, sumber terbuka, lintas platform, dan mudah digunakan. Perangkat lunak ini membantu mengatur keuangan dan melacak arus kas.
+    </p>
+    <p>
+      MMEX mencakup semua fitur dasar yang diinginkan 90% pengguna dalam aplikasi keuangan pribadi. Tujuan desainnya adalah untuk berkonsentrasi pada kesederhanaan dan kemudahan penggunaan – aplikasi yang dapat digunakan setiap hari.
     </p>
   </description>
   <description xml:lang="is">
     <p>
-      Hugbúnaður fyrir persónulegan fjármála- og peningastjórnun.
+      Money Manager Ex (MMEX) er ókeypis/frjáls, opinn uppspretta, þvert á vettvang, auðveldur í notkun persónulegur fjárhags- og peningastjórnunarhugbúnaður. Það hjálpar til við að skipuleggja fjármál og fylgjast með sjóðstreymi.
+    </p>
+    <p>
+      MMEX inniheldur alla grunneiginleika sem 90% notenda myndu vilja sjá í einkafjármálaforriti. Hönnunarmarkmiðin eru að einbeita sér að einfaldleika og notendavænni - forriti sem hægt er að nota á hverjum degi.
     </p>
   </description>
   <description xml:lang="it">
@@ -269,37 +305,58 @@
   </description>
   <description xml:lang="ja">
     <p>
-      個人の財務および資金管理ソフトウェア。
+      Money Manager Ex (MMEX) は、無料/自由、オープンソース、クロスプラットフォーム、使いやすい個人財務および資金管理ソフトウェアです。財務の整理とキャッシュフローの追跡に役立ちます。
+    </p>
+    <p>
+      MMEX には、ユーザーの 90% が個人財務アプリケーションに求める基本機能がすべて含まれています。設計目標は、シンプルさと使いやすさ、つまり毎日使用できるアプリケーションに集中することです。
     </p>
   </description>
   <description xml:lang="kn">
     <p>
-      ವೈಯಕ್ತಿಕ ಹಣಕಾಸು ಮತ್ತು ಹಣ ನಿರ್ವಹಣೆ ಸಾಫ್ಟ್‌ವೇರ್.
+      ಮನಿ ಮ್ಯಾನೇಜರ್ ಎಕ್ಸ್ (MMEX) ಒಂದು ಉಚಿತ/ಸ್ವಾತಂತ್ರ್ಯ, ಮುಕ್ತ-ಮೂಲ, ಅಡ್ಡ-ಪ್ಲಾಟ್‌ಫಾರ್ಮ್, ಬಳಸಲು ಸುಲಭವಾದ ವೈಯಕ್ತಿಕ ಹಣಕಾಸು ಮತ್ತು ಹಣ ನಿರ್ವಹಣೆ ಸಾಫ್ಟ್‌ವೇರ್ ಆಗಿದೆ. ಇದು ಹಣಕಾಸುಗಳನ್ನು ಸಂಘಟಿಸಲು ಮತ್ತು ನಗದು ಹರಿವನ್ನು ಟ್ರ್ಯಾಕ್ ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.
+    </p>
+    <p>
+      90% ಬಳಕೆದಾರರು ವೈಯಕ್ತಿಕ ಹಣಕಾಸು ಅಪ್ಲಿಕೇಶನ್‌ನಲ್ಲಿ ನೋಡಲು ಬಯಸುವ ಎಲ್ಲಾ ಮೂಲಭೂತ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು MMEX ಒಳಗೊಂಡಿದೆ. ವಿನ್ಯಾಸದ ಗುರಿಗಳು ಸರಳತೆ ಮತ್ತು ಬಳಕೆದಾರ ಸ್ನೇಹಪರತೆಯ ಮೇಲೆ ಕೇಂದ್ರೀಕರಿಸುವುದು - ಪ್ರತಿದಿನ ಬಳಸಬಹುದಾದ ಅಪ್ಲಿಕೇಶನ್.
     </p>
   </description>
   <description xml:lang="ko">
     <p>
-      개인 금융 및 자금 관리 소프트웨어.
+      Money Manager Ex(MMEX)는 무료/자유, 오픈 소스, 크로스 플랫폼, 사용하기 쉬운 개인 금융 및 자금 관리 소프트웨어입니다. 재정을 정리하고 현금 흐름을 추적하는 데 도움이 됩니다.
+    </p>
+    <p>
+      MMEX에는 사용자의 90%가 개인 금융 애플리케이션에서 보고 싶어하는 모든 기본 기능이 포함되어 있습니다. 디자인 목표는 단순성과 사용자 친화성에 집중하는 것입니다. 매일 사용할 수 있는 애플리케이션입니다.
     </p>
   </description>
   <description xml:lang="lt">
     <p>
-      Asmeninių finansų ir pinigų valdymo programinė įranga.
+      Money Manager Ex (MMEX) yra nemokama / nemokama, atvirojo kodo, kelių platformų, lengvai naudojama asmeninių finansų ir pinigų valdymo programinė įranga. Tai padeda organizuoti finansus ir sekti pinigų srautus.
+    </p>
+    <p>
+      MMEX apima visas pagrindines funkcijas, kurias asmeninių finansų programoje norėtų matyti 90 % vartotojų. Projektavimo tikslai yra sutelkti dėmesį į paprastumą ir patogumą vartotojui – programą, kurią galima naudoti kasdien.
     </p>
   </description>
   <description xml:lang="lv">
     <p>
-      Personīgo finanšu un naudas pārvaldības programmatūra.
+      Money Manager Ex (MMEX) ir bezmaksas/bezmaksas, atvērtā koda, vairāku platformu, viegli lietojama personīgo finanšu un naudas pārvaldības programmatūra. Tas palīdz organizēt finanses un izsekot naudas plūsmai.
+    </p>
+    <p>
+      MMEX ietver visas pamata funkcijas, kuras 90% lietotāju vēlētos redzēt personīgo finanšu lietojumprogrammā. Dizaina mērķi ir koncentrēties uz vienkāršību un lietotājam draudzīgumu – lietojumprogrammu, ko var izmantot ikdienā.
     </p>
   </description>
   <description xml:lang="nl">
     <p>
-      Software voor persoonlijk financieel en geldbeheer.
+      Money Manager Ex (MMEX) is een gratis/libre, open-source, cross-platform, gebruiksvriendelijke persoonlijke financiële en geldbeheersoftware. Het helpt bij het organiseren van financiën en het bijhouden van de cashflow.
+    </p>
+    <p>
+      MMEX bevat alle basisfuncties die 90% van de gebruikers in een persoonlijke financiële applicatie zou willen zien. De ontwerpdoelen zijn om zich te concentreren op eenvoud en gebruiksvriendelijkheid - een applicatie die dagelijks gebruikt kan worden.
     </p>
   </description>
   <description xml:lang="no_NY">
     <p>
-      Software voor persoonlijk financieel en geldbeheer.
+      Money Manager Ex (MMEX) er en gratis/fri, åpen kildekode, tverrplattform, brukervennlig programvare for personlig økonomi og pengestyring. Det hjelper med å organisere økonomi og spore kontantstrøm.
+    </p>
+    <p>
+      MMEX inkluderer alle de grunnleggende funksjonene som 90 % av brukerne ønsker å se i en personlig økonomiapplikasjon. Designmålene er å konsentrere seg om enkelhet og brukervennlighet – en applikasjon som kan brukes hver dag.
     </p>
   </description>
   <description xml:lang="pl">
@@ -327,17 +384,26 @@
   </description>
   <description xml:lang="pt_BR">
     <p>
-      Software de gestão financeira e financeira pessoal.
+      O Money Manager Ex (MMEX) é um software de gerenciamento financeiro e financeiro pessoal, gratuito, de código aberto, multiplataforma e fácil de usar. Ele ajuda a organizar as finanças e a rastrear o fluxo de caixa.
+    </p>
+    <p>
+      O MMEX inclui todos os recursos básicos que 90% dos usuários gostariam de ver em um aplicativo de finanças pessoais. Os objetivos do design são concentrar-se na simplicidade e na facilidade de uso — um aplicativo que pode ser usado todos os dias.
     </p>
   </description>
   <description xml:lang="pt">
     <p>
-      Software de gestão financeira e financeira pessoal.
+      O Money Manager Ex (MMEX) é um software financeiro e de gestão de dinheiro gratuito/libre, de código aberto, multiplataforma e fácil de utilizar. Ajuda a organizar as finanças e a rastrear o cash-flow.
+    </p>
+    <p>
+      O MMEX inclui todas as características básicas que 90% dos utilizadores gostariam de ver numa aplicação de finanças pessoais. Os objetivos de design são concentrar-se na simplicidade e na familyliness – uma aplicação que pode ser utilizada todos os dias.
     </p>
   </description>
   <description xml:lang="ro">
     <p>
-      Software financiar personal și software de gestionare a banilor.
+      Money Manager Ex (MMEX) este un software gratuit/libre, open-source, multi-platformă, ușor de utilizat, financiar personal și de gestionare a banilor. Ajută la organizarea finanțelor și la urmărirea fluxului de numerar.
+    </p>
+    <p>
+      MMEX include toate caracteristicile de bază pe care 90% dintre utilizatori ar dori să le vadă într-o aplicație de finanțe personale. Obiectivele de design sunt să se concentreze pe simplitate și ușurință în utilizare – o aplicație care poate fi folosită în fiecare zi.
     </p>
   </description>
   <description xml:lang="ru">
@@ -354,57 +420,90 @@
   </description>
   <description xml:lang="sk">
     <p>
-      Softvér na správu osobných financií a peňazí.
+      Money Manager Ex (MMEX) je bezplatný, open source, multiplatformový, ľahko použiteľný osobný finančný a peňažný manažérsky softvér. Pomáha organizovať financie a sledovať cash flow.
+    </p>
+    <p>
+      MMEX obsahuje všetky základné funkcie, ktoré by 90 % používateľov chcelo vidieť v aplikácii osobných financií. Cieľom dizajnu je sústrediť sa na jednoduchosť a užívateľskú prívetivosť – aplikáciu, ktorú možno používať každý deň.
     </p>
   </description>
   <description xml:lang="sl">
     <p>
-      Programska oprema za upravljanje osebnih financ in denarja.
+      Money Manager Ex (MMEX) je brezplačna/brezplačna, odprtokodna programska oprema za različne platforme, ki je enostavna za uporabo, za upravljanje osebnih financ in denarja. Pomaga organizirati finance in spremljati denarni tok.
+    </p>
+    <p>
+      MMEX vključuje vse osnovne funkcije, ki bi jih 90 % uporabnikov želelo videti v aplikaciji za osebne finance. Cilj oblikovanja je osredotočanje na preprostost in uporabniku prijaznost – aplikacijo, ki jo je mogoče uporabljati vsak dan.
     </p>
   </description>
   <description xml:lang="sq">
     <p>
-      Softuer personal financiar dhe i menaxhimit të parave.
+      Money Manager Ex (MMEX) është një softuer personal financiar dhe i menaxhimit të parave pa pagesë/libër, me burim të hapur, ndër-platformë, i lehtë për t'u përdorur. Ndihmon në organizimin e financave dhe gjurmimin e fluksit të parave.
+    </p>
+    <p>
+      MMEX përfshin të gjitha tiparet bazë që 90% e përdoruesve do të dëshironin të shihnin në një aplikacion të financave personale. Qëllimet e dizajnit janë të përqendrohen në thjeshtësinë dhe lehtësinë ndaj përdoruesit – një aplikacion që mund të përdoret çdo ditë.
     </p>
   </description>
   <description xml:lang="sr">
     <p>
-      Лични софтвер за управљање финансијама и новцем.
+      Монеи Манагер Ек (ММЕКС) је бесплатан/бесплатан, отвореног кода, вишеплатформски, једноставан за коришћење софтвер за личне финансијске и управљање новцем. Помаже у организацији финансија и праћењу новчаних токова.
+    </p>
+    <p>
+      ММЕКС укључује све основне карактеристике које би 90% корисника желело да види у апликацији за личне финансије. Циљеви дизајна су да се концентришу на једноставност и прилагођеност кориснику – апликацију која се може користити свакодневно.
     </p>
   </description>
   <description xml:lang="sv_SE">
     <p>
-      Programvara för personlig ekonomi och pengarhantering.
+      Money Manager Ex (MMEX) är en gratis/fri, öppen källkod, plattformsoberoende, lättanvänd programvara för personlig ekonomi och penninghantering. Det hjälper till att organisera ekonomin och spåra kassaflödet.
+    </p>
+    <p>
+      MMEX innehåller alla grundläggande funktioner som 90 % av användarna skulle vilja se i en privatekonomiapplikation. Designmålen är att koncentrera sig på enkelhet och användarvänlighet – en applikation som kan användas varje dag.
     </p>
   </description>
   <description xml:lang="ta">
     <p>
-      தனிப்பட்ட நிதி மற்றும் பண மேலாண்மை மென்பொருள்.
+      Money Manager Ex (MMEX) என்பது ஒரு இலவச/சுதந்திரம், திறந்த மூல, குறுக்கு-தளம், பயன்படுத்த எளிதான தனிப்பட்ட நிதி மற்றும் பண மேலாண்மை மென்பொருள். இது நிதிகளை ஒழுங்கமைக்கவும் பணப்புழக்கத்தைக் கண்காணிக்கவும் உதவுகிறது.
+    </p>
+    <p>
+      தனிப்பட்ட நிதி பயன்பாட்டில் 90% பயனர்கள் பார்க்க விரும்பும் அனைத்து அடிப்படை அம்சங்களையும் MMEX கொண்டுள்ளது. வடிவமைப்பு இலக்குகள் எளிமை மற்றும் பயனர் நட்பில் கவனம் செலுத்துவதாகும் - தினமும் பயன்படுத்தக்கூடிய ஒரு பயன்பாடு.
     </p>
   </description>
   <description xml:lang="tr">
     <p>
-      Kişisel finans ve para yönetimi yazılımı.
+      Money Manager Ex (MMEX), ücretsiz/özgür, açık kaynaklı, platformlar arası, kullanımı kolay kişisel finans ve para yönetimi yazılımıdır. Finansları düzenlemeye ve nakit akışını izlemeye yardımcı olur.
+    </p>
+    <p>
+      MMEX, kullanıcıların %90'ının kişisel finans uygulamasında görmek isteyeceği tüm temel özellikleri içerir. Tasarım hedefleri, basitlik ve kullanıcı dostu olmaya odaklanmaktır; her gün kullanılabilen bir uygulama.
     </p>
   </description>
   <description xml:lang="uk">
     <p>
-      Програмне забезпечення для управління особистими фінансами та грошима.
+      Money Manager Ex (MMEX) — це безкоштовне програмне забезпечення з відкритим вихідним кодом, кросплатформне, просте у користуванні для персональних фінансів і управління грошима. Це допомагає організувати фінанси та відстежувати грошові потоки.
+    </p>
+    <p>
+      MMEX містить усі основні функції, які 90% користувачів хотіли б бачити в додатку для персональних фінансів. Цілі дизайну полягають у тому, щоб зосередитися на простоті та зручності користувача – програмі, яку можна використовувати щодня.
     </p>
   </description>
   <description xml:lang="vi">
     <p>
-      Phần mềm quản lý tiền và tài chính cá nhân.
+      Money Manager Ex (MMEX) là phần mềm quản lý tiền bạc và tài chính cá nhân miễn phí/tự do, mã nguồn mở, đa nền tảng, dễ sử dụng. Phần mềm này giúp sắp xếp tài chính và theo dõi dòng tiền.
+    </p>
+    <p>
+      MMEX bao gồm tất cả các tính năng cơ bản mà 90% người dùng muốn thấy trong một ứng dụng tài chính cá nhân. Mục tiêu thiết kế là tập trung vào tính đơn giản và thân thiện với người dùng – một ứng dụng có thể sử dụng hàng ngày.
     </p>
   </description>
   <description xml:lang="zh_CN">
     <p>
-      个人财务和资金管理软件。
+      Money Manager Ex (MMEX) 是一款免费、开源、跨平台、易于使用的个人财务和资金管理软件。它有助于组织财务和跟踪现金流。
+    </p>
+    <p>
+      MMEX 包含 90% 用户希望在个人财务应用程序中看到的所有基本功能。设计目标是专注于简单性和用户友好性——一款可以每天使用的应用程序。
     </p>
   </description>
   <description xml:lang="zh_TW">
     <p>
-      個人財務和資金管理軟件。
+      Money Manager Ex (MMEX) 是一款免費、開放原始碼、跨平台、易於使用的個人財務和資金管理軟體。它有助於組織財務並追蹤現金流。
+    </p>
+    <p>
+      MMEX 包含 90% 使用者希望在個人理財應用程式中看到的所有基本功能。設計目標是專注於簡單性和用戶友好性——一個可以每天使用的應用程式。
     </p>
   </description>
   


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

### README.TXT
1. Alphabetical by locale code
2. Add magyar

Can README.TXT be deleted as information is now contained in org.moneymanagerex.MMEX.metainfo.xml.in?

### org.moneymanagerex.MMEX.metainfo.xml.in

1. Attempt to correctly apply the localize <description> tag to show correctly at https://flathub.org/hu/apps/org.moneymanagerex.MMEX
2. Add <description> to other locales to attempt to show correctly at:
* https://flathub.org/de/apps/org.moneymanagerex.MMEX
* https://flathub.org/fr/apps/org.moneymanagerex.MMEX
* https://flathub.org/ru/apps/org.moneymanagerex.MMEX
* https://flathub.org/ta/apps/org.moneymanagerex.MMEX
* `https://flathub.org/<locale>/apps/org.moneymanagerex.MMEX`
3. Note that the captions on the screenshots at `https://flathub.org/<locale>/apps/org.moneymanagerex.MMEX` are only localized for hu (magyar - Hungarian). Perhaps localizing screenshot captions can be done once this pull request is merged.

Thank you

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6869)
<!-- Reviewable:end -->
