### PR TITLE
add tip for SN in transactions panel

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -246,9 +246,10 @@ void TransactionListCtrl::sortTable()
     );
     m_cp->m_header_sortOrder->SetLabelText(sortText);
 
-    if (m_real_columns[g_sortcol] == COL_SN || m_real_columns[prev_g_sortcol] == COL_SN) {
+    if (m_real_columns[g_sortcol] == COL_SN)
         m_cp->showTips(_("SN (Sequence Number) has the same order as Date/ID."));
-    }
+    else if (m_real_columns[g_sortcol] == COL_ID)
+        m_cp->showTips(_("ID (identification number) is increasing with the time of creation in the database."));
 
     RefreshItems(0, m_trans.size() - 1);
 }

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -245,7 +245,11 @@ void TransactionListCtrl::sortTable()
         m_columns[prev_g_sortcol].HEADER, prev_g_asc ? L"\u25B2" : L"\u25BC"
     );
     m_cp->m_header_sortOrder->SetLabelText(sortText);
-    
+
+    if (m_real_columns[g_sortcol] == COL_SN || m_real_columns[prev_g_sortcol] == COL_SN) {
+        m_cp->showTips(_("SN (Sequence Number) has the same order as Date/ID."));
+    }
+
     RefreshItems(0, m_trans.size() - 1);
 }
 

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -922,6 +922,11 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
 
 void mmCheckingPanel::showTips()
 {
+    if (m_show_tips) {
+        m_show_tips = false;
+        return;
+    }
+
     if (Option::instance().getShowMoneyTips())
         m_info_panel->SetLabelText(
             wxGetTranslation(wxString::FromUTF8(
@@ -931,6 +936,15 @@ void mmCheckingPanel::showTips()
         );
     else
         m_info_panel->SetLabelText("");
+}
+
+void mmCheckingPanel::showTips(const wxString& tip)
+{
+    if (Option::instance().getShowMoneyTips())
+        m_info_panel->SetLabelText(tip);
+    else
+        m_info_panel->SetLabelText("");
+    m_show_tips = true;
 }
 //----------------------------------------------------------------------------
 

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -130,6 +130,7 @@ private:
     double m_account_balance = 0.0;
     double m_account_reconciled = 0.0;
     bool m_show_reconciled;
+    bool m_show_tips = false;
     TransactionListCtrl* m_listCtrlAccount = nullptr;
 
     int64 m_account_id = -1;                    // applicable if m_checking_id >= 1
@@ -180,6 +181,7 @@ private:
 
     /* updates the checking panel data */
     void showTips();
+    void showTips(const wxString& tip);
     void updateScheduledToolTip();
     void updateExtraTransactionData(bool single, int repeat_num, bool foreign);
     void enableButtons(bool edit, bool dup, bool del, bool enter, bool skip, bool attach);


### PR DESCRIPTION
The keyword SN for Sequence Number introduced in #7080, may be confusing or cryptic to users in the beginning (see also the discussion in #6964).

This PR shows the following tip in `m_info_panel` (bottom area of transaction panels), when SN is selected as the primary sorting column: "SN (Sequence Number) has the same order as Date/ID."

Note: A tooltip on the SN header would be more suitable, however wxWidgets does not support it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7095)
<!-- Reviewable:end -->
