### PR TITLE
fix(#7109, #7110): Date and Time in transaction panels

### DIFF
--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -642,7 +642,7 @@ wxString mmAssetsPanel::getItem(long item, long column)
     case COL_VALUE_CURRENT:
         return Model_Currency::toCurrency(Model_Asset::value(asset));
     case COL_DATE:
-        return mmGetDateForDisplay(asset.STARTDATE);
+        return mmGetDateTimeForDisplay(asset.STARTDATE);
     case COL_NOTES:
     {
         wxString full_notes = asset.NOTES;
@@ -810,7 +810,7 @@ void mmAssetsPanel::ViewAssetTrans(const int selected_index)
         if (asset_trans)
         {
             const auto aa = Model_Account::get_account_name(asset_trans->ACCOUNTID);
-            const auto ad = mmGetDateForDisplay(asset_trans->TRANSDATE);
+            const auto ad = mmGetDateTimeForDisplay(asset_trans->TRANSDATE);
             const auto av = Model_Currency::toString(asset_trans->TRANSAMOUNT); //TODO: check if currency needed
             msg << wxString::Format("%s \t%s   \t%s \n", aa, ad, av);
         }

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -473,9 +473,9 @@ wxString mmBillsDepositsPanel::getItem(long item, long column)
     case COL_ID:
         return wxString::Format("%lld", bill.BDID).Trim();
     case COL_PAYMENT_DATE:
-        return mmGetDateForDisplay(bill.TRANSDATE);
+        return mmGetDateTimeForDisplay(bill.TRANSDATE);
     case COL_DUE_DATE:
-        return mmGetDateForDisplay(bill.NEXTOCCURRENCEDATE);
+        return mmGetDateTimeForDisplay(bill.NEXTOCCURRENCEDATE);
     case COL_ACCOUNT:
         return bill.ACCOUNTNAME;
     case COL_PAYEE:

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -177,7 +177,7 @@ wxString mmBudgetingPanel::GetPanelTitle() const
 
     if (Option::instance().getBudgetDaysOffset() != 0)
     {
-        yearStr = wxString::Format(_("%1$s    Start Date of: %2$s"), yearStr, mmGetDateForDisplay(m_budget_offset_date));
+        yearStr = wxString::Format(_("%1$s    Start Date of: %2$s"), yearStr, mmGetDateTimeForDisplay(m_budget_offset_date));
     }
 
     return wxString::Format(_("Budget Planner for %s"), yearStr);

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -1556,7 +1556,7 @@ const wxString mmFilterTransactionsDialog::mmGetDescriptionToolTip() const
             {
                 wxDateTime dt;
                 if (mmParseISODate(value, dt))
-                    value = mmGetDateForDisplay(value);
+                    value = mmGetDateTimeForDisplay(value);
             }
             else if (pattern_type.Matches(value))
             {
@@ -1657,7 +1657,7 @@ void mmFilterTransactionsDialog::mmGetDescription(mmHTMLBuilder& hb)
             {
                 wxDateTime dt;
                 if (mmParseISODate(value, dt))
-                    value = mmGetDateForDisplay(value);
+                    value = mmGetDateTimeForDisplay(value);
             }
             else if (pattern_type.Matches(value))
             {

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -81,7 +81,7 @@ const wxString mmExportTransaction::getTransactionCSV(const Model_Checking::Full
             const wxString split_categ = Model_Category::full_name(split_entry.CATEGID, ":");
 
             buffer << inQuotes(wxString::Format("%lld", full_tran.TRANSID), delimiter) << delimiter;
-            buffer << inQuotes(mmGetDateForDisplay(full_tran.TRANSDATE, dateMask), delimiter) << delimiter;
+            buffer << inQuotes(mmGetDateTimeForDisplay(full_tran.TRANSDATE, dateMask), delimiter) << delimiter;
             buffer << inQuotes(full_tran.STATUS, delimiter) << delimiter;
             buffer << inQuotes(full_tran.TRANSCODE, delimiter) << delimiter;
 
@@ -101,7 +101,7 @@ const wxString mmExportTransaction::getTransactionCSV(const Model_Checking::Full
     else
     {
         buffer << inQuotes(wxString::Format("%lld", full_tran.TRANSID), delimiter) << delimiter;
-        buffer << inQuotes(mmGetDateForDisplay(full_tran.TRANSDATE, dateMask), delimiter) << delimiter;
+        buffer << inQuotes(mmGetDateTimeForDisplay(full_tran.TRANSDATE, dateMask), delimiter) << delimiter;
         buffer << inQuotes(full_tran.STATUS, delimiter) << delimiter;
         buffer << inQuotes(full_tran.TRANSCODE, delimiter) << delimiter;
 
@@ -164,7 +164,7 @@ const wxString mmExportTransaction::getTransactionQIF(const Model_Checking::Full
             categ.Append((i > 0 ? ":" : "") + Model_Tag::instance().get(full_tran.m_tags[i].TAGID)->TAGNAME);
     }
 
-    buffer << "D" << mmGetDateForDisplay(full_tran.TRANSDATE, dateMask) << "\n";
+    buffer << "D" << mmGetDateTimeForDisplay(full_tran.TRANSDATE, dateMask) << "\n";
     buffer << "C" << (full_tran.STATUS == Model_Checking::STATUS_KEY_RECONCILED ? "R" : "") << "\n";
     double value = Model_Checking::account_flow(full_tran
         , (reverce ? full_tran.TOACCOUNTID : full_tran.ACCOUNTID));

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -689,7 +689,7 @@ void mmQIFImportDialog::refreshTabs(int tabs)
                 wxDateTime dtdt;
                 wxString::const_iterator end;
                 if (dtdt.ParseFormat(dateStr, m_dateFormatStr, &end))
-                    dateStr = mmGetDateForDisplay(dtdt.FormatISODate());
+                    dateStr = mmGetDateTimeForDisplay(dtdt.FormatISODate());
                 else
                     dateStr.Prepend("!");
             }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1647,7 +1647,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                 switch (it.first)
                 {
                 case UNIV_CSV_DATE:
-                    entry = mmGetDateForDisplay(Model_Checking::TRANSDATE(pBankTransaction).FormatISODate(), date_format_);
+                    entry = mmGetDateTimeForDisplay(Model_Checking::TRANSDATE(pBankTransaction).FormatISODate(), date_format_);
                     break;
                 case UNIV_CSV_PAYEE:
                     entry = tran.real_payee_name(fromAccountID);
@@ -1719,7 +1719,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                         {
                             // format date fields
                             if (Model_CustomField::type_id(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::TYPE_ID_DATE)
-                                entry = mmGetDateForDisplay(data->CONTENT, date_format_);
+                                entry = mmGetDateTimeForDisplay(data->CONTENT, date_format_);
                             else
                                 entry = data->CONTENT;
                         }
@@ -1965,7 +1965,7 @@ void mmUnivCSVDialog::update_preview()
                             text << wxString::Format("%lld", tran.TRANSID);
                             break;
                         case UNIV_CSV_DATE:
-                            text << inQuotes(mmGetDateForDisplay(Model_Checking::TRANSDATE(pBankTransaction).FormatISODate(), date_format_), delimit);
+                            text << inQuotes(mmGetDateTimeForDisplay(Model_Checking::TRANSDATE(pBankTransaction).FormatISODate(), date_format_), delimit);
                             break;
                         case UNIV_CSV_PAYEE:
                             text << inQuotes(tran.real_payee_name(fromAccountID), delimit);
@@ -2031,7 +2031,7 @@ void mmUnivCSVDialog::update_preview()
                                 {
                                     // Format date fields
                                     if (Model_CustomField::type_id(Model_CustomField::instance().get(data->FIELDID)) == Model_CustomField::TYPE_ID_DATE)
-                                        text << inQuotes(mmGetDateForDisplay(data->CONTENT, date_format_), delimit);
+                                        text << inQuotes(mmGetDateTimeForDisplay(data->CONTENT, date_format_), delimit);
                                     else
                                         text << inQuotes(data->CONTENT, delimit);
                                 }

--- a/src/maincurrencydialog.cpp
+++ b/src/maincurrencydialog.cpp
@@ -600,7 +600,7 @@ void mmMainCurrencyDialog::ShowCurrencyHistory()
             item.SetData(d.CURRHISTID.GetValue());
             valueListBox_->InsertItem(item);
             const wxString dispAmount = Model_Currency::toString(d.CURRVALUE, currency, 6);
-            valueListBox_->SetItem(idx, 0, mmGetDateForDisplay(d.CURRDATE));
+            valueListBox_->SetItem(idx, 0, mmGetDateTimeForDisplay(d.CURRDATE));
             valueListBox_->SetItem(idx, 1, dispAmount);
 
 

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -167,12 +167,12 @@ void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
         std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByNOTES());
         break;
     case TransactionListCtrl::COL_DATE: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByTRANSDATE()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByTRANSDATE());
+        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTRANSDATE_DATE()) :
+        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTRANSDATE_DATE());
         break;
     case TransactionListCtrl::COL_TIME: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTRANSTIME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTRANSTIME());
+        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTRANSDATE_TIME()) :
+        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTRANSDATE_TIME());
         break;
     case TransactionListCtrl::COL_DELETEDTIME: ascend ?
         std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByDELETEDTIME()) :
