### PR TITLE
refactor choices in Model_Attachment

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -418,7 +418,7 @@ void mmNewAcctDialog::OnCurrency(wxCommandEvent& /*event*/)
 
 void mmNewAcctDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT);
+    wxString RefType = Model_Attachment::REFTYPE_STR_BANKACCOUNT;
     mmAttachmentDialog dlg(this, RefType, m_account->ACCOUNTID);
     dlg.ShowModal();
 }

--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -114,7 +114,7 @@ void mmAssetDialog::dataToControls()
     m_notes->SetValue(m_asset->NOTES);
     m_dpc->SetValue(Model_Asset::STARTDATE(m_asset));
     m_value->SetValue(std::abs(m_asset->VALUE));
-    Model_Translink::Data_Set translink = Model_Translink::TranslinkList(Model_Attachment::ASSET, m_asset->ASSETID);
+    Model_Translink::Data_Set translink = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_ASSET, m_asset->ASSETID);
     if (!translink.empty())
     {
         m_value->Enable(false);
@@ -365,7 +365,7 @@ void mmAssetDialog::OnOk(wxCommandEvent& /*event*/)
 
     if (old_asset_id < 0)
     {
-        const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+        const wxString& RefType = Model_Attachment::REFTYPE_STR_ASSET;
         mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, new_asset_id);
     }
     if (m_transaction_panel->ValidCheckingAccountEntry())
@@ -437,7 +437,7 @@ void mmAssetDialog::OnCancel(wxCommandEvent& /*event*/)
         return;
     else
     {
-        const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+        const wxString& RefType = Model_Attachment::REFTYPE_STR_ASSET;
         if (!this->m_asset)
             mmAttachmentManage::DeleteAllAttachments(RefType, 0);
         EndModal(wxID_CANCEL);
@@ -446,7 +446,7 @@ void mmAssetDialog::OnCancel(wxCommandEvent& /*event*/)
 
 void mmAssetDialog::OnQuit(wxCloseEvent& /*event*/)
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_ASSET;
     if (!this->m_asset)
         mmAttachmentManage::DeleteAllAttachments(RefType, 0);
     EndModal(wxID_CANCEL);
@@ -454,7 +454,7 @@ void mmAssetDialog::OnQuit(wxCloseEvent& /*event*/)
 
 void mmAssetDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_ASSET;
     int64 RefId;
     
     if (!this->m_asset)

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -214,8 +214,8 @@ void mmAssetsListCtrl::OnDeleteAsset(wxCommandEvent& /*event*/)
     {
         const Model_Asset::Data& asset = m_panel->m_assets[m_selected_row];
         Model_Asset::instance().remove(asset.ASSETID);
-        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::ASSET), asset.ASSETID);
-        Model_Translink::RemoveTransLinkRecords(Model_Attachment::ASSET, asset.ASSETID);
+        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_ASSET, asset.ASSETID);
+        Model_Translink::RemoveTransLinkRecords(Model_Attachment::REFTYPE_ID_ASSET, asset.ASSETID);
 
         m_panel->initVirtualListControl(-1, m_selected_col, m_asc);
         m_selected_row = -1;
@@ -270,7 +270,7 @@ void mmAssetsListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
     if (m_selected_row < 0) return;
 
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+    wxString RefType = Model_Attachment::REFTYPE_STR_ASSET;
     int64 RefId = m_panel->m_assets[m_selected_row].ASSETID;
 
     mmAttachmentDialog dlg(this, RefType, RefId);
@@ -283,7 +283,7 @@ void mmAssetsListCtrl::OnOpenAttachment(wxCommandEvent& /*event*/)
 {
     if (m_selected_row < 0) return;
 
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::ASSET);
+    wxString RefType = Model_Attachment::REFTYPE_STR_ASSET;
     int64 RefId = m_panel->m_assets[m_selected_row].ASSETID;
 
     mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);
@@ -647,7 +647,7 @@ wxString mmAssetsPanel::getItem(long item, long column)
     {
         wxString full_notes = asset.NOTES;
         full_notes.Replace("\n", " ");
-        if (Model_Attachment::NrAttachments(Model_Attachment::reftype_desc(Model_Attachment::ASSET), asset.ASSETID))
+        if (Model_Attachment::NrAttachments(Model_Attachment::REFTYPE_STR_ASSET, asset.ASSETID))
             full_notes = full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }
@@ -778,7 +778,7 @@ void mmAssetsPanel::AddAssetTrans(const int selected_index)
     }
     else
     {
-        Model_Translink::Data_Set translist = Model_Translink::TranslinkList(Model_Attachment::ASSET, asset->ASSETID);
+        Model_Translink::Data_Set translist = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_ASSET, asset->ASSETID);
         if (!translist.empty())
         {
             wxMessageBox(_(
@@ -800,7 +800,7 @@ void mmAssetsPanel::AddAssetTrans(const int selected_index)
 void mmAssetsPanel::ViewAssetTrans(const int selected_index)
 {
     Model_Asset::Data* asset = &m_assets[selected_index];
-    Model_Translink::Data_Set asset_list = Model_Translink::TranslinkList(Model_Attachment::ASSET, asset->ASSETID);
+    Model_Translink::Data_Set asset_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_ASSET, asset->ASSETID);
 
     // TODO create a panel to display all the information on one screen
     wxString msg = _("Account \t Date\t   Value\n\n");
@@ -828,7 +828,7 @@ void mmAssetsPanel::GotoAssetAccount(const int selected_index)
     }
     else
     {
-        Model_Translink::Data_Set asset_list = Model_Translink::TranslinkList(Model_Attachment::ASSET, asset->ASSETID);
+        Model_Translink::Data_Set asset_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_ASSET, asset->ASSETID);
         for (const auto &asset_entry : asset_list)
         {
             Model_Checking::Data* asset_trans = Model_Checking::instance().get(asset_entry.CHECKINGACCOUNTID);

--- a/src/attachmentdialog.cpp
+++ b/src/attachmentdialog.cpp
@@ -88,20 +88,20 @@ void mmAttachmentDialog::Create(wxWindow* parent, const wxString& name)
         wxString RefName;
         switch (refEnum)
         {
-        case Model_Attachment::STOCK:
+        case Model_Attachment::REFTYPE_ID_STOCK:
             RefName = Model_Stock::get_stock_name(m_RefId);
             break;
-        case Model_Attachment::ASSET:
+        case Model_Attachment::REFTYPE_ID_ASSET:
             RefName = Model_Asset::get_asset_name(m_RefId);
             break;
-        case Model_Attachment::BANKACCOUNT:
+        case Model_Attachment::REFTYPE_ID_BANKACCOUNT:
             RefName = Model_Account::get_account_name(m_RefId);
             break;
-        case Model_Attachment::PAYEE:
+        case Model_Attachment::REFTYPE_ID_PAYEE:
             RefName = Model_Payee::get_payee_name(m_RefId);
             break;
-        case Model_Attachment::TRANSACTION:
-        case Model_Attachment::BILLSDEPOSIT:
+        case Model_Attachment::REFTYPE_ID_TRANSACTION:
+        case Model_Attachment::REFTYPE_ID_BILLSDEPOSIT:
         default:
             RefName = "";
         }       
@@ -219,7 +219,7 @@ void mmAttachmentDialog::AddAttachment(wxString FilePath)
         m_attachment_id = Model_Attachment::instance().save(NewAttachment);
         m_attachment_id = NewAttachment->ATTACHMENTID;
 
-        if (m_RefType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+        if (m_RefType == Model_Attachment::REFTYPE_STR_TRANSACTION)
             Model_Checking::instance().updateTimestamp(m_RefId);
     }
 
@@ -255,7 +255,7 @@ void mmAttachmentDialog::EditAttachment()
         m_attachment_id = Model_Attachment::instance().save(attachment);
         m_attachment_id = attachment->ATTACHMENTID;
 
-        if (attachment->REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+        if (attachment->REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTION)
             Model_Checking::instance().updateTimestamp(attachment->REFID);
 
         fillControls();
@@ -276,7 +276,7 @@ void mmAttachmentDialog::DeleteAttachment()
             const wxString AttachmentsFolder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting()) + attachment->REFTYPE;
             if (mmAttachmentManage::DeleteAttachment(AttachmentsFolder + m_PathSep + attachment->FILENAME))
             {
-                if (attachment->REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+                if (attachment->REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTION)
                     Model_Checking::instance().updateTimestamp(attachment->REFID);
                 Model_Attachment::instance().remove(m_attachment_id);
             }
@@ -539,7 +539,7 @@ bool mmAttachmentManage::DeleteAllAttachments(const wxString& RefType, int64 Ref
         Model_Attachment::instance().remove(entry.ATTACHMENTID);
     }
 
-    if (RefType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (RefType == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(RefId);
 
     return true;
@@ -566,9 +566,9 @@ bool mmAttachmentManage::RelocateAllAttachments(const wxString& OldRefType, int6
     }
     Model_Attachment::instance().save(attachments);
 
-    if (OldRefType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (OldRefType == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(OldRefId);
-    if (NewRefType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (NewRefType == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(NewRefId);
 
     return true;
@@ -592,7 +592,7 @@ bool mmAttachmentManage::CloneAllAttachments(const wxString& RefType, int64 OldR
         Model_Attachment::instance().save(NewAttachment);
     }
 
-    if (RefType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (RefType == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(NewRefId);
 
     return true;

--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -131,12 +131,13 @@ mmBDDialog::mmBDDialog(wxWindow* parent, int64 bdID, bool duplicate, bool enterO
         m_bill_data.COLOR = bill->COLOR;
         wxArrayInt64 billtags;
         for (const auto& tag : Model_Taglink::instance().find(
-            Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)),
-            Model_Taglink::REFID(bill->BDID)))
+            Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
+            Model_Taglink::REFID(bill->BDID)
+        ))
             billtags.push_back(tag.TAGID);
         m_bill_data.TAGS = billtags;
         //
-        const wxString& splitRefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT);
+        const wxString& splitRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
         for (const auto& item : Model_Billsdeposits::split(bill)) {
             wxArrayInt64 splittags;
             for (const auto& tag : Model_Taglink::instance().find(Model_Taglink::REFTYPE(splitRefType), Model_Taglink::REFID(item.SPLITTRANSID)))
@@ -147,7 +148,7 @@ mmBDDialog::mmBDDialog(wxWindow* parent, int64 bdID, bool duplicate, bool enterO
         // If duplicate then we may need to copy the attachments
         if (m_dup_bill && Model_Infotable::instance().GetBoolInfo("ATTACHMENTSDUPLICATE", false))
         {
-            const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+            const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
             mmAttachmentManage::CloneAllAttachments(RefType, bdID, 0);
         }
     }
@@ -331,7 +332,7 @@ void mmBDDialog::SetDialogHeader(const wxString& header)
 void mmBDDialog::SetDialogParameters(int64 trx_id)
 {
     const auto split = Model_Splittransaction::instance().get_all();
-    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT));
+    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT);
     //const auto trx = Model_Checking::instance().find(Model_Checking::TRANSID(trx_id)).at(0);
     const auto trx = Model_Checking::instance().get(trx_id);
     Model_Checking::Full_Data t(*trx, split, tags);
@@ -679,7 +680,7 @@ void mmBDDialog::CreateControls()
 
 void mmBDDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     if (m_bill_data.BDID != 0)
         mmAttachmentManage::DeleteAllAttachments(RefType, m_bill_data.BDID);
     EndModal(wxID_CANCEL);
@@ -697,7 +698,7 @@ void mmBDDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
     }
 #endif
 
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     if (m_bill_data.BDID != 0)
         mmAttachmentManage::DeleteAllAttachments(RefType, m_bill_data.BDID);
     EndModal(wxID_CANCEL);
@@ -806,7 +807,7 @@ void mmBDDialog::OnComboKey(wxKeyEvent& event)
 
 void mmBDDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     mmAttachmentDialog dlg(this, RefType, m_bill_data.BDID);
     dlg.ShowModal();
 }
@@ -1080,7 +1081,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         Model_Budgetsplittransaction::instance().update(splt, m_trans_id);
 
         // Save split tags
-        const wxString& splitRefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT);
+        const wxString& splitRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
 
         for (size_t i = 0; i < m_bill_data.local_splits.size(); i++)
         {
@@ -1096,7 +1097,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             Model_Taglink::instance().update(splitTaglinks, splitRefType, splt.at(i).SPLITTRANSID);
         }
 
-        const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+        const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
         mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, m_trans_id);
 
         // Save base transaction tags
@@ -1159,7 +1160,7 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             Model_Splittransaction::instance().update(checking_splits, trans_id);
 
             // Save split tags
-            const wxString& splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+            const wxString& splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
 
             for (size_t i = 0; i < m_bill_data.local_splits.size(); i++)
             {
@@ -1178,8 +1179,8 @@ void mmBDDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             //Custom Data
             m_custom_fields->SaveCustomValues(trans_id);
 
-            const wxString& oldRefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
-            const wxString& newRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            const wxString& oldRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
+            const wxString& newRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
             mmAttachmentManage::RelocateAllAttachments(oldRefType, m_bill_data.BDID, newRefType, trans_id);
 
             // Save base transaction tags

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -519,7 +519,7 @@ wxString mmBillsDepositsPanel::getItem(long item, long column)
     {
         wxString value = bill.NOTES;
         value.Replace("\n", " ");
-        if (Model_Attachment::NrAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bill.BDID))
+        if (Model_Attachment::NrAttachments(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT, bill.BDID))
             value.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return value;
     }
@@ -680,7 +680,7 @@ void billsDepositsListCtrl::OnDeleteBDSeries(wxCommandEvent& WXUNUSED(event))
     {
         int64 BdId = m_bdp->bills_[m_selected_row].BDID;
         Model_Billsdeposits::instance().remove(BdId);
-        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), BdId);
+        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT, BdId);
         m_bdp->do_delete_custom_values(-BdId);
         m_bdp->initVirtualListControl();
         refreshVisualList(m_selected_row);
@@ -717,7 +717,7 @@ void billsDepositsListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
     if (m_selected_row == -1) return;
 
     int64 RefId = m_bdp->bills_[m_selected_row].BDID;
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
 
     mmAttachmentDialog dlg(this, RefType, RefId);
     dlg.ShowModal();
@@ -729,7 +729,7 @@ void billsDepositsListCtrl::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))
 {
     if (m_selected_row == -1) return;
     int64 RefId = m_bdp->bills_[m_selected_row].BDID;
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
 
     mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);
     refreshVisualList(m_bdp->initVirtualListControl(RefId));
