### PR TITLE
fix(#7204): correct usage of underscore translation macro

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -523,7 +523,7 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
             menu.Append(
                 MENU_ON_PASTE_TRANSACTION,
                 wxString::Format(
-                    wxPLURAL(_("&Paste Transaction"), _("&Paste Transactions (%d)"),
+                    wxPLURAL("&Paste Transaction", "&Paste Transactions (%d)",
                         (toPaste < 2) ? 1 : toPaste
                     ),
                     toPaste
@@ -1480,7 +1480,7 @@ void TransactionListCtrl::OnDeleteTransaction(wxCommandEvent& WXUNUSED(event))
             , "Do you want to delete the %i selected transactions?", sel)
             , sel);
     text += "\n\n";
-    text += _((m_cp->isDeletedTrans() || retainDays == 0) ? _("Unable to undo this action.")
+    text += ((m_cp->isDeletedTrans() || retainDays == 0) ? _("Unable to undo this action.")
         : _("Deleted transactions will be temporarily stored and can be restored from the Deleted Transactions view."));
 
     wxMessageDialog msgDlg(this
@@ -1543,10 +1543,10 @@ bool TransactionListCtrl::TransactionLocked(int64 accountID, const wxString& tra
         wxDateTime transaction_date;
         if (transaction_date.ParseDate(transdate)) {
             if (transaction_date <= Model_Account::DateOf(account->STATEMENTDATE)) {
-                wxMessageBox(_(wxString::Format(
+                wxMessageBox(wxString::Format(
                     _("Locked transaction to date: %s\n\n"
-                        "Reconciled transactions.")
-                    , mmGetDateTimeForDisplay(account->STATEMENTDATE)))
+                      "Reconciled transactions.")
+                    , mmGetDateTimeForDisplay(account->STATEMENTDATE))
                     , _("MMEX Transaction Check"), wxOK | wxICON_WARNING);
                 return true;
             }

--- a/src/optiondialog.cpp
+++ b/src/optiondialog.cpp
@@ -216,7 +216,7 @@ void mmOptionsDialog::OnApply(wxCommandEvent& /*event*/)
     int selected_page = m_listbook->GetSelection();
     if (m_panel_list[selected_page]->SaveSettings())
     {
-        const wxString& msg = wxString::Format(_("%s page has been saved."), _(s_pagetitle[selected_page]));
+        const wxString& msg = wxString::Format(_("%s page has been saved."), wxGetTranslation(s_pagetitle[selected_page]));
         wxMessageBox(msg, _("Settings"));
     }
 

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -84,7 +84,7 @@ wxString mmReportMyUsage::getHTMLText()
              {
                  const wxString rep_name_1 = pattern.GetMatch(rep_name, 1);
                  const wxString rep_name_2 = pattern.GetMatch(rep_name, 3);
-                 module += " / " + _(rep_name_1) + (rep_name_2.empty() ? "" : " - " + _(rep_name_2));
+                 module += " / " + wxGetTranslation(rep_name_1) + (rep_name_2.empty() ? "" : " - " + wxGetTranslation(rep_name_2));
              }
              else
              {

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -594,7 +594,7 @@ void mmStocksPanel::enableEditDeleteButtons(bool en)
     if (!en)
     {
         if (Option::instance().getShowMoneyTips())
-            stock_details_->SetLabelText(_(STOCKTIPS[rand() % (sizeof(STOCKTIPS) / sizeof(wxString))]));
+            stock_details_->SetLabelText(wxGetTranslation(STOCKTIPS[rand() % (sizeof(STOCKTIPS) / sizeof(wxString))]));
         stock_details_short_->SetLabelText(wxString::Format(_("Last updated %s"), strLastUpdate_));
     }
 }

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -744,10 +744,10 @@ bool mmTransDialog::ValidateData()
     {
         if (dpc_->GetValue() <= Model_Account::DateOf(account->STATEMENTDATE))
         {
-            if (wxMessageBox(_(wxString::Format(
-                "Locked transaction to date: %s\n\n"
-                "Do you want to continue?"
-                , mmGetDateTimeForDisplay(account->STATEMENTDATE)))
+            if (wxMessageBox(wxString::Format(
+                _("Locked transaction to date: %s\n\n"
+                  "Do you want to continue?")
+                , mmGetDateTimeForDisplay(account->STATEMENTDATE))
                 , _("MMEX Transaction Check"), wxYES_NO | wxICON_WARNING) == wxNO)
             {
                 return false;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7205)
<!-- Reviewable:end -->
