### PR TITLE
fix(#6938): fix common UI Language List translation catalog location

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -30,8 +30,6 @@ foreach(POFile ${POFiles})
     endif()
     # Copy po file and append common translations
     file(COPY ${CurrentFile}.po DESTINATION ${CMAKE_BINARY_DIR}/po)
-    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/common.po common_translations)
-    file(APPEND ${CMAKE_BINARY_DIR}/po/${CurrentFile}.po "\n${common_translations}")
     add_custom_command(
         OUTPUT ${CurrentFile}.mo
         COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -v --statistics -o ${CurrentFile}.mo ${CMAKE_BINARY_DIR}/po/${CurrentFile}.po
@@ -54,6 +52,28 @@ foreach(POFile ${POFiles})
 
     list(APPEND MOFiles "${CMAKE_CURRENT_BINARY_DIR}/${CurrentFile}.mo")
 endforeach()
+
+# put the common UI Languages translations in the en_US translations directory
+file(COPY "common.po" DESTINATION ${CMAKE_BINARY_DIR}/po)
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/po/common.mo
+    COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -v --statistics -o ${CMAKE_BINARY_DIR}/po/common.mo ${CMAKE_BINARY_DIR}/po/common.po
+    COMMENT ""
+    MAIN_DEPENDENCY common.po
+)
+
+if(APPLE)
+    set(MODir ${MMEX_EXE}.app/Contents/Resources/en_US.lproj)
+elseif(WIN32)
+    set(MODir bin/en_US)
+else()
+    set(MODir share/${MMEX_EXE}/en_US)
+endif()
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/common.mo"
+        DESTINATION ${MODir})
+
+list(APPEND MOFiles "${CMAKE_CURRENT_BINARY_DIR}/common.mo")
 
 add_custom_target(Translations ALL DEPENDS ${MOFiles}
     COMMENT "Generated translations")

--- a/po/common.po
+++ b/po/common.po
@@ -1,4 +1,9 @@
 # Translations of language descriptions into their native languages
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
 msgid "Albanian (Albania)"
 msgstr "sq-AL shqip (Shqipëri)"
 

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -76,6 +76,11 @@ bool mmGUIApp::setGUILanguage(wxLanguage lang)
         return false;
     }
     wxTranslations* trans = new wxTranslations;
+
+    // Add the common UI Language translation catalog
+    trans->SetLanguage(wxLANGUAGE_ENGLISH_US);
+    trans->AddCatalog("common", wxLANGUAGE_ENGLISH_US);
+
     trans->SetLanguage(lang);
     trans->AddStdCatalog();
     if (trans->AddCatalog("mmex", wxLANGUAGE_ENGLISH_US) || lang == wxLANGUAGE_ENGLISH_US || lang == wxLANGUAGE_DEFAULT)


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6941)
<!-- Reviewable:end -->
