### PR TITLE
fix(#6863): disallow blank payee name in edit dialog

### DIFF
--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -201,6 +201,10 @@ void mmEditPayeeDialog::OnOk(wxCommandEvent& /*event*/)
         return mmErrorDialogs::ToolTip4Object(m_category, _("Invalid value"), _("Category"));
 
     wxString name = m_payeeName->GetValue();
+
+    if (name.IsEmpty())
+        return mmErrorDialogs::ToolTip4Object(m_payeeName, _("Invalid value"), _("Payee"));
+
     Model_Payee::Data_Set payees = Model_Payee::instance().find(Model_Payee::PAYEENAME(name));
     if ((!m_payee && payees.empty()) ||
         (m_payee && (payees.empty() || name.CmpNoCase(m_payee->PAYEENAME) == 0)))


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6934)
<!-- Reviewable:end -->