@@ -624,7 +624,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
             copyText_ = m_trans[row].displayID;
             break;
         case COL_DATE: {
-            copyText_ = menuItemText = mmGetDateForDisplay(m_trans[row].TRANSDATE);
+            copyText_ = menuItemText = mmGetDateTimeForDisplay(m_trans[row].TRANSDATE);
             wxString strDate = Model_Checking::TRANSDATE(m_trans[row]).FormatISODate();
             rightClickFilter_ = "{\n\"DATE1\": \"" + strDate + "\",\n\"DATE2\" : \"" + strDate + "T23:59:59" + "\"\n}";
             break;
@@ -703,12 +703,12 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
         case COL_DELETEDTIME:
             datetime.ParseISOCombined(m_trans[row].DELETEDTIME);        
             if(datetime.IsValid())
-                copyText_ = mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
+                copyText_ = mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
             break;
         case COL_UPDATEDTIME:
             datetime.ParseISOCombined(m_trans[row].LASTUPDATEDTIME);
             if (datetime.IsValid())
-                copyText_ = mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
+                copyText_ = mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
             break;
         case COL_UDFC01:
             copyText_ = menuItemText = m_trans[row].UDFC_content[0];
@@ -1566,7 +1566,7 @@ bool TransactionListCtrl::TransactionLocked(int64 accountID, const wxString& tra
                 wxMessageBox(_(wxString::Format(
                     _("Locked transaction to date: %s\n\n"
                         "Reconciled transactions.")
-                    , mmGetDateForDisplay(account->STATEMENTDATE)))
+                    , mmGetDateTimeForDisplay(account->STATEMENTDATE)))
                     , _("MMEX Transaction Check"), wxOK | wxICON_WARNING);
                 return true;
             }
