### PR TITLE
new(#6860), part 8: add notes for scheduled transactions

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -708,23 +708,23 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
                 copyText_ = mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
             break;
         case COL_UDFC01:
-            copyText_ = menuItemText = m_trans[row].UDFC01;
+            copyText_ = menuItemText = m_trans[row].UDFC_content[0];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC01"));
             break;
         case COL_UDFC02:
-            copyText_ = menuItemText = m_trans[row].UDFC02;
+            copyText_ = menuItemText = m_trans[row].UDFC_content[1];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC02"));
             break;
         case COL_UDFC03:
-            copyText_ = menuItemText = m_trans[row].UDFC03;
+            copyText_ = menuItemText = m_trans[row].UDFC_content[2];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC03"));
             break;
         case COL_UDFC04:
-            copyText_ = menuItemText = m_trans[row].UDFC04;
+            copyText_ = menuItemText = m_trans[row].UDFC_content[3];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC04"));
             break;
         case COL_UDFC05:
-            copyText_ = menuItemText = m_trans[row].UDFC05;
+            copyText_ = menuItemText = m_trans[row].UDFC_content[4];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC05"));
             break;
         default:
@@ -2115,15 +2115,15 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
             return wxString("");
         return mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
     case TransactionListCtrl::COL_UDFC01:
-        return UDFCFormatHelper(fused.UDFC01_Type, fused.UDFC01);
+        return UDFCFormatHelper(fused.UDFC_type[0], fused.UDFC_content[0]);
     case TransactionListCtrl::COL_UDFC02:
-        return UDFCFormatHelper(fused.UDFC02_Type, fused.UDFC02);
+        return UDFCFormatHelper(fused.UDFC_type[1], fused.UDFC_content[1]);
     case TransactionListCtrl::COL_UDFC03:
-        return UDFCFormatHelper(fused.UDFC03_Type, fused.UDFC03);
+        return UDFCFormatHelper(fused.UDFC_type[2], fused.UDFC_content[2]);
     case TransactionListCtrl::COL_UDFC04:
-        return UDFCFormatHelper(fused.UDFC04_Type, fused.UDFC04);
+        return UDFCFormatHelper(fused.UDFC_type[3], fused.UDFC_content[3]);
     case TransactionListCtrl::COL_UDFC05:
-        return UDFCFormatHelper(fused.UDFC05_Type, fused.UDFC05);
+        return UDFCFormatHelper(fused.UDFC_type[4], fused.UDFC_content[4]);
     case TransactionListCtrl::COL_UPDATEDTIME:
         datetime.ParseISOCombined(fused.LASTUPDATEDTIME);
         if (!datetime.IsValid())

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -243,14 +243,54 @@ inline void TransactionListCtrl::setVisibleItemIndex(long v) { m_topItemIndex = 
 
 #endif // MM_EX_CHECKING_LIST_H_
 
-inline static bool SorterByUDFC01(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC01 < j.UDFC01); }
-inline static bool SorterByUDFC02(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC02 < j.UDFC02); }
-inline static bool SorterByUDFC03(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC03 < j.UDFC03); }
-inline static bool SorterByUDFC04(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC04 < j.UDFC04); }
-inline static bool SorterByUDFC05(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC05 < j.UDFC05); }
+inline static bool SorterByUDFC01(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_content[0] < j.UDFC_content[0]);
+}
+inline static bool SorterByUDFC02(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_content[1] < j.UDFC_content[1]);
+}
+inline static bool SorterByUDFC03(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_content[2] < j.UDFC_content[2]);
+}
+inline static bool SorterByUDFC04(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_content[3] < j.UDFC_content[3]);
+}
+inline static bool SorterByUDFC05(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_content[4] < j.UDFC_content[4]);
+}
 
-inline static bool SorterByUDFC01_val(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC01_val < j.UDFC01_val); }
-inline static bool SorterByUDFC02_val(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC02_val < j.UDFC02_val); }
-inline static bool SorterByUDFC03_val(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC03_val < j.UDFC03_val); }
-inline static bool SorterByUDFC04_val(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC04_val < j.UDFC04_val); }
-inline static bool SorterByUDFC05_val(const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j) { return (i.UDFC05_val < j.UDFC05_val); }
+inline static bool SorterByUDFC01_val(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_value[0] < j.UDFC_value[0]);
+}
+inline static bool SorterByUDFC02_val(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_value[1] < j.UDFC_value[1]);
+}
+inline static bool SorterByUDFC03_val(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_value[2] < j.UDFC_value[2]);
+}
+inline static bool SorterByUDFC04_val(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_value[3] < j.UDFC_value[3]);
+}
+inline static bool SorterByUDFC05_val(
+    const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
+) {
+    return (i.UDFC_value[4] < j.UDFC_value[4]);
+}

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -364,8 +364,19 @@ void mmCheckingPanel::filterTable()
                 }
             }
         }
