### PR TITLE
Update flatpak runtime to Gnome 47

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Build MoneyManagerEx (Flatpak)
           command: |
-            docker run -it --rm --privileged -w /moneymanagerex/build -v $HOME/.ccache:/root/.ccache -v $CIRCLE_WORKING_DIRECTORY:/moneymanagerex bilelmoussaoui/flatpak-github-actions:gnome-45 bash -c "rm -rf * && /usr/bin/xvfb-run --auto-servernum flatpak-builder --verbose --repo=repo --disable-rofiles-fuse --force-clean --default-branch=master --arch=x86_64 _build ../org.moneymanagerex.MMEX.yml && /usr/bin/xvfb-run --auto-servernum flatpak build-bundle --arch=x86_64 repo ../mmex.flatpak org.moneymanagerex.MMEX master && flatpak install --bundle --noninteractive ../mmex.flatpak" && \
+            docker run -it --rm --privileged -w /moneymanagerex/build -v $HOME/.ccache:/root/.ccache -v $CIRCLE_WORKING_DIRECTORY:/moneymanagerex bilelmoussaoui/flatpak-github-actions:gnome-47 bash -c "rm -rf * && /usr/bin/xvfb-run --auto-servernum flatpak-builder --verbose --repo=repo --disable-rofiles-fuse --force-clean --default-branch=master --arch=x86_64 _build ../org.moneymanagerex.MMEX.yml && /usr/bin/xvfb-run --auto-servernum flatpak build-bundle --arch=x86_64 repo ../mmex.flatpak org.moneymanagerex.MMEX master && flatpak install --bundle --noninteractive ../mmex.flatpak" && \
             cp $CIRCLE_WORKING_DIRECTORY/mmex*.flatpak /tmp/artifacts
       - store_artifacts:
           path: /tmp/artifacts
@@ -58,7 +58,7 @@ workflows:
       - build-linux
 #      - build-macosapp-id: org.moneymanagerex.MMEX
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: mmex
 cleanup:

--- a/org.moneymanagerex.MMEX.yml
+++ b/org.moneymanagerex.MMEX.yml
@@ -1,6 +1,6 @@
 app-id: org.moneymanagerex.MMEX
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: mmex
 cleanup:


### PR DESCRIPTION
A continuation from https://github.com/moneymanagerex/moneymanagerex/pull/6891 where merging failed due to the container image not being updated. The newest runtime should be available now:

```
$ skopeo list-tags docker://bilelmoussaoui/flatpak-github-actions
{
    "Repository": "docker.io/bilelmoussaoui/flatpak-github-actions",
    "Tags": [
        "elementary-juno",
        "freedesktop-20.08",
        "freedesktop-21.08",
        "freedesktop-22.08",
        "freedesktop-23.08",
        "freedesktop-24.08",
        "gnome-3.38",
        "gnome-40",
        "gnome-41",
        "gnome-42",
        "gnome-43",
        "gnome-44",
        "gnome-45",
        "gnome-46",
        "gnome-47",
        "gnome-nightly",
        "kde-5.15",
        "kde-5.15-21.08",
        "kde-5.15-22.08",
        "kde-5.15-23.08",
        "kde-6.2",
        "kde-6.3",
        "kde-6.4",
        "kde-6.5",
        "kde-6.6",
        "kde-6.7",
        "latest"
    ]
}
```


Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6905)
<!-- Reviewable:end -->