@@ -988,6 +988,6 @@ wxString  mmBillsDepositsPanel::BuildPage() const
 
 void mmBillsDepositsPanel::do_delete_custom_values(int64 id)
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     Model_CustomFieldData::DeleteAllData(RefType, id);
 }

--- a/src/categdialog.cpp
+++ b/src/categdialog.cpp
@@ -508,7 +508,7 @@ void mmCategDialog::mmDoDeleteSelectedCategory()
             Model_Splittransaction::instance().Savepoint();
             Model_Attachment::instance().Savepoint();
             Model_CustomFieldData::instance().Savepoint();
-            const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
             for (auto& split : splits) {
                 Model_Checking::instance().remove(split.TRANSID);
                 mmAttachmentManage::DeleteAllAttachments(RefType, split.TRANSID);

--- a/src/customfieldeditdialog.cpp
+++ b/src/customfieldeditdialog.cpp
@@ -43,7 +43,7 @@ wxEND_EVENT_TABLE()
 
 mmCustomFieldEditDialog::mmCustomFieldEditDialog(wxWindow* parent, Model_CustomField::Data* field)
     : m_field(field)
-    , m_fieldRefType(Model_Attachment::instance().all_type()[Model_Attachment::REFTYPE::TRANSACTION])
+    , m_fieldRefType(Model_Attachment::REFTYPE_STR_TRANSACTION)
 {
     this->SetFont(parent->GetFont());
     Create(parent);
@@ -124,7 +124,7 @@ void mmCustomFieldEditDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _("Attribute of")), g_flagsH);
     m_itemReference = new wxChoice(itemPanel5, wxID_HIGHEST);
     for (const auto& type : Model_Attachment::REFTYPE_CHOICES) {
-        if (type.first != Model_Attachment::BILLSDEPOSIT)
+        if (type.first != Model_Attachment::REFTYPE_ID_BILLSDEPOSIT)
             m_itemReference->Append(wxGetTranslation(type.second), new wxStringClientData(type.second));
     }
     mmToolTip(m_itemReference, _("Select the item that the custom field is associated with"));

--- a/src/filtertrans.cpp
+++ b/src/filtertrans.cpp
@@ -126,7 +126,7 @@ wxString mmFilterTransactions::getHTML()
     mmHTMLBuilder hb;
     m_trans.clear();
     const auto splits = Model_Splittransaction::instance().get_all();
-    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION));
+    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_TRANSACTION);
     for (const auto& tran : Model_Checking::instance().all()) //TODO: find should be faster
     {
         if (!mmIsRecordMatches(tran, splits)) continue;
@@ -186,7 +186,7 @@ table {
     hb.init(false, extra_style);
     hb.addReportHeader(_("Transaction Details"), 1, false);
 
-    const wxString& AttRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& AttRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     hb.addDivContainer();
     hb.addTableCellLink("back:",wxString::Format("<< %s", _("Back")));
     hb.endDiv();

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -416,7 +416,7 @@ void mmFilterTransactionsDialog::mmDoDataToControls(const wxString& json)
 
     // Custom Fields
     bool is_custom_found = false;
-    const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     for (const auto& i : Model_CustomField::instance().find(Model_CustomField::DB_Table_CUSTOMFIELD_V1::REFTYPE(RefType)))
     {
         const auto entry = wxString::Format("CUSTOM%lld", i.FIELDID);
@@ -1363,11 +1363,11 @@ bool mmFilterTransactionsDialog::mmIsTagMatches(const wxString& refType, int64 r
     // If we have a split, merge the transaciton tags so that an AND condition captures cases
     // where one tag is on the base txn and the other is on the split
     std::map<wxString, int64> txnTagnames;
-    if (refType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT))
-        txnTagnames = Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION),
+    if (refType == Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT)
+        txnTagnames = Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTION,
                                                     Model_Splittransaction::instance().get(refId)->TRANSID);
-    else if (refType == Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT))
-        txnTagnames = Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT),
+    else if (refType == Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT)
+        txnTagnames = Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT,
                                                     Model_Budgetsplittransaction::instance().get(refId)->TRANSID);
 
     if (mergeSplitTags)
@@ -1375,23 +1375,23 @@ bool mmFilterTransactionsDialog::mmIsTagMatches(const wxString& refType, int64 r
         // Merge transaction tags and split tags. This is necessary when checking
         // if a split record matches the filter since we are using mmIsRecordMatches
         // to validate the split which gives it the wrong refType & refId
-        if (refType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+        if (refType == Model_Attachment::REFTYPE_STR_TRANSACTION)
         {
             // Loop through checking splits and merge tags for each SPLITTRANSID
             for (const auto& split : Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(refId)))
             {
                 std::map<wxString, int64> splitTagnames =
-                    Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), split.SPLITTRANSID);
+                    Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, split.SPLITTRANSID);
                 txnTagnames.insert(splitTagnames.begin(), splitTagnames.end());
             }
         }
-        else if (refType == Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT))
+        else if (refType == Model_Attachment::REFTYPE_STR_BILLSDEPOSIT)
         {
             // Loop through scheduled txn splits and merge tags for each SPLITTRANSID
             for (const auto& split : Model_Budgetsplittransaction::instance().find(Model_Budgetsplittransaction::TRANSID(refId)))
             {
                 std::map<wxString, int64> splitTagnames =
-                    Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT), split.SPLITTRANSID);
+                    Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT, split.SPLITTRANSID);
                 txnTagnames.insert(splitTagnames.begin(), splitTagnames.end());
             }
         }
@@ -1456,9 +1456,9 @@ template <class MODEL, class DATA> bool mmFilterTransactionsDialog::mmIsRecordMa
         wxString refType;
         // Check the Data type to determine the tag RefType
         if (typeid(tran).hash_code() == typeid(Model_Checking::Data).hash_code())
-            refType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            refType = Model_Attachment::REFTYPE_STR_TRANSACTION;
         else if (typeid(tran).hash_code() == typeid(Model_Billsdeposits::Data).hash_code())
-            refType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+            refType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
         if (!mmIsTagMatches(refType, tran.id(), mergeSplitTags))
             ok = false;
     }
@@ -1471,11 +1471,11 @@ template <class MODEL, class DATA> bool mmFilterTransactionsDialog::mmIsSplitRec
 
     if (typeid(split).hash_code() == typeid(Model_Splittransaction::Data).hash_code())
     {
-        refType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+        refType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
     }
     else if (typeid(split).hash_code() == typeid(Model_Budgetsplittransaction::Data).hash_code())
     {
-        refType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT);
+        refType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
     }
 
     if (mmIsTagsChecked() && !mmIsTagMatches(refType, split.SPLITTRANSID))

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -183,7 +183,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
         buffer << "M" << notes << "\n";
     }
 
-    wxString reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+    wxString reftype = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
     for (const auto &split_entry : full_tran.m_splits)
     {
         double valueSplit = split_entry.SPLITTRANSAMOUNT;
@@ -435,7 +435,7 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
             json_writer.Double(valueSplit);
             json_writer.Key("TAGS");
             json_writer.StartArray();
-            for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), split_entry.SPLITTRANSID))
+            for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, split_entry.SPLITTRANSID))
                 json_writer.Int64(tag.second.GetValue());
             json_writer.EndArray();
             json_writer.EndObject();
@@ -444,7 +444,7 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
         json_writer.EndArray();
     }
 
-    const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(RefType, full_tran.id());
 
     if (!attachments.empty())
