### PR TITLE
fix(#6975): save/restore column order by account type

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -269,7 +269,15 @@ TransactionListCtrl::TransactionListCtrl(
     // V2 used as now maps to real column names and this resets everything to default
     // to avoid strange column widths when this code version is first
     m_col_width = m_cp->isAllAccounts_ ? "ALLTRANS_COLV2%d_WIDTH" : "CHECK2_COLV2%d_WIDTH";
-    m_col_idstr = m_cp->isAllAccounts_ ? "ALLTRANS" : "CHECK2";
+    if (m_cp->isAllAccounts_)
+    {
+        m_col_idstr = "ALLTRANS";
+    }
+    else if (!m_cp->isTrash_)
+    {
+        m_col_idstr = Model_Account::instance().get(m_cp->m_AccountID)->ACCOUNTTYPE.Upper();
+        m_col_idstr.Replace(" ", "_");
+    }
 
     resetColumns();
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/6982)
<!-- Reviewable:end -->
