### PR TITLE
new(#7059), part 4: refine mmCheckingPanel

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -1080,7 +1080,7 @@ void TransactionListCtrl::OnDuplicateTransaction(wxCommandEvent& WXUNUSED(event)
     FindSelectedTransactions();
     Fused_Transaction::IdRepeat id = m_selected_id[0];
 
-    mmTransDialog dlg(this, m_cp->m_checking_id, {id.first, id.second != 0}, true);
+    mmTransDialog dlg(this, m_cp->m_account_id, {id.first, id.second != 0}, true);
     if (dlg.ShowModal() != wxID_CANCEL) {
         m_selected_id.clear();
         m_pasted_id.push_back({dlg.GetTransactionID(), 0});
@@ -1630,7 +1630,7 @@ void TransactionListCtrl::OnEditTransaction(wxCommandEvent& /*event*/)
             }
         }
         else {
-            mmTransDialog dlg(this, m_cp->m_checking_id, {id.first, false});
+            mmTransDialog dlg(this, m_cp->m_account_id, {id.first, false});
             if (dlg.ShowModal() != wxID_CANCEL)
                 refreshVisualList();
         }
@@ -1663,7 +1663,7 @@ void TransactionListCtrl::OnNewTransaction(wxCommandEvent& event)
         break;
     }
 
-    mmTransDialog dlg(this, m_cp->m_checking_id, {0, false}, false, type);
+    mmTransDialog dlg(this, m_cp->m_account_id, {0, false}, false, type);
     int i = dlg.ShowModal();
     if (i != wxID_CANCEL) {
         m_selected_id.clear();
@@ -1849,8 +1849,8 @@ void TransactionListCtrl::OnViewOtherAccount(wxCommandEvent& /*event*/)
         Fused_Transaction::Full_Data(*Model_Checking::instance().get(id.first)) :
         Fused_Transaction::Full_Data(*Model_Billsdeposits::instance().get(id.first));
 
-    int64 gotoAccountID = (m_cp->m_checking_id == tran.ACCOUNTID) ? tran.TOACCOUNTID : tran.ACCOUNTID;
-    wxString gotoAccountName = (m_cp->m_checking_id == tran.ACCOUNTID) ? tran.TOACCOUNTNAME : tran.ACCOUNTNAME;   
+    int64 gotoAccountID = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTID : tran.ACCOUNTID;
+    wxString gotoAccountName = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTNAME : tran.ACCOUNTNAME;   
 
     m_cp->m_frame->setNavTreeAccount(gotoAccountName);
     m_cp->m_frame->setGotoAccountID(gotoAccountID, id);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -143,8 +143,7 @@ bool mmCheckingPanel::Create(
     wxWindow* parent,
     const wxPoint& pos, const wxSize& size,
     long style, const wxString& name
-)
-{
+) {
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
     if (!wxPanel::Create(parent, mmID_CHECKING, pos, size, style, name))
         return false;
@@ -164,7 +163,7 @@ bool mmCheckingPanel::Create(
             wxString::Format("CHECK_FILTER_ID_ADV_%lld", m_checking_id),
             def_view
         );
-        m_trans_filter_dlg = new mmFilterTransactionsDialog(parent, m_checking_id, false, json);
+        m_trans_filter_dlg = new mmFilterTransactionsDialog(parent, m_account_id, false, json);
         m_bitmapTransFilter->SetToolTip(m_trans_filter_dlg->mmGetDescriptionToolTip());
     }
 
@@ -970,14 +969,17 @@ void mmCheckingPanel::OnOpenAttachment(wxCommandEvent& event)
 
 void mmCheckingPanel::initFilterChoices()
 {
-    const wxString& def_view = wxString::Format("{ \"FILTER\": \"%s\" }",
-        Model_Setting::instance().ViewTransactions());
+    const wxString& def_view = wxString::Format(
+        "{ \"FILTER\": \"%s\" }",
+        Model_Setting::instance().ViewTransactions()
+    );
     const auto& data = Model_Infotable::instance().GetStringInfo(
-        wxString::Format("CHECK_FILTER_ID_%lld", m_checking_id), def_view);
+        wxString::Format("CHECK_FILTER_ID_%lld", m_checking_id),
+        def_view
+    );
     Document j_doc;
-    if (j_doc.Parse(data.utf8_str()).HasParseError()) {
+    if (j_doc.Parse(data.utf8_str()).HasParseError())
         j_doc.Parse("{}");
-    }
 
     Value& j_filter = GetValueByPointerWithDefault(j_doc, "/FILTER", "");
     m_filter_id = j_filter.IsString() ?
@@ -1032,7 +1034,10 @@ void mmCheckingPanel::saveFilterChoices()
     }
 
     json = JSON_PrettyFormated(j_doc);
