### PR TITLE
new(#7122): add compounding period in asset dialog

### DIFF
--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -118,8 +118,11 @@ void mmAssetDialog::dataToControls()
 
     // m_asset->VALUECHANGERATE is the rate with daily compounding
     double valueChangeRate = m_asset->VALUECHANGERATE;
-    if (m_compounding != Option::COMPOUNDING_ID_DAY)
+    if (valueChangeType != Model_Asset::CHANGE_ID_NONE &&
+        m_compounding != Option::COMPOUNDING_ID_DAY
+    ) {
         valueChangeRate = convertRate(valueChangeType, valueChangeRate, Option::COMPOUNDING_ID_DAY, m_compounding);
+    }
     m_valueChangeRate->SetValue(valueChangeRate, 3);
     enableDisableRate(valueChangeType != Model_Asset::CHANGE_ID_NONE);
 

--- a/src/assetdialog.h
+++ b/src/assetdialog.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "option.h"
 #include "model/Model_Asset.h"
 #include "model/Model_Translink.h"
 
@@ -51,8 +52,10 @@ private:
     void OnOk(wxCommandEvent& event);
     void OnCancel(wxCommandEvent& event);
     void OnAttachments(wxCommandEvent& event);
-    void OnChangeAppreciationType(wxCommandEvent& event);
     void enableDisableRate(bool en);
+    double convertRate(int changeType, double xRate, int xCompounding, int yCompounding = Option::COMPOUNDING_ID_DAY);
+    void OnChangeAppreciationType(wxCommandEvent& event);
+    void OnChangeCompounding(wxCommandEvent& event);
     void dataToControls();
     void changeFocus(wxChildFocusEvent& event);
     void OnQuit(wxCloseEvent& event);
@@ -65,9 +68,12 @@ private:
     mmDatePickerCtrl* m_dpc = nullptr;
     wxTextCtrl* m_notes = nullptr;
     mmTextCtrl* m_value = nullptr;
-    mmTextCtrl* m_valueChangeRate = nullptr;
-    wxChoice*  m_valueChange = nullptr;
+    wxChoice* m_valueChange = nullptr;
+    wxStaticText* m_compoundingLabel = nullptr;
+    wxChoice* m_compoundingChoice = nullptr;
+    Option::COMPOUNDING_ID m_compounding = Option::COMPOUNDING_ID_DAY;
     wxStaticText* m_valueChangeRateLabel = nullptr;
+    mmTextCtrl* m_valueChangeRate = nullptr;
     wxBitmapButton* bAttachments_ = nullptr;
     wxStaticBox* m_transaction_frame = nullptr;
     UserTransactionPanel* m_transaction_panel = nullptr;
@@ -80,8 +86,9 @@ private:
     enum
     {
         IDC_COMBO_TYPE = wxID_HIGHEST + 1100,
-        IDC_NOTES,
         IDC_VALUE,
+        IDC_COMPOUNDING,
         IDC_RATE,
+        IDC_NOTES,
     };
 };

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -30,6 +30,21 @@
 #include "model/Model_Currency.h"
 #include "model/Model_CurrencyHistory.h"
 
+const std::vector<std::pair<Option::COMPOUNDING_ID, wxString> > Option::COMPOUNDING_NAME =
+{
+    { Option::COMPOUNDING_ID_DAY,   wxString(wxTRANSLATE("Day")) },
+    { Option::COMPOUNDING_ID_WEEK,  wxString(wxTRANSLATE("Week")) },
+    { Option::COMPOUNDING_ID_MONTH, wxString(wxTRANSLATE("Month")) },
+    { Option::COMPOUNDING_ID_YEAR,  wxString(wxTRANSLATE("Year")) },
+};
+const std::vector<std::pair<Option::COMPOUNDING_ID, int> > Option::COMPOUNDING_N =
+{
+    { Option::COMPOUNDING_ID_DAY,   365 },
+    { Option::COMPOUNDING_ID_WEEK,  52 },
+    { Option::COMPOUNDING_ID_MONTH, 12 },
+    { Option::COMPOUNDING_ID_YEAR,  1 },
+};
+
 //----------------------------------------------------------------------------
 Option::Option()
 :   m_dateFormat(mmex::DEFDATEFORMAT)
