### PR TITLE
fix(#6924): restrict date controls to DATE_MAX

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -215,6 +215,7 @@ const wxString ATTACHMENTS_FOLDER_APPDATA = "%APPDATA%";
 
 const wxString INIDB_NEWS_LAST_READ_DATE = "NEWS_LAST_READ_DATE";
 
+const wxDateTime DATE_MAX = wxDateTime(32503679999).ToUTC() /* Dec 31, 2999 23:59:59 UTC*/;
 
 const wxString g_fiat_curr()
 {

--- a/src/constants.h
+++ b/src/constants.h
@@ -125,6 +125,8 @@ extern const wxString ATTACHMENTS_FOLDER_APPDATA;
 
 extern const wxString INIDB_NEWS_LAST_READ_DATE;
 
+extern const wxDateTime DATE_MAX;
+
 extern const wxArrayString g_locales();
 extern const wxString g_fiat_curr();
 

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -41,8 +41,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <wx/regex.h>
 #include <wx/valnum.h>
 
-constexpr auto DATE_MAX = 253402214400 /* Dec 31, 9999 */;
-
 static const wxString COLUMN_NAMES[] = { "ID", "Color", "Date", "Number", "Account", "Payee", "Status", "Category", "Type", "Amount",
                                          "Notes", "UDFC01", "UDFC02", "UDFC03", "UDFC04", "UDFC05", "Tags", "FX Rate", "Time" };
 

--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -615,6 +615,7 @@ mmDatePickerCtrl::mmDatePickerCtrl(wxWindow* parent, wxWindowID id, wxDateTime d
     wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
     SetSizer(sizer);
     datePicker_ = new wxDatePickerCtrl(this, id, dt, wxDefaultPosition, wxDefaultSize, style);
+    datePicker_->SetRange(wxDateTime(), DATE_MAX);
     datePicker_->Bind(wxEVT_DATE_CHANGED, &mmDatePickerCtrl::OnDateChanged, this);
     sizer->Add(datePicker_);
 }
@@ -662,9 +663,14 @@ wxSpinButton* mmDatePickerCtrl::getSpinButton()
 
 void mmDatePickerCtrl::SetValue(const wxDateTime &dt)
 {
-    datePicker_->SetValue(dt);
+    if (dt > DATE_MAX)
+        datePicker_->SetValue(DATE_MAX);
+    else
+        datePicker_->SetValue(dt);
+
     if (timePicker_)
         timePicker_->SetValue(dt);
+
     //trigger date change event
     wxDateEvent dateEvent(this, dt, wxEVT_DATE_CHANGED);
     OnDateChanged(dateEvent);
@@ -717,15 +723,15 @@ wxBoxSizer* mmDatePickerCtrl::mmGetLayoutWithTime()
 
 void mmDatePickerCtrl::OnDateChanged(wxDateEvent& event)
 {
-    if (itemStaticTextWeek_)
-    {
-        wxDateTime dt = event.GetDate();
-        itemStaticTextWeek_->SetLabelText(wxGetTranslation(dt.GetEnglishWeekDayName(dt.GetWeekDay())));
-    }
     if (timePicker_)
         dt_.ParseISOCombined(datePicker_->GetValue().FormatISODate() + "T" + timePicker_->GetValue().FormatISOTime());
     else
         dt_ = datePicker_->GetValue();
+
+    if (itemStaticTextWeek_)
+    {
+        itemStaticTextWeek_->SetLabelText(wxGetTranslation(dt_.GetEnglishWeekDayName(dt_.GetWeekDay())));
+    }
 
     event.SetDate(dt_);
     event.Skip();

--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -610,12 +610,14 @@ mmDatePickerCtrl::mmDatePickerCtrl(wxWindow* parent, wxWindowID id, wxDateTime d
     : wxPanel(parent, id, pos, size, style)
     , dt_(dt), parent_(parent)
 {
+    wxLogDebug(dt.FormatISOCombined());
     if (!dt.IsValid())
         dt_ = wxDateTime::Now();
     wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
     SetSizer(sizer);
     datePicker_ = new wxDatePickerCtrl(this, id, dt, wxDefaultPosition, wxDefaultSize, style);
     datePicker_->SetRange(wxDateTime(), DATE_MAX);
+    SetValue(dt_);
     datePicker_->Bind(wxEVT_DATE_CHANGED, &mmDatePickerCtrl::OnDateChanged, this);
     sizer->Add(datePicker_);
 }
@@ -663,8 +665,8 @@ wxSpinButton* mmDatePickerCtrl::getSpinButton()
 
 void mmDatePickerCtrl::SetValue(const wxDateTime &dt)
 {
-    if (dt > DATE_MAX)
-        datePicker_->SetValue(DATE_MAX);
+    if (dt > DATE_MAX.GetDateOnly())
+        datePicker_->SetValue(DATE_MAX.GetDateOnly());
     else
         datePicker_->SetValue(dt);
 

--- a/src/reports/mmDateRange.cpp
+++ b/src/reports/mmDateRange.cpp
@@ -19,14 +19,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ********************************************************/
 
 #include "mmDateRange.h"
+#include "constants.h"
 #include "option.h"
 #include <wx/intl.h>
 
-#define DATE_MAX 32503679999 /* Dec 31, 2999 23:59:59 UTC*/
-
 mmDateRange::mmDateRange() : today_(wxDateTime::Today())
     , today_end_(wxDateTime(23, 59, 59, 999))
-    , future_(wxDateTime(DATE_MAX).ToUTC())
+    , future_(DATE_MAX)
     , futureIgnored_(false)
 {
     start_date_ = today_;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7115)
<!-- Reviewable:end -->