@@ -2043,7 +2043,7 @@ wxString UDFCFormatHelper(Model_CustomField::TYPE_ID type, wxString data)
     if (!data.empty()) {
         switch (type) {
         case Model_CustomField::TYPE_ID_DATE:
-            formattedData = mmGetDateForDisplay(data);
+            formattedData = mmGetDateTimeForDisplay(data);
             break;
         case Model_CustomField::TYPE_ID_BOOLEAN:
             v = wxString("TRUE|true|1").Contains(data);
@@ -2116,7 +2116,7 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
         datetime.ParseISOCombined(fused.DELETEDTIME);        
         if(!datetime.IsValid())
             return wxString("");
-        return mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
+        return mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
     case TransactionListCtrl::COL_UDFC01:
         return UDFCFormatHelper(fused.UDFC_type[0], fused.UDFC_content[0]);
     case TransactionListCtrl::COL_UDFC02:
@@ -2131,7 +2131,7 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
         datetime.ParseISOCombined(fused.LASTUPDATEDTIME);
         if (!datetime.IsValid())
             return wxString("");
-        return mmGetDateForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
+        return mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
     }
 
     switch (realenum ? column : m_real_columns[column]) {

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -90,142 +90,106 @@ TransactionListCtrl::EColumn TransactionListCtrl::toEColumn(const unsigned long 
     return res;
 }
 
+template<class Compare>
+void TransactionListCtrl::SortBy(Compare comp, bool ascend)
+{
+    if (ascend)
+        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), comp);
+    else
+        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), comp);
+}
+
 void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
 {
     const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
     Model_CustomField::TYPE_ID type;
 
     switch (m_real_columns[sortcol]) {
-    case TransactionListCtrl::COL_SN: ascend ?
-        std::stable_sort(
-            this->m_trans.begin(), this->m_trans.end(),
-            Fused_Transaction::SorterByFUSEDTRANSSN()
-        ) :
-        std::stable_sort(
-            this->m_trans.rbegin(), this->m_trans.rend(),
-            Fused_Transaction::SorterByFUSEDTRANSSN()
-        );
+    case TransactionListCtrl::COL_SN:
+        SortBy(Fused_Transaction::SorterByFUSEDTRANSSN(), ascend);
         break;
-    case TransactionListCtrl::COL_ID: ascend ?
-        std::stable_sort(
-            this->m_trans.begin(), this->m_trans.end(),
-            Fused_Transaction::SorterByFUSEDTRANSID()
-        ) :
-        std::stable_sort(
-            this->m_trans.rbegin(), this->m_trans.rend(),
-            Fused_Transaction::SorterByFUSEDTRANSID()
-        );
+    case TransactionListCtrl::COL_ID:
+        SortBy(Fused_Transaction::SorterByFUSEDTRANSID(), ascend);
         break;
-    case TransactionListCtrl::COL_NUMBER: ascend ?
-        std::stable_sort(
-            this->m_trans.begin(), this->m_trans.end(),
-            Model_Checking::SorterByNUMBER()
-        ) :
-        std::stable_sort(
-            this->m_trans.rbegin(), this->m_trans.rend(),
-            Model_Checking::SorterByNUMBER()
-        );
+    case TransactionListCtrl::COL_NUMBER:
+        SortBy(Model_Checking::SorterByNUMBER(), ascend);
         break;
-    case TransactionListCtrl::COL_ACCOUNT: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByACCOUNTNAME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByACCOUNTNAME());
+    case TransactionListCtrl::COL_ACCOUNT:
+        SortBy(SorterByACCOUNTNAME(), ascend);
         break;
-    case TransactionListCtrl::COL_PAYEE_STR: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByPAYEENAME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByPAYEENAME());
+    case TransactionListCtrl::COL_PAYEE_STR:
+        SortBy(SorterByPAYEENAME(), ascend);
         break;