@@ -51,6 +66,12 @@ void Option::LoadOptions(bool include_infotable)
         m_financialYearStartDayString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_DAY", "1");
         m_financialYearStartMonthString = Model_Infotable::instance().GetStringInfo("FINANCIAL_YEAR_START_MONTH", "7");
         m_sharePrecision = Model_Infotable::instance().GetIntInfo("SHARE_PRECISION", 4);
+        wxString assetCompounding = Model_Infotable::instance().GetStringInfo("ASSET_COMPOUNDING", "Day");
+        m_assetCompounding = Option::COMPOUNDING_ID_DAY;
+        for (const auto& a : Option::COMPOUNDING_NAME) if (assetCompounding == a.second) {
+            m_assetCompounding = a.first;
+            break;
+        }
         m_baseCurrency = Model_Infotable::instance().GetInt64Info("BASECURRENCYID", -1);
         m_currencyHistoryEnabled = Model_Infotable::instance().GetBoolInfo(INIDB_USE_CURRENCY_HISTORY, true);
         m_budget_days_offset = Model_Infotable::instance().GetIntInfo("BUDGET_DAYS_OFFSET", 0);
@@ -371,6 +392,17 @@ void Option::SharePrecision(const int value)
 int Option::SharePrecision() const noexcept
 {
     return m_sharePrecision;
+}
+
+void Option::AssetCompounding(const int value)
+{
+    Model_Infotable::instance().Set("ASSET_COMPOUNDING", Option::COMPOUNDING_NAME[value].second);
+    m_assetCompounding = value;
+}
+
+int Option::AssetCompounding() const noexcept
+{
+    return m_assetCompounding;
 }
 
 void Option::SendUsageStatistics(const bool value)

--- a/src/option.h
+++ b/src/option.h
@@ -33,6 +33,15 @@ class Option
 public:
     enum USAGE_TYPE { NONE = 0, LASTUSED, UNUSED, DEFAULT };
     enum THEME_MODE { AUTO = 0, LIGHT, DARK };
+    enum COMPOUNDING_ID {
+        COMPOUNDING_ID_DAY = 0,
+        COMPOUNDING_ID_WEEK,
+        COMPOUNDING_ID_MONTH,
+        COMPOUNDING_ID_YEAR,
+        COMPOUNDING_ID_size
+    };
+    static const std::vector<std::pair<COMPOUNDING_ID, wxString> > COMPOUNDING_NAME;
+    static const std::vector<std::pair<COMPOUNDING_ID, int> > COMPOUNDING_N;
 
 public:
     Option();
@@ -126,6 +135,9 @@ public:
     void SharePrecision(const int value);
     int SharePrecision() const noexcept;
 
+    void AssetCompounding(const int value);
+    int AssetCompounding() const noexcept;
+
     // Allows a year or financial year to start before or after the 1st of the month.
     void setBudgetDaysOffset(const int value);
     int getBudgetDaysOffset() const noexcept;
@@ -205,6 +217,7 @@ private:
     bool m_usageStatistics = true;
     bool m_newsChecking = true;                    //INIDB_CHECK_NEWS
     int m_sharePrecision = 4;
+    int m_assetCompounding = Option::COMPOUNDING_ID_DAY;
 
     int m_theme_mode = Option::AUTO;
     int m_html_font_size = 100;

--- a/src/optionsettingsmisc.cpp
+++ b/src/optionsettingsmisc.cpp
@@ -88,13 +88,25 @@ void OptionSettingsMisc::Create()
         , wxSP_ARROW_KEYS, 2, 10, Option::instance().SharePrecision());
     m_share_precision->SetValue(Option::instance().SharePrecision());
     mmToolTip(m_share_precision, _("Set the precision for Share prices"));
