### PR TITLE
fix(#6990): crowdin sync workflows

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,34 @@
+name: Crowdin Download
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * FRI"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crowdin-download:
+    if: github.repository_owner == 'moneymanagerex'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v2.4.0
+        with:
+          upload_sources: false
+          download_translations: true
+          localization_branch_name: l10n
+          crowdin_branch_name: master
+          create_pull_request: true
+          pull_request_title: 'fix(l10n): new translations'
+          pull_request_body: 'New translations downloaded via GitHub Action'
+          pull_request_base_branch_name: 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,24 @@
+name: Crowdin Upload
+
+on:
+  push:
+    paths:
+      - 'po/mmex.pot'
+    branches: 
+      - master
+
+jobs:
+  crowdin-upload:
+    if: github.repository_owner == 'moneymanagerex'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v2.4.0
+        with:
+          crowdin_branch_name: master
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/update-po-template.yml
+++ b/.github/workflows/update-po-template.yml
@@ -1,0 +1,56 @@
+name: Update mmex.pot translation template
+
+on:
+  push:
+    branches:
+      - master
+      
+jobs:
+  update-po-template:
+    if: github.repository_owner == 'moneymanagerex'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install gettext
+        run: sudo apt-get install -y gettext
+        
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: l10n
+
+      - name: Execute update script
+        run: |
+          : # reset the l10n branch to match master
+          git fetch origin
+          git reset --hard origin/master
+          git push origin l10n --force
+          
+          : # run the po update script
+          bash util/update-po-files.sh
+
+          : # add the new template to a commit and check if there are any changes
+          git config --global user.name 'MMEX'
+          git config --global user.email 'developer@moneymanagerex.org'
+          git add po/mmex.pot
+          echo "CHANGES"="$(git diff --shortstat --cached | awk '{print $4 + $6}')" >> $GITHUB_ENV
+          echo $CHANGES
+          
+      - name: Commit changes
+        if: ${{ env.CHANGES > 2 }}
+        run: |
+          git commit -m "fix(l10n): update mmex.pot"
+          git push
+      
+      - name: Check for open pull request
+        if: ${{ env.CHANGES > 2 }}
+        run: |
+          echo "OPEN_PR"="$(gh pr list --state open -H l10n --json headRefName -q '.[].headRefName' | grep -c "l10n")" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Create pull request
+        if: ${{ env.CHANGES > 2 && env.OPEN_PR == 0 }}
+        run: |
+          gh pr create -B master -H l10n --title "fix(l10n): update mmex.pot" --body 'Updated PO translation template via GitHub Action'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,10 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+"base_url": "https://api.crowdin.com"
+
+"preserve_hierarchy": true
+
 files:
   - source: /po/mmex.pot
     translation: /po/%locale_with_underscore%.po

--- a/util/update-po-files.sh
+++ b/util/update-po-files.sh
@@ -7,22 +7,25 @@ XGETTEXT_ARGS="-k_ -kN_ -kwxGetTranslation -kwxTRANSLATE -kwxPLURAL:1,2 \
                --from-code=UTF-8 \
                --add-location \
                --package-name=MMEX \
-               --width=78 \
+               --no-wrap \
                --msgid-bugs-address=developer@moneymanagerex.org"
 MSGMERGE_ARGS="--quiet \
                --update \
                --sort-by-file \
                --add-location \
-               --width=78 \
-               --backup=none"
-POT=MoneyManagerEx.pot
+               --no-wrap \
+               --backup=none" 
+POT=mmex.pot
 
 echo "Extracting strings into po/$POT..."
-find src -name \*.cpp -o -name \*.h | xgettext -f - $XGETTEXT_ARGS -o po/$POT
+cd src
+find . \( -name \*.cpp -o -name \*.h \) ! -name 'DB_Upgrade.h' ! -name 'DB_Table_Currencyformats_V1.h' | xgettext -f - $XGETTEXT_ARGS -o ../po/$POT
 
 echo "Merging into *.po..."
-for p in po/*.po ; do
+for p in ../po/*.po ; do
     echo "Merging $p ..."
-    msgmerge $MSGMERGE_ARGS $p po/$POT
+    msgmerge $MSGMERGE_ARGS $p ../po/$POT
 done
+
+cd ..
 echo "Finished"

--- a/util/update-po-files.sh
+++ b/util/update-po-files.sh
@@ -19,12 +19,12 @@ POT=mmex.pot
 
 echo "Extracting strings into po/$POT..."
 cd src
-find . \( -name \*.cpp -o -name \*.h \) ! -name 'DB_Upgrade.h' ! -name 'DB_Table_Currencyformats_V1.h' | xgettext -f - $XGETTEXT_ARGS -o ../po/$POT
+find . \( -name \*.cpp -o -name \*.h \) ! -name 'DB_Upgrade.h' ! -name 'DB_Table_Currencyformats_V1.h' | xgettext -f - $XGETTEXT_ARGS -o "../po/$POT"
 
 echo "Merging into *.po..."
 for p in ../po/*.po ; do
     echo "Merging $p ..."
-    msgmerge $MSGMERGE_ARGS $p ../po/$POT
+    msgmerge $MSGMERGE_ARGS "$p" "../po/$POT"
 done
 
 cd ..


### PR DESCRIPTION
Three new GitHub Actions to automate Crowdin integration:

1.    An "Update PO Template" action. On every pull request merged to master the po/mmex.pot file is regenerated. If there are changes, a new PR is opened with the updated po/mmex.pot.

2.    A "Crowdin Upload" action. Whenever a pull request that contains po/mmex.pot is merged to master, it uploads the new po/mmex.pot source to Crowdin.

3.    A "Crowdin Download" action. When the action is triggered, it downloads the translations from Crowdin to the po directory and opens a PR with the new translations. It runs automatically at midnight every Friday, but can be triggered manually at any time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7019)
<!-- Reviewable:end -->