@@ -486,7 +486,7 @@ void mmExportTransaction::getAttachmentsJSON(PrettyWriter<StringBuffer>& json_wr
 
     if (!allAttachment4Export.empty())
     {
-        const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+        const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
         const wxString folder = Model_Infotable::instance().GetStringInfo("ATTACHMENTSFOLDER:" + mmPlatformType(), "");
         const wxString AttachmentsFolder = mmex::getPathAttachment(folder);
 
@@ -523,7 +523,7 @@ void mmExportTransaction::getCustomFieldsJSON(PrettyWriter<StringBuffer>& json_w
 
     if (!allCustomFields4Export.empty())
     {
-        const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+        const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
 
         json_writer.Key("CUSTOM_FIELDS");
         json_writer.StartObject();

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -467,7 +467,7 @@ void mmQIFExportDialog::mmExportQIF()
 
     std::map<int64 /*account ID*/, wxString> allAccounts4Export;
     wxArrayInt64 allPayees4Export;
-    const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     wxArrayInt64 allAttachments4Export;
     wxArrayInt64 allCustomFields4Export;
     wxArrayInt64 allTags4Export;
@@ -486,7 +486,7 @@ void mmQIFExportDialog::mmExportQIF()
             , 100, this, wxPD_APP_MODAL | wxPD_CAN_ABORT);
 
         const auto splits = Model_Splittransaction::instance().get_all();
-        const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION));
+        const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_TRANSACTION);
 
         const wxString begin_date = fromDateCtrl_->GetValue().FormatISODate();
         const wxString end_date = toDateCtrl_->GetValue().FormatISODate();
@@ -549,7 +549,7 @@ void mmQIFExportDialog::mmExportQIF()
                 // store tags from the splits
                 for (const auto& split : full_tran.m_splits)
                 {
-                    for (const auto& taglink : Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), split.SPLITTRANSID))
+                    for (const auto& taglink : Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, split.SPLITTRANSID))
                     {
                         if (std::find(allTags4Export.begin(), allTags4Export.end(), taglink.second) == allTags4Export.end())
                             allTags4Export.push_back(taglink.second);

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1114,7 +1114,7 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
                 Model_Taglink::Cache taglinks;
                 if (!tagStr.IsEmpty())
                 {
-                    wxString reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+                    wxString reftype = Model_Attachment::REFTYPE_STR_TRANSACTION;
                     wxStringTokenizer tagTokens = wxStringTokenizer(tagStr, ":");
                     while (tagTokens.HasMoreTokens())
                     {
@@ -1481,7 +1481,7 @@ bool mmQIFImportDialog::completeTransaction(/*in*/ const std::unordered_map <int
             if (!tagStr.IsEmpty())
             {
                 Model_Taglink::Cache splitTaglinks;
-                wxString reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+                wxString reftype = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
                 wxStringTokenizer tagTokens = wxStringTokenizer(tagStr, ":");
                 while (tagTokens.HasMoreTokens())
                 {

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -284,7 +284,7 @@ void mmUnivCSVDialog::CreateControls()
         csvFieldCandicate_->Append(wxGetTranslation(it.second), new mmListBoxItem(it.first, it.second));
 
     //Custom Fields
-    Model_CustomField::Data_Set fields = Model_CustomField::instance().find(Model_CustomField::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION)));
+    Model_CustomField::Data_Set fields = Model_CustomField::instance().find(Model_CustomField::REFTYPE(Model_Attachment::REFTYPE_STR_TRANSACTION));
     if (!fields.empty())
     {
         std::sort(fields.begin(), fields.end(), SorterByDESCRIPTION());
@@ -1360,7 +1360,7 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& WXUNUSED(event))
     m_reverce_sign = m_choiceAmountFieldSign->GetCurrentSelection() == PositiveIsWithdrawal;
     // A place to store all rejected rows to display after import
     wxString rejectedRows;
-    wxString reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    wxString reftype = Model_Attachment::REFTYPE_STR_TRANSACTION;
     for (long nLines = firstRow; nLines < lastRow; nLines++)
     {
         const wxString& progressMsg = wxString::Format(_("Transactions imported to account %s: %ld")
@@ -1582,7 +1582,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
         return mmErrorDialogs::ToolTip4Object(m_choice_account_, _("Invalid Account"), _("Error"));
 
     const auto split = Model_Splittransaction::instance().get_all();
-    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION));
+    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_TRANSACTION);
     int64 fromAccountID = from_account->ACCOUNTID;
 
     long numRecords = 0;
@@ -1678,7 +1678,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                 case UNIV_CSV_TAGS:
                 {
                     wxString splitTags;
-                    for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), splt.SPLITTRANSID))
+                    for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, splt.SPLITTRANSID))
                         splitTags.Append((splitTags.IsEmpty() ? "" : " ") + tag.first);
                     entry = tran.TAGNAMES;
                     if (!splitTags.IsEmpty())
@@ -1903,7 +1903,7 @@ void mmUnivCSVDialog::update_preview()
         if (from_account)
         {
             const auto split = Model_Splittransaction::instance().get_all();
-            const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION));
+            const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_TRANSACTION);
             int64 fromAccountID = from_account->ACCOUNTID;
             size_t count = 0;
             int row = 0;
@@ -1998,7 +1998,7 @@ void mmUnivCSVDialog::update_preview()
                         {
                             wxString splitTags;
                             for (const auto& tag :
-                                 Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), splt.SPLITTRANSID))
+                                 Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, splt.SPLITTRANSID))
                                 splitTags.Append((splitTags.IsEmpty() ? "" : " ") + tag.first);
                             text << inQuotes(tran.TAGNAMES + (tran.TAGNAMES.IsEmpty() ? "" : " ") + splitTags, delimit);
                             break;

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -94,7 +94,7 @@ TransactionListCtrl::EColumn TransactionListCtrl::toEColumn(const unsigned long 
 
 void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
 {
-    const auto& ref_type = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
     Model_CustomField::TYPE_ID type;
 
     switch (m_real_columns[sortcol])
@@ -356,7 +356,7 @@ void TransactionListCtrl::resetColumns()
     }
 
     int i = COL_UDFC01;
-    const auto& ref_type = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
     for (const auto& udfc_entry : Model_CustomField::UDFC_FIELDS())
     {
         if (udfc_entry.empty()) continue;
@@ -540,7 +540,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
         if (column < m_columns.size())
         {
             wxString menuItemText;
-            wxString refType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            wxString refType = Model_Attachment::REFTYPE_STR_TRANSACTION;
             wxDateTime datetime;
             wxString dateFormat = Option::instance().getDateFormat();
             bool is_transfer = Model_Checking::is_transfer(m_trans[row].TRANSCODE)
@@ -1104,7 +1104,7 @@ int64 TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
 
     // Clone transaction tags
     Model_Taglink::Cache copy_taglinks;
-    wxString reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    wxString reftype = Model_Attachment::REFTYPE_STR_TRANSACTION;
     for (const auto& link : Model_Taglink::instance().find(Model_Taglink::REFTYPE(reftype), Model_Taglink::REFID(tran->TRANSID)))
     {
         Model_Taglink::Data* taglink = Model_Taglink::instance().clone(&link);
@@ -1113,7 +1113,7 @@ int64 TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
     }
 
     // Clone split transactions
-    reftype = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+    reftype = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
     for (const auto& split_item : Model_Checking::split(tran))
     {
         Model_Splittransaction::Data *copy_split_item = Model_Splittransaction::instance().clone(&split_item);
@@ -1149,7 +1149,7 @@ int64 TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
     // Clone attachments if wanted
     if (Model_Infotable::instance().GetBoolInfo("ATTACHMENTSDUPLICATE", false))
     {
-        const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+        const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
         mmAttachmentManage::CloneAllAttachments(RefType, tran->TRANSID, transactionID);
     }
 
@@ -1164,8 +1164,8 @@ void TransactionListCtrl::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))
     Fused_Transaction::IdRepeat id = m_selected_id[0];
 
     const wxString refType = !id.second ?
-        Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) :
-        Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+        Model_Attachment::REFTYPE_STR_TRANSACTION :
+        Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     mmAttachmentManage::OpenAttachmentFromPanelIcon(this, refType, id.first);
     refreshVisualList();
 }
@@ -1568,13 +1568,13 @@ void TransactionListCtrl::OnEditTransaction(wxCommandEvent& /*event*/)
 
         if (Model_Checking::foreignTransaction(*checking_entry)) {
             Model_Translink::Data translink = Model_Translink::TranslinkRecord(id.first);
-            if (translink.LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::STOCK))
+            if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK)
             {
                 ShareTransactionDialog dlg(this, &translink, checking_entry);
                 if (dlg.ShowModal() == wxID_OK)
                     refreshVisualList();
             }
-            else if (translink.LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::ASSET))
+            else if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_ASSET)
             {
                 mmAssetDialog dlg(this, m_cp->m_frame, &translink, checking_entry);
                 if (dlg.ShowModal() == wxID_OK)
@@ -1841,8 +1841,8 @@ void TransactionListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
     Fused_Transaction::IdRepeat id = m_selected_id[0];
 
     const wxString refType = !id.second ?
-        Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) :
-        Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+        Model_Attachment::REFTYPE_STR_TRANSACTION :
+        Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     mmAttachmentDialog dlg(this, refType, id.first);
     dlg.ShowModal();
     refreshVisualList();
@@ -2054,7 +2054,7 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
         value = fused.TAGNAMES;
         if (!fused.displayID.Contains("."))
         {
-            const wxString splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+            const wxString splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
             for (const auto& split : fused.m_splits)
             {
                 wxString tagnames;

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -174,10 +174,10 @@ void mmCheckingPanel::filterTable()
     m_show_reconciled = false;
     m_account_flow = 0.0;
 
-    const wxString transRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
-    const wxString splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
-    const wxString billsRefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
-    const wxString billsplitRefType = Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT);
+    const wxString transRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
+    const wxString splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
+    const wxString billsRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
+    const wxString billsplitRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
 
     Model_CustomField::TYPE_ID UDFC01_Type = Model_CustomField::getUDFCType(transRefType, "UDFC01");
     Model_CustomField::TYPE_ID UDFC02_Type = Model_CustomField::getUDFCType(transRefType, "UDFC02");
@@ -190,8 +190,8 @@ void mmCheckingPanel::filterTable()
     int UDFC04_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC04"));
     int UDFC05_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC05"));
 
-    auto trans_fields_data = Model_CustomFieldData::instance().get_all(Model_Attachment::TRANSACTION);
-    const auto matrix = Model_CustomField::getMatrix(Model_Attachment::TRANSACTION);
+    auto trans_fields_data = Model_CustomFieldData::instance().get_all(Model_Attachment::REFTYPE_ID_TRANSACTION);
+    const auto matrix = Model_CustomField::getMatrix(Model_Attachment::REFTYPE_ID_TRANSACTION);
     int64 udfc01_ref_id = matrix.at("UDFC01");
     int64 udfc02_ref_id = matrix.at("UDFC02");
     int64 udfc03_ref_id = matrix.at("UDFC03");
@@ -206,7 +206,7 @@ void mmCheckingPanel::filterTable()
     const auto trans_splits = Model_Splittransaction::instance().get_all();
     const auto trans_tags = Model_Taglink::instance().get_all(transRefType);
     const auto trans_attachments = Model_Attachment::instance().get_all(
-        Model_Attachment::TRANSACTION);
+        Model_Attachment::REFTYPE_ID_TRANSACTION);
     const auto trans = (isAllAccounts_ || isTrash_) ?
         Model_Checking::instance().all() :
         Model_Account::transaction(this->m_account);
