### PR TITLE
fix(#6956): round split total to curr precision before validation

### DIFF
--- a/src/splittransactionsdialog.cpp
+++ b/src/splittransactionsdialog.cpp
@@ -408,6 +408,7 @@ void mmSplitTransactionDialog::OnOk( wxCommandEvent& /*event*/ )
     totalAmount_ = 0;
     for (const auto& entry : m_splits)
         totalAmount_ += entry.SPLITTRANSAMOUNT;
+    totalAmount_ = std::round(totalAmount_ * m_currency->SCALE.GetValue()) / m_currency->SCALE.GetValue();
     if (totalAmount_ < 0) {
         return mmErrorDialogs::MessageError(this, _("Invalid Total Amount"), _("Error"));
     }


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7040)
<!-- Reviewable:end -->
