### PR TITLE
fix(#6957): reset total for each category

### DIFF
--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -290,6 +290,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
                             hb.endTableRow();
                             totals_stack.pop_back();
                         }
+                    estimateTotal[12] = 0;  // reset estimateTotal for new category
                 }
 
                 // the very last subcategory, so show the rest of the pending totals


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6960)
<!-- Reviewable:end -->
