### PR TITLE
fix(#7130): allow '^' in stock symbols for online quotes

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -610,7 +610,6 @@ mmDatePickerCtrl::mmDatePickerCtrl(wxWindow* parent, wxWindowID id, wxDateTime d
     : wxPanel(parent, id, pos, size, style)
     , dt_(dt), parent_(parent)
 {
-    wxLogDebug(dt.FormatISOCombined());
     if (!dt.IsValid())
         dt_ = wxDateTime::Now();
     wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -816,7 +816,7 @@ bool get_yahoo_prices(std::map<wxString, double>& symbols
 
     for (const auto& entry : symbols)
     {
-        wxRegEx pattern(R"(^([-a-zA-Z0-9_@=\.]+)$)");
+        wxRegEx pattern(R"(^([\^-a-zA-Z0-9_@=\.]+)$)");
         if (!pattern.Matches(entry.first))
             continue;
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7132)
<!-- Reviewable:end -->
