### PR TITLE
fix(#6945): correct encoding of "LAST_USED" transaction filter

### DIFF
--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -2213,12 +2213,12 @@ void mmFilterTransactionsDialog::mmDoSaveSettings(bool is_user_request)
             StringBuffer buffer;
             Writer<StringBuffer> writer(buffer);
             j_doc.Accept(writer);
-            Model_Infotable::instance().Set(m_filter_key + "_LAST_USED", wxString(buffer.GetString()));
+            Model_Infotable::instance().Set(m_filter_key + "_LAST_USED", wxString::FromUTF8(buffer.GetString()));
             // Update the settings list with the new data
             mmDoInitSettingNameChoice();
         }
     }
-    Model_Infotable::instance().Set("TRANSACTION_FILTER_LAST_USED", m_settings_json);
+    Model_Infotable::instance().Set("TRANSACTIONS_FILTER_LAST_USED", m_settings_json);
 }
 
 void mmFilterTransactionsDialog::OnSaveSettings(wxCommandEvent& WXUNUSED(event))


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6946)
<!-- Reviewable:end -->
