### PR TITLE
tidy: unicode translation macro

### DIFF
--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -97,19 +97,19 @@ void mmAssetsListCtrl::OnMouseRightClick(wxMouseEvent& event)
     }
     m_panel->updateExtraAssetData(m_selected_row);
     wxMenu menu;
-    menu.Append(MENU_TREEPOPUP_NEW, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Asset…"))));
+    menu.Append(MENU_TREEPOPUP_NEW, _u("&New Asset…"));
     menu.AppendSeparator();
-    menu.Append(MENU_ON_DUPLICATE_TRANSACTION, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("D&uplicate Asset…"))));
+    menu.Append(MENU_ON_DUPLICATE_TRANSACTION, _u("D&uplicate Asset…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_ADDTRANS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Add Asset Transaction…"))));
+    menu.Append(MENU_TREEPOPUP_ADDTRANS, _u("&Add Asset Transaction…"));
     menu.Append(MENU_TREEPOPUP_VIEWTRANS, _("&View Asset Transactions"));
-    menu.Append(MENU_TREEPOPUP_GOTOACCOUNT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Open Asset Account…"))));
+    menu.Append(MENU_TREEPOPUP_GOTOACCOUNT, _u("&Open Asset Account…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_EDIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Asset…"))));
+    menu.Append(MENU_TREEPOPUP_EDIT, _u("&Edit Asset…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_DELETE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Asset…"))));
+    menu.Append(MENU_TREEPOPUP_DELETE, _u("&Delete Asset…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Organize Attachments…"))));
+    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, _u("&Organize Attachments…"));
     if (m_selected_row < 0)
     {
         menu.Enable(MENU_ON_DUPLICATE_TRANSACTION, false);

--- a/src/attachmentdialog.cpp
+++ b/src/attachmentdialog.cpp
@@ -57,7 +57,7 @@ mmAttachmentDialog::mmAttachmentDialog (wxWindow* parent, const wxString& RefTyp
     if (AttachmentsFolder == wxEmptyString)
     {
         wxString msgStr = wxString() << _("Attachment folder not defined.") << "\n"
-            << wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Please set it in Tools → Settings… → Attachments"))) << "\n";
+            << _u("Please set it in Tools → Settings… → Attachments") << "\n";
         wxMessageBox(msgStr, _("Attachment folder not defined"), wxICON_ERROR);
     }
     else if (!wxDirExists(AttachmentsFolder))

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -442,17 +442,17 @@ void billsDepositsListCtrl::OnItemRightClick(wxMouseEvent& event)
     m_bdp->updateBottomPanelData(m_selected_row);
     bool item_active = (m_selected_row >= 0);
     wxMenu menu;
-    menu.Append(MENU_POPUP_BD_ENTER_OCCUR, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Enter next Occurrence…"))));
+    menu.Append(MENU_POPUP_BD_ENTER_OCCUR, _u("Enter next Occurrence…"));
     menu.AppendSeparator();
     menu.Append(MENU_POPUP_BD_SKIP_OCCUR, _("Skip next Occurrence"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_NEW, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Scheduled Transaction…"))));
-    menu.Append(MENU_TREEPOPUP_EDIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Scheduled Transaction…"))));
-    menu.Append(MENU_TREEPOPUP_DUPLICATE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("D&uplicate Scheduled Transaction…"))));
+    menu.Append(MENU_TREEPOPUP_NEW, _u("&New Scheduled Transaction…"));
+    menu.Append(MENU_TREEPOPUP_EDIT, _u("&Edit Scheduled Transaction…"));
+    menu.Append(MENU_TREEPOPUP_DUPLICATE, _u("D&uplicate Scheduled Transaction…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_DELETE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Scheduled Transaction…"))));
+    menu.Append(MENU_TREEPOPUP_DELETE, _u("&Delete Scheduled Transaction…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Organize Attachments…"))));
+    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, _u("&Organize Attachments…"));
 
     menu.Enable(MENU_POPUP_BD_ENTER_OCCUR, item_active);
     menu.Enable(MENU_POPUP_BD_SKIP_OCCUR, item_active);

--- a/src/categdialog.cpp
+++ b/src/categdialog.cpp
@@ -472,7 +472,7 @@ void mmCategDialog::showCategDialogDeleteError(bool category)
         deleteCategoryErrMsg << "\n\n" << _("Tip: Change all transactions using this Subcategory to\n"
             "another Category using the merge command:");
 
-    deleteCategoryErrMsg << "\n\n" << wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Tools → Merge → Categories")));
+    deleteCategoryErrMsg << "\n\n" << _u("Tools → Merge → Categories");
 
     wxMessageBox(deleteCategoryErrMsg, _("Category Manager: Delete Error"), wxOK | wxICON_ERROR);
 }