-
     share_precision_sizer->Add(m_share_precision, wxSizerFlags(g_flagsExpand).Proportion(0));
 
     m_refresh_quotes_on_open = new wxCheckBox(misc_panel, wxID_REFRESH, _("Refresh at Startup"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_refresh_quotes_on_open->SetValue(Model_Setting::instance().GetBoolSetting("REFRESH_STOCK_QUOTES_ON_OPEN", false));
     share_precision_sizer->Add(m_refresh_quotes_on_open, wxSizerFlags(g_flagsH).Border(wxLEFT, 20));
     othersPanelSizer->Add(share_precision_sizer, g_flagsBorder1V);
+
+    // Asset Compounding
+    wxFlexGridSizer* asset_compounding_sizer = new wxFlexGridSizer(0, 3, 0, 0);
+    asset_compounding_sizer->Add(new wxStaticText(misc_panel, wxID_STATIC, _("Asset Compounding Period")), g_flagsH);
+    m_asset_compounding = new wxChoice(misc_panel, ID_DIALOG_OPTIONS_ASSET_COMPOUNDING);
+    for (const auto& a : Option::COMPOUNDING_NAME)
+        m_asset_compounding->Append(wxGetTranslation(a.second));
+    m_asset_compounding->SetSelection(Option::instance().AssetCompounding());
+    mmToolTip(m_asset_compounding,
+        _("Select the compounding period for the appreciation/depreciation rate of assets")
+    );
+    asset_compounding_sizer->Add(m_asset_compounding, wxSizerFlags(g_flagsExpand).Proportion(0));
+    othersPanelSizer->Add(asset_compounding_sizer, g_flagsBorder1V);
 
     // New transaction dialog settings
     wxStaticBox* transSettingsStaticBox = new wxStaticBox(misc_panel, wxID_STATIC, _("New Transaction"));
@@ -132,10 +144,8 @@ void OptionSettingsMisc::Create()
 
     wxChoice* default_status = new wxChoice(misc_panel
         , ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS);
-
     for (const auto& i : Model_Checking::STATUS_STR)
         default_status->Append(wxGetTranslation(i), new wxStringClientData(i));
-
     default_status->SetSelection(Option::instance().TransStatusReconciled());
 
     wxArrayString true_false;
@@ -282,6 +292,7 @@ bool OptionSettingsMisc::SaveSettings()
 
     SaveStocksUrl();
     Option::instance().SharePrecision(m_share_precision->GetValue());
+    Option::instance().AssetCompounding(m_asset_compounding->GetSelection());
 
     wxCheckBox* itemCheckBox = static_cast<wxCheckBox*>(FindWindow(ID_DIALOG_OPTIONS_CHK_BACKUP));
     Model_Setting::instance().Set("BACKUPDB", itemCheckBox->GetValue());

--- a/src/optionsettingsmisc.h
+++ b/src/optionsettingsmisc.h
@@ -51,6 +51,7 @@ private:
     wxSpinCtrl* m_deleted_trans_retain_days = nullptr;
     wxSpinCtrl* m_share_precision = nullptr;
     wxCheckBox* m_refresh_quotes_on_open = nullptr;
+    wxChoice* m_asset_compounding = nullptr;
 
     enum
     {
@@ -58,6 +59,7 @@ private:
         ID_DIALOG_OPTIONS_CHK_BACKUP,
         ID_DIALOG_OPTIONS_CHK_BACKUP_UPDATE,
         ID_DIALOG_OPTIONS_TEXTCTRL_STOCKURL,
+        ID_DIALOG_OPTIONS_ASSET_COMPOUNDING,
         ID_DIALOG_OPTIONS_BULK_ENTER,
         ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_PAYEE,
         ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_CATEGORY_NONTRANSFER,


### PR DESCRIPTION
This PR adds a choice for compounding period in asset dialog.

The asset value is appreciated/depreciated if `ASSETS_V1.VALUECHANGE` is "Appreciates" or "Depreciates", resp., using the "compounding interest formula" with annual rate equal to `ASSETS_V1.VALUECHANGERATE` and with daily compounding.

Although the rate is always stored into the database with daily compounding, the asset dialog shows the equivalent rate for the user's preferable compounding period.

## Change in Infotable

- Add `ASSET_COMPOUNDING` of type string and values "Day", "Week", "Month", "Year".

## Change in Settings

- In Settings -> Other, add "Asset Compounding Period", connected to Infotable `ASSET_COMPOUNDING`.

## Changes in `Option`

- Add enum `COMPOUNDING_ID`.
- Add `COMPOUNDING_NAME`, `COMPOUNDING_N`.
- Add `AssetCompounding()`.
- Refine `LoadOptions()`.

## Changes in `OptionSettingsMisc`

- Refine `Create()`, `SaveSettings()`.

## Changes in `mmAssetDialog`

- Add `convertRate()`, `OnChangeCompounding()`.
- Refine `dataToControls()`, `CreateControls()`, `OnOk()`, `enableDisableRate()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7138)
<!-- Reviewable:end -->
