### PR TITLE
new: add sequence number in transactions panel

### DIFF
--- a/src/fusedtransaction.h
+++ b/src/fusedtransaction.h
@@ -61,12 +61,14 @@ public:
         explicit Full_Data(const Model_Checking::Data& t);
         Full_Data(const Model_Checking::Data& t,
             const std::map<int64 /* TRANSID */, Split_Data_Set>& splits,
-            const std::map<int64 /* TRANSID */, Taglink_Data_Set>& tags);
+            const std::map<int64 /* TRANSID */, Taglink_Data_Set>& tags
+        );
         Full_Data(const Model_Billsdeposits::Data& r);
         Full_Data(const Model_Billsdeposits::Data& r, wxString date, int repeat_num);
         Full_Data(const Model_Billsdeposits::Data& r, wxString date, int repeat_num,
             const std::map<int64 /* BDID */, Budgetsplit_Data_Set>& budgetsplits,
-            const std::map<int64 /* BDID */, Taglink_Data_Set>& tags);
+            const std::map<int64 /* BDID */, Taglink_Data_Set>& tags
+        );
         ~Full_Data();
 
         int64 m_bdid;
@@ -80,6 +82,15 @@ public:
         bool operator()(const DATA& x, const DATA& y)
         {
             return (!x.m_repeat_num && (y.m_repeat_num || x.TRANSID < y.TRANSID));
+        }
+    };
+
+    struct SorterByFUSEDTRANSSN
+    { 
+        template<class DATA>
+        bool operator()(const DATA& x, const DATA& y)
+        {
+            return (!x.m_repeat_num && (y.m_repeat_num || x.SN < y.SN));
         }
     };
 

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -911,7 +911,8 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     m_sortCol = toEColumn(ColumnNr);
     g_sortcol = m_sortCol;
 