--- a/src/dbupgrade.cpp
+++ b/src/dbupgrade.cpp
@@ -118,7 +118,7 @@ bool dbUpgrade::UpgradeDB(wxSQLite3Database * db, const wxString& DbFileName)
     }
 
     wxMessageBox(wxString::Format(_("MMEX database succesfully upgraded to version %i"), ver) + "\n\n"
-        + wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("We suggest a database optimization under Tools → Database → Optimize")))
+        + _u("We suggest a database optimization under Tools → Database → Optimize")
             , _("MMEX database upgrade"), wxOK | wxICON_INFORMATION);
 
     return true;

--- a/src/defs.h
+++ b/src/defs.h
@@ -69,5 +69,8 @@
 #pragma warning (disable:4100)
 #endif
 
+#define wxPLURAL_U8(singular, plural, n) wxPLURAL(wxString::FromUTF8(singular), wxString::FromUTF8(plural), n)
+#define _u(unicode_string) wxGetTranslation(wxString::FromUTF8(wxTRANSLATE(unicode_string)))
+
 #endif // MM_EX_DEFS_H_
 

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -729,18 +729,18 @@ void mmGeneralReportManager::OnItemRightClick(wxTreeEvent& event)
     Model_Report::Data *report = Model_Report::instance().get(report_id);
 
     wxMenu* samplesMenu = new wxMenu;
-    samplesMenu->Append(ID_NEW_SAMPLE_ASSETS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Assets…"))));
+    samplesMenu->Append(ID_NEW_SAMPLE_ASSETS, _u("Assets…"));
 
     wxMenu customReportMenu;
-    customReportMenu.Append(ID_NEW_EMPTY, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("New Empty Report…"))));
+    customReportMenu.Append(ID_NEW_EMPTY, _u("New Empty Report…"));
     customReportMenu.Append(wxID_ANY, _("New Sample Report"), samplesMenu);
     customReportMenu.AppendSeparator();
     if (report)
-        customReportMenu.Append(ID_GROUP, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Change Group…"))));
+        customReportMenu.Append(ID_GROUP, _u("Change Group…"));
     else
-        customReportMenu.Append(ID_GROUP, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Rename Group…"))));
+        customReportMenu.Append(ID_GROUP, _u("Rename Group…"));
     customReportMenu.Append(ID_UNGROUP, _("UnGroup"));
-    customReportMenu.Append(ID_RENAME, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Rename Report…"))));
+    customReportMenu.Append(ID_RENAME, _u("Rename Report…"));
     customReportMenu.AppendSeparator();
 
     wxMenuItem* menuItemActive = new wxMenuItem(&customReportMenu, ID_ACTIVE,
@@ -748,7 +748,7 @@ void mmGeneralReportManager::OnItemRightClick(wxTreeEvent& event)
     customReportMenu.Append(menuItemActive);
 
     customReportMenu.AppendSeparator();
-    customReportMenu.Append(ID_DELETE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Delete Report…"))));
+    customReportMenu.Append(ID_DELETE, _u("Delete Report…"));
 
     if (report)
     {

--- a/src/images_list.cpp
+++ b/src/images_list.cpp
@@ -455,7 +455,7 @@ bool checkThemeContents(wxArrayString *filesinTheme)
     {
         missingIcons.RemoveLast(2);
         if (erroredIcons > maxCutOff) {
-            missingIcons << " " << wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("and more…")));
+            missingIcons << " " << _u("and more…");
         }
         wxMessageBox(wxString::Format(_("There are %1$d missing or invalid icons in chosen theme '%2$s': %3$s")
             , erroredIcons, Model_Setting::instance().Theme(), missingIcons), _("Warning"), wxOK | wxICON_WARNING);

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -200,7 +200,7 @@ void mmQIFExportDialog::CreateControls()
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE );
     toFileCheckBox_->SetValue(true);
     file_name_label_ = new wxStaticText(main_tab, wxID_ANY, _("File Name:"));
-    button_search_ = new wxButton(main_tab, wxID_SAVE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Browse…"))));
+    button_search_ = new wxButton(main_tab, wxID_SAVE, _u("&Browse…"));
     button_search_->Connect(wxID_SAVE, wxEVT_COMMAND_BUTTON_CLICKED
         , wxCommandEventHandler(mmQIFExportDialog::OnFileSearch), nullptr, this);
 

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -132,7 +132,7 @@ void mmQIFImportDialog::CreateControls()
     file_name_ctrl_->Connect(wxID_FILE
         , wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(mmQIFImportDialog::OnFileNameChanged), nullptr, this);
 
-    button_search_ = new wxButton(file_panel, wxID_OPEN, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Browse…"))));
+    button_search_ = new wxButton(file_panel, wxID_OPEN, _u("&Browse…"));
     itemBoxSizer7->Add(button_search_, g_flagsH);
     button_search_->Connect(wxID_OPEN, wxEVT_COMMAND_BUTTON_CLICKED
         , wxCommandEventHandler(mmQIFImportDialog::OnFileSearch), nullptr, this);

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -198,7 +198,7 @@ void mmUnivCSVDialog::CreateControls()
     m_text_ctrl_->Connect(ID_FILE_NAME
         , wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(mmUnivCSVDialog::OnFileNameEntered), nullptr, this);
 
-    const wxString file_button_label = wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Browse…")));
+    const wxString file_button_label = _u("&Browse…");
     wxButton* button_browse = new wxButton(itemPanel6, wxID_BROWSE, file_button_label);
     itemBoxSizer7->Add(button_browse, g_flagsH);
 

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -39,7 +39,7 @@
 #include <algorithm>
 #include <wx/sound.h>
 //----------------------------------------------------------------------------
-#define wxPLURAL_U8(singular, plural, n) wxPLURAL(wxString::FromUTF8(singular), wxString::FromUTF8(plural), n)
+
 wxBEGIN_EVENT_TABLE(TransactionListCtrl, mmListCtrl)
     EVT_LIST_ITEM_ACTIVATED(wxID_ANY, TransactionListCtrl::OnListItemActivated)
     EVT_LIST_ITEM_SELECTED(wxID_ANY, TransactionListCtrl::OnListItemSelected)
@@ -535,10 +535,10 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
     }
     wxMenu menu;
     if (!m_cp->isDeletedTrans()) {
-        menu.Append(MENU_TREEPOPUP_WITHDRAWAL, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("New &Withdrawal…"))));
-        menu.Append(MENU_TREEPOPUP_DEPOSIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("New &Deposit…"))));
+        menu.Append(MENU_TREEPOPUP_WITHDRAWAL, _u("New &Withdrawal…"));
+        menu.Append(MENU_TREEPOPUP_DEPOSIT, _u("New &Deposit…"));
         if (Model_Account::instance().all_checking_account_names(true).size() > 1)
-            menu.Append(MENU_TREEPOPUP_TRANSFER, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("New &Transfer…"))));
+            menu.Append(MENU_TREEPOPUP_TRANSFER, _u("New &Transfer…"));
 
         menu.AppendSeparator();
 