-    case TransactionListCtrl::COL_STATUS: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterBySTATUS()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterBySTATUS());
+    case TransactionListCtrl::COL_STATUS:
+        SortBy(SorterBySTATUS(), ascend);
         break;
-    case TransactionListCtrl::COL_CATEGORY: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByCATEGNAME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByCATEGNAME());
+    case TransactionListCtrl::COL_CATEGORY:
+        SortBy(SorterByCATEGNAME(), ascend);
         break;
-    case TransactionListCtrl::COL_TAGS: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTAGNAMES()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTAGNAMES());
+    case TransactionListCtrl::COL_TAGS:
+        SortBy(Model_Checking::SorterByTAGNAMES(), ascend);
         break;
-    case TransactionListCtrl::COL_WITHDRAWAL: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByWITHDRAWAL()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByWITHDRAWAL());
+    case TransactionListCtrl::COL_WITHDRAWAL:
+        SortBy(Model_Checking::SorterByWITHDRAWAL(), ascend);
         break;
-    case TransactionListCtrl::COL_DEPOSIT: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByDEPOSIT()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByDEPOSIT());
+    case TransactionListCtrl::COL_DEPOSIT:
+        SortBy(Model_Checking::SorterByDEPOSIT(), ascend);
         break;
-    case TransactionListCtrl::COL_BALANCE: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByBALANCE()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByBALANCE());
+    case TransactionListCtrl::COL_BALANCE:
+        SortBy(Model_Checking::SorterByBALANCE(), ascend);
         break;
-    case TransactionListCtrl::COL_CREDIT: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByBALANCE()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByBALANCE());
+    case TransactionListCtrl::COL_CREDIT:
+        SortBy(Model_Checking::SorterByBALANCE(), ascend);
         break;
-    case TransactionListCtrl::COL_NOTES: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByNOTES()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByNOTES());
+    case TransactionListCtrl::COL_NOTES:
+        SortBy(SorterByNOTES(), ascend);
         break;
-    case TransactionListCtrl::COL_DATE: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTRANSDATE_DATE()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTRANSDATE_DATE());
+    case TransactionListCtrl::COL_DATE:
+        SortBy(Model_Checking::SorterByTRANSDATE_DATE(), ascend);
         break;
-    case TransactionListCtrl::COL_TIME: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), Model_Checking::SorterByTRANSDATE_TIME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), Model_Checking::SorterByTRANSDATE_TIME());
+    case TransactionListCtrl::COL_TIME:
+        SortBy(Model_Checking::SorterByTRANSDATE_TIME(), ascend);
         break;
-    case TransactionListCtrl::COL_DELETEDTIME: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByDELETEDTIME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByDELETEDTIME());
+    case TransactionListCtrl::COL_DELETEDTIME:
+        SortBy(SorterByDELETEDTIME(), ascend);
         break;
     case TransactionListCtrl::COL_UDFC01:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC01");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC01_val)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC01_val);