-        else if (repeat_num > 0) {
-            // not yet implemented: custom fields for scheduled transaction
+        else if (repeat_num > 0 && tranFieldData.find(-full_tran.m_bdid) != tranFieldData.end()) {
+            for (const auto& udfc : tranFieldData.at(-full_tran.m_bdid)) {
+                for (int i = 0; i < 5; i++) {
+                    if (udfc.FIELDID == udfc_id[i]) {
+                        full_tran.UDFC_type[i] = udfc_type[i];
+                        full_tran.UDFC_content[i] = udfc.CONTENT;
+                        full_tran.UDFC_value[i] = cleanseNumberStringToDouble(
+                            udfc.CONTENT, udfc_scale[i] > 0
+                        );
+                        break;
+                    }
+                }
+            }
         }
 
         if (repeat_num == 0)

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -190,29 +190,26 @@ void mmCheckingPanel::filterTable()
     m_show_reconciled = false;
     m_account_flow = 0.0;
 
-    const wxString transRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
-    const wxString splitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
-    const wxString billsRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
-    const wxString billsplitRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
+    const wxString tranRefType = Model_Attachment::REFTYPE_STR_TRANSACTION;
+    const wxString billRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
+    const wxString tranSplitRefType = Model_Attachment::REFTYPE_STR_TRANSACTIONSPLIT;
+    const wxString billSplitRefType = Model_Attachment::REFTYPE_STR_BILLSDEPOSITSPLIT;
 
-    Model_CustomField::TYPE_ID UDFC01_Type = Model_CustomField::getUDFCType(transRefType, "UDFC01");
-    Model_CustomField::TYPE_ID UDFC02_Type = Model_CustomField::getUDFCType(transRefType, "UDFC02");
-    Model_CustomField::TYPE_ID UDFC03_Type = Model_CustomField::getUDFCType(transRefType, "UDFC03");
-    Model_CustomField::TYPE_ID UDFC04_Type = Model_CustomField::getUDFCType(transRefType, "UDFC04");
-    Model_CustomField::TYPE_ID UDFC05_Type = Model_CustomField::getUDFCType(transRefType, "UDFC05");
-    int UDFC01_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC01"));
-    int UDFC02_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC02"));
-    int UDFC03_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC03"));
-    int UDFC04_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC04"));
-    int UDFC05_Scale = Model_CustomField::getDigitScale(Model_CustomField::getUDFCProperties(transRefType, "UDFC05"));
+    static wxArrayString udfc_fields = Model_CustomField::UDFC_FIELDS();
+    int64 udfc_id[5];
+    Model_CustomField::TYPE_ID udfc_type[5];
+    int udfc_scale[5];
+    for (int i = 0; i < 5; i++) {
+        // note: udfc_fields starts with ""
+        wxString field = udfc_fields[i+1];
+        udfc_id[i] = Model_CustomField::getUDFCID(tranRefType, field);
+        udfc_type[i] = Model_CustomField::getUDFCType(tranRefType, field);
+        udfc_scale[i] = Model_CustomField::getDigitScale(
+            Model_CustomField::getUDFCProperties(tranRefType, field)
+        );
+    }
 
-    auto trans_fields_data = Model_CustomFieldData::instance().get_all(Model_Attachment::REFTYPE_ID_TRANSACTION);
-    const auto matrix = Model_CustomField::getMatrix(Model_Attachment::REFTYPE_ID_TRANSACTION);
-    int64 udfc01_ref_id = matrix.at("UDFC01");
-    int64 udfc02_ref_id = matrix.at("UDFC02");
-    int64 udfc03_ref_id = matrix.at("UDFC03");
-    int64 udfc04_ref_id = matrix.at("UDFC04");
-    int64 udfc05_ref_id = matrix.at("UDFC05");
+    auto tranFieldData = Model_CustomFieldData::instance().get_all(Model_Attachment::REFTYPE_ID_TRANSACTION);
 
     bool ignore_future = Option::instance().getIgnoreFutureTransactions();
     const wxString today_date = Option::instance().UseTransDateTime() ?
@@ -223,7 +220,7 @@ void mmCheckingPanel::filterTable()
         Model_Account::transactionsByDateId(m_account) :
         Model_Checking::instance().allByDateId();
     const auto trans_splits = Model_Splittransaction::instance().get_all();
-    const auto trans_tags = Model_Taglink::instance().get_all(transRefType);
+    const auto trans_tags = Model_Taglink::instance().get_all(tranRefType);
     const auto trans_attachments = Model_Attachment::instance().get_all(
         Model_Attachment::REFTYPE_ID_TRANSACTION
     );
@@ -240,7 +237,7 @@ void mmCheckingPanel::filterTable()
     std::vector<bills_index_t> bills_index;
     if (m_scheduled_enable && m_scheduled_selected) {
         bills_splits = Model_Budgetsplittransaction::instance().get_all();
-        bills_tags = Model_Taglink::instance().get_all(billsRefType);
+        bills_tags = Model_Taglink::instance().get_all(billRefType);
         bills_attachments = Model_Attachment::instance().get_all(
             Model_Attachment::REFTYPE_ID_BILLSDEPOSIT
         );
@@ -348,43 +345,22 @@ void mmCheckingPanel::filterTable()
                 full_tran.ATTACHMENT_DESCRIPTION.Add(entry.DESCRIPTION);
         }
 
-        full_tran.UDFC01_Type = Model_CustomField::TYPE_ID_UNKNOWN;
-        full_tran.UDFC02_Type = Model_CustomField::TYPE_ID_UNKNOWN;
-        full_tran.UDFC03_Type = Model_CustomField::TYPE_ID_UNKNOWN;
-        full_tran.UDFC04_Type = Model_CustomField::TYPE_ID_UNKNOWN;
-        full_tran.UDFC05_Type = Model_CustomField::TYPE_ID_UNKNOWN;
-        full_tran.UDFC01_val = -DBL_MAX;
-        full_tran.UDFC02_val = -DBL_MAX;
-        full_tran.UDFC03_val = -DBL_MAX;
-        full_tran.UDFC04_val = -DBL_MAX;
-        full_tran.UDFC05_val = -DBL_MAX;
+        for (int i = 0; i < 5; i++) {
+            full_tran.UDFC_type[i] = Model_CustomField::TYPE_ID_UNKNOWN;
+            full_tran.UDFC_value[i] = -DBL_MAX;
+        }
 
-        if (repeat_num == 0 && trans_fields_data.find(tran->TRANSID) != trans_fields_data.end()) {
-            for (const auto& udfc : trans_fields_data.at(tran->TRANSID)) {
-                if (udfc.FIELDID == udfc01_ref_id) {
-                    full_tran.UDFC01 = udfc.CONTENT;
-                    full_tran.UDFC01_val = cleanseNumberStringToDouble(udfc.CONTENT, UDFC01_Scale);
-                    full_tran.UDFC01_Type = UDFC01_Type;
-                }
-                else if (udfc.FIELDID == udfc02_ref_id) {
-                    full_tran.UDFC02 = udfc.CONTENT;
-                    full_tran.UDFC02_val = cleanseNumberStringToDouble(udfc.CONTENT, UDFC02_Scale);
-                    full_tran.UDFC02_Type = UDFC02_Type;
-                }
-                else if (udfc.FIELDID == udfc03_ref_id) {
-                    full_tran.UDFC03 = udfc.CONTENT;
-                    full_tran.UDFC03_val = cleanseNumberStringToDouble(udfc.CONTENT, UDFC03_Scale);
-                    full_tran.UDFC03_Type = UDFC03_Type;
-                }
-                else if (udfc.FIELDID == udfc04_ref_id) {
-                    full_tran.UDFC04 = udfc.CONTENT;
-                    full_tran.UDFC04_val = cleanseNumberStringToDouble(udfc.CONTENT, UDFC04_Scale);
-                    full_tran.UDFC04_Type = UDFC04_Type;
-                }
-                else if (udfc.FIELDID == udfc05_ref_id) {
-                    full_tran.UDFC05 = udfc.CONTENT;
-                    full_tran.UDFC05_val = cleanseNumberStringToDouble(udfc.CONTENT, UDFC05_Scale);
-                    full_tran.UDFC05_Type = UDFC05_Type;
+        if (repeat_num == 0 && tranFieldData.find(tran->TRANSID) != tranFieldData.end()) {
+            for (const auto& udfc : tranFieldData.at(tran->TRANSID)) {
+                for (int i = 0; i < 5; i++) {
+                    if (udfc.FIELDID == udfc_id[i]) {
+                        full_tran.UDFC_type[i] = udfc_type[i];
+                        full_tran.UDFC_content[i] = udfc.CONTENT;
+                        full_tran.UDFC_value[i] = cleanseNumberStringToDouble(
+                            udfc.CONTENT, udfc_scale[i] > 0
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -442,7 +418,7 @@ void mmCheckingPanel::filterTable()
             }
             full_tran.NOTES.Append((tran->NOTES.IsEmpty() ? "" : " ") + split.NOTES);
             wxString tagnames;
-            const wxString reftype = (repeat_num == 0) ? splitRefType : billsplitRefType;
+            const wxString reftype = (repeat_num == 0) ? tranSplitRefType : billSplitRefType;
             for (const auto& tag : Model_Taglink::instance().get(reftype, split.SPLITTRANSID))
                 tagnames.Append(tag.first + " ");
             if (!tagnames.IsEmpty())

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -825,7 +825,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
                 }
             if (full_tran.has_attachment()) {
                 const wxString& refType = Model_Attachment::REFTYPE_STR_TRANSACTION;
-                Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(refType, full_tran.id());
+                Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(refType, full_tran.TRANSID);
                 for (const auto& i : attachments) {
                     notesStr += notesStr.empty() ? "" : "\n";
                     notesStr += _("Attachment") + " " + i.DESCRIPTION + " " + i.FILENAME;
@@ -833,7 +833,22 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
             }
         }
         else {
-            // not yet implemented
+            auto splits = Model_Budgetsplittransaction::instance().find(
+                Model_Budgetsplittransaction::TRANSID(full_tran.m_bdid)
+            );
+            for (const auto& split : splits)
+                if (!split.NOTES.IsEmpty()) {
+                    notesStr += notesStr.empty() ? "" : "\n";
+                    notesStr += split.NOTES;
+                }
+            if (full_tran.has_attachment()) {
+                const wxString& refType = Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
+                Model_Attachment::Data_Set attachments = Model_Attachment::instance().FilterAttachments(refType, full_tran.m_bdid);
+                for (const auto& i : attachments) {
+                    notesStr += notesStr.empty() ? "" : "\n";
+                    notesStr += _("Attachment") + " " + i.DESCRIPTION + " " + i.FILENAME;
+                }
+            }
         }
         m_info_panel->SetLabelText(notesStr);
     }

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -397,13 +397,7 @@ wxString Model_Checking::status_key(const wxString& r)
 Model_Checking::Full_Data::Full_Data() :
     Data(0), TAGNAMES(""),
     SN(0), ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
-    ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0),
-    UDFC01_val(0), UDFC02_val(0), UDFC03_val(0), UDFC04_val(0), UDFC05_val(0),
-    UDFC01_Type(Model_CustomField::TYPE_ID_UNKNOWN),
-    UDFC02_Type(Model_CustomField::TYPE_ID_UNKNOWN),
-    UDFC03_Type(Model_CustomField::TYPE_ID_UNKNOWN),
-    UDFC04_Type(Model_CustomField::TYPE_ID_UNKNOWN),
-    UDFC05_Type(Model_CustomField::TYPE_ID_UNKNOWN)
+    ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0)
 {
 }
 

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -113,11 +113,15 @@ public:
         double ACCOUNT_FLOW;
         double ACCOUNT_BALANCE;
         wxArrayString ATTACHMENT_DESCRIPTION;
-        wxString UDFC01; double UDFC01_val; Model_CustomField::TYPE_ID UDFC01_Type;
-        wxString UDFC02; double UDFC02_val; Model_CustomField::TYPE_ID UDFC02_Type;
-        wxString UDFC03; double UDFC03_val; Model_CustomField::TYPE_ID UDFC03_Type;
-        wxString UDFC04; double UDFC04_val; Model_CustomField::TYPE_ID UDFC04_Type;
-        wxString UDFC05; double UDFC05_val; Model_CustomField::TYPE_ID UDFC05_Type;
+        Model_CustomField::TYPE_ID UDFC_type[5] = {
+            Model_CustomField::TYPE_ID_UNKNOWN,
+            Model_CustomField::TYPE_ID_UNKNOWN,
+            Model_CustomField::TYPE_ID_UNKNOWN,
+            Model_CustomField::TYPE_ID_UNKNOWN,
+            Model_CustomField::TYPE_ID_UNKNOWN
+        };
+        wxString UDFC_content[5];
+        double UDFC_value[5] = {0, 0, 0, 0, 0};
     };
 
     typedef std::vector<Full_Data> Full_Data_Set;


### PR DESCRIPTION
This PR depends on (includes) #7081.

## Changes in `mmCheckingPanel`
- Refine `updateExtraTransactionData()`: add `notesStr` for scheduled transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7084)
<!-- Reviewable:end -->
