### PR TITLE
Update Gnome SDK to latest version in flatpak manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
       - build-linux
 #      - build-macosapp-id: org.moneymanagerex.MMEX
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: mmex
 cleanup:

--- a/org.moneymanagerex.MMEX.yml
+++ b/org.moneymanagerex.MMEX.yml
@@ -1,6 +1,6 @@
 app-id: org.moneymanagerex.MMEX
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: mmex
 cleanup:


### PR DESCRIPTION
There's a new version of the Gnome runtime available for MMEX:

```
$ flatpak remote-info flathub org.gnome.Platform//47

GNOME Application Platform version 47 - Shared libraries used by GNOME
applications

        ID: org.gnome.Platform
       Ref: runtime/org.gnome.Platform/x86_64/47
      Arch: x86_64
    Branch: 47
   License: GPL-2.0+
Collection: org.flathub.Stable
  Download: 383.8 MB
 Installed: 1.0 GB

    Commit: 5a76da0daccad115565c2bf2279c85e487203af01ef3bde34bb149fe048c54ab
   Subject: Export org.gnome.Platform
      Date: 2024-09-18 04:26:21 +0000
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6891)
<!-- Reviewable:end -->
