### PR TITLE
refine order of items in navtree

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -823,6 +823,11 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
         mmTreeItemData::CHECKING, -1
     );
 
+    wxTreeItemId bills = addNavTreeSection(
+        root, "Scheduled Transactions", img::SCHEDULE_PNG,
+        mmTreeItemData::BILLS
+    );
+
     wxTreeItemId favorites = addNavTreeSection(
         root, "Favorites", img::FAVOURITE_PNG,
         mmTreeItemData::CHECKING, -3
@@ -852,16 +857,6 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
             dataType, dataId
         );
     }
-
-    wxTreeItemId bills = addNavTreeSection(
-        root, "Scheduled Transactions", img::SCHEDULE_PNG,
-        mmTreeItemData::BILLS
-    );
-
-    wxTreeItemId trash = addNavTreeSection(
-        root, "Deleted Transactions", img::TRASH_PNG,
-        mmTreeItemData::CHECKING, -2
-    );
 
     // TODO: check mismatch between section name and search data
     wxTreeItemId budgeting = m_nav_tree_ctrl->AppendItem(
@@ -894,6 +889,11 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
         mmTreeItemData::HELP_PAGE_GRM
     );
     this->DoUpdateGRMNavigation(grm);
+
+    wxTreeItemId trash = addNavTreeSection(
+        root, "Deleted Transactions", img::TRASH_PNG,
+        mmTreeItemData::CHECKING, -2
+    );
 
     wxTreeItemId help = addNavTreeSection(
         root, "Help", img::HELP_PNG,


### PR DESCRIPTION
## Motivation

The order of items in Navigator is:
- Dashboard
- All Transactions
- ... account groups (Favorites and account types)
- Scheduled Transactions
- Deleted Transactions
- Budget Planner
- ... reports
- Help

Scheduled Transactions are used quite often. This PR moves them closer to the top (after All Transactions), so it is a little easier/faster to find them.

Deleted Transactions are rarely used. This PR moves them at the bottom (before Help).

The proposed order is:
- Dashboard
- All Transactions
- Scheduled Transactions
- ... account groups (Favorites and account types)
- Budget Planner
- ... reports
- Deleted Transactions
- Help

## Changes in `mmGUIFrame::DoRecreateNavTreeControl()`

- Move "Scheduled Transactions" after "All Transactions"
- Move "Deleted Transactions" before "Help".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7086)
<!-- Reviewable:end -->