@@ -565,7 +565,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
                 menu.Enable(MENU_ON_PASTE_TRANSACTION, false);
         }
 
-        menu.Append(MENU_ON_DUPLICATE_TRANSACTION, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("D&uplicate Transaction…"))));
+        menu.Append(MENU_ON_DUPLICATE_TRANSACTION, _u("D&uplicate Transaction…"));
         if (is_nothing_selected || multiselect)
             menu.Enable(MENU_ON_DUPLICATE_TRANSACTION, false);
 
@@ -583,13 +583,13 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
         if (is_nothing_selected || multiselect || have_category)
             menu.Enable(MENU_TREEPOPUP_VIEW_SPLIT_CATEGORIES, false);
 
-        menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Organize Attachments…"))));
+        menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, _u("&Organize Attachments…"));
         if (is_nothing_selected || multiselect)
             menu.Enable(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, false);
 
         menu.Append(
             MENU_TREEPOPUP_CREATE_REOCCURANCE,
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Create Scheduled T&ransaction…")))
+            _u("Create Scheduled T&ransaction…")
         );
         if (is_nothing_selected || multiselect)
             menu.Enable(MENU_TREEPOPUP_CREATE_REOCCURANCE, false);
@@ -603,7 +603,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
             menu.Enable(MENU_TREEPOPUP_RESTORE, false);
         menu.Append(
             MENU_TREEPOPUP_RESTORE_VIEWED,
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Restore &all transactions in current view…")))
+            _u("Restore &all transactions in current view…")
         );
     }
     bool columnIsAmount = false;
