### PR TITLE
fix(#7030): import CSV with in-field newline chars

### DIFF
--- a/src/import_export/parsers.cpp
+++ b/src/import_export/parsers.cpp
@@ -50,8 +50,19 @@ bool FileCSV::Load(const wxString& fileName, unsigned int itemsInLine)
     // Parse rows
     wxString line;
     int row = 0;
+    wxRegEx splitLinePattern("[" + delimiter_ + "\ufffd]{1}\\\"[^\"]*?$");
     for (line = txtFile.GetFirstLine(); !txtFile.Eof(); line = txtFile.GetNextLine())
     {
+        // remove double sets of quotes which parse as the double quote literal
+        line.Replace("\"\"", "\ufffd");
+        // if there is an unclosed quote, the line has an in-field newline char
+        while (splitLinePattern.Matches(line))
+        {
+            // append the next line
+            line += "\n" + txtFile.GetNextLine();
+        }
+        // add double quotes back in
+        line.Replace("\ufffd", "\"\"");
         csv2tab_separated_values(line, delimiter_);
         wxStringTokenizer tkz(line, "\t", wxTOKEN_RET_EMPTY_ALL);
         itemsTable_.push_back(std::vector<ValueAndType>());


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7035)
<!-- Reviewable:end -->