@@ -222,7 +222,7 @@ void mmCheckingPanel::filterTable()
         bills_splits = Model_Budgetsplittransaction::instance().get_all();
         bills_tags = Model_Taglink::instance().get_all(billsRefType);
         bills_attachments = Model_Attachment::instance().get_all(
-            Model_Attachment::BILLSDEPOSIT);
+            Model_Attachment::REFTYPE_ID_BILLSDEPOSIT);
         bills = (isAllAccounts_ || isTrash_) ?
             Model_Billsdeposits::instance().all() :
             Model_Account::billsdeposits(this->m_account);
@@ -431,8 +431,8 @@ void mmCheckingPanel::OnButtonRightDown(wxMouseEvent& event)
         auto selected_id = m_listCtrlAccount->getSelectedId();
         if (selected_id.size() == 1) {
             const wxString refType = !selected_id[0].second ?
-                Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) :
-                Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+                Model_Attachment::REFTYPE_STR_TRANSACTION :
+                Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
             mmAttachmentDialog dlg(this, refType, selected_id[0].first);
             dlg.ShowModal();
             RefreshList();
@@ -762,7 +762,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
                     notesStr += split.NOTES;
                 }
             if (full_tran.has_attachment()) {
-                const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+                const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
                 Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(RefType, full_tran.id());
                 for (const auto& i : attachments) {
                     notesStr += notesStr.empty() ? "" : "\n";

--- a/src/mmcustomdata.cpp
+++ b/src/mmcustomdata.cpp
@@ -54,7 +54,7 @@ mmCustomData::mmCustomData(wxDialog* dialog, const wxString& ref_type, int64 ref
 
 mmCustomDataTransaction::mmCustomDataTransaction(wxDialog* dialog, int64 ref_id, wxWindowID base_id)
     : mmCustomData(dialog
-        , Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION)
+        , Model_Attachment::REFTYPE_STR_TRANSACTION
         , ref_id)
 {
     SetBaseID(base_id);
@@ -505,7 +505,7 @@ bool mmCustomData::SaveCustomValues(int64 ref_id)
 
     Model_CustomFieldData::instance().ReleaseSavepoint();
 
-    if (updateTimestamp && m_ref_type == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (updateTimestamp && m_ref_type == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(ref_id);        
 
     return true;
@@ -555,7 +555,7 @@ void mmCustomData::UpdateCustomValues(int64 ref_id)
 
     Model_CustomFieldData::instance().ReleaseSavepoint();
 
-    if (updateTimestamp && m_ref_type == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+    if (updateTimestamp && m_ref_type == Model_Attachment::REFTYPE_STR_TRANSACTION)
         Model_Checking::instance().updateTimestamp(ref_id);        
 }
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -567,7 +567,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                     checking_splits.push_back(split);
                     wxArrayInt64 tags;
                     for (const auto& tag :
-                         Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT)),
+                         Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT),
                                                         Model_Taglink::REFID(item.SPLITTRANSID)))
                         tags.push_back(tag.TAGID);
                     splitTags.push_back(tags);
@@ -575,7 +575,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 Model_Splittransaction::instance().save(checking_splits);
 
                 // Save split tags
-                const wxString& splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+                const wxString& splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
 
                 for (size_t i = 0; i < checking_splits.size(); i++)
                 {
@@ -606,8 +606,8 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 
                 // Save base transaction tags
                 Model_Taglink::Data_Set taglinks;
-                const wxString& txnRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
-                for (const auto& tag : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)),
+                const wxString& txnRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
+                for (const auto& tag : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
                                                                       Model_Taglink::REFID(q1.BDID)))
                 {
                     Model_Taglink::Data* t = Model_Taglink::instance().create();
@@ -1258,7 +1258,7 @@ void mmGUIFrame::OnAccountAttachments(wxCommandEvent& /*event*/)
     if (selectedItemData_)
     {
         int64 RefId = selectedItemData_->getData();
-        wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT);
+        wxString RefType = Model_Attachment::REFTYPE_STR_BANKACCOUNT;
 
         mmAttachmentDialog dlg(this, RefType, RefId);
         dlg.ShowModal();
@@ -1414,7 +1414,7 @@ void mmGUIFrame::OnPopupDeleteAccount(wxCommandEvent& /*event*/)
             if (msgDlg.ShowModal() == wxID_YES)
             {
                 Model_Account::instance().remove(account->ACCOUNTID);
-                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT), account->ACCOUNTID);
+                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_BANKACCOUNT, account->ACCOUNTID);
                 DoRecreateNavTreeControl(true);
             }
         }
@@ -3632,7 +3632,7 @@ void mmGUIFrame::OnDeleteAccount(wxCommandEvent& /*event*/)
         if (msgDlg.ShowModal() == wxID_YES)
         {
             Model_Account::instance().remove(account->id());
-            mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BANKACCOUNT), account->id());
+            mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_BANKACCOUNT, account->id());
         }
     }
     DoRecreateNavTreeControl(true);