-    Model_Infotable::instance().Set(wxString::Format("CHECK_FILTER_ID_%lld", m_checking_id), json);
+    Model_Infotable::instance().Set(
+        wxString::Format("CHECK_FILTER_ID_%lld", m_checking_id),
+        json
+    );
 }
 //----------------------------------------------------------------------------
 
@@ -1143,7 +1148,7 @@ void mmCheckingPanel::OnViewPopupSelected(wxCommandEvent& event)
                 def_view
             );
             m_trans_filter_dlg.reset(
-                new mmFilterTransactionsDialog(this, m_checking_id, false, json)
+                new mmFilterTransactionsDialog(this, m_account_id, false, json)
             );
         }
 
@@ -1152,7 +1157,7 @@ void mmCheckingPanel::OnViewPopupSelected(wxCommandEvent& event)
         if (oldView == FILTER_ID_DIALOG) {
             if (status != wxID_OK)
                 m_trans_filter_dlg.reset(
-                    new mmFilterTransactionsDialog(this, m_checking_id, false, json_settings)
+                    new mmFilterTransactionsDialog(this, m_account_id, false, json_settings)
                 );
         }
         else {
@@ -1206,7 +1211,7 @@ void mmCheckingPanel::DisplaySplitCategories(Fused_Transaction::IdB fused_id)
     }
     if (splits.empty()) return;
     int tranType = Model_Checking::type_id(fused.TRANSCODE);
-    mmSplitTransactionDialog splitTransDialog(this, splits, m_checking_id, tranType, 0.0, true);
+    mmSplitTransactionDialog splitTransDialog(this, splits, m_account_id, tranType, 0.0, true);
 
     //splitTransDialog.SetDisplaySplitCategories();
     splitTransDialog.ShowModal();
@@ -1257,7 +1262,7 @@ void mmCheckingPanel::DisplayAccountDetails(int64 account_id)
             def_view
         );
         m_trans_filter_dlg.reset(
-            new mmFilterTransactionsDialog(this, m_checking_id, false, json)
+            new mmFilterTransactionsDialog(this, m_account_id, false, json)
         );
         m_bitmapTransFilter->SetToolTip(
             m_trans_filter_dlg->mmGetDescriptionToolTip()


### PR DESCRIPTION
## Changes in `mmCheckingPanel`

- When a new `mmFilterTransactionsDialog` is created, its `accountID` is set to `m_account_id` (instead of `m_checking_id`).

## Behavior

`mmFilterTransactionsDialog` shows an account filter when its `accountID` argument is equal to -1. `m_account_id` in `mmCheckingPanel` is equal to -1 for all multi-account checking panels (All Transactions, Deleted Transactions, account group).

In `mmFilterTransactionsDialog` for an account group, the list of available accounts is not limited, since the account group itself is an account filter. This feature allows for a search in which any other account appears in a transfer transaction, together with an account from the account group.

## Additional fix

In MMEX 1.8.1, `mmFilterTransactionsDialog` for Deleted Transactions does not show an account filter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7076)
<!-- Reviewable:end -->