@@ -764,17 +764,17 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
     subGlobalOpMenuDelete->Append(
         MENU_TREEPOPUP_DELETE_VIEWED,
         !m_cp->isDeletedTrans() ?
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Delete &all transactions in current view…"))) :
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Permanently delete &all transactions in current view…")))
+            _u("Delete &all transactions in current view…") :
+            _u("Permanently delete &all transactions in current view…")
     );
     if (!m_cp->isDeletedTrans()) {
         subGlobalOpMenuDelete->Append(
             MENU_TREEPOPUP_DELETE_FLAGGED,
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Delete Viewed “&Follow Up” Transactions…")))
+            _u("Delete Viewed “&Follow Up” Transactions…")
         );
         subGlobalOpMenuDelete->Append(
             MENU_TREEPOPUP_DELETE_UNRECONCILED,
-            wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Delete Viewed “&Unreconciled” Transactions…")))
+            _u("Delete Viewed “&Unreconciled” Transactions…")
         );
     }
     menu.Append(MENU_TREEPOPUP_DELETE2, _("De&lete "), subGlobalOpMenuDelete);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -463,9 +463,9 @@ void mmCheckingPanel::OnButtonRightDown(wxMouseEvent& event)
     }
     case wxID_NEW: {
         wxMenu menu;
-        menu.Append(Model_Checking::TYPE_ID_WITHDRAWAL, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Withdrawal…"))));
-        menu.Append(Model_Checking::TYPE_ID_DEPOSIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Deposit…"))));
-        menu.Append(Model_Checking::TYPE_ID_TRANSFER, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Transfer…"))));
+        menu.Append(Model_Checking::TYPE_ID_WITHDRAWAL, _u("&New Withdrawal…"));
+        menu.Append(Model_Checking::TYPE_ID_DEPOSIT, _u("&New Deposit…"));
+        menu.Append(Model_Checking::TYPE_ID_TRANSFER, _u("&New Transfer…"));
         PopupMenu(&menu);
     }
     default:

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1515,19 +1515,19 @@ void mmGUIFrame::AppendImportMenu(wxMenu& menu)
 {
     wxMenu* importFrom(new wxMenu);
     menu.AppendSubMenu(importFrom, _("&Import from"));
-    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTUNIVCSV, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&CSV Files…"))));
-    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTXML, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&XML Files…"))), _("Import from XML file (Excel format)"));
+    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTUNIVCSV, _u("&CSV Files…"));
+    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTXML, _u("&XML Files…"), _("Import from XML file (Excel format)"));
     importFrom->AppendSeparator();
-    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTQIF, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&QIF Files…"))));
+    importFrom->Append(MENU_TREEPOPUP_ACCOUNT_IMPORTQIF, _u("&QIF Files…"));
 
     wxMenu* exportTo(new wxMenu);
     menu.AppendSubMenu(exportTo, _("&Export as"));
-    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2CSV, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&CSV File…"))));
-    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2XML, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&XML File…"))));
+    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2CSV, _u("&CSV File…"));
+    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2XML, _u("&XML File…"));
     exportTo->AppendSeparator();
-    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2MMEX, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&MMEX CSV File…"))));
-    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2JSON, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&JSON File…"))));
-    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2QIF, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&QIF File…"))));
+    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2MMEX, _u("&MMEX CSV File…"));
+    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2JSON, _u("&JSON File…"));
+    exportTo->Append(MENU_TREEPOPUP_ACCOUNT_EXPORT2QIF, _u("&QIF File…"));
 }
 
 void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