+            SortBy(SorterByUDFC01_val, ascend);
         else
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC01)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC01);
+            SortBy(SorterByUDFC01, ascend);
         break;
     case TransactionListCtrl::COL_UDFC02:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC02");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC02_val)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC02_val);
+            SortBy(SorterByUDFC02_val, ascend);
         else
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC02)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC02);
+            SortBy(SorterByUDFC02, ascend);
         break;
     case TransactionListCtrl::COL_UDFC03:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC03");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC03_val)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC03_val);
+            SortBy(SorterByUDFC03_val, ascend);
         else
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC03)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC03);
+            SortBy(SorterByUDFC03, ascend);
         break;
     case TransactionListCtrl::COL_UDFC04:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC04");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC04_val)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC04_val);
+            SortBy(SorterByUDFC04_val, ascend);
         else
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC04)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC04);
+            SortBy(SorterByUDFC04, ascend);
         break;
     case TransactionListCtrl::COL_UDFC05:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC05");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC05_val)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC05_val);
+            SortBy(SorterByUDFC05_val, ascend);
         else
-            ascend ? std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByUDFC05)
-                  : std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByUDFC05);
+            SortBy(SorterByUDFC05, ascend);
         break;
-    case TransactionListCtrl::COL_UPDATEDTIME: ascend ?
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), SorterByLASTUPDATEDTIME()) :
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), SorterByLASTUPDATEDTIME());
+    case TransactionListCtrl::COL_UPDATEDTIME:
+        SortBy(SorterByLASTUPDATEDTIME(), ascend);
         break;
     default:
         break;

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -217,6 +217,8 @@ private:
     void FindSelectedTransactions();
     bool CheckForClosedAccounts();
     void setExtraTransactionData(const bool single);
+    template<class Compare>
+    void SortBy(Compare comp, bool ascend);
     void SortTransactions(int sortcol, bool ascend);
     void findInAllTransactions(wxCommandEvent&);
     void OnCopyText(wxCommandEvent&);

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -3687,7 +3687,7 @@ void mmGUIFrame::OnRates(wxCommandEvent& WXUNUSED(event))
             Model_StockHistory::instance().ReleaseSavepoint();
             wxString strLastUpdate;
             strLastUpdate.Printf(_("%1$s on %2$s"), wxDateTime::Now().FormatTime()
-                , mmGetDateForDisplay(wxDateTime::Now().FormatISODate()));
+                , mmGetDateTimeForDisplay(wxDateTime::Now().FormatISODate()));
             Model_Infotable::instance().Set("STOCKS_LAST_REFRESH_DATETIME", strLastUpdate);
         }
 

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -220,7 +220,7 @@ const Model_Checking::Data_Set Model_Account::transactionsByDateId(const Data*r)
     auto trans = Model_Checking::instance().find_or(Model_Checking::ACCOUNTID(r->ACCOUNTID)
         , Model_Checking::TOACCOUNTID(r->ACCOUNTID));
     std::sort(trans.begin(), trans.end());
-    std::stable_sort(trans.begin(), trans.end(), SorterByTRANSDATE());
+    std::stable_sort(trans.begin(), trans.end(), Model_Checking::SorterByTRANSDATE_DATE());
 
     return trans;
 }

--- a/src/model/Model_Checking.cpp
+++ b/src/model/Model_Checking.cpp
@@ -186,7 +186,7 @@ const Model_Checking::Data_Set Model_Checking::allByDateId()
 {
     auto trans = Model_Checking::instance().all();
     std::sort(trans.begin(), trans.end());
-    std::stable_sort(trans.begin(), trans.end(), SorterByTRANSDATE());
+    std::stable_sort(trans.begin(), trans.end(), Model_Checking::SorterByTRANSDATE_DATE());
     return trans;
 }
 

--- a/src/model/Model_Checking.h
+++ b/src/model/Model_Checking.h
@@ -168,12 +168,20 @@ public:
             return x.TAGNAMES < y.TAGNAMES;
         }
     };
-    struct SorterByTRANSTIME
+    struct SorterByTRANSDATE_DATE
     {
         template <class DATA>
         bool operator()(const DATA& x, const DATA& y)
         {
-            return x.TRANSDATE < y.TRANSDATE;
+            return x.TRANSDATE.Left(10) < y.TRANSDATE.Left(10);
+        }
+    };
+    struct SorterByTRANSDATE_TIME
+    {
+        template <class DATA>
+        bool operator()(const DATA& x, const DATA& y)
+        {
+            return mmGetTimeForDisplay(x.TRANSDATE) < mmGetTimeForDisplay(y.TRANSDATE);
         }
     };
 

