### PR TITLE
fix(#7210): generate and process new tag events in split dialog

### DIFF
--- a/src/mmSimpleDialogs.cpp
+++ b/src/mmSimpleDialogs.cpp
@@ -1784,6 +1784,13 @@ bool mmTagTextCtrl::Validate(const wxString& tagText)
                 // Save the new tag to reference
                 tag_map_[tag] = newTag->TAGID;
                 tagCheckListBox_->Append(tag);
+
+                // Generate an event to tell the parent that a new tag has been added
+                // This is necessary for dialogs that contain multiple tag controls (e.g. split transaction)
+                // since the parent must reinitialize other tag controls to include the new tag
+                wxListEvent evt(wxEVT_COMMAND_LIST_INSERT_ITEM);
+                evt.SetId(GetId());
+                GetEventHandler()->AddPendingEvent(evt);
             }
             else
             {

--- a/src/splittransactionsdialog.cpp
+++ b/src/splittransactionsdialog.cpp
@@ -137,6 +137,7 @@ EVT_CHILD_FOCUS(mmSplitTransactionDialog::OnFocusChange)
 EVT_BUTTON(wxID_OK, mmSplitTransactionDialog::OnOk)
 EVT_BUTTON(mmID_SPLIT, mmSplitTransactionDialog::OnAddRow)
 EVT_BUTTON(mmID_REMOVE, mmSplitTransactionDialog::OnRemoveRow)
+EVT_LIST_INSERT_ITEM(wxID_ANY, mmSplitTransactionDialog::OnNewTagCreated)
 wxEND_EVENT_TABLE()
 
 // Used to determine if we need to refresh the tag text ctrl after
@@ -476,6 +477,19 @@ void mmSplitTransactionDialog::OnTextEntered(wxCommandEvent& event)
         UpdateSplitTotal();
     }
     event.Skip();
+}
+
+void mmSplitTransactionDialog::OnNewTagCreated(wxListEvent& event)
+{
+    // Get the ID of the tag control that had a new tag added
+    int id = event.GetId();
+
+    // Loop through all split rows and reinitialize all other tag controls to pick up the new tag
+    for (auto row : m_splits_widgets)
+    {
+        if (row.tags->GetId() != id)
+            row.tags->Reinitialize();
+    }
 }
 
 void mmSplitTransactionDialog::OnOtherButton(wxCommandEvent& event)

--- a/src/splittransactionsdialog.h
+++ b/src/splittransactionsdialog.h
@@ -95,6 +95,7 @@ private:
 
     void OnOk(wxCommandEvent& event);
     void OnAddRow(wxCommandEvent& event);
+    void OnNewTagCreated(wxListEvent& event);
     void OnRemoveRow(wxCommandEvent&);
     void OnOtherButton(wxCommandEvent& event);
     void OnTextEntered(wxCommandEvent& event);


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7219)
<!-- Reviewable:end -->