@@ -1550,9 +1550,9 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
     case mmTreeItemData::FILTER_REPORT: {
         const wxString data = iData->getString();
         wxLogDebug("MENU FILTER: %s", data);
-        menu.Append(MENU_TREEPOPUP_FILTER_EDIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Customize Report…"))));
-        menu.Append(MENU_TREEPOPUP_FILTER_RENAME, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Rename Report…"))));
-        menu.Append(MENU_TREEPOPUP_FILTER_DELETE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Report…"))));
+        menu.Append(MENU_TREEPOPUP_FILTER_EDIT, _u("&Customize Report…"));
+        menu.Append(MENU_TREEPOPUP_FILTER_RENAME, _u("&Rename Report…"));
+        menu.Append(MENU_TREEPOPUP_FILTER_DELETE, _u("&Delete Report…"));
         PopupMenu(&menu, pt);
         break;
     }
@@ -1567,15 +1567,15 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
         if (account) {
             menu.Append(
                 MENU_TREEPOPUP_EDIT,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Account…")))
+                _u("&Edit Account…")
             );
             menu.Append(
                 MENU_TREEPOPUP_DELETE,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Account…")))
+                _u("&Delete Account…")
             );
             menu.AppendSeparator();
             menu.Append(MENU_TREEPOPUP_LAUNCHWEBSITE, _("&Launch Account Website"));
-            menu.Append(MENU_TREEPOPUP_ACCOUNTATTACHMENTS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Attachment Manager…"))));
+            menu.Append(MENU_TREEPOPUP_ACCOUNTATTACHMENTS, _u("&Attachment Manager…"));
             menu.Enable(MENU_TREEPOPUP_LAUNCHWEBSITE, !account->WEBSITE.IsEmpty());
             PopupMenu(&menu, pt);
         }
@@ -1589,22 +1589,22 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
                 break;
             menu.Append(
                 MENU_TREEPOPUP_EDIT,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Account…")))
+                _u("&Edit Account…")
             );
             menu.Append(
                 MENU_TREEPOPUP_REALLOCATE,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Change Account Type…")))
+                _u("&Change Account Type…")
             );
             menu.AppendSeparator();
             menu.Append(
                 MENU_TREEPOPUP_DELETE,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Account…")))
+                _u("&Delete Account…")
             );
             menu.AppendSeparator();
             menu.Append(MENU_TREEPOPUP_LAUNCHWEBSITE, _("&Launch Account Website"));
             menu.Append(
                 MENU_TREEPOPUP_ACCOUNTATTACHMENTS,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Attachment Manager…")))
+                _u("&Attachment Manager…")
             );
             menu.Enable(MENU_TREEPOPUP_LAUNCHWEBSITE, !account->WEBSITE.IsEmpty());
             menu.Enable(MENU_TREEPOPUP_REALLOCATE, account->ACCOUNTTYPE != Model_Account::TYPE_STR_SHARES);
@@ -1615,17 +1615,17 @@ void mmGUIFrame::showTreePopupMenu(const wxTreeItemId& id, const wxPoint& pt)
         else if (acct_id == -1 || acct_id <= -3) { // isAllTrans, isGroup
             menu.Append(
                 MENU_TREEPOPUP_ACCOUNT_NEW,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Account…")))
+                _u("&New Account…")
             );
             menu.Append(
                 MENU_TREEPOPUP_ACCOUNT_EDIT,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Account…")))
+                _u("&Edit Account…")
             );
             menu.Append(MENU_TREEPOPUP_ACCOUNT_LIST, _("Account &List"));
             menu.AppendSeparator();
             menu.Append(
                 MENU_TREEPOPUP_ACCOUNT_DELETE,
-                wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Account…")))
+                _u("&Delete Account…")
             );
             menu.AppendSeparator();
 
@@ -1695,9 +1695,9 @@ void mmGUIFrame::createMenu()
 {
     wxMenu* menu_file = new wxMenu;
 
-    wxMenuItem* menuItemNew = new wxMenuItem(menu_file, MENU_NEW, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Database…"))), _("New Database"));
-    wxMenuItem* menuItemOpen = new wxMenuItem(menu_file, MENU_OPEN, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Open Database…\tCtrl-O"))), _("Open Database"));
-    wxMenuItem* menuItemSaveAs = new wxMenuItem(menu_file, MENU_SAVE_AS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Save Database &As…"))), _("Save Database As"));
+    wxMenuItem* menuItemNew = new wxMenuItem(menu_file, MENU_NEW, _u("&New Database…"), _("New Database"));
+    wxMenuItem* menuItemOpen = new wxMenuItem(menu_file, MENU_OPEN, _u("&Open Database…\tCtrl-O"), _("Open Database"));
+    wxMenuItem* menuItemSaveAs = new wxMenuItem(menu_file, MENU_SAVE_AS, _u("Save Database &As…"), _("Save Database As"));
     menu_file->Append(menuItemNew);
     menu_file->Append(menuItemOpen);
     menu_file->Append(menuItemSaveAs);
@@ -1711,28 +1711,28 @@ void mmGUIFrame::createMenu()
 
     wxMenu* importMenu = new wxMenu;
     menu_file->Append(MENU_IMPORT, _("&Import from"), importMenu);
-    importMenu->Append(MENU_IMPORT_UNIVCSV, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&CSV File…"))), _("Import from CSV file"));
-    importMenu->Append(MENU_IMPORT_XML, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&XML File…"))), _("Import from XML file (Excel format)"));
+    importMenu->Append(MENU_IMPORT_UNIVCSV, _u("&CSV File…"), _("Import from CSV file"));
+    importMenu->Append(MENU_IMPORT_XML, _u("&XML File…"), _("Import from XML file (Excel format)"));
     importMenu->AppendSeparator();
-    importMenu->Append(MENU_IMPORT_QIF, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&QIF File…"))), _("Import from QIF file"));
+    importMenu->Append(MENU_IMPORT_QIF, _u("&QIF File…"), _("Import from QIF file"));
     importMenu->AppendSeparator();
-    importMenu->Append(MENU_IMPORT_WEBAPP, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&WebApp…"))), _("Import from the WebApp"));
+    importMenu->Append(MENU_IMPORT_WEBAPP, _u("&WebApp…"), _("Import from the WebApp"));
 
     wxMenu* exportMenu = new wxMenu;
     menu_file->Append(MENU_EXPORT, _("&Export as"), exportMenu);
-    exportMenu->Append(MENU_EXPORT_CSV, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&CSV File…"))), _("Export as CSV file"));
-    exportMenu->Append(MENU_EXPORT_XML, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&XML File…"))), _("Export as XML file"));
+    exportMenu->Append(MENU_EXPORT_CSV, _u("&CSV File…"), _("Export as CSV file"));
+    exportMenu->Append(MENU_EXPORT_XML, _u("&XML File…"), _("Export as XML file"));
     exportMenu->AppendSeparator();
-    exportMenu->Append(MENU_EXPORT_MMEX, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&MMEX CSV File…"))), _("Export as fixed CSV file"));
-    exportMenu->Append(MENU_EXPORT_JSON, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&JSON File…"))), _("Export as JSON file"));
-    exportMenu->Append(MENU_EXPORT_QIF, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&QIF File…"))), _("Export as QIF file"));
+    exportMenu->Append(MENU_EXPORT_MMEX, _u("&MMEX CSV File…"), _("Export as fixed CSV file"));
+    exportMenu->Append(MENU_EXPORT_JSON, _u("&JSON File…"), _("Export as JSON file"));
+    exportMenu->Append(MENU_EXPORT_QIF, _u("&QIF File…"), _("Export as QIF file"));
     exportMenu->AppendSeparator();
-    exportMenu->Append(MENU_EXPORT_HTML, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&HTML File…"))), _("Export as HTML file"));
+    exportMenu->Append(MENU_EXPORT_HTML, _u("&HTML File…"), _("Export as HTML file"));
 
     menu_file->AppendSeparator();
 
     wxMenuItem* menuItemPrint = new wxMenuItem(menu_file, wxID_PRINT,
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Print…"))), _("Print current view"));
+        _u("&Print…"), _("Print current view"));
     menu_file->Append(menuItemPrint);
 
     menu_file->AppendSeparator();
@@ -1887,28 +1887,28 @@ void mmGUIFrame::createMenu()
     wxMenuItem* menuItemNewAcct = new wxMenuItem(
         menuAccounts,
         MENU_NEWACCT,
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Account…"))),
+        _u("&New Account…"),
         _("New Account")
     );
 
     wxMenuItem* menuItemAcctEdit = new wxMenuItem(
         menuAccounts,
         MENU_ACCTEDIT,
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Account…"))),
+        _u("&Edit Account…"),
         _("Edit Account")
     );
 
     wxMenuItem* menuItemReallocateAcct = new wxMenuItem(
         menuAccounts,
         MENU_ACCOUNT_REALLOCATE,
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Change Account Type…"))),
+        _u("&Change Account Type…"),
         _("Change the account type of an account")
     );
 
     wxMenuItem* menuItemAcctDelete = new wxMenuItem(
         menuAccounts,
         MENU_ACCTDELETE,
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Account…"))),
+        _u("&Delete Account…"),
         _("Delete Account from database")
     );
 
@@ -1929,29 +1929,29 @@ void mmGUIFrame::createMenu()
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemPayee = new wxMenuItem(menuTools
-        , MENU_ORGPAYEE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Payee Manager…"))), _("Payee Manager"));
+        , MENU_ORGPAYEE, _u("&Payee Manager…"), _("Payee Manager"));
     menuTools->Append(menuItemPayee);
 
     wxMenuItem* menuItemCateg = new wxMenuItem(menuTools
-        , MENU_ORGCATEGS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Category Manager…"))), _("Category Manager"));
+        , MENU_ORGCATEGS, _u("&Category Manager…"), _("Category Manager"));
     menuTools->Append(menuItemCateg);
 
     wxMenuItem* menuItemTags = new wxMenuItem(menuTools
-        , MENU_ORGTAGS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Tag Manager…"))), _("Tag Manager"));
+        , MENU_ORGTAGS, _u("&Tag Manager…"), _("Tag Manager"));
     menuTools->Append(menuItemTags);
 
     wxMenuItem* menuItemCurrency = new wxMenuItem(menuTools, MENU_CURRENCY
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Curre&ncy Manager…"))), _("Currency Manager"));
+        , _u("Curre&ncy Manager…"), _("Currency Manager"));
     menuTools->Append(menuItemCurrency);
 
     wxMenuItem* menuItemCategoryRelocation = new wxMenuItem(menuTools
-        , MENU_CATEGORY_RELOCATION, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Categories…")))
+        , MENU_CATEGORY_RELOCATION, _u("&Categories…")
         , _("Merge categories"));
     wxMenuItem* menuItemPayeeRelocation = new wxMenuItem(menuTools
-        , MENU_PAYEE_RELOCATION, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Payees…")))
+        , MENU_PAYEE_RELOCATION, _u("&Payees…")
         , _("Merge payees"));
     wxMenuItem* menuItemTagRelocation = new wxMenuItem(menuTools
-        , MENU_TAG_RELOCATION, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Tags…")))
+        , MENU_TAG_RELOCATION, _u("&Tags…")
         , _("Merge tags"));
     wxMenuItem* menuItemRelocation = new wxMenuItem(menuTools
         , MENU_RELOCATION, _("&Merge")
@@ -1966,7 +1966,7 @@ void mmGUIFrame::createMenu()
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemBudgeting = new wxMenuItem(menuTools, MENU_BUDGETSETUPDIALOG
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Budget Planner…"))), _("Budget Planner"));
+        , _u("&Budget Planner…"), _("Budget Planner"));
     menuTools->Append(menuItemBudgeting);
 
     wxMenuItem* menuItemBillsDeposits = new wxMenuItem(menuTools, MENU_BILLSDEPOSITS
@@ -1980,50 +1980,50 @@ void mmGUIFrame::createMenu()
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemThemes = new wxMenuItem(menuTools, MENU_THEME_MANAGER
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("T&heme Manager…"))), _("Theme Manager"));
+        , _u("T&heme Manager…"), _("Theme Manager"));
     menuTools->Append(menuItemThemes);
 
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemTransactions = new wxMenuItem(menuTools, MENU_TRANSACTIONREPORT
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Tra&nsaction Report…"))), _("Transaction Report"));
+        , _u("Tra&nsaction Report…"), _("Transaction Report"));
     menuTools->Append(menuItemTransactions);
 
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemGRM = new wxMenuItem(menuTools, wxID_VIEW_LIST
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&General Report Manager…"))), _("General Report Manager"));
+        , _u("&General Report Manager…"), _("General Report Manager"));
     menuTools->Append(menuItemGRM);
 
     wxMenuItem* menuItemCF = new wxMenuItem(menuTools, wxID_BROWSE
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("C&ustom Field Manager…"))), _("Custom Field Manager"));
+        , _u("C&ustom Field Manager…"), _("Custom Field Manager"));
     menuTools->Append(menuItemCF);
 
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemWA = new wxMenuItem(menuTools, MENU_REFRESH_WEBAPP
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Refresh &WebApp…"))), _("Refresh WebApp"));
+        , _u("Refresh &WebApp…"), _("Refresh WebApp"));
     menuTools->Append(menuItemWA);
     menuTools->AppendSeparator();
 
     wxMenuItem* menuItemOptions = new wxMenuItem(menuTools, wxID_PREFERENCES
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Settings…\tAlt-F12"))), _("Settings"));
+        , _u("&Settings…\tAlt-F12"), _("Settings"));
     menuTools->Append(menuItemOptions);
 
     menuTools->AppendSeparator();
 
     wxMenu* menuDatabase = new wxMenu;
     wxMenuItem* menuItemConvertDB = new wxMenuItem(menuTools, MENU_CONVERT_ENC_DB
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Decrypt Encrypted Database…")))
+        , _u("&Decrypt Encrypted Database…")
         , _("Convert encrypted database to unencrypted database"));
     wxMenuItem* menuItemChangeEncryptPassword = new wxMenuItem(menuTools, MENU_CHANGE_ENCRYPT_PASSWORD
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Change Encrypted &Password…")))
+        , _u("Change Encrypted &Password…")
         , _("Change the password of an encrypted database"));
     wxMenuItem* menuItemVacuumDB = new wxMenuItem(menuTools, MENU_DB_VACUUM
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Optimize Database…")))
+        , _u("&Optimize Database…")
         , _("Optimize database for space and performance"));
     wxMenuItem* menuItemCheckDB = new wxMenuItem(menuTools, MENU_DB_DEBUG
-        , wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Database Check and De&bug…")))
+        , _u("Database Check and De&bug…")
         , _("Generate database report or fix errors"));
     menuDatabase->Append(menuItemConvertDB);
     menuDatabase->Append(menuItemChangeEncryptPassword);
@@ -2389,7 +2389,7 @@ bool mmGUIFrame::createDataStore(const wxString& fileName, const wxString& pwd, 
         }
 
         wxButton* next = static_cast<wxButton*>(wizard->FindWindow(wxID_FORWARD)); //FIXME: 
-        if (next) next->SetLabel(wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Next →"))));
+        if (next) next->SetLabel(_u("&Next →"));
 
         SetDataBaseParameters(fileName);
         /* Jump to new account creation screen */
@@ -3643,7 +3643,7 @@ void mmGUIFrame::OnRates(wxCommandEvent& WXUNUSED(event))
         wxBusyInfoFlags()
         .Parent(this)
         .Title(_("Downloading stock prices from Yahoo"))
-        .Text(wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Please wait…"))))
+        .Text(_u("Please wait…"))
         .Foreground(*wxWHITE)
         .Background(wxColour(0, 102, 51))
         .Transparency(4 * wxALPHA_OPAQUE / 5)

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -360,7 +360,7 @@ void mmReportsPanel::CreateControls()
             itemBoxSizerHeader->AddSpacer(5);
             m_accounts = new wxChoice(itemPanel3, ID_CHOICE_ACCOUNTS);
             m_accounts->Append(_("All Accounts"));
-            m_accounts->Append(wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Specific Accounts…"))));
+            m_accounts->Append(_u("Specific Accounts…"));
             for (const auto& e : Model_Account::TYPE_CHOICES)
             {
                 if (e.first != Model_Account::TYPE_ID_INVESTMENT) {

--- a/src/payeedialog.cpp
+++ b/src/payeedialog.cpp
@@ -740,7 +740,7 @@ void mmPayeeDialog::DeletePayee()
                     << "\n\n"
                     << _("Tip: Change all transactions using this Payee to another Payee"
                         " using the merge command:")
-                    << "\n\n" << wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Tools → Merge → Payees")));
+                    << "\n\n" << _u("Tools → Merge → Payees");
                 wxMessageBox(deletePayeeErrMsg, _("Payee Manager: Delete Error"), wxOK | wxICON_ERROR);
                 continue;
             }

--- a/src/reports/bugreport.h
+++ b/src/reports/bugreport.h
@@ -71,7 +71,7 @@ wxString mmBugReport::getHTMLText()
     wxURI req = mmex::weblink::BugReport + "/new?body=" + info + "\n<hr>" + diag;
 
     const wxString texts[] = {
-        wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Use Help → Check for Updates in MMEX to get latest version, where your problem might be already fixed."))),
+        _u("Use Help → Check for Updates in MMEX to get latest version, where your problem might be already fixed."),
         wxString::Format(_("Search <a href='%s'>a list of known issues</a> for similar problem. If so, update existing issue instead of creating a new one.")
             ,  do_href_wrap(mmex::weblink::BugReport)),
         wxString::Format(_("As you know, <a href='%s'>a forum</a> for users is available where you can discuss problems and find solutions.") , do_href_wrap(mmex::weblink::Forum)),

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -143,16 +143,16 @@ void StocksListCtrl::OnMouseRightClick(wxMouseEvent& event)
     bool hide_menu_item = (m_selected_row < 0);
 
     wxMenu menu;
-    menu.Append(MENU_TREEPOPUP_NEW, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&New Stock Investment…"))));
+    menu.Append(MENU_TREEPOPUP_NEW, _u("&New Stock Investment…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_ADDTRANS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Add Stock Transactions…"))));
+    menu.Append(MENU_TREEPOPUP_ADDTRANS, _u("&Add Stock Transactions…"));
     menu.Append(MENU_TREEPOPUP_VIEWTRANS, _("&View Stock Transactions"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_EDIT, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Edit Stock Investment…"))));
+    menu.Append(MENU_TREEPOPUP_EDIT, _u("&Edit Stock Investment…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_DELETE, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Delete Stock Investment…"))));
+    menu.Append(MENU_TREEPOPUP_DELETE, _u("&Delete Stock Investment…"));
     menu.AppendSeparator();
-    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("&Organize Attachments…"))));
+    menu.Append(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, _u("&Organize Attachments…"));
     menu.Append(wxID_INDEX, _("Stock &Web Page"));
 
     menu.Enable(MENU_TREEPOPUP_EDIT, !hide_menu_item);

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -449,7 +449,7 @@ bool mmStocksPanel::onlineQuoteRefresh(wxString& msg)
     }
 
     refresh_button_->SetBitmapLabel(mmBitmapBundle(png::LED_YELLOW, mmBitmapButtonSize));
-    stock_details_->SetLabelText(wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Connecting…"))));
+    stock_details_->SetLabelText(_u("Connecting…"));
 
     std::map<wxString, double > stocks_data;
     bool ok = get_yahoo_prices(symbols, stocks_data, base_currency_symbol, msg, yahoo_price_type::SHARES);

--- a/src/wizard_newaccount.cpp
+++ b/src/wizard_newaccount.cpp
@@ -162,7 +162,7 @@ bool mmAddAccountTypePage::TransferDataFromWindow()
     {
         wxString errorMsg;
         errorMsg << _("Base Account Currency Not set.") << "\n"
-                 << wxGetTranslation(wxString::FromUTF8(wxTRANSLATE("Set that first using Tools → Settings… menu and then add a new account.")));
+                 << _u("Set that first using Tools → Settings… menu and then add a new account.");
         wxMessageBox( errorMsg, _("New Account"), wxOK|wxICON_WARNING, this);
         return false;
     }

--- a/util/update-po-files.sh
+++ b/util/update-po-files.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-XGETTEXT_ARGS="-k_ -kN_ -kwxGetTranslation -kwxTRANSLATE -kwxPLURAL:1,2 -kwxPLURAL_U8:1,2 \
+XGETTEXT_ARGS="-k_ -kN_ -kwxGetTranslation -kwxTRANSLATE -kwxPLURAL:1,2 -kwxPLURAL_U8:1,2 -k_u\
                --language=C++ \
                --sort-by-file \
                --add-comments=TRANSLATORS \


### PR DESCRIPTION
A small refactor which adds a macro to simplify translation of strings containing unicode characters

`wxGetTranslation(wxString::FromUTF8(wxTRANSLATE(unicode_string)))` can now be written `_u(unicode_string)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7121)
<!-- Reviewable:end -->