--- a/src/optionsettingsgeneral.cpp
+++ b/src/optionsettingsgeneral.cpp
@@ -116,7 +116,7 @@ void OptionSettingsGeneral::Create()
     m_sample_date_text = new wxStaticText(dateFormatStaticBox, wxID_STATIC, "redefined elsewhere");
     dateFormatStaticBoxSizer->Add(new wxStaticText(dateFormatStaticBox, wxID_STATIC, _("Date format sample:")), wxSizerFlags(g_flagsH).Border(wxLEFT, 15));
     dateFormatStaticBoxSizer->Add(m_sample_date_text, wxSizerFlags(g_flagsH).Border(wxLEFT, 5));
-    m_sample_date_text->SetLabelText(mmGetDateForDisplay(wxDateTime::Now().FormatISODate()));
+    m_sample_date_text->SetLabelText(mmGetDateTimeForDisplay(wxDateTime::Now().FormatISODate()));
     SetBoldFont(dateFormatStaticBox);
 
     // Currency Settings
@@ -248,7 +248,7 @@ void OptionSettingsGeneral::OnDateFormatChanged(wxCommandEvent& /*event*/)
     if (data)
     {
         m_date_format = data->GetData();
-        m_sample_date_text->SetLabelText(mmGetDateForDisplay(wxDateTime::Now().FormatISODate(), m_date_format));
+        m_sample_date_text->SetLabelText(mmGetDateTimeForDisplay(wxDateTime::Now().FormatISODate(), m_date_format));
     }
 
 }

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -152,7 +152,7 @@ mmHTMLBuilder::mmHTMLBuilder()
 {
     today_.date = wxDateTime::Now();
     today_.todays_date = wxString::Format(_("Report Generated %1$s %2$s")
-        , mmGetDateForDisplay(today_.date.FormatISODate())
+        , mmGetDateTimeForDisplay(today_.date.FormatISODate())
         , today_.date.FormatISOTime());
 }
 
@@ -213,8 +213,8 @@ void mmHTMLBuilder::DisplayDateHeading(const wxDateTime& startDate, const wxDate
     wxString sDate;
     if (withDateRange && startDate.IsValid() && endDate.IsValid()) {
         sDate << wxString::Format(_("From %1$s till %2$s")
-            , mmGetDateForDisplay(startDate.FormatISODate())
-            , withNoEndDate ? _("Future") : mmGetDateForDisplay(endDate.FormatISODate()));
+            , mmGetDateTimeForDisplay(startDate.FormatISODate())
+            , withNoEndDate ? _("Future") : mmGetDateTimeForDisplay(endDate.FormatISODate()));
     }
     else if (!withDateRange) {
         sDate << _("Over Time");
@@ -377,7 +377,7 @@ void mmHTMLBuilder::addTableCellDate(const wxString& iso_date)
 {
     html_ += wxString::Format(tags::TABLE_CELL
         , wxString::Format(" class='text-left' sorttable_customkey = '%s' nowrap", iso_date));
-    html_ += mmGetDateForDisplay(iso_date);
+    html_ += mmGetDateTimeForDisplay(iso_date);
     this->endTableCell();
 }
 

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -75,7 +75,7 @@ void mmReportTransactions::UDFCFormatHelper(Model_CustomField::TYPE_ID type, int
             bool v = wxString("TRUE|true|1").Contains(data);
             hb.addTableCell(v ? "&check;" : "&cross;", false, true);
         } else
-            hb.addTableCell(type == Model_CustomField::TYPE_ID_DATE && !data.empty() ? mmGetDateForDisplay(data) : data);
+            hb.addTableCell(type == Model_CustomField::TYPE_ID_DATE && !data.empty() ? mmGetDateTimeForDisplay(data) : data);
     }
 }
 
