### PR TITLE
fix(#7030): fix regex for double quote at start of field

### DIFF
--- a/src/import_export/parsers.cpp
+++ b/src/import_export/parsers.cpp
@@ -50,11 +50,11 @@ bool FileCSV::Load(const wxString& fileName, unsigned int itemsInLine)
     // Parse rows
     wxString line;
     int row = 0;
-    wxRegEx splitLinePattern("[" + delimiter_ + "\ufffd]{1}\\\"[^\"]*?$");
+    wxRegEx splitLinePattern(delimiter_ + "[\x1a]?\"[^\"]*?$");
     for (line = txtFile.GetFirstLine(); !txtFile.Eof(); line = txtFile.GetNextLine())
     {
         // remove double sets of quotes which parse as the double quote literal
-        line.Replace("\"\"", "\ufffd");
+        line.Replace("\"\"", "\x1a");
         // if there is an unclosed quote, the line has an in-field newline char
         while (splitLinePattern.Matches(line))
         {
@@ -62,7 +62,7 @@ bool FileCSV::Load(const wxString& fileName, unsigned int itemsInLine)
             line += "\n" + txtFile.GetNextLine();
         }
         // add double quotes back in
-        line.Replace("\ufffd", "\"\"");
+        line.Replace("\x1a", "\"\"");
         csv2tab_separated_values(line, delimiter_);
         wxStringTokenizer tkz(line, "\t", wxTOKEN_RET_EMPTY_ALL);
         itemsTable_.push_back(std::vector<ValueAndType>());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1675,10 +1675,12 @@ const wxString mmSeparator::getSeparator() const
 bool mmSeparator::isStringHasSeparator(const wxString &string)
 {
     bool result = false;
-    bool skip = false;
+
     for (const auto& entry : m_separators)
     {
-        for (const auto& letter : string) {
+        bool skip = false;
+        for (const auto& letter : string)
+        {
             if (letter == '"') {
                 skip = !skip;
             }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7038)
<!-- Reviewable:end -->
