### PR TITLE
fix(#7009): set infotable key with int64 value

### DIFF
--- a/src/model/Model_Infotable.cpp
+++ b/src/model/Model_Infotable.cpp
@@ -60,6 +60,11 @@ Model_Infotable& Model_Infotable::instance()
 }
 
 // Setter
+void Model_Infotable::Set(const wxString& key, int64 value)
+{
+    this->Set(key, wxString::Format("%lld", value));
+}
+
 void Model_Infotable::Set(const wxString& key, int value)
 {
     this->Set(key, wxString::Format("%d", value));

--- a/src/model/Model_Infotable.h
+++ b/src/model/Model_Infotable.h
@@ -47,6 +47,7 @@ public:
 
 public:
     // Setter
+    void Set(const wxString& key, int64 value);
     void Set(const wxString& key, int value);
     void Set(const wxString& key, bool value);
     void Set(const wxString& key, const wxDateTime& date);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7010)
<!-- Reviewable:end -->