-    // If primary sort is DATE then secondary is always ID in the same direction
+    // disabled: If primary sort is DATE then secondary is always ID in the same direction
+    // decouple DATE and ID, since SN may be used instead of ID (see #7080)
     if (false && ColumnNr == COL_DATE) {
         prev_g_sortcol = toEColumn(COL_ID);
         prev_g_asc = m_asc;        

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -84,7 +84,7 @@ wxEND_EVENT_TABLE();
 
 TransactionListCtrl::EColumn TransactionListCtrl::toEColumn(const unsigned long col)
 {
-    EColumn res = COL_DEF_SORT;
+    EColumn res = COL_def_sort;
     if (col < m_real_columns.size())
         res = static_cast<EColumn>(col);
     return res;
@@ -96,6 +96,16 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
     Model_CustomField::TYPE_ID type;
 
     switch (m_real_columns[sortcol]) {
+    case TransactionListCtrl::COL_SN: ascend ?
+        std::stable_sort(
+            this->m_trans.begin(), this->m_trans.end(),
+            Fused_Transaction::SorterByFUSEDTRANSSN()
+        ) :
+        std::stable_sort(
+            this->m_trans.rbegin(), this->m_trans.rend(),
+            Fused_Transaction::SorterByFUSEDTRANSSN()
+        );
+        break;
     case TransactionListCtrl::COL_ID: ascend ?
         std::stable_sort(
             this->m_trans.begin(), this->m_trans.end(),
@@ -345,7 +355,7 @@ TransactionListCtrl::TransactionListCtrl(
 
     resetColumns();
 
-    m_default_sort_column = COL_DEF_SORT;
+    m_default_sort_column = COL_def_sort;
     m_today = Option::instance().UseTransDateTime() ?
         wxDateTime::Now().FormatISOCombined() :
         wxDateTime(23, 59, 59, 999).FormatISOCombined();
@@ -359,6 +369,8 @@ void TransactionListCtrl::resetColumns()
     m_real_columns.clear();
     m_columns.push_back(PANEL_COLUMN(" ", 25, wxLIST_FORMAT_CENTER, false));
     m_real_columns.push_back(COL_IMGSTATUS);
+    m_columns.push_back(PANEL_COLUMN(_("SN"), wxLIST_AUTOSIZE, wxLIST_FORMAT_RIGHT, true));
+    m_real_columns.push_back(COL_SN);
     m_columns.push_back(PANEL_COLUMN(_("ID"), wxLIST_AUTOSIZE, wxLIST_FORMAT_RIGHT, true));
     m_real_columns.push_back(COL_ID);
     m_columns.push_back(PANEL_COLUMN(_("Date"), 112, wxLIST_FORMAT_LEFT, true));
@@ -602,6 +614,9 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
             && m_cp->m_account_id != m_trans[row].ACCOUNTID;
 
         switch (m_real_columns[column]) {
+        case COL_SN:
+            copyText_ = m_trans[row].displaySN;
+            break;
         case COL_ID:
             copyText_ = m_trans[row].displayID;
             break;
@@ -879,7 +894,7 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     else
         ColumnNr = m_ColumnHeaderNbr;
 
-    if (0 > ColumnNr || ColumnNr >= COL_MAX || ColumnNr == COL_IMGSTATUS) return;
+    if (0 > ColumnNr || ColumnNr >= COL_size || ColumnNr == COL_IMGSTATUS) return;
 
     /* Clear previous column image */
     if (m_sortCol != ColumnNr) {
@@ -897,7 +912,7 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     g_sortcol = m_sortCol;
 
     // If primary sort is DATE then secondary is always ID in the same direction
-    if (ColumnNr == COL_DATE) {
+    if (false && ColumnNr == COL_DATE) {
         prev_g_sortcol = toEColumn(COL_ID);
         prev_g_asc = m_asc;        
     }
@@ -2047,6 +2062,8 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
     wxDateTime datetime;
     wxString dateFormat = Option::instance().getDateFormat();
     switch (realenum ? column : m_real_columns[column]) {
+    case TransactionListCtrl::COL_SN:
+        return fused.displaySN;
     case TransactionListCtrl::COL_ID:
         return fused.displayID;
     case TransactionListCtrl::COL_ACCOUNT:

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -67,14 +67,15 @@ public:
         COL_UDFC04,
         COL_UDFC05,
         COL_UPDATEDTIME,
-        COL_MAX, // number of columns
-        COL_DEF_SORT = COL_DATE, // don't omit any columns before this
-        COL_DEF_SORT2 = COL_ID 
+        COL_SN,
+        COL_size, // number of columns
+        COL_def_sort = COL_DATE, // don't omit any columns before this
+        COL_def_sort2 = COL_ID 
     };
     EColumn toEColumn(const unsigned long col);
 
-    EColumn g_sortcol = COL_DEF_SORT; // index of primary column to sort by
-    EColumn prev_g_sortcol = COL_DEF_SORT2; // index of secondary column to sort by
+    EColumn g_sortcol = COL_def_sort; // index of primary column to sort by
+    EColumn prev_g_sortcol = COL_def_sort2; // index of secondary column to sort by
     bool g_asc = true; // asc\desc sorting for primary sort column
     bool prev_g_asc = true; // asc\desc sorting for secondary sort column
 
@@ -224,7 +225,7 @@ private:
     /* The topmost visible item - this will be used to set
     where to display the list again after refresh */
     long m_topItemIndex = -1;
-    EColumn m_sortCol = COL_DEF_SORT;
+    EColumn m_sortCol = COL_def_sort;
     wxString m_today;
     bool m_firstSort = true;
     wxString rightClickFilter_;

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -220,8 +220,8 @@ void mmCheckingPanel::filterTable()
         wxDateTime(23, 59, 59, 999).FormatISOCombined();
 
     const auto trans = m_account ?
-        Model_Account::transaction(m_account) :
-        Model_Checking::instance().allByDate();
+        Model_Account::transactionsByDateId(m_account) :
+        Model_Checking::instance().allByDateId();
     const auto trans_splits = Model_Splittransaction::instance().get_all();
     const auto trans_tags = Model_Taglink::instance().get_all(transRefType);
     const auto trans_attachments = Model_Attachment::instance().get_all(

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -221,7 +221,7 @@ void mmCheckingPanel::filterTable()
 
     const auto trans = m_account ?
         Model_Account::transaction(m_account) :
-        Model_Checking::instance().all();
+        Model_Checking::instance().allByDate();
     const auto trans_splits = Model_Splittransaction::instance().get_all();
     const auto trans_tags = Model_Taglink::instance().get_all(transRefType);
     const auto trans_attachments = Model_Attachment::instance().get_all(

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -184,6 +184,7 @@ void mmCheckingPanel::filterTable()
 {
     m_listCtrlAccount->m_trans.clear();
 
+    int sn = 0; // sequence number
     m_account_balance = m_account ? m_account->INITIALBAL : 0.0;
     m_account_reconciled = m_account_balance;
     m_show_reconciled = false;
@@ -391,7 +392,13 @@ void mmCheckingPanel::filterTable()
             // not yet implemented: custom fields for scheduled transaction
         }
 
+        if (repeat_num == 0)
+            full_tran.SN = ++sn;
+
         if (!expandSplits) {
+            full_tran.displaySN = (repeat_num == 0) ?
+                wxString::Format("%ld", full_tran.SN) :
+                wxString("");
             m_listCtrlAccount->m_trans.push_back(full_tran);
             if (isAccount())
                 m_account_flow += account_flow;
@@ -405,11 +412,16 @@ void mmCheckingPanel::filterTable()
         for (const auto& split : full_tran.m_splits) {
             if (!m_trans_filter_dlg->mmIsSplitRecordMatches<Model_Splittransaction>(split))
                 continue;
-            if (repeat_num == 0)
+            if (repeat_num == 0) {
                 full_tran.displayID = wxString::Format("%lld", tran->TRANSID) +
                     "." + wxString::Format("%i", splitIndex);
-            else
+                full_tran.displaySN = wxString::Format("%ld", full_tran.SN) +
+                    "." + wxString::Format("%i", splitIndex);
+            }
+            else {
                 full_tran.displayID = ".";
+                full_tran.displaySN = ".";
+            }
             splitIndex++;
             full_tran.CATEGID = split.CATEGID;
             full_tran.CATEGNAME = Model_Category::full_name(split.CATEGID);
@@ -561,14 +573,14 @@ void mmCheckingPanel::CreateControls()
         isGroup() ? "MULTI" :
         "CHECK";
 
-    long val = m_listCtrlAccount->COL_DEF_SORT;
+    long val = m_listCtrlAccount->COL_def_sort;
     wxString strVal = Model_Setting::instance().GetStringSetting(
         wxString::Format("%s_SORT_COL", m_sortSaveTitle),
         wxString() << val
     );
     if (strVal.ToLong(&val))
         m_listCtrlAccount->g_sortcol = m_listCtrlAccount->toEColumn(val);
-    val = m_listCtrlAccount->COL_DEF_SORT2;
+    val = m_listCtrlAccount->COL_def_sort2;
     strVal = Model_Setting::instance().GetStringSetting(
         wxString::Format("%s_SORT_COL2", m_sortSaveTitle),
         wxString() << val
@@ -738,18 +750,19 @@ void mmCheckingPanel::setAccountSummary()
 
     if (m_account) {
         bool show_displayed_balance_ = (m_transFilterActive || m_filter_id != FILTER_ID_ALL);
-        wxString summaryLine = wxString::Format("%s%s" "%s%s%s" "%s%s%s" "%s%s%s"
-            , _("Account Bal: ")
-            , Model_Account::toCurrency(m_account_balance, m_account)
-            , m_show_reconciled ? "     " : ""
-            , m_show_reconciled ? _("Reconciled Bal: ") : ""
-            , m_show_reconciled ? Model_Account::toCurrency(m_account_reconciled, m_account) : ""
-            , m_show_reconciled ? "     " : ""
-            , m_show_reconciled ? _("Diff: ") : ""
-            , m_show_reconciled ? Model_Account::toCurrency(m_account_balance - m_account_reconciled, m_account) : ""
-            , show_displayed_balance_ ? "     " : ""
-            , show_displayed_balance_ ? _("Filtered Flow: ") : ""
-            , show_displayed_balance_ ? Model_Account::toCurrency(m_account_flow, m_account) : "");
+        wxString summaryLine = wxString::Format("%s%s" "%s%s%s" "%s%s%s" "%s%s%s",
+            _("Account Bal: "),
+            Model_Account::toCurrency(m_account_balance, m_account),
+            m_show_reconciled ? "     " : "",
+            m_show_reconciled ? _("Reconciled Bal: ") : "",
+            m_show_reconciled ? Model_Account::toCurrency(m_account_reconciled, m_account) : "",
+            m_show_reconciled ? "     " : "",
+            m_show_reconciled ? _("Diff: ") : "",
+            m_show_reconciled ? Model_Account::toCurrency(m_account_balance - m_account_reconciled, m_account) : "",
+            show_displayed_balance_ ? "     " : "",
+            show_displayed_balance_ ? _("Filtered Flow: ") : "",
+            show_displayed_balance_ ? Model_Account::toCurrency(m_account_flow, m_account) : ""
+        );
         if (m_account->CREDITLIMIT != 0.0) {
             double limit = 100.0 * ((m_account_balance < 0.0) ? -m_account_balance / m_account->CREDITLIMIT : 0.0);
             summaryLine.Append(

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -215,7 +215,7 @@ Model_Currency::Data* Model_Account::currency(const Data& r)
     return currency(&r);
 }
 
-const Model_Checking::Data_Set Model_Account::transaction(const Data*r)
+const Model_Checking::Data_Set Model_Account::transactionsByDateId(const Data*r)
 {
     auto trans = Model_Checking::instance().find_or(Model_Checking::ACCOUNTID(r->ACCOUNTID)
         , Model_Checking::TOACCOUNTID(r->ACCOUNTID));
@@ -225,9 +225,9 @@ const Model_Checking::Data_Set Model_Account::transaction(const Data*r)
     return trans;
 }
 
-const Model_Checking::Data_Set Model_Account::transaction(const Data& r)
+const Model_Checking::Data_Set Model_Account::transactionsByDateId(const Data& r)
 {
-    return transaction(&r);
+    return transactionsByDateId(&r);
 }
 
 const Model_Billsdeposits::Data_Set Model_Account::billsdeposits(const Data* r)
@@ -243,7 +243,7 @@ const Model_Billsdeposits::Data_Set Model_Account::billsdeposits(const Data& r)
 double Model_Account::balance(const Data* r)
 {
     double sum = r->INITIALBAL;
-    for (const auto& tran: transaction(r))
+    for (const auto& tran: transactionsByDateId(r))
     {
         sum += Model_Checking::account_flow(tran, r->ACCOUNTID); 
     }

--- a/src/model/Model_Account.h
+++ b/src/model/Model_Account.h
@@ -108,8 +108,8 @@ public:
     static Model_Currency::Data* currency(const Data* r);
     static Model_Currency::Data* currency(const Data& r);
 
-    static const Model_Checking::Data_Set transaction(const Data* r);
-    static const Model_Checking::Data_Set transaction(const Data& r);
+    static const Model_Checking::Data_Set transactionsByDateId(const Data* r);
+    static const Model_Checking::Data_Set transactionsByDateId(const Data& r);
 
     static const Model_Billsdeposits::Data_Set billsdeposits(const Data* r);
     static const Model_Billsdeposits::Data_Set billsdeposits(const Data& r);

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -182,6 +182,14 @@ int Model_Checking::save(std::vector<Data*>& rows)
     return rows.size();
 }
 
+const Model_Checking::Data_Set Model_Checking::allByDate()
+{
+    auto trans = Model_Checking::instance().all();
+    std::sort(trans.begin(), trans.end());
+    std::stable_sort(trans.begin(), trans.end(), SorterByTRANSDATE());
+    return trans;
+}
+
 const Model_Splittransaction::Data_Set Model_Checking::split(const Data* r)
 {
     return Model_Splittransaction::instance().find(Model_Splittransaction::TRANSID(r->TRANSID));

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -388,7 +388,7 @@ wxString Model_Checking::status_key(const wxString& r)
 
 Model_Checking::Full_Data::Full_Data() :
     Data(0), TAGNAMES(""),
-    ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
+    SN(0), ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
     ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0),
     UDFC01_val(0), UDFC02_val(0), UDFC03_val(0), UDFC04_val(0), UDFC05_val(0),
     UDFC01_Type(Model_CustomField::TYPE_ID_UNKNOWN),
@@ -401,7 +401,7 @@ Model_Checking::Full_Data::Full_Data() :
 
 Model_Checking::Full_Data::Full_Data(const Data& r) :
     Data(r),
-    ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
+    SN(0), ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
     ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0),
     m_splits(Model_Splittransaction::instance().find(
         Model_Splittransaction::TRANSID(r.TRANSID))),
@@ -412,12 +412,13 @@ Model_Checking::Full_Data::Full_Data(const Data& r) :
     fill_data();
 }
 
-Model_Checking::Full_Data::Full_Data(const Data& r
-    , const std::map<int64 /*trans id*/, Model_Splittransaction::Data_Set /*split trans*/ > & splits
-    , const std::map<int64 /*trans id*/, Model_Taglink::Data_Set /*split trans*/ >& tags)
-:
+Model_Checking::Full_Data::Full_Data(
+    const Data& r,
+    const std::map<int64 /* TRANSID */, Model_Splittransaction::Data_Set>& splits,
+    const std::map<int64 /* TRANSID */, Model_Taglink::Data_Set>& tags
+) :
     Data(r),
-    ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
+    SN(0), ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
     ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0)
 {
     const auto it = splits.find(this->id());

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -182,7 +182,7 @@ int Model_Checking::save(std::vector<Data*>& rows)
     return rows.size();
 }
 
-const Model_Checking::Data_Set Model_Checking::allByDate()
+const Model_Checking::Data_Set Model_Checking::allByDateId()
 {
     auto trans = Model_Checking::instance().all();
     std::sort(trans.begin(), trans.end());

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -199,6 +199,7 @@ public:
     int save(std::vector<Data*>& rows);
     void updateTimestamp(int64 id);
 public:
+    static const Model_Checking::Data_Set allByDate();
     static const Split_Data_Set split(const Data* r);
     static const Split_Data_Set split(const Data& r);
 

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -199,7 +199,7 @@ public:
     int save(std::vector<Data*>& rows);
     void updateTimestamp(int64 id);
 public:
-    static const Model_Checking::Data_Set allByDate();
+    static const Model_Checking::Data_Set allByDateId();
     static const Split_Data_Set split(const Data* r);
     static const Split_Data_Set split(const Data& r);
 

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -77,9 +77,10 @@ public:
     {
         Full_Data();
         explicit Full_Data(const Data& r);
-        Full_Data(const Data& r
-            , const std::map<int64 /*trans id*/, Model_Splittransaction::Data_Set /*split trans*/ > & splits
-            , const std::map<int64 /*trans id*/, Model_Taglink::Data_Set /*split trans*/ >& tags);
+        Full_Data(const Data& r,
+            const std::map<int64 /* TRANSID */, Model_Splittransaction::Data_Set> & splits,
+            const std::map<int64 /* TRANSID */, Model_Taglink::Data_Set> & tags
+        );
         ~Full_Data();
         void fill_data();
         wxString real_payee_name(int64 account_id) const;
@@ -93,27 +94,32 @@ public:
         wxString info() const;
         const wxString to_json();
 
-        Split_Data_Set m_splits;
-        Taglink_Data_Set m_tags;
+        // filled-in by constructor
         wxString displayID;
         wxString ACCOUNTNAME, TOACCOUNTNAME;
         wxString PAYEENAME;
         wxString CATEGNAME;
+        Split_Data_Set m_splits;
+        Taglink_Data_Set m_tags;
         wxString TAGNAMES;
 
+        // filled-in by constructor; overwritten by mmCheckingPanel::filterTable()
         int64 ACCOUNTID_W, ACCOUNTID_D;
         double TRANSAMOUNT_W, TRANSAMOUNT_D;
+
+        // filled-in by mmCheckingPanel::filterTable()
+        long SN;
+        wxString displaySN;
         double ACCOUNT_FLOW;
         double ACCOUNT_BALANCE;
         wxArrayString ATTACHMENT_DESCRIPTION;
-
-        // Reserved string variables for custom data
         wxString UDFC01; double UDFC01_val; Model_CustomField::TYPE_ID UDFC01_Type;
         wxString UDFC02; double UDFC02_val; Model_CustomField::TYPE_ID UDFC02_Type;
         wxString UDFC03; double UDFC03_val; Model_CustomField::TYPE_ID UDFC03_Type;
         wxString UDFC04; double UDFC04_val; Model_CustomField::TYPE_ID UDFC04_Type;
         wxString UDFC05; double UDFC05_val; Model_CustomField::TYPE_ID UDFC05_Type;
     };
+
     typedef std::vector<Full_Data> Full_Data_Set;
 
     struct SorterByBALANCE

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -90,7 +90,7 @@ void mmReportCashFlow::getTransactions()
 
         m_account_id.push_back(account.ACCOUNTID);
 
-        for (const auto& tran : Model_Account::transaction(account))
+        for (const auto& tran : Model_Account::transactionsByDateId(account))
         {
             wxString strDate = Model_Checking::TRANSDATE(tran).FormatISOCombined();
             // Do not include asset or stock transfers in income expense calculations.

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -48,7 +48,7 @@ std::map<wxDate, double> mmReportSummaryByDate::createCheckingBalanceMap(const M
     std::map<wxDate, double> balanceMap;
     double balance = account.INITIALBAL;
 
-    for (const auto& tran : Model_Account::transaction(account))
+    for (const auto& tran : Model_Account::transactionsByDateId(account))
     {
         wxDate date = Model_Checking::TRANSDATE(tran);
         balance += Model_Checking::account_flow(tran, account.ACCOUNTID);


### PR DESCRIPTION
This PR adds a sequence number in transaction panels.

## Motivation

The transaction ID used to be assigned by SQLite and it was essentially a sequence number, indicating the order of creation. With the introduction of SUID (see #6964), the transaction ID is a long number and its appearance in transaction panels becomes less convenient.

The ID column in transaction panels is useful for sorting (by order of creation), although the exact value of a transaction ID is essentially opaque (i.e., of little interest to the user).

This PR adds one more column in transaction panels, containing a sequence number (SN) for each transaction, which is assigned sequentially (starting with 1) when a transactions list is generated. The order of SN is equivalent to the order of Date/ID, i.e., transactions are sorted by Date and ID, and then an SN is assigned to them sequentially.

From user's perspective, either the SN or the ID can be used for sorting. Users may hide one of the two columns, according to their preference. The SN has the advantage that it is a shorter number, but it may be confusing since it is assigned dynamically. On the other hand, the ID is static, but it is a longer number and may look random and confusing.

## Design

The displayed SN for executions of scheduled transactions in a transactions panel, follows the same rules as the displayed ID. The SN of scheduled transactions is empty, while the SN of scheduled splits appears as ".", in order to distinguish the scheduled transactions from the rest of transactions, when either the SN or the ID column is used.

## Implementation

- In `Model_Checking::Full_Data`: add long `SN`, wxString `displaySN`.
- In `Fused_Transaction`: add struct `SorterByFUSEDTRANSSN`.
- Refine `mmCheckingPanel::filterTable()`. Fix bug with wrong filtering when "Ignore Future Transactions" is set.
- In `TransactionListCtrl::EColumn`: add `COL_SN` at the end of the list (in order to preserve already assigned column numbers).
- Refine `TransactionListCtrl`.
- In `TransactionListCtrl::OnColClick()`, break the association between Date and ID.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7080)
<!-- Reviewable:end -->
