### PR TITLE
fix(#6897): use translated report title in acct selection dialog

### DIFF
--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -230,7 +230,7 @@ void mmPrintableBase::setAccounts(int selection, const wxString& name)
             }
 
             auto parent = wxWindow::FindWindowById(mmID_REPORTS);
-            mmMultiChoiceDialog mcd(parent ? parent : 0, _("Choose Accounts"), m_title, accounts);
+            mmMultiChoiceDialog mcd(parent ? parent : 0, _("Choose Accounts"), wxGetTranslation(m_title), accounts);
 
             if (selectedAccountArray_ && !selectedAccountArray_->IsEmpty())
             {


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6911)
<!-- Reviewable:end -->