@@ -3888,7 +3888,7 @@ void mmGUIFrame::autocleanDeletedTransactions() {
             Model_Checking::instance().remove(transaction.TRANSID);
 
             // remove also any attachments for the transaction
-            const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
             mmAttachmentManage::DeleteAllAttachments(RefType, transaction.TRANSID);
 
             // remove also any custom fields for the transaction

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -636,7 +636,7 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
                 if (Model_Checking::foreignTransaction(*transaction))
                 {
                     Model_Translink::Data translink = Model_Translink::TranslinkRecord(transId);
-                    if (translink.LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::STOCK))
+                    if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK)
                     {
                         ShareTransactionDialog dlg(m_frame, &translink, transaction);
                         if (dlg.ShowModal() == wxID_OK)
@@ -674,7 +674,7 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
         const wxString RefType = sData.BeforeFirst('|');
         int RefId = wxAtoi(sData.AfterFirst('|'));
 
-        if (Model_Attachment::instance().all_type().Index(RefType) != wxNOT_FOUND && RefId > 0)
+        if (Model_Attachment::REFTYPE_STR.Index(RefType) != wxNOT_FOUND && RefId > 0)
         {
             mmAttachmentManage::OpenAttachmentFromPanelIcon(m_frame, RefType, RefId);
             const auto name = getVFname4print("rep", getPrintableBase()->getHTMLText());

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -190,7 +190,7 @@ bool Model_Account::remove(int64 id)
 
     for (const auto& r : Model_Stock::instance().find(Model_Stock::HELDAT(id)))
     {
-        Model_Translink::RemoveTransLinkRecords(Model_Attachment::STOCK, r.STOCKID);
+        Model_Translink::RemoveTransLinkRecords(Model_Attachment::REFTYPE_ID_STOCK, r.STOCKID);
         Model_Stock::instance().remove(r.STOCKID);
     }
     this->ReleaseSavepoint();

--- a/src/model/Model_Asset.cpp
+++ b/src/model/Model_Asset.cpp
@@ -235,7 +235,10 @@ double Model_Asset::valueAtDate(const Data* r, const wxDate date)
 {
     double balance = 0;
     if (date >= STARTDATE(r)) {
-        Model_Translink::Data_Set translink_records = Model_Translink::instance().find(Model_Translink::LINKRECORDID(r->ASSETID), Model_Translink::LINKTYPE(Model_Attachment::reftype_desc(Model_Attachment::ASSET)));
+        Model_Translink::Data_Set translink_records = Model_Translink::instance().find(
+            Model_Translink::LINKRECORDID(r->ASSETID),
+            Model_Translink::LINKTYPE(Model_Attachment::REFTYPE_STR_ASSET)
+        );
         if (!translink_records.empty())
         {
             for (const auto& link : translink_records)

--- a/src/model/Model_Attachment.cpp
+++ b/src/model/Model_Attachment.cpp
@@ -19,17 +19,26 @@
 #include "Model_Attachment.h"
 #include <wx/string.h>
 
-const std::vector<std::pair<Model_Attachment::REFTYPE, wxString> > Model_Attachment::REFTYPE_CHOICES =
+const std::vector<std::pair<Model_Attachment::REFTYPE_ID, wxString> > Model_Attachment::REFTYPE_CHOICES =
 {
-    {Model_Attachment::TRANSACTION, wxTRANSLATE("Transaction")},
-    {Model_Attachment::STOCK, wxTRANSLATE("Stock")},
-    {Model_Attachment::ASSET, wxTRANSLATE("Asset")},
-    {Model_Attachment::BANKACCOUNT, wxTRANSLATE("BankAccount")},
-    {Model_Attachment::BILLSDEPOSIT, wxTRANSLATE("RecurringTransaction")},
-    {Model_Attachment::PAYEE, wxTRANSLATE("Payee")},
-    {Model_Attachment::TRANSACTIONSPLIT, wxTRANSLATE("TransactionSplit")},
-    {Model_Attachment::BILLSDEPOSITSPLIT, wxTRANSLATE("RecurringTransactionSplit")}
+    { Model_Attachment::REFTYPE_ID_TRANSACTION,       wxTRANSLATE("Transaction") },
+    { Model_Attachment::REFTYPE_ID_STOCK,             wxTRANSLATE("Stock") },
+    { Model_Attachment::REFTYPE_ID_ASSET,             wxTRANSLATE("Asset") },
+    { Model_Attachment::REFTYPE_ID_BANKACCOUNT,       wxTRANSLATE("BankAccount") },
+    { Model_Attachment::REFTYPE_ID_BILLSDEPOSIT,      wxTRANSLATE("RecurringTransaction") },
+    { Model_Attachment::REFTYPE_ID_PAYEE,             wxTRANSLATE("Payee") },
+    { Model_Attachment::REFTYPE_ID_TRANSACTIONSPLIT,  wxTRANSLATE("TransactionSplit") },
+    { Model_Attachment::REFTYPE_ID_BILLSDEPOSITSPLIT, wxTRANSLATE("RecurringTransactionSplit") },
 };
+wxArrayString Model_Attachment::REFTYPE_STR = reftype_str_all();
+const wxString Model_Attachment::REFTYPE_STR_TRANSACTION       = REFTYPE_STR[REFTYPE_ID_TRANSACTION];
+const wxString Model_Attachment::REFTYPE_STR_STOCK             = REFTYPE_STR[REFTYPE_ID_STOCK];
+const wxString Model_Attachment::REFTYPE_STR_ASSET             = REFTYPE_STR[REFTYPE_ID_ASSET];
+const wxString Model_Attachment::REFTYPE_STR_BANKACCOUNT       = REFTYPE_STR[REFTYPE_ID_BANKACCOUNT];
+const wxString Model_Attachment::REFTYPE_STR_BILLSDEPOSIT      = REFTYPE_STR[REFTYPE_ID_BILLSDEPOSIT];
+const wxString Model_Attachment::REFTYPE_STR_PAYEE             = REFTYPE_STR[REFTYPE_ID_PAYEE];
+const wxString Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT  = REFTYPE_STR[REFTYPE_ID_TRANSACTIONSPLIT];
+const wxString Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT = REFTYPE_STR[REFTYPE_ID_BILLSDEPOSITSPLIT];
 
 Model_Attachment::Model_Attachment()
 : Model<DB_Table_ATTACHMENT_V1>()
@@ -60,13 +69,16 @@ Model_Attachment& Model_Attachment::instance()
     return Singleton<Model_Attachment>::instance();
 }
 
-/** Return all attachments references */
-wxArrayString Model_Attachment::all_type()
+wxArrayString Model_Attachment::reftype_str_all()
 {
-    wxArrayString types;
+    wxArrayString reftype;
+    int i = 0;
     for (const auto& item : REFTYPE_CHOICES)
-        types.Add(item.second);
-    return types;
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Attachment::REFTYPE_CHOICES");
+        reftype.Add(item.second);
+    }
+    return reftype;
 }
 
 /** Return a dataset with attachments linked to a specific object */
@@ -104,20 +116,12 @@ int Model_Attachment::LastAttachmentNumber(const wxString& RefType, const int64 
     return LastAttachmentNumber;
 }
 
-/** Return the description of the choice reftype */
-wxString Model_Attachment::reftype_desc(const int RefTypeEnum)
-{
-    const auto& item = REFTYPE_CHOICES[RefTypeEnum];
-    wxString reftype_desc = item.second;
-    return reftype_desc;
-}
-
 /** Return a dataset with attachments linked to a specific type*/
-std::map<int64, Model_Attachment::Data_Set> Model_Attachment::get_all(REFTYPE reftype)
+std::map<int64, Model_Attachment::Data_Set> Model_Attachment::get_all(REFTYPE_ID reftype)
 {
     std::map<int64, Model_Attachment::Data_Set> data;
-    wxString reftype_desc = Model_Attachment::reftype_desc(reftype);
-    for (const auto & attachment : this->find(Model_Attachment::DB_Table_ATTACHMENT_V1::REFTYPE(reftype_desc)))
+    wxString reftype_str = Model_Attachment::REFTYPE_STR[reftype];
+    for (const auto & attachment : this->find(Model_Attachment::DB_Table_ATTACHMENT_V1::REFTYPE(reftype_str)))
     {
         data[attachment.REFID].push_back(attachment);
     }

--- a/src/model/Model_Attachment.h
+++ b/src/model/Model_Attachment.h
@@ -26,9 +26,30 @@ class Model_Attachment : public Model<DB_Table_ATTACHMENT_V1>
 {
 public:
     using Model<DB_Table_ATTACHMENT_V1>::get;
-    enum REFTYPE { TRANSACTION = 0, STOCK, ASSET, BANKACCOUNT, BILLSDEPOSIT, PAYEE, TRANSACTIONSPLIT, BILLSDEPOSITSPLIT};
+    enum REFTYPE_ID {
+        REFTYPE_ID_TRANSACTION = 0,
+        REFTYPE_ID_STOCK,
+        REFTYPE_ID_ASSET,
+        REFTYPE_ID_BANKACCOUNT,
+        REFTYPE_ID_BILLSDEPOSIT,
+        REFTYPE_ID_PAYEE,
+        REFTYPE_ID_TRANSACTIONSPLIT,
+        REFTYPE_ID_BILLSDEPOSITSPLIT
+    };
+    static wxArrayString REFTYPE_STR;
+    static const wxString REFTYPE_STR_TRANSACTION;
+    static const wxString REFTYPE_STR_STOCK;
+    static const wxString REFTYPE_STR_ASSET;
+    static const wxString REFTYPE_STR_BANKACCOUNT;
+    static const wxString REFTYPE_STR_BILLSDEPOSIT;
+    static const wxString REFTYPE_STR_PAYEE;
+    static const wxString REFTYPE_STR_TRANSACTIONSPLIT;
+    static const wxString REFTYPE_STR_BILLSDEPOSITSPLIT;
 
-    static const std::vector<std::pair<REFTYPE, wxString> > REFTYPE_CHOICES;
+    static const std::vector<std::pair<REFTYPE_ID, wxString> > REFTYPE_CHOICES;
+
+private:
+    static wxArrayString reftype_str_all();
 
 public:
     Model_Attachment();
@@ -50,9 +71,6 @@ public:
     static Model_Attachment& instance();
 
 public:
-    /** Return all attachments references */
-    wxArrayString all_type();
-
     /** Return a dataset with attachments linked to a specific object */
     const Data_Set FilterAttachments(const wxString& RefType, const int64 RefId);
 
@@ -62,11 +80,8 @@ public:
     /** Return the last attachment number linked to a specific object */
     static int LastAttachmentNumber(const wxString& RefType, const int64 RefId);
 
-    /** Return the description of the choice reftype */
-    static wxString reftype_desc(const int RefTypeEnum);
-
     /** Return a dataset with attachments linked to a specific type*/
-    std::map<int64, Data_Set> get_all(REFTYPE reftype);
+    std::map<int64, Data_Set> get_all(REFTYPE_ID reftype);
 
     /** Return all attachments descriptions*/
     wxArrayString allDescriptions();

--- a/src/model/Model_Billsdeposits.cpp
+++ b/src/model/Model_Billsdeposits.cpp
@@ -108,7 +108,7 @@ bool Model_Billsdeposits::remove(int64 id)
     for (auto &item : Model_Billsdeposits::split(get(id)))
         Model_Budgetsplittransaction::instance().remove(item.SPLITTRANSID);
     // Delete tags for the scheduled transaction
-    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), id);
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT, id);
     return this->remove(id, db_);
 }
 
@@ -136,7 +136,7 @@ const Model_Budgetsplittransaction::Data_Set Model_Billsdeposits::split(const Da
 const Model_Taglink::Data_Set Model_Billsdeposits::taglink(const Data* r)
 {
     return Model_Taglink::instance().find(
-        Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)),
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
         Model_Taglink::REFID(r->BDID));
 }
 
@@ -244,7 +244,7 @@ void Model_Billsdeposits::completeBDInSeries(int64 bdID)
 
     if ((repeats == REPEAT_TYPE::REPEAT_ONCE) || ((repeats < REPEAT_TYPE::REPEAT_IN_X_DAYS || repeats > REPEAT_TYPE::REPEAT_EVERY_X_MONTHS) && numRepeats == 1))
     {
-        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT), bdID);
+        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT, bdID);
         remove(bdID);
         return;
     }
@@ -372,7 +372,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) :
     Data(r),
     m_bill_splits(split(r)),
     m_tags(Model_Taglink::instance().find(
-        Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)),
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
         Model_Taglink::REFID(r.BDID)))
 {
     if (!m_tags.empty()) {
@@ -393,7 +393,7 @@ Model_Billsdeposits::Full_Data::Full_Data(const Data& r) :
                 + Model_Category::full_name(entry.CATEGID);
 
             wxString splitTags;
-            for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT), entry.SPLITTRANSID))
+            for (const auto& tag : Model_Taglink::instance().get(Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT, entry.SPLITTRANSID))
                 splitTags.Append(tag.first + " ");
             if (!splitTags.IsEmpty())
                 TAGNAMES.Append((TAGNAMES.IsEmpty() ? "" : ", ") + splitTags.Trim());

--- a/src/model/Model_Budget.cpp
+++ b/src/model/Model_Budget.cpp
@@ -262,7 +262,7 @@ void Model_Budget::copyBudgetYear(int64 newYearID, int64 baseYearID)
         double yearAmount = getEstimate(false, period_id(data), data.AMOUNT);
         if (optionDeductMonthly && budgetedMonths > 0)
         {
-            budgetEntry->PERIOD = PERIOD_CHOICES[PERIOD_ID_MONTHLY].second;
+            budgetEntry->PERIOD = PERIOD_STR[PERIOD_ID_MONTHLY];
             if (yearDeduction[budgetEntry->CATEGID] / yearAmount < 1)
                 budgetEntry->AMOUNT = (yearAmount - yearDeduction[budgetEntry->CATEGID]) / (12 - budgetedMonths);
             else budgetEntry->AMOUNT = 0;

--- a/src/model/Model_Budgetsplittransaction.cpp
+++ b/src/model/Model_Budgetsplittransaction.cpp
@@ -61,7 +61,7 @@ double Model_Budgetsplittransaction::get_total(const Data_Set& rows)
 bool Model_Budgetsplittransaction::remove(int64 id)
 {
     // Delete all tags for the split before removing it
-    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT), id);
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT, id);
     return this->remove(id, db_);
 }
 

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -136,7 +136,7 @@ bool Model_Checking::remove(int64 id)
         Model_Splittransaction::instance().remove(r.SPLITTRANSID);
     if(foreignTransaction(*instance().get(id))) Model_Translink::RemoveTranslinkEntry(id);
 
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     // remove all attachments
     mmAttachmentManage::DeleteAllAttachments(RefType, id);
     // remove all custom fields for the transaction
@@ -406,7 +406,7 @@ Model_Checking::Full_Data::Full_Data(const Data& r) :
     m_splits(Model_Splittransaction::instance().find(
         Model_Splittransaction::TRANSID(r.TRANSID))),
     m_tags(Model_Taglink::instance().find(
-        Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION)),
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_TRANSACTION),
         Model_Taglink::REFID(r.TRANSID)))
 {
     fill_data();

--- a/src/model/Model_CustomField.cpp
+++ b/src/model/Model_CustomField.cpp
@@ -64,10 +64,10 @@ Model_CustomField& Model_CustomField::instance()
 }
 
 ///** Return a dataset with fields linked to a specific object */
-//const Model_CustomField::Data_Set Model_CustomField::GetFields(Model_Attachment::REFTYPE RefType)
+//const Model_CustomField::Data_Set Model_CustomField::GetFields(Model_Attachment::REFTYPE_ID RefType)
 //{
 //    Data_Set fields;
-//    wxString reftype_desc = Model_Attachment::reftype_desc(RefType);
+//    wxString reftype_str = Model_Attachment::REFTYPE_STR[RefType];
 //    for (const auto & field : this->find(Model_CustomField::DB_Table_CUSTOMFIELD::REFTYPE(RefType)))
 //    {
 //        fields.push_back(field);
@@ -132,7 +132,7 @@ const wxString Model_CustomField::getTooltip(const wxString& Properties)
 
 int Model_CustomField::getReference(const wxString& Properties)
 {
-    int ref_type_id = Model_Attachment::instance().all_type().Index(Properties);
+    int ref_type_id = Model_Attachment::REFTYPE_STR.Index(Properties);
     return ref_type_id;
 }
 
@@ -207,14 +207,14 @@ const wxString Model_CustomField::getUDFC(const wxString& Properties)
     return "";
 }
 