@@ -167,7 +167,7 @@ table {
         else if (groupBy == mmFilterTransactionsDialog::GROUPBY_TYPE)
             sortLabel = wxGetTranslation(transaction.TRANSCODE);
         else if (groupBy == mmFilterTransactionsDialog::GROUPBY_DAY)
-            sortLabel = mmGetDateForDisplay(transaction.TRANSDATE);
+            sortLabel = mmGetDateTimeForDisplay(transaction.TRANSDATE);
         else if (groupBy == mmFilterTransactionsDialog::GROUPBY_MONTH)
             sortLabel = Model_Checking::TRANSDATE(transaction).Format("%Y-%m");
         else if (groupBy == mmFilterTransactionsDialog::GROUPBY_YEAR)

--- a/src/stockdialog.cpp
+++ b/src/stockdialog.cpp
@@ -886,7 +886,7 @@ void mmStockDialog::OnHistoryAddButton(wxCommandEvent& /*event*/)
     if (i != m_price_listbox->GetItemCount())
     {
         listStr = Model_Account::toString(dPrice, account, Option::instance().SharePrecision());
-        m_price_listbox->SetItem(i, 0, mmGetDateForDisplay(m_history_date_ctrl->GetValue().FormatISODate()));
+        m_price_listbox->SetItem(i, 0, mmGetDateTimeForDisplay(m_history_date_ctrl->GetValue().FormatISODate()));
         m_price_listbox->SetItem(i, 1, listStr);
     }
     if (i == m_price_listbox->GetNextItem(-1)) // changed the current price/value
@@ -940,7 +940,7 @@ void mmStockDialog::ShowStockHistory()
             m_price_listbox->InsertItem(item);
             const wxDate dtdt = Model_StockHistory::DATE(histData.at(idx));
             const wxString dispAmount = Model_Account::toString(histData.at(idx).VALUE, account, Option::instance().SharePrecision());
-            m_price_listbox->SetItem(static_cast<long>(idx), 0, mmGetDateForDisplay(histData.at(idx).DATE));
+            m_price_listbox->SetItem(static_cast<long>(idx), 0, mmGetDateTimeForDisplay(histData.at(idx).DATE));
             m_price_listbox->SetItem(static_cast<long>(idx), 1, dispAmount);
             if (idx == 0)
             {

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -172,7 +172,7 @@ wxString StocksListCtrl::OnGetItemText(long item, long column) const
     column = m_real_columns[column];
 
     if (column == COL_ID)           return wxString::Format("%lld", m_stocks[item].STOCKID).Trim();
-    if (column == COL_DATE)         return mmGetDateForDisplay(m_stocks[item].PURCHASEDATE);
+    if (column == COL_DATE)         return mmGetDateTimeForDisplay(m_stocks[item].PURCHASEDATE);
     if (column == COL_NAME)         return m_stocks[item].STOCKNAME;
     if (column == COL_SYMBOL)       return m_stocks[item].SYMBOL;
     if (column == COL_NUMBER)
@@ -186,7 +186,7 @@ wxString StocksListCtrl::OnGetItemText(long item, long column) const
     if (column == COL_GAIN_LOSS)    return Model_Currency::toString(GetGainLoss(item), m_stock_panel->m_currency);
     if (column == COL_CURRENT)      return Model_Currency::toString(m_stocks[item].CURRENTPRICE, m_stock_panel->m_currency, 4);
     if (column == COL_CURRVALUE)    return Model_Currency::toString(Model_Stock::CurrentValue(m_stocks[item]), m_stock_panel->m_currency);
-    if (column == COL_PRICEDATE)    return mmGetDateForDisplay(Model_Stock::instance().lastPriceDate(&m_stocks[item]));
+    if (column == COL_PRICEDATE)    return mmGetDateTimeForDisplay(Model_Stock::instance().lastPriceDate(&m_stocks[item]));
     if (column == COL_COMMISSION)   return Model_Currency::toString(m_stocks[item].COMMISSION, m_stock_panel->m_currency);
     if (column == COL_NOTES)
     {

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -233,7 +233,7 @@ void mmStocksPanel::ViewStockTransactions(int selectedIndex)
         if (share_entry && ((share_entry->SHARENUMBER > 0) || (share_entry->SHAREPRICE > 0)))
         {
             stockTxnListCtrl->SetItemData(index, stock_trans.TRANSID.GetValue());
-            stockTxnListCtrl->SetItem(index, 0, mmGetDateForDisplay(stock_trans.TRANSDATE));
+            stockTxnListCtrl->SetItem(index, 0, mmGetDateTimeForDisplay(stock_trans.TRANSDATE));
             stockTxnListCtrl->SetItem(index, 1, share_entry->SHARELOT);
 
             int precision = share_entry->SHARENUMBER == floor(share_entry->SHARENUMBER) ? 0 : Option::instance().SharePrecision();
@@ -254,7 +254,7 @@ void mmStocksPanel::ViewStockTransactions(int selectedIndex)
 
         // Update the item fields in case something changed
         Model_Shareinfo::Data* share_entry = Model_Shareinfo::ShareEntry(txn->TRANSID);
-        stockTxnListCtrl->SetItem(index, 0, mmGetDateForDisplay(txn->TRANSDATE));
+        stockTxnListCtrl->SetItem(index, 0, mmGetDateTimeForDisplay(txn->TRANSDATE));
         stockTxnListCtrl->SetItem(index, 1, share_entry->SHARELOT);
 
         int precision = share_entry->SHARENUMBER == floor(share_entry->SHARENUMBER) ? 0 : Option::instance().SharePrecision();
@@ -494,7 +494,7 @@ bool mmStocksPanel::onlineQuoteRefresh(wxString& msg)
     StocksRefreshStatus_ = true;
 
     strLastUpdate_.Printf(_("%1$s on %2$s"), LastRefreshDT_.FormatTime()
-        , mmGetDateForDisplay(LastRefreshDT_.FormatISODate()));
+        , mmGetDateTimeForDisplay(LastRefreshDT_.FormatISODate()));
     Model_Infotable::instance().Set("STOCKS_LAST_REFRESH_DATETIME", strLastUpdate_);
 
     return true;

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -747,7 +747,7 @@ bool mmTransDialog::ValidateData()
             if (wxMessageBox(_(wxString::Format(
                 "Locked transaction to date: %s\n\n"
                 "Do you wish to continue ? "
-                , mmGetDateForDisplay(account->STATEMENTDATE)))
+                , mmGetDateTimeForDisplay(account->STATEMENTDATE)))
                 , _("MMEX Transaction Check"), wxYES_NO | wxICON_WARNING) == wxNO)
             {
                 return false;

--- a/src/util.h
+++ b/src/util.h
@@ -198,8 +198,9 @@ static const wxString MONTHS[12] =
 const wxDateTime getUserDefinedFinancialYear(bool prevDayRequired = false);
 const std::map<wxString, wxString> &date_formats_regex();
 bool mmParseISODate(const wxString& in_str, wxDateTime& out_date);
-const wxString mmGetDateForDisplay(const wxString &iso_date, const wxString& dateFormat = Option::instance().getDateFormat());
-const wxString mmGetTimeForDisplay(const wxString& iso_date);
+const wxString mmGetDateTimeForDisplay(const wxString &datetime_iso, const wxString& format = Option::instance().getDateFormat());
+const wxString mmGetDateForDisplay(const wxString &datetime_iso, const wxString& format = Option::instance().getDateFormat());
+const wxString mmGetTimeForDisplay(const wxString& datetime_iso);
 bool mmParseDisplayStringToDate(wxDateTime& date, const wxString& sDate, const wxString& sDateMask);
 extern const std::vector<std::pair<wxString, wxString>> g_date_formats_map();
 extern const std::map<int, std::pair<wxConvAuto, wxString> > g_encoding;

--- a/src/webappdialog.cpp
+++ b/src/webappdialog.cpp
@@ -215,7 +215,7 @@ void mmWebAppDialog::fillControls()
     {
         wxVector<wxVariant> data;
         data.push_back(wxVariant(wxString::Format(wxT("%lld"), WebTran.ID))); //WEBTRAN_ID
-        data.push_back(wxVariant(mmGetDateForDisplay(WebTran.Date.FormatISODate()))); //WEBTRAN_DATE
+        data.push_back(wxVariant(mmGetDateTimeForDisplay(WebTran.Date.FormatISODate()))); //WEBTRAN_DATE
         data.push_back(wxVariant(WebTran.Account)); //WEBTRAN_ACCOUNT
         data.push_back(wxVariant(WebTran.Status)); //WEBTRAN_STATUS
         data.push_back(wxVariant(wxGetTranslation(WebTran.Type))); //WEBTRAN_TYPE


### PR DESCRIPTION
This PR fixes the sorting by Date and Time in transaction panels.

## Changes in `util`

- Rename and fix `mmGetDateForDisplay` -> `mmGetDateTimeForDisplay`.
  - Match date pattern at the beginning of the string.
  - Fix double translation of `mon` and `weekday`.
  - Reset cache when it becomes too big (2000 entries).

- Add `mmGetDateForDisplay` (this is a new function).
  - Copy from `mmGetDateTimeForDisplay`.
  - Keep only the date part in the input ISO string.
  - Do not format time.

## Changes in `Model_Checking`

- Add `SorterByTRANSDATE_DATE`.

- Rename and fix `SorterByTRANSTIME` -> `SorterByTRANSDATE_TIME`.

- Fix `allByDateId()`.

## Changes in `Model_Account`

- Fix `transactionsByDateId()`.

## Changes in `TransactionListCtrl`

- Refactor `SortTransactions()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7135)
<!-- Reviewable:end -->
