### PR TITLE
Missing hb.endSpan(); leading to wrong color in summaryStocks

### DIFF
--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -192,6 +192,7 @@ wxString mmReportSummaryStocks::getHTMLText()
                     hb.endSpan();
                     hb.startSpan(Model_Currency::toCurrency(forex_real_gain_loss), wxString::Format(" style='text-align:right;%s' nowrap"
                         , forex_real_gain_loss < 0 ? "color:red;" : ""));
+                    hb.endSpan();
                     hb.startSpan(" FX", "");
                     hb.endSpan();
                     hb.addLineBreak();


### PR DESCRIPTION
Missing hb.endSpan(); leading to wrong color if real_forex_gain_loss was < 0 and the m_real_gain_loss_sum_total was > 0. It was displayed in red