-const std::map<wxString, int64> Model_CustomField::getMatrix(Model_Attachment::REFTYPE reftype)
+const std::map<wxString, int64> Model_CustomField::getMatrix(Model_Attachment::REFTYPE_ID reftype)
 {
     std::map<wxString, int64> m;
-    const wxString& reftype_desc = Model_Attachment::reftype_desc(reftype);
+    const wxString& reftype_str = Model_Attachment::REFTYPE_STR[reftype];
     for (const auto& entry : UDFC_FIELDS())
     {
         if (entry.empty()) continue;
-        m[entry] = getUDFCID(reftype_desc, entry);
+        m[entry] = getUDFCID(reftype_str, entry);
     }
     return m;
 }
@@ -317,7 +317,7 @@ const wxArrayString Model_CustomField::UDFC_FIELDS()
 
 const wxArrayString Model_CustomField::getUDFCList(DB_Table_CUSTOMFIELD_V1::Data* r)
 {
-    const wxString& ref_type = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
     const auto& a = Model_CustomField::instance().find(Model_CustomField::DB_Table_CUSTOMFIELD_V1::REFTYPE(ref_type));
 
     wxArrayString choices = UDFC_FIELDS();

--- a/src/model/Model_CustomField.h
+++ b/src/model/Model_CustomField.h
@@ -80,7 +80,7 @@ public:
     static TYPE_ID getUDFCType(const wxString& ref_type, const wxString& name);
     static const wxString getUDFCProperties(const wxString& ref_type, const wxString& name);
     static int64 getUDFCID(const wxString& ref_type, const wxString& name);
-    static const std::map<wxString, int64> getMatrix(Model_Attachment::REFTYPE reftype);
+    static const std::map<wxString, int64> getMatrix(Model_Attachment::REFTYPE_ID reftype);
     static int getDigitScale(const wxString& Properties);
     static const wxString formatProperties(const wxString& Tooltip, const wxString& RegEx
         , bool Autocomplete, const wxString& Default, const wxArrayString& Choices

--- a/src/model/Model_CustomFieldData.cpp
+++ b/src/model/Model_CustomFieldData.cpp
@@ -57,11 +57,11 @@ Model_CustomFieldData::Data* Model_CustomFieldData::get(int64 FieldID, int64 Ref
     return nullptr;
 }
 
-std::map<int64, Model_CustomFieldData::Data_Set> Model_CustomFieldData::get_all(Model_Attachment::REFTYPE reftype)
+std::map<int64, Model_CustomFieldData::Data_Set> Model_CustomFieldData::get_all(Model_Attachment::REFTYPE_ID reftype)
 {
-    const wxString& reftype_desc = Model_Attachment::reftype_desc(reftype);
+    const wxString& reftype_str = Model_Attachment::REFTYPE_STR[reftype];
     Model_CustomField::Data_Set custom_fields = Model_CustomField::instance()
-        .find(Model_CustomField::DB_Table_CUSTOMFIELD_V1::REFTYPE(reftype_desc));
+        .find(Model_CustomField::DB_Table_CUSTOMFIELD_V1::REFTYPE(reftype_str));
     std::map<int64, Model_CustomFieldData::Data_Set> data;
     for (const auto& entry : custom_fields)
     {

--- a/src/model/Model_CustomFieldData.h
+++ b/src/model/Model_CustomFieldData.h
@@ -48,7 +48,7 @@ public:
     static Model_CustomFieldData& instance();
 
 public:
-    std::map<int64, Data_Set> get_all(Model_Attachment::REFTYPE reftype);
+    std::map<int64, Data_Set> get_all(Model_Attachment::REFTYPE_ID reftype);
     Data* get(int64 FieldID, int64 RefID);
     wxArrayString allValue(const int64 FieldID);
     static bool DeleteAllData(const wxString& RefType, int64 RefID);

--- a/src/model/Model_Splittransaction.cpp
+++ b/src/model/Model_Splittransaction.cpp
@@ -53,7 +53,7 @@ Model_Splittransaction& Model_Splittransaction::instance()
 bool Model_Splittransaction::remove(int64 id)
 {
     // Delete all tags for the split before removing it
-    Model_Taglink::instance().DeleteAllTags(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT), id);
+    Model_Taglink::instance().DeleteAllTags(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT, id);
     return this->remove(id, db_);
 }
 

--- a/src/model/Model_Stock.cpp
+++ b/src/model/Model_Stock.cpp
@@ -188,7 +188,7 @@ double Model_Stock::getDailyBalanceAt(const Model_Account::Data *account, const 
 
         double numShares = 0.0;
 
-        Model_Translink::Data_Set linkrecords = Model_Translink::TranslinkList(Model_Attachment::REFTYPE::STOCK, stock.STOCKID);
+        Model_Translink::Data_Set linkrecords = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, stock.STOCKID);
         for (const auto& linkrecord : linkrecords)
         {
             Model_Checking::Data* txn = Model_Checking::instance().get(linkrecord.CHECKINGACCOUNTID);
@@ -218,7 +218,7 @@ to base currency.
 double Model_Stock::RealGainLoss(const Data* r, bool to_base_curr)
 {
     Model_Currency::Data* currency = Model_Account::currency(Model_Account::instance().get(r->HELDAT));
-    Model_Translink::Data_Set trans_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE::STOCK, r->STOCKID);
+    Model_Translink::Data_Set trans_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, r->STOCKID);
     double real_gain_loss = 0;
     double total_shares = 0;
     double total_initial_value = 0;
@@ -289,7 +289,7 @@ double Model_Stock::UnrealGainLoss(const Data* r, bool to_base_curr)
     {
         Model_Currency::Data* currency = Model_Account::currency(Model_Account::instance().get(r->HELDAT));
         double conv_rate = Model_CurrencyHistory::getDayRate(currency->CURRENCYID);
-        Model_Translink::Data_Set trans_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE::STOCK, r->STOCKID);
+        Model_Translink::Data_Set trans_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, r->STOCKID);
         if (!trans_list.empty())
         {
             double total_shares = 0;

--- a/src/model/Model_Tag.cpp
+++ b/src/model/Model_Tag.cpp
@@ -69,13 +69,13 @@ int Model_Tag::is_used(int64 id)
 
     for (const auto& link : taglink)
     {
-        if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+        if (link.REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTION)
         {
             Model_Checking::Data* t = Model_Checking::instance().get(link.REFID);
             if (t && t->DELETEDTIME.IsEmpty())
                 return 1;
         }
-        else if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT))
+        else if (link.REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT)
         {
             Model_Splittransaction::Data* s = Model_Splittransaction::instance().get(link.REFID);
             if (s)

--- a/src/model/Model_Taglink.cpp
+++ b/src/model/Model_Taglink.cpp
@@ -123,9 +123,9 @@ int Model_Taglink::update(const Data_Set& rows, const wxString& refType, int64 r
 
     if (updateTimestamp)
     {
-        if (refType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+        if (refType == Model_Attachment::REFTYPE_STR_TRANSACTION)
             Model_Checking::instance().updateTimestamp(refId);
-        else if (refType == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT))
+        else if (refType == Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT)
             Model_Checking::instance().updateTimestamp(Model_Splittransaction::instance().get(refId)->TRANSID);
     }
 

--- a/src/model/Model_Translink.cpp
+++ b/src/model/Model_Translink.cpp
@@ -67,7 +67,7 @@ Model_Translink::Data* Model_Translink::SetAssetTranslink(const int64 asset_id
     , const CHECKING_TYPE checking_type)
 {
     return SetTranslink(checking_id, checking_type
-        , Model_Attachment::reftype_desc(Model_Attachment::ASSET), asset_id);
+        , Model_Attachment::REFTYPE_STR_ASSET, asset_id);
 }
 
 Model_Translink::Data* Model_Translink::SetStockTranslink(const int64 stock_id
@@ -75,7 +75,7 @@ Model_Translink::Data* Model_Translink::SetStockTranslink(const int64 stock_id
     , const CHECKING_TYPE checking_type)
 {
     return SetTranslink(checking_id, checking_type
-        , Model_Attachment::reftype_desc(Model_Attachment::STOCK), stock_id);
+        , Model_Attachment::REFTYPE_STR_STOCK, stock_id);
 }
 
 Model_Translink::Data* Model_Translink::SetTranslink(const int64 checking_id
@@ -99,11 +99,11 @@ Model_Translink::Data* Model_Translink::SetTranslink(const int64 checking_id
     return translink;
 }
 
-Model_Translink::Data_Set Model_Translink::TranslinkList(Model_Attachment::REFTYPE link_table
+Model_Translink::Data_Set Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID link_table
     , const int64 link_entry_id)
 {
     Model_Translink::Data_Set translink_list = Model_Translink::instance().find(
-        Model_Translink::LINKTYPE(Model_Attachment::reftype_desc(link_table))
+        Model_Translink::LINKTYPE(Model_Attachment::REFTYPE_STR[link_table])
         , Model_Translink::LINKRECORDID(link_entry_id));
 
     return translink_list;
@@ -111,7 +111,7 @@ Model_Translink::Data_Set Model_Translink::TranslinkList(Model_Attachment::REFTY
 
 bool Model_Translink::HasShares(const int64 stock_id)
 {
-    if (TranslinkList(Model_Attachment::STOCK, stock_id).empty())
+    if (TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, stock_id).empty())
     {
         return false;
     }
@@ -132,7 +132,7 @@ Model_Translink::Data Model_Translink::TranslinkRecord(const int64 checking_id)
     }
 }
 
-void Model_Translink::RemoveTransLinkRecords(Model_Attachment::REFTYPE table_type, const int64 entry_id)
+void Model_Translink::RemoveTransLinkRecords(Model_Attachment::REFTYPE_ID table_type, const int64 entry_id)
 {
     for (const auto& translink : TranslinkList(table_type, entry_id))
     {
@@ -146,13 +146,13 @@ void Model_Translink::RemoveTranslinkEntry(const int64 checking_account_id)
     Model_Shareinfo::RemoveShareEntry(translink.CHECKINGACCOUNTID);
     Model_Translink::instance().remove(translink.TRANSLINKID);
 
-    if (translink.LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::ASSET))
+    if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_ASSET)
     {
         Model_Asset::Data* asset_entry = Model_Asset::instance().get(translink.LINKRECORDID);
         UpdateAssetValue(asset_entry);
     }
 
-    if (translink.LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::STOCK))
+    if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK)
     {
         Model_Stock::Data* stock_entry = Model_Stock::instance().get(translink.LINKRECORDID);
         UpdateStockValue(stock_entry);
@@ -161,7 +161,7 @@ void Model_Translink::RemoveTranslinkEntry(const int64 checking_account_id)
 
 void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
 {
-    Data_Set trans_list = TranslinkList(Model_Attachment::REFTYPE::STOCK, stock_entry->STOCKID);
+    Data_Set trans_list = TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, stock_entry->STOCKID);
     double total_shares = 0;
     double total_initial_value = 0;
     double total_commission = 0;
@@ -217,7 +217,7 @@ void Model_Translink::UpdateStockValue(Model_Stock::Data* stock_entry)
 
 void Model_Translink::UpdateAssetValue(Model_Asset::Data* asset_entry)
 {
-    Data_Set trans_list = TranslinkList(Model_Attachment::REFTYPE::ASSET, asset_entry->ASSETID);
+    Data_Set trans_list = TranslinkList(Model_Attachment::REFTYPE_ID_ASSET, asset_entry->ASSETID);
     double new_value = 0;
     for (const auto &trans : trans_list)
     {
@@ -247,7 +247,7 @@ void Model_Translink::UpdateAssetValue(Model_Asset::Data* asset_entry)
 
 bool Model_Translink::ShareAccountId(int64& stock_entry_id)
 {
-    Model_Translink::Data_Set stock_translink_list = TranslinkList(Model_Attachment::STOCK, stock_entry_id);
+    Model_Translink::Data_Set stock_translink_list = TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, stock_entry_id);
 
     if (!stock_translink_list.empty())
     {

--- a/src/model/Model_Translink.h
+++ b/src/model/Model_Translink.h
@@ -69,7 +69,7 @@ public:
     select * from TRANSLINK_V1 where LINKTYPE = "Asset" AND LINKRECORDID = link_id;
     select * from TRANSLINK_V1 where LINKTYPE = "Stock" AND LINKRECORDID = link_id;
     */
-    static Model_Translink::Data_Set TranslinkList(Model_Attachment::REFTYPE link_table
+    static Model_Translink::Data_Set TranslinkList(Model_Attachment::REFTYPE_ID link_table
         , const int64 link_id);
 
     static bool HasShares(const int64 stock_id);
@@ -82,7 +82,7 @@ public:
     static Model_Translink::Data TranslinkRecord(const int64 checking_id);
 
     /* Remove all records associated with the Translink list */
-    static void RemoveTransLinkRecords(Model_Attachment::REFTYPE table_type, const int64 entry_id);
+    static void RemoveTransLinkRecords(Model_Attachment::REFTYPE_ID table_type, const int64 entry_id);
  
     /* Remove the checking account entry and its associated transfer transaction. */
     static void RemoveTranslinkEntry(const int64 checking_account_id);

--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -764,7 +764,7 @@ void mmPayeeDialog::DeletePayee()
                     Model_Splittransaction::instance().Savepoint();
                     Model_Attachment::instance().Savepoint();
                     Model_CustomFieldData::instance().Savepoint();
-                    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+                    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
 
                     for (auto& tran : deletedTrans) {
                         Model_Checking::instance().remove(tran.TRANSID);
@@ -779,7 +779,7 @@ void mmPayeeDialog::DeletePayee()
                 }
 
                 Model_Payee::instance().remove(p);
-                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::PAYEE), p);
+                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_PAYEE, p);
                 m_payee_id = -1;
                 refreshRequested_ = true;
                 fillControls();
@@ -820,7 +820,7 @@ void mmPayeeDialog::RemoveDefaultCategory()
 
 void mmPayeeDialog::OnOrganizeAttachments()
 {
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::PAYEE);
+    wxString RefType = Model_Attachment::REFTYPE_STR_PAYEE;
 
     mmAttachmentDialog dlg(this, RefType, m_payee_id);
     dlg.ShowModal();

--- a/src/relocatepayeedialog.cpp
+++ b/src/relocatepayeedialog.cpp
@@ -178,7 +178,7 @@ void relocatePayeeDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         {
             if (Model_Payee::instance().remove(sourcePayeeID_))
             {
-                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::PAYEE), sourcePayeeID_);
+                mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_PAYEE, sourcePayeeID_);
                 mmWebApp::MMEX_WebApp_UpdatePayee();
             }
             cbSourcePayee_->mmDoReInitialize();

--- a/src/relocatetagdialog.cpp
+++ b/src/relocatetagdialog.cpp
@@ -187,10 +187,22 @@ void relocateTagDialog::IsOkOk()
     Model_Tag::Data* dest = Model_Tag::instance().get(cbDestTag_->GetValue());
     if (dest) destTagID_ = dest->TAGID;
     if (source) sourceTagID_ = source->TAGID;
-    int trxs_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION)), Model_Taglink::TAGID(sourceTagID_)).size();
-    int split_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT)), Model_Taglink::TAGID(sourceTagID_)).size();
-    int bills_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)), Model_Taglink::TAGID(sourceTagID_)).size();
-    int bill_split_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(Model_Taglink::REFTYPE(Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT)), Model_Taglink::TAGID(sourceTagID_)).size();
+    int trxs_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_TRANSACTION),
+        Model_Taglink::TAGID(sourceTagID_)
+    ).size();
+    int split_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT),
+        Model_Taglink::TAGID(sourceTagID_)
+    ).size();
+    int bills_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
+        Model_Taglink::TAGID(sourceTagID_)
+    ).size();
+    int bill_split_size = (sourceTagID_ < 0) ? 0 : Model_Taglink::instance().find(
+        Model_Taglink::REFTYPE(Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT),
+        Model_Taglink::TAGID(sourceTagID_)
+    ).size();
 
     if (destTagID_ < 0 || sourceTagID_ < 0
         || destTagID_ == sourceTagID_

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -126,7 +126,7 @@ table {
     hb.DisplayFooter(_("Accounts: ") + accounts_label);
 
     m_noOfCols = (m_transDialog->mmIsHideColumnsChecked()) ? m_transDialog->mmGetHideColumnsID().GetCount() : 11;
-    const wxString& AttRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& AttRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     const int groupBy = m_transDialog->mmGetGroupBy();
     const int chart = m_transDialog->mmGetChart();
     wxString lastSortLabel = "";
@@ -139,7 +139,7 @@ table {
     std::map<int64, double> grand_total_in_base_curr_extrans; //Grand - Store transactions amount daily converted to base currency - excluding TRANSFERS
     std::map<wxString, double> values_chart; // Store grouped values for chart
 
-    const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     Model_CustomField::TYPE_ID UDFC01_Type = Model_CustomField::getUDFCType(RefType, "UDFC01");
     Model_CustomField::TYPE_ID UDFC02_Type = Model_CustomField::getUDFCType(RefType, "UDFC02");
     Model_CustomField::TYPE_ID UDFC03_Type = Model_CustomField::getUDFCType(RefType, "UDFC03");
@@ -227,7 +227,7 @@ table {
                 hb.addTableHeaderCell(_("FX Rate"), "Rate text-right");
             if (showColumnById(mmFilterTransactionsDialog::COL_NOTES))
                 hb.addTableHeaderCell(_("Notes"), "Notes");
-            const auto& ref_type = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
             int colNo = mmFilterTransactionsDialog::COL_UDFC01;
             for (const auto& udfc_entry : Model_CustomField::UDFC_FIELDS())
             {
@@ -267,7 +267,7 @@ table {
         bool is_time_used = Option::instance().UseTransDateTime();
         const wxString mask = is_time_used ? "%Y-%m-%dT%H:%M:%S" : "%Y-%m-%d";
 
-        auto custom_fields_data = Model_CustomFieldData::instance().get_all(Model_Attachment::TRANSACTION);
+        auto custom_fields_data = Model_CustomFieldData::instance().get_all(Model_Attachment::REFTYPE_ID_TRANSACTION);
         while (noOfTrans--)
         {
             hb.startTableRow();
@@ -377,7 +377,7 @@ table {
 
                 // Custom Fields
 
-                const auto matrix = Model_CustomField::getMatrix(Model_Attachment::TRANSACTION);
+                const auto matrix = Model_CustomField::getMatrix(Model_Attachment::REFTYPE_ID_TRANSACTION);
                 int64 udfc01_ref_id = matrix.at("UDFC01");
                 int64 udfc02_ref_id = matrix.at("UDFC02");
                 int64 udfc03_ref_id = matrix.at("UDFC03");
@@ -573,9 +573,9 @@ void mmReportTransactions::Run(wxSharedPtr<mmFilterTransactionsDialog>& dlg)
 {
     trans_.clear();
     const auto splits = Model_Splittransaction::instance().get_all();
-    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION));
+    const auto tags = Model_Taglink::instance().get_all(Model_Attachment::REFTYPE_STR_TRANSACTION);
     bool combine_splits = dlg.get()->mmIsCombineSplitsChecked();
-    const wxString splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+    const wxString splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
     for (const auto& tran : Model_Checking::instance().all())
     {
         Model_Checking::Full_Data full_tran(tran, splits, tags);

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -71,7 +71,7 @@ ShareTransactionDialog::ShareTransactionDialog(wxWindow* parent, Model_Translink
     {
         m_translink_entry = translink_entry;
         m_stock = Model_Stock::instance().get(translink_entry->LINKRECORDID);
-        if (translink_entry->LINKTYPE == Model_Attachment::reftype_desc(Model_Attachment::STOCK))
+        if (translink_entry->LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK)
         {
             m_share_entry = Model_Shareinfo::ShareEntry(translink_entry->CHECKINGACCOUNTID);
         }
@@ -118,7 +118,7 @@ void ShareTransactionDialog::DataToControls()
     m_stock_symbol_ctrl->Enable(false);
     m_notes_ctrl->Enable(false);
 
-    Model_Translink::Data_Set translink_list = Model_Translink::TranslinkList(Model_Attachment::STOCK, m_stock->STOCKID);
+    Model_Translink::Data_Set translink_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, m_stock->STOCKID);
 
     if (translink_list.empty())
     {   // Set up the transaction as the first entry.
@@ -330,7 +330,7 @@ void ShareTransactionDialog::CreateControls()
 
 void ShareTransactionDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_STOCK;
     if (!this->m_stock)
         mmAttachmentManage::DeleteAllAttachments(RefType, 0);
     EndModal(wxID_CANCEL);
@@ -339,7 +339,7 @@ void ShareTransactionDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 
 void ShareTransactionDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_STOCK;
     if (m_stock_id <= 0)
         mmAttachmentManage::DeleteAllAttachments(RefType, 0);
     EndModal(wxID_CANCEL);

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -154,7 +154,7 @@ void mmStockDialog::CreateControls()
     bool initial_stock_transaction = true;
     if (m_stock)
     {
-        if (!Model_Translink::TranslinkList(Model_Attachment::STOCK, m_stock->STOCKID).empty())
+        if (!Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, m_stock->STOCKID).empty())
         {
             initial_stock_transaction = false;
         }
@@ -344,7 +344,7 @@ void mmStockDialog::CreateControls()
 
 void mmStockDialog::OnQuit(wxCloseEvent& /*event*/)
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_STOCK;
     if (!m_edit)
         mmAttachmentManage::DeleteAllAttachments(RefType, 0);
     EndModal(wxID_CANCEL);
@@ -352,7 +352,7 @@ void mmStockDialog::OnQuit(wxCloseEvent& /*event*/)
 
 void mmStockDialog::OnCancel(wxCommandEvent& /*event*/)
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_STOCK;
     if (m_stock_id <= 0)
         mmAttachmentManage::DeleteAllAttachments(RefType, 0);
     EndModal(wxID_CANCEL);
@@ -360,7 +360,7 @@ void mmStockDialog::OnCancel(wxCommandEvent& /*event*/)
 
 void mmStockDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    const wxString RefType = Model_Attachment::REFTYPE_STR_STOCK;
     int64 RefId = m_stock_id;
 
     if (RefId < 0)
@@ -462,7 +462,7 @@ void mmStockDialog::OnSave(wxCommandEvent & /*event*/)
 
     if (!m_edit)
     {
-        const wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+        const wxString RefType = Model_Attachment::REFTYPE_STR_STOCK;
         mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, m_stock->STOCKID);
     }
 

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -192,7 +192,7 @@ wxString StocksListCtrl::OnGetItemText(long item, long column) const
     {
         wxString full_notes = m_stocks[item].NOTES;
         full_notes.Replace("\n", " ");
-        if (Model_Attachment::NrAttachments(Model_Attachment::reftype_desc(Model_Attachment::STOCK), m_stocks[item].STOCKID))
+        if (Model_Attachment::NrAttachments(Model_Attachment::REFTYPE_STR_STOCK, m_stocks[item].STOCKID))
             full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }
@@ -291,8 +291,8 @@ void StocksListCtrl::OnDeleteStocks(wxCommandEvent& /*event*/)
     if (msgDlg.ShowModal() == wxID_YES)
     {
         Model_Stock::instance().remove(m_stocks[m_selected_row].STOCKID);
-        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::reftype_desc(Model_Attachment::STOCK), m_stocks[m_selected_row].STOCKID);
-        Model_Translink::RemoveTransLinkRecords(Model_Attachment::STOCK, m_stocks[m_selected_row].STOCKID);
+        mmAttachmentManage::DeleteAllAttachments(Model_Attachment::REFTYPE_STR_STOCK, m_stocks[m_selected_row].STOCKID);
+        Model_Translink::RemoveTransLinkRecords(Model_Attachment::REFTYPE_ID_STOCK, m_stocks[m_selected_row].STOCKID);
         DeleteItem(m_selected_row);
         doRefreshItems(-1);
         m_stock_panel->m_frame->RefreshNavigationTree();
@@ -346,7 +346,7 @@ void StocksListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
     if (m_selected_row < 0) return;
 
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    wxString RefType = Model_Attachment::REFTYPE_STR_STOCK;
     int64 RefId = m_stocks[m_selected_row].STOCKID;
 
     mmAttachmentDialog dlg(this, RefType, RefId);
@@ -372,7 +372,7 @@ void StocksListCtrl::OnOpenAttachment(wxCommandEvent& /*event*/)
 {
     if (m_selected_row < 0) return;
 
-    wxString RefType = Model_Attachment::reftype_desc(Model_Attachment::STOCK);
+    wxString RefType = Model_Attachment::REFTYPE_STR_STOCK;
     int64 RefId = m_stocks[m_selected_row].STOCKID;
 
     mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -216,7 +216,7 @@ void mmStocksPanel::ViewStockTransactions(int selectedIndex)
     stockTxnListCtrl->AppendColumn(_("Commission"), wxLIST_FORMAT_RIGHT);
     topsizer->Add(stockTxnListCtrl, wxSizerFlags(g_flagsExpand).TripleBorder());
 
-    const Model_Translink::Data_Set stock_list = Model_Translink::TranslinkList(Model_Attachment::STOCK, stock->STOCKID);
+    const Model_Translink::Data_Set stock_list = Model_Translink::TranslinkList(Model_Attachment::REFTYPE_ID_STOCK, stock->STOCKID);
     Model_Checking::Data_Set checking_list;
     for (const auto &trans : stock_list)
     {

--- a/src/tagdialog.cpp
+++ b/src/tagdialog.cpp
@@ -306,9 +306,9 @@ void mmTagDialog::OnDelete(wxCommandEvent& WXUNUSED(event))
             for (const auto& link : taglinks)
                 // Taglinks for deleted transactions are either TRANSACTION or TRANSACTIONSPLIT type.
                 // Remove the transactions which will delete all associated tags.
-                if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION))
+                if (link.REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTION)
                     Model_Checking::instance().remove(link.REFID);
-                else if (link.REFTYPE == Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT))
+                else if (link.REFTYPE == Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT)
                     Model_Checking::instance().remove(Model_Splittransaction::instance().get(link.REFID)->TRANSID);
             Model_Tag::instance().remove(tag->TAGID);
             tagList_.Remove(selection);

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -455,7 +455,7 @@ void transactionsUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         // Update tags
         if (tag_checkbox_->IsChecked()) {
             Model_Taglink::Data_Set taglinks;
-            const wxString& refType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+            const wxString& refType = Model_Attachment::REFTYPE_STR_TRANSACTION;
             wxArrayInt64 tagIds = tagTextCtrl_->GetTagIDs();
 
             if (tag_append_checkbox_->IsChecked()) {

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -105,8 +105,8 @@ mmTransDialog::mmTransDialog(wxWindow* parent,
         // a bill can only be duplicated
         m_mode = (duplicate || fused_id.second) ? MODE_DUP : MODE_EDIT;
         const wxString& splitRefType = (m_fused_data.m_repeat_num == 0) ?
-            Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT) :
-            Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSITSPLIT);
+            Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT :
+            Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
         for (const auto& split : Fused_Transaction::split(m_fused_data)) {
             wxArrayInt64 tags;
             for (const auto& tag : Model_Taglink::instance().find(
@@ -141,7 +141,7 @@ mmTransDialog::mmTransDialog(wxWindow* parent,
     // If duplicate then we may need to copy the attachments
     if (m_mode == MODE_DUP && Model_Infotable::instance().GetBoolInfo("ATTACHMENTSDUPLICATE", false))
     {
-        const wxString& refType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+        const wxString& refType = Model_Attachment::REFTYPE_STR_TRANSACTION;
         mmAttachmentManage::CloneAllAttachments(refType, fused_id.first, -1);
     }
 
@@ -368,8 +368,8 @@ void mmTransDialog::dataToControls()
         wxArrayInt64 tagIds;
         for (const auto& tag : Model_Taglink::instance().find(
             Model_Taglink::REFTYPE((m_fused_data.m_repeat_num == 0) ?
-                Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) :
-                Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT)),
+                Model_Attachment::REFTYPE_STR_TRANSACTION :
+                Model_Attachment::REFTYPE_STR_BILLSDEPOSIT),
             Model_Taglink::REFID((m_fused_data.m_repeat_num == 0) ?
                 m_fused_data.TRANSID :
                 m_fused_data.m_bdid))
@@ -1116,8 +1116,8 @@ void mmTransDialog::OnCategs(wxCommandEvent& WXUNUSED(event))
 void mmTransDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
     const wxString& refType = (m_fused_data.m_repeat_num == 0) ?
-        Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) :
-        Model_Attachment::reftype_desc(Model_Attachment::BILLSDEPOSIT);
+        Model_Attachment::REFTYPE_STR_TRANSACTION :
+        Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
     int64 transID = (m_mode == MODE_DUP) ? -1 : m_fused_data.TRANSID;
     mmAttachmentDialog dlg(this, refType, transID);
     dlg.ShowModal();
@@ -1224,7 +1224,7 @@ void mmTransDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     Model_Splittransaction::instance().update(splt, m_fused_data.TRANSID);
 
     // Save split tags
-    const wxString& splitRefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTIONSPLIT);
+    const wxString& splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
 
     for (unsigned int i = 0; i < m_local_splits.size(); i++)
     {
@@ -1239,7 +1239,7 @@ void mmTransDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         }
         Model_Taglink::instance().update(splitTaglinks, splitRefType, splt.at(i).SPLITTRANSID);
     }
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     if (m_mode != MODE_EDIT) {
         mmAttachmentManage::RelocateAllAttachments(RefType, -1, RefType, m_fused_data.TRANSID);
     }
@@ -1282,7 +1282,7 @@ void mmTransDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 #endif
 
     if (m_mode != MODE_EDIT) {
-        const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+        const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
         mmAttachmentManage::DeleteAllAttachments(RefType, -1);
         Model_CustomFieldData::instance().DeleteAllData(RefType, -1);
     }
@@ -1340,7 +1340,7 @@ void mmTransDialog::SetTooltips()
 
 void mmTransDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     if (m_mode != MODE_EDIT) {
         mmAttachmentManage::DeleteAllAttachments(RefType, -1);
         Model_CustomFieldData::instance().DeleteAllData(RefType, -1);

--- a/src/usertransactionpanel.cpp
+++ b/src/usertransactionpanel.cpp
@@ -351,7 +351,7 @@ void UserTransactionPanel::onSelectedNote(wxCommandEvent& event)
 
 void UserTransactionPanel::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+    const wxString& RefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
     int64 RefId = m_transaction_id;
 
     if (RefId < 0)

--- a/src/webapp.cpp
+++ b/src/webapp.cpp
@@ -616,7 +616,7 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
                     if (DesktopAttachmentName != wxEmptyString)
                     {
                         Model_Attachment::Data* NewAttachment = Model_Attachment::instance().create();
-                        NewAttachment->REFTYPE = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION);
+                        NewAttachment->REFTYPE = Model_Attachment::REFTYPE_STR_TRANSACTION;
                         NewAttachment->REFID = DeskNewTrID;
                         NewAttachment->DESCRIPTION = _("Attachment") + "_" << AttachmentNr;
                         NewAttachment->FILENAME = DesktopAttachmentName;
@@ -666,10 +666,10 @@ bool mmWebApp::WebApp_DeleteOneTransaction(int64 WebAppTransactionId)
 wxString mmWebApp::WebApp_DownloadOneAttachment(const wxString& AttachmentName, int64 DesktopTransactionID, int AttachmentNr, wxString& Error)
 {
     wxString FileExtension = wxFileName(AttachmentName).GetExt().MakeLower();
-    wxString FileName = Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) + "_" + wxString::Format("%lld", DesktopTransactionID)
+    wxString FileName = Model_Attachment::REFTYPE_STR_TRANSACTION + "_" + wxString::Format("%lld", DesktopTransactionID)
         + "_Attach" + wxString::Format("%i", AttachmentNr) + "." + FileExtension;
     const wxString FilePath = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting())
-        + Model_Attachment::reftype_desc(Model_Attachment::TRANSACTION) + wxFileName::GetPathSeparator() + FileName;
+        + Model_Attachment::REFTYPE_STR_TRANSACTION + wxFileName::GetPathSeparator() + FileName;
     wxString URL = mmWebApp::getServicesPageURL() + "&" + WebAppParam::DownloadAttachments + "=" + AttachmentName;
     CURLcode CurlStatus = http_download_file(URL, FilePath);
     if (CurlStatus == CURLE_OK)


### PR DESCRIPTION
## Changes in `Model_Attachment`

- Rename enum `REFTYPE` -> `REFTYPE_ID`
- Add prefix `REFTYPE_ID_` into enum cases
- Create static wxArrayString `REFTYPE_STR`
- Create static wxString `REFTYPE_STR_*`
- Rename `all_type()` -> `reftype_str_all()`
- Remove `reftype_desc()`; replace with `REFTYPE_STR[]` or `REFTYPE_STR_*`

## Change in `Model_Budget::copyBudgetYear()`

- `PERIOD_CHOICES[PERIOD_ID_MONTHLY].second` -> `PERIOD_STR[PERIOD_ID_MONTHLY]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7046)
<!-- Reviewable:end -->
