### PR TITLE
fix(#7099): handle missing column enums in sort & ordering

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -236,6 +236,12 @@ void TransactionListCtrl::sortTable()
 {
     if (m_trans.empty()) return;
 
+    if (std::find(m_real_columns.begin(), m_real_columns.end(), g_sortcol) == m_real_columns.end())
+        g_sortcol = COL_def_sort;
+
+    if (std::find(m_real_columns.begin(), m_real_columns.end(), prev_g_sortcol) == m_real_columns.end())
+        prev_g_sortcol = COL_def_sort2;
+
     SortTransactions(prev_g_sortcol, prev_g_asc);
     SortTransactions(g_sortcol, g_asc);
 

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -368,7 +368,8 @@ std::vector<int> mmListCtrl::GetColumnOrder()
     std::vector<int> columnOrder;
     for (const auto& col_enum : columnStringList)
     {
-        columnOrder.push_back(std::atoi(col_enum.c_str()));
+        if (std::find(m_real_columns.begin(), m_real_columns.end(), wxAtoi(col_enum)) != m_real_columns.end())
+            columnOrder.push_back(wxAtoi(col_enum));
     }
 
     // add missing column enums


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7100)
<!-- Reviewable:end -->
