### PR TITLE
fix(#7059): filter by statementdate in mmCheckingPanel

### DIFF
--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -458,7 +458,7 @@ void mmCheckingPanel::OnMouseLeftDown(wxCommandEvent& event)
     int id = 0;
     for (const auto& item : FILTER_STR)
     {
-        if (!isAllAccounts_ || (FILTER_ID_STATEMENTDATE != id))
+        if ((!isAllAccounts_ && !isTrash_) || (FILTER_ID_STATEMENTDATE != id))
             menu.Append(wxID_HIGHEST + id, wxGetTranslation(item));
         id++;
     }


### PR DESCRIPTION
## Problem

MMEX version:
- [X] 1.8.1
- [X] master (as of 2024-12-26)

Operating system:
- [X] macOS

The application crashes when "View Since Statement Date" is selected in the filter of "Deleted Transactions". This option does not make sense for deleted transactions and should not be available.

## Fix

- Disable `FILTER_ID_STATEMENTDATE` if `isTrash_`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7062)
<!-- Reviewable:end -->
