### PR TITLE
new(#7150), part 5: refine mmCheckingPanel, TransactionListCtrl

### DIFF
--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -316,13 +316,16 @@ bool mmAssetsListCtrl::EditAsset(Model_Asset::Data* pEntry)
 void mmAssetsListCtrl::OnColClick(wxListEvent& event)
 {
     int ColumnNr;
-    if (event.GetId() != MENU_HEADER_SORT)
-         ColumnNr = event.GetColumn();
+    if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
+        ColumnNr = event.GetColumn();
     else
-         ColumnNr = m_ColumnHeaderNbr;
+        ColumnNr = m_ColumnHeaderNbr;
     if (0 > ColumnNr || ColumnNr >= m_panel->col_max() || ColumnNr == 0) return;
 
-    if (m_selected_col == ColumnNr && event.GetId() != MENU_HEADER_SORT) m_asc = !m_asc;
+    if (m_selected_col == ColumnNr &&
+        event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
+    )
+        m_asc = !m_asc;
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -178,13 +178,15 @@ billsDepositsListCtrl::~billsDepositsListCtrl()
 void billsDepositsListCtrl::OnColClick(wxListEvent& event)
 {
     int ColumnNr;
-    if (event.GetId() != MENU_HEADER_SORT)
+    if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
         ColumnNr = event.GetColumn();
     else
         ColumnNr = m_ColumnHeaderNbr;
     if (0 > ColumnNr || ColumnNr >= m_bdp->getColumnsNumber() || ColumnNr == 0) return;
 
-    if (m_selected_col == ColumnNr && event.GetId() != MENU_HEADER_SORT) m_asc = !m_asc;
+    if (m_selected_col == ColumnNr &&
+        event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
+    ) m_asc = !m_asc;
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);

--- a/src/daterange2.cpp
+++ b/src/daterange2.cpp
@@ -290,6 +290,16 @@ const wxString DateRange2::Spec::getLabel() const
     return sb.buffer;
 }
 
+const wxString DateRange2::Spec::getLabelName() const
+{
+    wxString s = getLabel();
+    if (!name.empty()) {
+        s.append("; ");
+        s.append(name);
+    }
+    return s;
+}
+
 const wxString DateRange2::Spec::checking_name() const
 {
     wxString str = getLabel();
@@ -301,6 +311,7 @@ const wxString DateRange2::Spec::checking_description() const
 {
     static StringBuilder sb;
     sb.reset();
+    sb.append(getLabel());
     // TODO
     return sb.buffer;
 }
@@ -454,6 +465,32 @@ wxDateTime DateRange2::reporting_end() const
     return wxInvalidDateTime;
 }
 
+const wxString DateRange2::checking_tooltip() const
+{
+    static StringBuilder sb;
+    sb.reset();
+
+    wxDateTime date1 = checking_start();
+    wxDateTime date2 = checking_end();
+    if (date1 != wxInvalidDateTime)
+        sb.append(dateISO(date1));
+    sb.sep(); sb.append(".."); sb.sep();
+    if (date2 != wxInvalidDateTime)
+        sb.append(dateISO(date2));
+    sb.flush();
+
+    sb.append("\n");
+    sb.append(spec.checking_description());
+    return sb.buffer;
+}
+
+const wxString DateRange2::reporting_tooltip() const
+{
+    // TODO
+    return "";
+}
+
+
 #ifndef NDEBUG
 DateRange2::DateRange2(
     int firstDay_new_0, int firstDay_new_1,
@@ -523,7 +560,7 @@ bool DateRange2::debug()
             wxLogDebug("ERROR in checking[%d]: Cannot parse [%s]", i, spec);
             continue;
         }
-        wxString label = dr.getSpec().getLabel();
+        wxString label = dr.getLabel();
         if (label != spec)
             wxLogDebug("checking[%d] [%s]: label=[%s]", i, spec, label);
         wxString sc = dateISO(dr.checking_start());

--- a/src/daterange2.h
+++ b/src/daterange2.h
@@ -80,8 +80,10 @@ public:
         void parseName(StringIt &str_i, StringIt str_end);
         void setName(const wxString &name_new);
         bool parseSpec(const wxString &str, const wxString &name_new = "");
+        bool hasPeriodS() const;
         const wxString getLabel() const;
         const wxString getName() const;
+        const wxString getLabelName() const;
         const wxString checking_name() const;
         const wxString checking_description() const;
 
@@ -96,12 +98,12 @@ public:
     DateRange2(wxDateTime date_s = wxInvalidDateTime, wxDateTime date_t = wxInvalidDateTime);
 
 protected:
-    const int firstDay[2];                  // first day in PERIOD_ID_[YQM] (1..28)
-    const wxDateTime::Month firstMonth[2];  // first month in PERIOD_ID_[YQ] (0..11)
-    const wxDateTime::WeekDay firstWeekday; // first weekday in PERIOD_ID_W (0=Sun, 1=Mon)
-    wxDateTime date_t;                      // the date of PERIOD_ID_T
-    wxDateTime date_s;                      // the date of PERIOD_ID_S
-    Spec spec;                              // range specification
+    int firstDay[2];                  // first day in PERIOD_ID_[YQM] (1..28)
+    wxDateTime::Month firstMonth[2];  // first month in PERIOD_ID_[YQ] (0..11)
+    wxDateTime::WeekDay firstWeekday; // first weekday in PERIOD_ID_W (0=Sun, 1=Mon)
+    wxDateTime date_t;                // the date of PERIOD_ID_T
+    wxDateTime date_s;                // the date of PERIOD_ID_S
+    Spec spec;                        // range specification
 
 public:
     void setDateT(wxDateTime date = wxInvalidDateTime);
@@ -111,12 +113,21 @@ public:
     void setSpec(const Spec &spec_new);
     bool parseSpec(const wxString &str, const wxString &name = "");
     Spec getSpec() const;
+    const wxString getLabel() const;
+    const wxString getName() const;
+    const wxString getLabelName() const;
     wxDateTime period_start(wxDateTime date, PERIOD_ID period) const;
     wxDateTime period_end(wxDateTime date, PERIOD_ID period) const;
     wxDateTime checking_start() const;
     wxDateTime checking_end() const;
     wxDateTime reporting_start() const;
     wxDateTime reporting_end() const;
+    const wxString checking_start_str() const;
+    const wxString checking_end_str() const;
+    const wxString reporting_start_str() const;
+    const wxString reporting_end_str() const;
+    const wxString checking_tooltip() const;
+    const wxString reporting_tooltip() const;
 
 private:
     static wxDateTime addOffset(wxDateTime date, int offset, PERIOD_ID period);
@@ -137,6 +148,13 @@ public:
 inline void DateRange2::Spec::setName(const wxString &name_new)
 {
     name = name_new;
+}
+
+inline bool DateRange2::Spec::hasPeriodS() const
+{
+    return
+        sp1 == PERIOD_ID_S || ep1 == PERIOD_ID_S ||
+        sp2 == PERIOD_ID_S || ep2 == PERIOD_ID_S;
 }
 
 inline const wxString DateRange2::Spec::offset_str(int offset, bool show_zero)
@@ -191,5 +209,40 @@ inline void DateRange2::setSpec(const DateRange2::Spec &spec_new)
 inline DateRange2::Spec DateRange2::getSpec() const
 {
     return spec;
+}
+
+inline const wxString DateRange2::getLabel() const
+{
+    return spec.getLabel();
+}
+
+inline const wxString DateRange2::getName() const
+{
+    return spec.getName();
+}
+
+inline const wxString DateRange2::getLabelName() const
+{
+    return spec.getLabelName();
+}
+
+inline const wxString DateRange2::checking_start_str() const
+{
+    return dateISOStart(checking_start());
+}
+
+inline const wxString DateRange2::checking_end_str() const
+{
+    return dateISOEnd(checking_end());
+}
+
+inline const wxString DateRange2::reporting_start_str() const
+{
+    return dateISOStart(reporting_start());
+}
+
+inline const wxString DateRange2::reporting_end_str() const
+{
+    return dateISOEnd(reporting_end());
 }
 

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -1532,7 +1532,7 @@ int mmFilterTransactionsDialog::mmIsRecordMatches(const Model_Billsdeposits::Dat
 const wxString mmFilterTransactionsDialog::mmGetDescriptionToolTip() const
 {
     wxString buffer;
-    wxString data = mmGetJsonSetings(true);
+    wxString data = mmGetJsonSettings(true);
     Document j_doc;
     if (j_doc.Parse(data.utf8_str()).HasParseError())
     {
@@ -1631,7 +1631,7 @@ void mmFilterTransactionsDialog::mmGetDescription(mmHTMLBuilder& hb)
 {
     hb.addHeader(4, _("Filtering Details: "));
     // Extract the parameters from the transaction dialog and add them to the report.
-    wxString data = mmGetJsonSetings(true);
+    wxString data = mmGetJsonSettings(true);
     Document j_doc;
     if (j_doc.Parse(data.utf8_str()).HasParseError())
     {
@@ -1744,7 +1744,7 @@ const wxString mmFilterTransactionsDialog::mmGetTypes() const
     return type;
 }
 
-const wxString mmFilterTransactionsDialog::mmGetJsonSetings(bool i18n) const
+const wxString mmFilterTransactionsDialog::mmGetJsonSettings(bool i18n) const
 {
     StringBuffer json_buffer;
     PrettyWriter<StringBuffer> json_writer(json_buffer);
@@ -2111,14 +2111,14 @@ void mmFilterTransactionsDialog::mmDoUpdateSettings()
     if (isMultiAccount_ && m_setting_name->GetSelection() != wxNOT_FOUND) {
         int i = Model_Infotable::instance().findArrayItem(m_filter_key, mmGetLabelString());
         if (i != wxNOT_FOUND) {
-            m_settings_json = mmGetJsonSetings();
+            m_settings_json = mmGetJsonSettings();
             Model_Infotable::instance().updateArrayItem(m_filter_key, i, m_settings_json);
         }
     }
     if (!isReportMode_) {
         Model_Infotable::instance().setString(
             wxString::Format("CHECK_FILTER_ID_ADV_%lld", accountID_),
-            mmGetJsonSetings()
+            mmGetJsonSettings()
         );
     }
 }
@@ -2145,7 +2145,7 @@ void mmFilterTransactionsDialog::mmDoSaveSettings(bool is_user_request)
         {
             m_setting_name->Append(user_label);
             m_setting_name->SetStringSelection(user_label);
-            m_settings_json = mmGetJsonSetings();
+            m_settings_json = mmGetJsonSettings();
             Model_Infotable::instance().prependArrayItem(m_filter_key, m_settings_json, -1);
         }
         else if (label == user_label)
@@ -2170,7 +2170,7 @@ void mmFilterTransactionsDialog::mmDoSaveSettings(bool is_user_request)
             // Named filters are updated automatically in the "All Transactions" panel
             if (m_setting_name->GetStringSelection() == "")
             {
-                m_settings_json = mmGetJsonSetings();
+                m_settings_json = mmGetJsonSettings();
                 updateLastUsed = true;
             }
         }
@@ -2180,7 +2180,7 @@ void mmFilterTransactionsDialog::mmDoSaveSettings(bool is_user_request)
             const auto& l = mmGetLabelString();
             int sel_json = Model_Infotable::instance().findArrayItem(m_filter_key, l);
             const auto& json = sel_json != wxNOT_FOUND ? filter_settings[sel_json] : "";
-            m_settings_json = mmGetJsonSetings();
+            m_settings_json = mmGetJsonSettings();
             if (isMultiAccount_ && json != m_settings_json && !label.empty())
             {
                 if (wxMessageBox(_("Filter settings have changed") + "\n" + _("Do you want to save them before continuing?") + "\n\n", _("Please confirm"),

--- a/src/filtertransdialog.h
+++ b/src/filtertransdialog.h
@@ -118,7 +118,7 @@ public:
     const wxString mmGetEndDate() const;
     int mmGetStartDay() const;
     bool mmIsFutureIgnored() const;
-    const wxString mmGetJsonSetings(bool i18n = false) const;
+    const wxString mmGetJsonSettings(bool i18n = false) const;
     const wxString mmGetLabelString() const;
 
 private:

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -43,184 +43,56 @@
 //----------------------------------------------------------------------------
 
 wxBEGIN_EVENT_TABLE(TransactionListCtrl, mmListCtrl)
-    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, TransactionListCtrl::OnListItemActivated)
-    EVT_LIST_ITEM_SELECTED(wxID_ANY, TransactionListCtrl::OnListItemSelected)
-    EVT_LIST_ITEM_DESELECTED(wxID_ANY, TransactionListCtrl::OnListItemDeSelected)
-    EVT_LIST_ITEM_FOCUSED(wxID_ANY, TransactionListCtrl::OnListItemFocused)
-    EVT_RIGHT_DOWN(TransactionListCtrl::OnMouseRightClick)
-    EVT_LEFT_DOWN(TransactionListCtrl::OnListLeftClick)
-    EVT_LIST_KEY_DOWN(wxID_ANY, TransactionListCtrl::OnListKeyDown)
-    
-    EVT_MENU_RANGE(MENU_TREEPOPUP_MARKRECONCILED
-        , MENU_TREEPOPUP_MARKDELETE, TransactionListCtrl::OnMarkTransaction)
+    EVT_CHAR(TransactionListCtrl::onChar)
+    EVT_LEFT_DOWN(TransactionListCtrl::onListLeftClick)
+    EVT_RIGHT_DOWN(TransactionListCtrl::onMouseRightClick)
 
-    EVT_MENU(MENU_TREEPOPUP_WITHDRAWAL, TransactionListCtrl::OnNewTransaction)
-    EVT_MENU(MENU_TREEPOPUP_DEPOSIT, TransactionListCtrl::OnNewTransaction)
-    EVT_MENU(MENU_TREEPOPUP_TRANSFER, TransactionListCtrl::OnNewTransaction)
-    EVT_MENU(MENU_TREEPOPUP_DELETE2, TransactionListCtrl::OnDeleteTransaction)
-    EVT_MENU(MENU_TREEPOPUP_RESTORE, TransactionListCtrl::OnRestoreTransaction)
-    EVT_MENU(MENU_TREEPOPUP_RESTORE_VIEWED, TransactionListCtrl::OnRestoreViewedTransaction)
-    EVT_MENU_RANGE(MENU_TREEPOPUP_DELETE_VIEWED, MENU_TREEPOPUP_DELETE_UNRECONCILED, TransactionListCtrl::OnDeleteViewedTransaction)
-    EVT_MENU(MENU_TREEPOPUP_EDIT2, TransactionListCtrl::OnEditTransaction)
-    EVT_MENU(MENU_TREEPOPUP_MOVE2, TransactionListCtrl::OnMoveTransaction)
+    EVT_LIST_ITEM_ACTIVATED(wxID_ANY,  TransactionListCtrl::onListItemActivated)
+    EVT_LIST_ITEM_SELECTED(wxID_ANY,   TransactionListCtrl::onListItemSelected)
+    EVT_LIST_ITEM_DESELECTED(wxID_ANY, TransactionListCtrl::onListItemDeSelected)
+    EVT_LIST_ITEM_FOCUSED(wxID_ANY,    TransactionListCtrl::onListItemFocused)
+    EVT_LIST_KEY_DOWN(wxID_ANY,        TransactionListCtrl::onListKeyDown)
 
-    EVT_MENU(MENU_ON_SELECT_ALL, TransactionListCtrl::OnSelectAll)
-    EVT_MENU(MENU_ON_COPY_TRANSACTION, TransactionListCtrl::OnCopy)
-    EVT_MENU(MENU_ON_PASTE_TRANSACTION, TransactionListCtrl::OnPaste)
-    EVT_MENU(MENU_ON_NEW_TRANSACTION, TransactionListCtrl::OnNewTransaction)
-    EVT_MENU(MENU_ON_DUPLICATE_TRANSACTION, TransactionListCtrl::OnDuplicateTransaction)
-    EVT_MENU(MENU_ON_ENTER_SCHEDULED, TransactionListCtrl::OnEnterScheduled)
-    EVT_MENU(MENU_ON_SKIP_SCHEDULED, TransactionListCtrl::OnSkipScheduled)
-    EVT_MENU_RANGE(MENU_ON_SET_UDC0, MENU_ON_SET_UDC7, TransactionListCtrl::OnSetUserColour)
+    EVT_MENU(MENU_TREEPOPUP_WITHDRAWAL,            TransactionListCtrl::onNewTransaction)
+    EVT_MENU(MENU_TREEPOPUP_DEPOSIT,               TransactionListCtrl::onNewTransaction)
+    EVT_MENU(MENU_TREEPOPUP_TRANSFER,              TransactionListCtrl::onNewTransaction)
+    EVT_MENU(MENU_TREEPOPUP_DELETE2,               TransactionListCtrl::onDeleteTransaction)
+    EVT_MENU(MENU_TREEPOPUP_RESTORE,               TransactionListCtrl::onRestoreTransaction)
+    EVT_MENU(MENU_TREEPOPUP_RESTORE_VIEWED,        TransactionListCtrl::onRestoreViewedTransaction)
+    EVT_MENU(MENU_TREEPOPUP_EDIT2,                 TransactionListCtrl::onEditTransaction)
+    EVT_MENU(MENU_TREEPOPUP_MOVE2,                 TransactionListCtrl::onMoveTransaction)
+    EVT_MENU(MENU_TREEPOPUP_VIEW_OTHER_ACCOUNT,    TransactionListCtrl::onViewOtherAccount)
+    EVT_MENU(MENU_TREEPOPUP_VIEW_SPLIT_CATEGORIES, TransactionListCtrl::onViewSplitTransaction)
+    EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS,  TransactionListCtrl::onOrganizeAttachments)
+    EVT_MENU(MENU_TREEPOPUP_CREATE_REOCCURANCE,    TransactionListCtrl::onCreateReoccurance)
+    EVT_MENU(MENU_TREEPOPUP_FIND,                  TransactionListCtrl::onFind)
+    EVT_MENU(MENU_TREEPOPUP_COPYTEXT,              TransactionListCtrl::onCopyText)
+    EVT_MENU_RANGE(
+        MENU_TREEPOPUP_MARKRECONCILED,
+        MENU_TREEPOPUP_MARKDELETE,
+        TransactionListCtrl::onMarkTransaction
+    )
+    EVT_MENU_RANGE(
+        MENU_TREEPOPUP_DELETE_VIEWED,
+        MENU_TREEPOPUP_DELETE_UNRECONCILED,
+        TransactionListCtrl::onDeleteViewedTransaction
+    )
 
-    EVT_MENU(MENU_TREEPOPUP_VIEW_OTHER_ACCOUNT, TransactionListCtrl::OnViewOtherAccount)
-    EVT_MENU(MENU_TREEPOPUP_VIEW_SPLIT_CATEGORIES, TransactionListCtrl::OnViewSplitTransaction)
-    EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, TransactionListCtrl::OnOrganizeAttachments)
-    EVT_MENU(MENU_TREEPOPUP_CREATE_REOCCURANCE, TransactionListCtrl::OnCreateReoccurance)
-    EVT_MENU(MENU_TREEPOPUP_FIND, TransactionListCtrl::findInAllTransactions)
-    EVT_MENU(MENU_TREEPOPUP_COPYTEXT, TransactionListCtrl::OnCopyText)
-    EVT_CHAR(TransactionListCtrl::OnChar)
-
+    EVT_MENU(MENU_ON_SELECT_ALL,            TransactionListCtrl::onSelectAll)
+    EVT_MENU(MENU_ON_COPY_TRANSACTION,      TransactionListCtrl::onCopy)
+    EVT_MENU(MENU_ON_PASTE_TRANSACTION,     TransactionListCtrl::onPaste)
+    EVT_MENU(MENU_ON_NEW_TRANSACTION,       TransactionListCtrl::onNewTransaction)
+    EVT_MENU(MENU_ON_DUPLICATE_TRANSACTION, TransactionListCtrl::onDuplicateTransaction)
+    EVT_MENU(MENU_ON_ENTER_SCHEDULED,       TransactionListCtrl::onEnterScheduled)
+    EVT_MENU(MENU_ON_SKIP_SCHEDULED,        TransactionListCtrl::onSkipScheduled)
+    EVT_MENU_RANGE(
+        MENU_ON_SET_UDC0,
+        MENU_ON_SET_UDC7,
+        TransactionListCtrl::onSetUserColour
+    )
 wxEND_EVENT_TABLE();
+
 //----------------------------------------------------------------------------
-
-TransactionListCtrl::EColumn TransactionListCtrl::toEColumn(const unsigned long col)
-{
-    EColumn res = COL_def_sort;
-    if (col < m_real_columns.size())
-        res = static_cast<EColumn>(col);
-    return res;
-}
-
-template<class Compare>
-void TransactionListCtrl::SortBy(Compare comp, bool ascend)
-{
-    if (ascend)
-        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), comp);
-    else
-        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), comp);
-}
-
-void TransactionListCtrl::SortTransactions(int sortcol, bool ascend)
-{
-    const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
-    Model_CustomField::TYPE_ID type;
-
-    switch (m_real_columns[sortcol]) {
-    case TransactionListCtrl::COL_SN:
-        SortBy(Fused_Transaction::SorterByFUSEDTRANSSN(), ascend);
-        break;
-    case TransactionListCtrl::COL_ID:
-        SortBy(Fused_Transaction::SorterByFUSEDTRANSID(), ascend);
-        break;
-    case TransactionListCtrl::COL_NUMBER:
-        SortBy(Model_Checking::SorterByNUMBER(), ascend);
-        break;
-    case TransactionListCtrl::COL_ACCOUNT:
-        SortBy(SorterByACCOUNTNAME(), ascend);
-        break;
-    case TransactionListCtrl::COL_PAYEE_STR:
-        SortBy(SorterByPAYEENAME(), ascend);
-        break;
-    case TransactionListCtrl::COL_STATUS:
-        SortBy(SorterBySTATUS(), ascend);
-        break;
-    case TransactionListCtrl::COL_CATEGORY:
-        SortBy(SorterByCATEGNAME(), ascend);
-        break;
-    case TransactionListCtrl::COL_TAGS:
-        SortBy(Model_Checking::SorterByTAGNAMES(), ascend);
-        break;
-    case TransactionListCtrl::COL_WITHDRAWAL:
-        SortBy(Model_Checking::SorterByWITHDRAWAL(), ascend);
-        break;
-    case TransactionListCtrl::COL_DEPOSIT:
-        SortBy(Model_Checking::SorterByDEPOSIT(), ascend);
-        break;
-    case TransactionListCtrl::COL_BALANCE:
-        SortBy(Model_Checking::SorterByBALANCE(), ascend);
-        break;
-    case TransactionListCtrl::COL_CREDIT:
-        SortBy(Model_Checking::SorterByBALANCE(), ascend);
-        break;
-    case TransactionListCtrl::COL_NOTES:
-        SortBy(SorterByNOTES(), ascend);
-        break;
-    case TransactionListCtrl::COL_DATE:
-        SortBy(Model_Checking::SorterByTRANSDATE_DATE(), ascend);
-        break;
-    case TransactionListCtrl::COL_TIME:
-        SortBy(Model_Checking::SorterByTRANSDATE_TIME(), ascend);
-        break;
-    case TransactionListCtrl::COL_DELETEDTIME:
-        SortBy(SorterByDELETEDTIME(), ascend);
-        break;
-    case TransactionListCtrl::COL_UDFC01:
-        type = Model_CustomField::getUDFCType(ref_type, "UDFC01");
-        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            SortBy(SorterByUDFC01_val, ascend);
-        else
-            SortBy(SorterByUDFC01, ascend);
-        break;
-    case TransactionListCtrl::COL_UDFC02:
-        type = Model_CustomField::getUDFCType(ref_type, "UDFC02");
-        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            SortBy(SorterByUDFC02_val, ascend);
-        else
-            SortBy(SorterByUDFC02, ascend);
-        break;
-    case TransactionListCtrl::COL_UDFC03:
-        type = Model_CustomField::getUDFCType(ref_type, "UDFC03");
-        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            SortBy(SorterByUDFC03_val, ascend);
-        else
-            SortBy(SorterByUDFC03, ascend);
-        break;
-    case TransactionListCtrl::COL_UDFC04:
-        type = Model_CustomField::getUDFCType(ref_type, "UDFC04");
-        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            SortBy(SorterByUDFC04_val, ascend);
-        else
-            SortBy(SorterByUDFC04, ascend);
-        break;
-    case TransactionListCtrl::COL_UDFC05:
-        type = Model_CustomField::getUDFCType(ref_type, "UDFC05");
-        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-            SortBy(SorterByUDFC05_val, ascend);
-        else
-            SortBy(SorterByUDFC05, ascend);
-        break;
-    case TransactionListCtrl::COL_UPDATEDTIME:
-        SortBy(SorterByLASTUPDATEDTIME(), ascend);
-        break;
-    default:
-        break;
-    }
-}
-
-void TransactionListCtrl::sortTable()
-{
-    if (m_trans.empty()) return;
-
-    SortTransactions(prev_g_sortcol, prev_g_asc);
-    SortTransactions(g_sortcol, g_asc);
-
-    wxString sortText = wxString::Format(
-        "%s: %s %s / %s %s", _("Sort Order"),
-        m_columns[g_sortcol].HEADER, g_asc ? L"\u25B2" : L"\u25BC",
-        m_columns[prev_g_sortcol].HEADER, prev_g_asc ? L"\u25B2" : L"\u25BC"
-    );
-    m_cp->m_header_sortOrder->SetLabelText(sortText);
-
-    if (m_real_columns[g_sortcol] == COL_SN)
-        m_cp->showTips(_("SN (Sequence Number) has the same order as Date/ID (or Date/Time/ID if Time is enabled)."));
-    else if (m_real_columns[g_sortcol] == COL_ID)
-        m_cp->showTips(_("ID (identification number) is increasing with the time of creation in the database."));
-    else if (m_real_columns[g_sortcol] == COL_BALANCE)
-        m_cp->showTips(_("Balance is calculated in the order of SN (Sequence Number)."));
-
-    RefreshItems(0, m_trans.size() - 1);
-}
 
 TransactionListCtrl::TransactionListCtrl(
     mmCheckingPanel *cp,
@@ -296,8 +168,7 @@ TransactionListCtrl::TransactionListCtrl(
     m_selectedForCopy.clear();
     mmThemeMetaColour(this, meta::COLOR_LISTPANEL);
 
-    const wxAcceleratorEntry entries[] =
-    {
+    const wxAcceleratorEntry entries[] = {
         wxAcceleratorEntry(wxACCEL_CTRL, 'A', MENU_ON_SELECT_ALL),
         wxAcceleratorEntry(wxACCEL_CTRL, 'C', MENU_ON_COPY_TRANSACTION),
         wxAcceleratorEntry(wxACCEL_CTRL, 'V', MENU_ON_PASTE_TRANSACTION),
@@ -335,6 +206,11 @@ TransactionListCtrl::TransactionListCtrl(
 
     SetSingleStyle(wxLC_SINGLE_SEL, false);
 }
+
+TransactionListCtrl::~TransactionListCtrl()
+{}
+
+//----------------------------------------------------------------------------
 
 void TransactionListCtrl::resetColumns()
 {
@@ -410,77 +286,359 @@ void TransactionListCtrl::resetColumns()
     CreateColumns();
 }
 
-TransactionListCtrl::~TransactionListCtrl()
-{}
-
-void TransactionListCtrl::setExtraTransactionData(const bool single)
+void TransactionListCtrl::refreshVisualList(bool filter)
 {
-    int repeat_num = 0;
-    bool isForeign = false;
-    if (single) {
-        Fused_Transaction::IdRepeat id = m_selected_id[0];
-        Fused_Transaction::Data tran = !id.second ?
-            Fused_Transaction::Data(*Model_Checking::instance().get(id.first)) :
-            Fused_Transaction::Data(*Model_Billsdeposits::instance().get(id.first));
-        if (Model_Checking::foreignTransaction(tran))
-            isForeign = true;
-        repeat_num = id.second;
+    wxLogDebug("refreshVisualList: %i selected, filter: %d", GetSelectedItemCount(), filter);
+
+    // Grab the selected transactions unless we have freshly pasted transactions in which case use them
+    if (m_pasted_id.empty()) {
+        findSelectedTransactions();
     }
-    m_cp->updateExtraTransactionData(single, repeat_num, isForeign);
+    else {
+        m_selected_id.clear();
+        m_selected_id.insert(std::end(m_selected_id), std::begin(m_pasted_id), std::end(m_pasted_id));
+        m_pasted_id.clear();    // Now clear them
+    }
+
+    m_today = Option::instance().UseTransDateTime() ?
+        wxDateTime::Now().FormatISOCombined() :
+        wxDateTime(23, 59, 59, 999).FormatISOCombined();
+    this->SetEvtHandlerEnabled(false);
+    Hide();
+
+    // decide whether top or down icon needs to be shown
+    setColumnImage(g_sortCol1, g_sortAsc1 ? mmCheckingPanel::ICON_DESC : mmCheckingPanel::ICON_ASC);
+    if (filter)
+        m_cp->filterList();
+    SetItemCount(m_trans.size());
+    Show();
+    sortTable();
+    markSelectedTransaction();
+
+    long i = static_cast<long>(m_trans.size());
+    if (m_topItemIndex > i || m_topItemIndex < 0)
+        m_topItemIndex = g_sortAsc1 ? i - 1 : 0;
+
+    i = 0;
+    for(const auto& entry : m_trans) {
+        int64 id = !entry.m_repeat_num ? entry.TRANSID : entry.m_bdid;
+        for (const auto& item : m_selected_id) {
+            if (item.first == id && item.second == entry.m_repeat_num) {
+                SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+                SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+                EnsureVisible(i);
+            }
+        }
+        i++;
+    }
+    findSelectedTransactions();
+
+    if (m_topItemIndex >= 0 && m_topItemIndex < i && m_selected_id.empty())
+        EnsureVisible(m_topItemIndex);
+
+    m_cp->updateHeader();
+    setExtraTransactionData(GetSelectedItemCount() == 1);
+    this->SetEvtHandlerEnabled(true);
+    Refresh();
+    Update();
+    SetFocus();
 }
+
+void TransactionListCtrl::sortTable()
+{
+    if (m_trans.empty()) return;
+
+    sortTransactions(g_sortCol2, g_sortAsc2);
+    sortTransactions(g_sortCol1, g_sortAsc1);
+
+    wxString sortText = wxString::Format(
+        "%s: %s %s / %s %s", _("Sort Order"),
+        m_columns[g_sortCol1].HEADER, g_sortAsc1 ? L"\u25B2" : L"\u25BC",
+        m_columns[g_sortCol2].HEADER, g_sortAsc2 ? L"\u25B2" : L"\u25BC"
+    );
+    m_cp->m_header_sortOrder->SetLabelText(sortText);
+
+    if (m_real_columns[g_sortCol1] == COL_SN)
+        m_cp->showTips(_("SN (Sequence Number) has the same order as Date/ID (or Date/Time/ID if Time is enabled)."));
+    else if (m_real_columns[g_sortCol1] == COL_ID)
+        m_cp->showTips(_("ID (identification number) is increasing with the time of creation in the database."));
+    else if (m_real_columns[g_sortCol1] == COL_BALANCE)
+        m_cp->showTips(_("Balance is calculated in the order of SN (Sequence Number)."));
+
+    RefreshItems(0, m_trans.size() - 1);
+}
+
+template<class Compare>
+void TransactionListCtrl::sortBy(Compare comp, bool ascend)
+{
+    if (ascend)
+        std::stable_sort(this->m_trans.begin(), this->m_trans.end(), comp);
+    else
+        std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), comp);
+}
+
+void TransactionListCtrl::sortTransactions(int sortcol, bool ascend)
+{
+    const auto& ref_type = Model_Attachment::REFTYPE_STR_TRANSACTION;
+    Model_CustomField::TYPE_ID type;
+
+    switch (m_real_columns[sortcol]) {
+    case TransactionListCtrl::COL_SN:
+        sortBy(Fused_Transaction::SorterByFUSEDTRANSSN(), ascend);
+        break;
+    case TransactionListCtrl::COL_ID:
+        sortBy(Fused_Transaction::SorterByFUSEDTRANSID(), ascend);
+        break;
+    case TransactionListCtrl::COL_NUMBER:
+        sortBy(Model_Checking::SorterByNUMBER(), ascend);
+        break;
+    case TransactionListCtrl::COL_ACCOUNT:
+        sortBy(SorterByACCOUNTNAME(), ascend);
+        break;
+    case TransactionListCtrl::COL_PAYEE_STR:
+        sortBy(SorterByPAYEENAME(), ascend);
+        break;
+    case TransactionListCtrl::COL_STATUS:
+        sortBy(SorterBySTATUS(), ascend);
+        break;
+    case TransactionListCtrl::COL_CATEGORY:
+        sortBy(SorterByCATEGNAME(), ascend);
+        break;
+    case TransactionListCtrl::COL_TAGS:
+        sortBy(Model_Checking::SorterByTAGNAMES(), ascend);
+        break;
+    case TransactionListCtrl::COL_WITHDRAWAL:
+        sortBy(Model_Checking::SorterByWITHDRAWAL(), ascend);
+        break;
+    case TransactionListCtrl::COL_DEPOSIT:
+        sortBy(Model_Checking::SorterByDEPOSIT(), ascend);
+        break;
+    case TransactionListCtrl::COL_BALANCE:
+        sortBy(Model_Checking::SorterByBALANCE(), ascend);
+        break;
+    case TransactionListCtrl::COL_CREDIT:
+        sortBy(Model_Checking::SorterByBALANCE(), ascend);
+        break;
+    case TransactionListCtrl::COL_NOTES:
+        sortBy(SorterByNOTES(), ascend);
+        break;
+    case TransactionListCtrl::COL_DATE:
+        sortBy(Model_Checking::SorterByTRANSDATE_DATE(), ascend);
+        break;
+    case TransactionListCtrl::COL_TIME:
+        sortBy(Model_Checking::SorterByTRANSDATE_TIME(), ascend);
+        break;
+    case TransactionListCtrl::COL_DELETEDTIME:
+        sortBy(SorterByDELETEDTIME(), ascend);
+        break;
+    case TransactionListCtrl::COL_UDFC01:
+        type = Model_CustomField::getUDFCType(ref_type, "UDFC01");
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
+            sortBy(SorterByUDFC01_val, ascend);
+        else
+            sortBy(SorterByUDFC01, ascend);
+        break;
+    case TransactionListCtrl::COL_UDFC02:
+        type = Model_CustomField::getUDFCType(ref_type, "UDFC02");
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
+            sortBy(SorterByUDFC02_val, ascend);
+        else
+            sortBy(SorterByUDFC02, ascend);
+        break;
+    case TransactionListCtrl::COL_UDFC03:
+        type = Model_CustomField::getUDFCType(ref_type, "UDFC03");
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
+            sortBy(SorterByUDFC03_val, ascend);
+        else
+            sortBy(SorterByUDFC03, ascend);
+        break;
+    case TransactionListCtrl::COL_UDFC04:
+        type = Model_CustomField::getUDFCType(ref_type, "UDFC04");
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
+            sortBy(SorterByUDFC04_val, ascend);
+        else
+            sortBy(SorterByUDFC04, ascend);
+        break;
+    case TransactionListCtrl::COL_UDFC05:
+        type = Model_CustomField::getUDFCType(ref_type, "UDFC05");
+        if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
+            sortBy(SorterByUDFC05_val, ascend);
+        else
+            sortBy(SorterByUDFC05, ascend);
+        break;
+    case TransactionListCtrl::COL_UPDATEDTIME:
+        sortBy(SorterByLASTUPDATEDTIME(), ascend);
+        break;
+    default:
+        break;
+    }
+}
+
 //----------------------------------------------------------------------------
 
-void TransactionListCtrl::OnListItemSelected(wxListEvent&)
+wxString TransactionListCtrl::OnGetItemText(long item, long column) const
 {
-    wxLogDebug("OnListItemSelected: %i selected", GetSelectedItemCount());
-    FindSelectedTransactions();
-    setExtraTransactionData(GetSelectedItemCount() == 1);
+    return getItem(item, column);
 }
 
-void TransactionListCtrl::OnListItemDeSelected(wxListEvent&)
+// Returns the icon to be shown for each transaction for the required column
+int TransactionListCtrl::OnGetItemColumnImage(long item, long column) const
 {
-    wxLogDebug("OnListItemDeSelected: %i selected", GetSelectedItemCount());
-    FindSelectedTransactions();
-    setExtraTransactionData(GetSelectedItemCount() == 1);
+    if (m_trans.empty()) return -1;
+
+    int res = -1;
+    if (m_real_columns[static_cast<int>(column)] == COL_IMGSTATUS) {
+        wxString status = getItem(item, COL_STATUS, true);
+        if (status.length() > 1)
+            status = status.Mid(2, 1);
+        if (status == Model_Checking::STATUS_KEY_FOLLOWUP)
+            res = mmCheckingPanel::ICON_FOLLOWUP;
+        else if (status == Model_Checking::STATUS_KEY_RECONCILED)
+            res = mmCheckingPanel::ICON_RECONCILED;
+        else if (status == Model_Checking::STATUS_KEY_VOID)
+            res = mmCheckingPanel::ICON_VOID;
+        else if (status == Model_Checking::STATUS_KEY_DUPLICATE)
+            res = mmCheckingPanel::ICON_DUPLICATE;
+        else
+            res = mmCheckingPanel::ICON_UNRECONCILED;
+    }
+
+    return res;
 }
 
-void TransactionListCtrl::OnListItemFocused(wxListEvent& WXUNUSED(event))
+// Failed wxASSERT will hang application if active modal dialog presents on screen.
+// Assertion's message box will be hidden until you press tab to activate one.
+wxListItemAttr* TransactionListCtrl::OnGetItemAttr(long item) const
 {
-    wxLogDebug("OnListItemFocused: %i selected", GetSelectedItemCount());
-    FindSelectedTransactions();
-    setExtraTransactionData(GetSelectedItemCount() == 1);
+    if (item < 0 || item >= static_cast<int>(m_trans.size())) return 0;
+
+    wxString strDate = Model_Checking::TRANSDATE(m_trans[item]).FormatISOCombined();
+    bool in_the_future = (strDate > m_today);
+
+    // apply alternating background pattern
+    int user_color_id = m_trans[item].COLOR.GetValue();
+    if (user_color_id < 0) user_color_id = 0;
+    else if (user_color_id > 7) user_color_id = 0;
+
+    if (user_color_id == 0) {
+        if (in_the_future) {
+            return (item % 2 ? m_attr3.get() : m_attr4.get());
+        }
+        return (item % 2 ? m_attr1.get() : m_attr2.get());
+    }
+
+    switch (user_color_id) {
+    case 1: return m_attr11.get();
+    case 2: return m_attr12.get();
+    case 3: return m_attr13.get();
+    case 4: return m_attr14.get();
+    case 5: return m_attr15.get();
+    case 6: return m_attr16.get();
+    case 7: return m_attr17.get();
+    }
+    return (item % 2 ? m_attr1.get() : m_attr2.get());
 }
 
-void TransactionListCtrl::OnListLeftClick(wxMouseEvent& event)
+void TransactionListCtrl::OnColClick(wxListEvent& event)
 {
-    wxLogDebug("OnListLeftClick: %i selected", GetSelectedItemCount());
+    findSelectedTransactions();
+    int sortCol;
+    bool sortAsc;
+    if (event.GetId() == MENU_HEADER_SORT) {
+        sortCol = m_ColumnHeaderNbr;
+        sortAsc = g_sortAsc1;
+    }
+    else if (event.GetId() == MENU_HEADER_RESET) {
+        sortCol = m_ColumnHeaderNbr;
+        sortAsc = true;
+        g_sortAsc1 = true;
+    }
+    else {
+        sortCol = event.GetColumn();
+        sortAsc = (sortCol == g_sortCol1) ? !g_sortAsc1 : g_sortAsc1;
+    }
+
+    if (sortCol < 0 || sortCol >= m_real_columns.size() ||
+        GetRealColumn(sortCol) == COL_IMGSTATUS
+    )
+        return;
+
+    if (sortCol != g_sortCol1) {
+        setColumnImage(g_sortCol1, -1); // clear previous column image
+        g_sortCol2 = g_sortCol1;
+        g_sortAsc2 = g_sortAsc1;
+    }
+    g_sortCol1 = sortCol;
+    g_sortAsc1 = sortAsc;
+
+    // #7080: Decouple DATE and ID, since SN may be used instead of ID.
+    /*
+    // If primary is DATE, then set secondary to ID in the same direction
+    if (GetRealColumn(g_sortCol1) == COL_DATE) {
+        g_sortCol2 = GetColumnOrder(COL_ID);
+        g_sortAsc2 = g_sortAsc1;        
+    }
+    */
+
+    // store sort settings
+    wxString prefix = m_cp->sortPrefix();
+    Model_Setting::instance().setInt(wxString::Format("%s_SORT_COL", prefix), g_sortCol1);
+    Model_Setting::instance().setInt(wxString::Format("%s_SORT_COL2", prefix), g_sortCol2);
+    Model_Setting::instance().setInt(wxString::Format("%s_ASC", prefix), (g_sortAsc1 ? 1 : 0));
+    Model_Setting::instance().setInt(wxString::Format("%s_ASC2", prefix), (g_sortAsc2 ? 1 : 0));
+
+    refreshVisualList(false);
+}
+
+//----------------------------------------------------------------------------
+
+// If any of these keys are encountered, the search for the event handler
+// should continue as these keys may be processed by the operating system.
+void TransactionListCtrl::onChar(wxKeyEvent& event)
+{
+
+    int key = event.GetKeyCode();
+    if (key == WXK_ALT ||
+        key == WXK_COMMAND ||
+        key == WXK_UP ||
+        key == WXK_DOWN ||
+        key == WXK_LEFT ||
+        key == WXK_RIGHT ||
+        key == WXK_HOME ||
+        key == WXK_END ||
+        key == WXK_PAGEUP ||
+        key == WXK_PAGEDOWN ||
+        key == WXK_NUMPAD_UP ||
+        key == WXK_NUMPAD_DOWN ||
+        key == WXK_NUMPAD_LEFT ||
+        key == WXK_NUMPAD_RIGHT ||
+        key == WXK_NUMPAD_PAGEDOWN ||
+        key == WXK_NUMPAD_PAGEUP ||
+        key == WXK_NUMPAD_HOME ||
+        key == WXK_NUMPAD_END ||
+        key == WXK_DELETE ||
+        key == WXK_NUMPAD_DELETE ||
+        key == WXK_TAB ||
+        key == WXK_RETURN ||
+        key == WXK_NUMPAD_ENTER ||
+        key == WXK_SPACE ||
+        key == WXK_NUMPAD_SPACE
+    ) {
+        event.Skip();
+    }
+}
+
+void TransactionListCtrl::onListLeftClick(wxMouseEvent& event)
+{
+    wxLogDebug("onListLeftClick: %i selected", GetSelectedItemCount());
     event.Skip();
 }
 
-void TransactionListCtrl::OnListItemActivated(wxListEvent& /*event*/)
-{
-    wxLogDebug("OnListItemActivated: %i selected", GetSelectedItemCount());
-    wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_EDIT2);
-    AddPendingEvent(evt);
-}
-
-int TransactionListCtrl::getColumnFromPosition(int xPos)
-{
-    int column = 0;
-    int x = -GetScrollPos(wxHORIZONTAL);
-    for (column = 0; column < GetColumnCount(); column++) {
-        x += GetColumnWidth(column);
-        if (x >= xPos) break;
-    }
-    if (!(column < GetColumnCount())) return -1;
-    return column;
-}
-
-void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
+void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
 {
     rightClickFilter_ = "";
     copyText_ = "";
-    wxLogDebug("OnMouseRightClick: %i selected", GetSelectedItemCount());
+    wxLogDebug("onMouseRightClick: %i selected", GetSelectedItemCount());
     int selected = GetSelectedItemCount();
 
     bool is_nothing_selected = (selected < 1);
@@ -778,15 +936,490 @@ void TransactionListCtrl::OnMouseRightClick(wxMouseEvent& event)
     PopupMenu(&menu, event.GetPosition());
 }
 
-void TransactionListCtrl::findInAllTransactions(wxCommandEvent&) {
+//----------------------------------------------------------------------------
+
+void TransactionListCtrl::onListItemActivated(wxListEvent& /*event*/)
+{
+    wxLogDebug("onListItemActivated: %i selected", GetSelectedItemCount());
+    wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_EDIT2);
+    AddPendingEvent(evt);
+}
+
+void TransactionListCtrl::onListItemSelected(wxListEvent&)
+{
+    wxLogDebug("onListItemSelected: %i selected", GetSelectedItemCount());
+    findSelectedTransactions();
+    setExtraTransactionData(GetSelectedItemCount() == 1);
+}
+
+void TransactionListCtrl::onListItemDeSelected(wxListEvent&)
+{
+    wxLogDebug("onListItemDeSelected: %i selected", GetSelectedItemCount());
+    findSelectedTransactions();
+    setExtraTransactionData(GetSelectedItemCount() == 1);
+}
+
+void TransactionListCtrl::onListItemFocused(wxListEvent& WXUNUSED(event))
+{
+    wxLogDebug("onListItemFocused: %i selected", GetSelectedItemCount());
+    findSelectedTransactions();
+    setExtraTransactionData(GetSelectedItemCount() == 1);
+}
+
+void TransactionListCtrl::onListKeyDown(wxListEvent& event)
+{
+    if (wxGetKeyState(WXK_COMMAND) || wxGetKeyState(WXK_ALT) || wxGetKeyState(WXK_CONTROL))
+        return event.Skip();
+
+    int key = event.GetKeyCode();
+    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
+
+    if (!m_cp->isDeletedTrans()) {
+        if (key == wxKeyCode('R')) {
+            // Reconciled
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKRECONCILED);
+            onMarkTransaction(evt);
+        }
+        else if (key == wxKeyCode('U')) {
+            // Unreconciled
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKUNRECONCILED);
+            onMarkTransaction(evt);
+        }
+        else if (key == wxKeyCode('F')) {
+            // Follow Up
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARK_ADD_FLAG_FOLLOWUP);
+            onMarkTransaction(evt);
+        }
+        else if (key == wxKeyCode('D')) {
+            // Duplicate
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKDUPLICATE);
+            onMarkTransaction(evt);
+        }
+        else if (key == wxKeyCode('V')) {
+            // Void
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKVOID);
+            onMarkTransaction(evt);
+        }
+        else if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE)
+        {
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_DELETE2);
+            onDeleteTransaction(evt);
+        }
+        else {
+            event.Skip();
+            return;
+        }
+    }
+    else {
+        if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE) {
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_DELETE2);
+            onDeleteTransaction(evt);
+        }
+        else if (key == wxKeyCode('R')) {
+            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_RESTORE);
+            onRestoreTransaction(evt);
+        }
+        else {
+            event.Skip();
+            return;
+        }
+    }
+}
+
+//----------------------------------------------------------------------------
+
+void TransactionListCtrl::onNewTransaction(wxCommandEvent& event)
+{
+    int id = event.GetId();
+    int type;
+
+    switch (id) {
+    case MENU_TREEPOPUP_WITHDRAWAL:
+        type = Model_Checking::TYPE_ID_WITHDRAWAL;
+        break;
+    case MENU_TREEPOPUP_DEPOSIT:
+        type = Model_Checking::TYPE_ID_DEPOSIT;
+        break;
+    case MENU_TREEPOPUP_TRANSFER:
+        type = Model_Checking::TYPE_ID_TRANSFER;
+        break;
+    default:
+        type = Model_Checking::TYPE_ID_WITHDRAWAL;
+        break;
+    }
+
+    mmTransDialog dlg(this, m_cp->m_account_id, {0, false}, false, type);
+    int i = dlg.ShowModal();
+    if (i != wxID_CANCEL) {
+        m_selected_id.clear();
+        m_pasted_id.push_back({dlg.GetTransactionID(), 0});
+        m_cp->mmPlayTransactionSound();
+        refreshVisualList();
+
+        if (i == wxID_NEW) {
+            onNewTransaction(event);
+        }
+    }
+}
+
+void TransactionListCtrl::onDeleteTransaction(wxCommandEvent& WXUNUSED(event))
+{
+    // check if any transactions selected
+    int sel = GetSelectedItemCount();
+    if (sel < 1) return;
+
+    findSelectedTransactions();
+    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
+
+    //ask if they want to delete
+    wxString text = (m_cp->isDeletedTrans() || retainDays == 0)?
+        wxString::Format(wxPLURAL("Do you want to permanently delete the selected transaction?"
+        , "Do you want to permanently delete the %i selected transactions?", sel)
+        , sel)
+        :
+        wxString::Format(wxPLURAL("Do you want to delete the selected transaction?"
+            , "Do you want to delete the %i selected transactions?", sel)
+            , sel);
+    text += "\n\n";
+    text += ((m_cp->isDeletedTrans() || retainDays == 0) ? _("Unable to undo this action.")
+        : _("Deleted transactions will be temporarily stored and can be restored from the Deleted Transactions view."));
+
+    wxMessageDialog msgDlg(this
+        , text
+        , _("Confirm Transaction Deletion")
+        , wxYES_NO | wxYES_DEFAULT | (m_cp->isDeletedTrans() ? wxICON_ERROR : wxICON_WARNING));
+
+    if (msgDlg.ShowModal() == wxID_YES) {
+        wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
+        std::set<std::pair<wxString, int64>> assetStockAccts;
+        Model_Checking::instance().Savepoint();
+        Model_Attachment::instance().Savepoint();
+        Model_Splittransaction::instance().Savepoint();
+        Model_CustomFieldData::instance().Savepoint();
+        for (const auto& id : m_selected_id) {
+            if (id.second) continue;
+            Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
+
+            if (checkTransactionLocked(trx->ACCOUNTID, trx->TRANSDATE)) {
+                continue;
+            }
+
+            if (m_cp->isDeletedTrans() || retainDays == 0) {
+                // remove also removes split transactions, translink entries, attachments, and custom field data
+                Model_Checking::instance().remove(id.first);
+            }
+            else {
+                trx->DELETEDTIME = deletionTime;
+                Model_Checking::instance().save(trx);
+                Model_Translink::Data_Set translink = Model_Translink::instance().find(Model_Translink::CHECKINGACCOUNTID(trx->TRANSID));
+                if (!translink.empty()) {
+                    assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
+                }
+            }
+            m_selectedForCopy.erase(std::remove(m_selectedForCopy.begin(), m_selectedForCopy.end(), id)
+              , m_selectedForCopy.end());
+        }
+        m_selected_id.clear();
+        Model_CustomFieldData::instance().ReleaseSavepoint();
+        Model_Splittransaction::instance().ReleaseSavepoint();
+        Model_Attachment::instance().ReleaseSavepoint();
+        Model_Checking::instance().ReleaseSavepoint();
+
+        if (!assetStockAccts.empty()) {
+            for (const auto& i : assetStockAccts) {
+                if (i.first == "Asset") Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
+                else if (i.first == "Stock") Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
+            }
+        }
+    }
+    refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
+}
+
+void TransactionListCtrl::onRestoreTransaction(wxCommandEvent& WXUNUSED(event))
+{
+    // check if any transactions selected
+    int sel = GetSelectedItemCount();
+    if (sel < 1) return;
+
+    findSelectedTransactions();
+
+    //ask if they want to restore
+    const wxString text = wxString::Format(
+        wxPLURAL(
+            "Do you want to restore the selected transaction?",
+            "Do you want to restore the %i selected transactions?", sel
+        ),
+        sel
+    );
+
+    wxMessageDialog msgDlg(
+        this,
+        text,
+        _("Confirm Transaction Restore"),
+        wxYES_NO | wxYES_DEFAULT | wxICON_WARNING
+    );
+
+    if (msgDlg.ShowModal() == wxID_YES) {
+        std::set<std::pair<wxString, int64>> assetStockAccts;
+        for (const auto& id : m_selected_id) {
+            if (!id.second) {
+                Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
+                trx->DELETEDTIME.Clear();
+                Model_Checking::instance().save(trx);
+                Model_Translink::Data_Set translink = Model_Translink::instance().find(
+                    Model_Translink::CHECKINGACCOUNTID(trx->TRANSID)
+                );
+                if (!translink.empty()) {
+                    assetStockAccts.insert(std::make_pair(
+                        translink.at(0).LINKTYPE,
+                        translink.at(0).LINKRECORDID
+                    ));
+                }
+            }
+        }
+        m_selected_id.clear();
+        if (!assetStockAccts.empty()) {
+            for (const auto& i : assetStockAccts) {
+                if (i.first == "Asset")
+                    Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
+                else if (i.first == "Stock")
+                    Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
+            }
+        }
+    }
+
+    refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
+}
+
+void TransactionListCtrl::onRestoreViewedTransaction(wxCommandEvent&)
+{
+    wxMessageDialog msgDlg(
+        this,
+        _("Do you want to restore all of the transactions shown?"),
+        _("Confirm Transaction Restore"),
+        wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
+    );
+    if (msgDlg.ShowModal() == wxID_YES) {
+        std::set<std::pair<wxString, int64>> assetStockAccts;
+        for (const auto& tran : this->m_trans) {
+            if (tran.m_repeat_num) continue;
+            Model_Checking::Data* trx = Model_Checking::instance().get(tran.TRANSID);
+            trx->DELETEDTIME.Clear();
+            Model_Checking::instance().save(trx);
+            Model_Translink::Data_Set translink = Model_Translink::instance().find(
+                Model_Translink::CHECKINGACCOUNTID(trx->TRANSID)
+            );
+            if (!translink.empty()) {
+                assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
+            }
+        }
+        if (!assetStockAccts.empty()) {
+            for (const auto& i : assetStockAccts) {
+                if (i.first == "Asset")
+                    Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
+                else if (i.first == "Stock")
+                    Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
+            }
+        }
+    }
+    
+    refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
+}
+
+void TransactionListCtrl::onEditTransaction(wxCommandEvent& /*event*/)
+{
+    // check if anything to edit
+    if (GetSelectedItemCount() < 1) return;
+    findSelectedTransactions();
+
+    // edit multiple transactions
+    if (m_selected_id.size() > 1) {
+        std::vector<int64> transid;
+        for (const auto& id : m_selected_id)
+            if (!id.second)
+                transid.push_back(id.first);
+        if (transid.size() == 0) return;
+        if (!checkForClosedAccounts()) return;
+        transactionsUpdateDialog dlg(this, transid);
+        if (dlg.ShowModal() == wxID_OK)
+            refreshVisualList();
+        return;
+    }
+
+    // edit single transaction
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+    if (!id.second) {
+        Model_Checking::Data* checking_entry = Model_Checking::instance().get(id.first);
+        if (checkTransactionLocked(checking_entry->ACCOUNTID, checking_entry->TRANSDATE))
+            return;
+
+        if (Model_Checking::foreignTransaction(*checking_entry)) {
+            Model_Translink::Data translink = Model_Translink::TranslinkRecord(id.first);
+            if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK) {
+                ShareTransactionDialog dlg(this, &translink, checking_entry);
+                if (dlg.ShowModal() == wxID_OK)
+                    refreshVisualList();
+            }
+            else if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_ASSET) {
+                mmAssetDialog dlg(this, m_cp->m_frame, &translink, checking_entry);
+                if (dlg.ShowModal() == wxID_OK)
+                    refreshVisualList();
+            }
+            else {
+                wxASSERT(false);
+            }
+        }
+        else {
+            mmTransDialog dlg(this, m_cp->m_account_id, {id.first, false});
+            if (dlg.ShowModal() != wxID_CANCEL)
+                refreshVisualList();
+        }
+    }
+    else {
+        mmBDDialog dlg(this, id.first, false, false);
+        if ( dlg.ShowModal() == wxID_OK )
+            refreshVisualList();
+    }
+    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
+}
+
+void TransactionListCtrl::onMoveTransaction(wxCommandEvent& /*event*/)
+{
+    findSelectedTransactions();
+    int sel = GetSelectedItemCount();
+
+    //ask if they want to move
+    const wxString text = wxString::Format(
+        wxPLURAL("Do you want to move the selected transaction?"
+            , "Do you want to move the %i selected transactions?", sel)
+        , sel);
+    wxMessageDialog msgDlg(this
+        , text
+        , _("Confirm Transaction Move")
+        , wxYES_NO | wxYES_DEFAULT | wxICON_ERROR);
+
+    if (msgDlg.ShowModal() == wxID_YES) {
+        const wxString headerMsg = wxString::Format(
+                wxPLURAL_U8("Moving transaction to…"
+                , "Moving %i transactions to…", sel)
+                , sel);
+        mmSingleChoiceDialog scd(this
+            , _("Select the destination Account ")
+            , headerMsg
+            , Model_Account::instance().all_checking_account_names());
+        if (scd.ShowModal() == wxID_OK) {
+            int64 dest_account_id = -1;
+            wxString dest_account_name = scd.GetStringSelection();
+            Model_Account::Data* dest_account = Model_Account::instance().get(dest_account_name);
+            if (dest_account)
+                dest_account_id = dest_account->ACCOUNTID;
+            else
+                return;
+            std::vector<int64> skip_trx;
+            Model_Checking::instance().Savepoint();
+            for (const auto& id : m_selected_id) {
+                if (!id.second) {
+                    Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
+                    if (checkTransactionLocked(trx->ACCOUNTID, trx->TRANSDATE)
+                            || Model_Checking::foreignTransaction(*trx)
+                            || Model_Checking::type_id(trx->TRANSCODE) == Model_Checking::TYPE_ID_TRANSFER
+                            || trx->TRANSDATE < dest_account->INITIALDATE
+                    ) {
+                        skip_trx.push_back(trx->TRANSID);
+                    } else {
+                        trx->ACCOUNTID = dest_account_id;
+                        Model_Checking::instance().save(trx);
+                    }
+                }
+            }
+            Model_Checking::instance().ReleaseSavepoint();
+            if (!skip_trx.empty()) {
+                const wxString detail = wxString::Format("%s\n%s: %zu\n%s: %zu"
+                                , _("This is due to some elements of the transaction or account detail not allowing the move")
+                                , _("Moved"), m_selected_id.size() - skip_trx.size()
+                                , _("Not moved"), skip_trx.size());
+                mmErrorDialogs::MessageWarning(this
+                    , detail
+                    , _("Unable to move some transactions."));
+            }
+            //TODO: enable report to detail transactions that are unable to be moved
+            refreshVisualList();
+        }
+    }
+}
+
+void TransactionListCtrl::onViewOtherAccount(wxCommandEvent& /*event*/)
+{
+    // we can only get here for a single transfer transaction
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+
+    Fused_Transaction::Full_Data tran = !id.second ?
+        Fused_Transaction::Full_Data(*Model_Checking::instance().get(id.first)) :
+        Fused_Transaction::Full_Data(*Model_Billsdeposits::instance().get(id.first));
+
+    int64 gotoAccountID = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTID : tran.ACCOUNTID;
+    wxString gotoAccountName = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTNAME : tran.ACCOUNTNAME;   
+
+    m_cp->m_frame->setNavTreeAccount(gotoAccountName);
+    m_cp->m_frame->setGotoAccountID(gotoAccountID, id);
+    wxCommandEvent event(wxEVT_COMMAND_MENU_SELECTED, MENU_GOTOACCOUNT);
+    m_cp->m_frame->GetEventHandler()->AddPendingEvent(event);
+}
+
+void TransactionListCtrl::onViewSplitTransaction(wxCommandEvent& /*event*/)
+{
+    // we can only view a single transaction
+    if (GetSelectedItemCount() != 1) return;
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+
+    m_cp->displaySplitCategories({id.first, id.second != 0});
+}
+
+void TransactionListCtrl::onOrganizeAttachments(wxCommandEvent& /*event*/)
+{
+    // we only support a single transaction
+    if (GetSelectedItemCount() != 1) return;
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+
+    const wxString refType = !id.second ?
+        Model_Attachment::REFTYPE_STR_TRANSACTION :
+        Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
+    mmAttachmentDialog dlg(this, refType, id.first);
+    dlg.ShowModal();
+    refreshVisualList();
+}
+
+void TransactionListCtrl::onCreateReoccurance(wxCommandEvent& /*event*/)
+{
+     // we only support a single transaction
+    if (GetSelectedItemCount() != 1) return;
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+
+    if (!id.second) {
+        mmBDDialog dlg(this, 0, false, false);
+        dlg.SetDialogParameters(id.first);
+        if (dlg.ShowModal() == wxID_OK)
+            wxMessageBox(_("Scheduled transaction saved."));
+    }
+}
+
+void TransactionListCtrl::onFind(wxCommandEvent&)
+{
     if (rightClickFilter_.IsEmpty())
         return;
     // save the filter as the "Advanced" filter for All Transactions
     Model_Infotable::instance().setString("CHECK_FILTER_ID_ADV_-1", rightClickFilter_);
     // set All Transactions to use the "Advanced" filter
     Model_Infotable::instance().setString(
-        "CHECK_FILTER_ID_-1",
-        "{\n\"FILTER\": \"" + mmCheckingPanel::FILTER_STR_DIALOG + "\"\n}"
+        "CHECK_FILTER_-1",
+        "{ \"FILTER\": \"" + mmCheckingPanel::FILTER_NAME_ADVANCED + "\" }"
     );
     // Navigate to the All Transactions panel
     wxTreeItemId currentId = m_cp->m_frame->GetNavTreeSelection();
@@ -796,15 +1429,14 @@ void TransactionListCtrl::findInAllTransactions(wxCommandEvent&) {
         m_cp->m_trans_filter_dlg.reset(
             new mmFilterTransactionsDialog(this, -1, false, rightClickFilter_)
         );
-        m_cp->m_filter_id = mmCheckingPanel::FILTER_ID_DIALOG;
-        m_cp->updateFilterState();
+        m_cp->setFilterAdvanced();
         refreshVisualList();
     }
     else
         m_cp->m_frame->SetNavTreeSelection(m_cp->m_frame->GetNavTreeSelection());
 }
 
-void TransactionListCtrl::OnCopyText(wxCommandEvent&)
+void TransactionListCtrl::onCopyText(wxCommandEvent&)
 {
     if (!copyText_.IsEmpty()) {
         if (wxTheClipboard->Open()) {
@@ -813,11 +1445,10 @@ void TransactionListCtrl::OnCopyText(wxCommandEvent&)
         }
     }
 }
-//----------------------------------------------------------------------------
 
-void TransactionListCtrl::OnMarkTransaction(wxCommandEvent& event)
+void TransactionListCtrl::onMarkTransaction(wxCommandEvent& event)
 {
-    FindSelectedTransactions();
+    findSelectedTransactions();
     int evt = event.GetId();
     //bool bRefreshRequired = false;
     wxString org_status = "";
@@ -854,179 +1485,55 @@ void TransactionListCtrl::OnMarkTransaction(wxCommandEvent& event)
 
     refreshVisualList();
 }
-//----------------------------------------------------------------------------
 
-void TransactionListCtrl::OnColClick(wxListEvent& event)
+void TransactionListCtrl::onDeleteViewedTransaction(wxCommandEvent& event)
 {
-    FindSelectedTransactions();
-    int ColumnNr;
-    if (event.GetId() != MENU_HEADER_SORT)
-        ColumnNr = event.GetColumn();
-    else
-        ColumnNr = m_ColumnHeaderNbr;
+    auto i = event.GetId();
+    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
 
-    if (0 > ColumnNr || ColumnNr >= COL_size || ColumnNr == COL_IMGSTATUS) return;
+    if (i == MENU_TREEPOPUP_DELETE_VIEWED) {
+        wxString text = !(m_cp->isDeletedTrans() || retainDays == 0)
+            ? _("Do you want to delete all the transactions shown?")
+            : _("Do you want to permanently delete all the transactions shown?");
 
-    /* Clear previous column image */
-    if (m_sortCol != ColumnNr) {
-        setColumnImage(m_sortCol, -1);
-        prev_g_sortcol = g_sortcol;
-        prev_g_asc = m_asc;
-    }
+        text += "\n\n";
+        text += !(m_cp->isDeletedTrans() || retainDays == 0)
+            ? _("Deleted transactions will be temporarily stored and can be restored from the Deleted Transactions view.")
+            : _("Unable to undo this action.");
 
-    if (g_sortcol == ColumnNr && event.GetId() != MENU_HEADER_SORT) {
-        m_asc = !m_asc; // toggle sort order
-    }
-    g_asc = m_asc;
-
-    m_sortCol = toEColumn(ColumnNr);
-    g_sortcol = m_sortCol;
-
-    // disabled: If primary sort is DATE then secondary is always ID in the same direction
-    // decouple DATE and ID, since SN may be used instead of ID (see #7080)
-    if (false && ColumnNr == COL_DATE) {
-        prev_g_sortcol = toEColumn(COL_ID);
-        prev_g_asc = m_asc;        
-    }
-    Model_Setting::instance().setInt(
-        wxString::Format("%s_ASC2", m_cp->m_sortSaveTitle),
-        (prev_g_asc ? 1 : 0)
-    );
-    Model_Setting::instance().setInt(
-        wxString::Format("%s_SORT_COL2", m_cp->m_sortSaveTitle),
-        prev_g_sortcol
-    );
-    Model_Setting::instance().setInt(
-        wxString::Format("%s_ASC", m_cp->m_sortSaveTitle),
-        (g_asc ? 1 : 0)
-    );
-    Model_Setting::instance().setInt(
-        wxString::Format("%s_SORT_COL", m_cp->m_sortSaveTitle),
-        g_sortcol
-    );
-
-    refreshVisualList(false);
-
-}
-//----------------------------------------------------------------------------
-
-void TransactionListCtrl::setColumnImage(EColumn col, int image)
-{
-    wxListItem item;
-    item.SetMask(wxLIST_MASK_IMAGE);
-    item.SetImage(image);
-
-    SetColumn(col, item);
-}
-//----------------------------------------------------------------------------
-
-wxString TransactionListCtrl::OnGetItemText(long item, long column) const
-{
-    return getItem(item, column);
-}
-//----------------------------------------------------------------------------
-
-/*
-    Returns the icon to be shown for each transaction for the required column
-*/
-int TransactionListCtrl::OnGetItemColumnImage(long item, long column) const
-{
-    if (m_trans.empty()) return -1;
-
-    int res = -1;
-    if (m_real_columns[static_cast<int>(column)] == COL_IMGSTATUS) {
-        wxString status = getItem(item, COL_STATUS, true);
-        if (status.length() > 1)
-            status = status.Mid(2, 1);
-        if (status == Model_Checking::STATUS_KEY_FOLLOWUP)
-            res = mmCheckingPanel::ICON_FOLLOWUP;
-        else if (status == Model_Checking::STATUS_KEY_RECONCILED)
-            res = mmCheckingPanel::ICON_RECONCILED;
-        else if (status == Model_Checking::STATUS_KEY_VOID)
-            res = mmCheckingPanel::ICON_VOID;
-        else if (status == Model_Checking::STATUS_KEY_DUPLICATE)
-            res = mmCheckingPanel::ICON_DUPLICATE;
-        else
-            res = mmCheckingPanel::ICON_UNRECONCILED;
-    }
-
-    return res;
-}
-//----------------------------------------------------------------------------
-
-/*
-    Failed wxASSERT will hang application if active modal dialog presents on screen.
-    Assertion's message box will be hidden until you press tab to activate one.
-*/
-wxListItemAttr* TransactionListCtrl::OnGetItemAttr(long item) const
-{
-    if (item < 0 || item >= static_cast<int>(m_trans.size())) return 0;
-
-    wxString strDate = Model_Checking::TRANSDATE(m_trans[item]).FormatISOCombined();
-    bool in_the_future = (strDate > m_today);
-
-    // apply alternating background pattern
-    int user_color_id = m_trans[item].COLOR.GetValue();
-    if (user_color_id < 0) user_color_id = 0;
-    else if (user_color_id > 7) user_color_id = 0;
-
-    if (user_color_id == 0) {
-        if (in_the_future) {
-            return (item % 2 ? m_attr3.get() : m_attr4.get());
+        wxMessageDialog msgDlg(this
+            , text
+            , _("Confirm Transaction Deletion")
+            , wxYES_NO | wxNO_DEFAULT | (m_cp->isDeletedTrans() ? wxICON_ERROR : wxICON_WARNING));
+        if (msgDlg.ShowModal() == wxID_YES) {
+            deleteTransactionsByStatus("");
         }
-        return (item % 2 ? m_attr1.get() : m_attr2.get());
     }
-
-    switch (user_color_id) {
-    case 1: return m_attr11.get();
-    case 2: return m_attr12.get();
-    case 3: return m_attr13.get();
-    case 4: return m_attr14.get();
-    case 5: return m_attr15.get();
-    case 6: return m_attr16.get();
-    case 7: return m_attr17.get();
+    else if (i == MENU_TREEPOPUP_DELETE_FLAGGED) {
+        wxMessageDialog msgDlg(this
+            , wxString::Format(_u("Do you want to delete all the “%s” transactions shown?"), _("Follow Up"))
+            , _("Confirm Transaction Deletion")
+            , wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+        if (msgDlg.ShowModal() == wxID_YES) {
+            deleteTransactionsByStatus(Model_Checking::STATUS_STR_FOLLOWUP);
+        }
     }
-    return (item % 2 ? m_attr1.get() : m_attr2.get());
+    else if (i == MENU_TREEPOPUP_DELETE_UNRECONCILED) {
+        wxMessageDialog msgDlg(this
+            , wxString::Format(_u("Do you want to delete all the “%s” transactions shown?"), _("Unreconciled"))
+            , _("Confirm Transaction Deletion")
+            , wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+        if (msgDlg.ShowModal() == wxID_YES) {
+            deleteTransactionsByStatus(Model_Checking::STATUS_STR_NONE);
+        }
+    }
+    refreshVisualList();
+    m_cp->m_frame->RefreshNavigationTree();
 }
-//----------------------------------------------------------------------------
-// If any of these keys are encountered, the search for the event handler
-// should continue as these keys may be processed by the operating system.
-void TransactionListCtrl::OnChar(wxKeyEvent& event)
-{
 
-    int key = event.GetKeyCode();
-    if (key == WXK_ALT ||
-        key == WXK_COMMAND ||
-        key == WXK_UP ||
-        key == WXK_DOWN ||
-        key == WXK_LEFT ||
-        key == WXK_RIGHT ||
-        key == WXK_HOME ||
-        key == WXK_END ||
-        key == WXK_PAGEUP ||
-        key == WXK_PAGEDOWN ||
-        key == WXK_NUMPAD_UP ||
-        key == WXK_NUMPAD_DOWN ||
-        key == WXK_NUMPAD_LEFT ||
-        key == WXK_NUMPAD_RIGHT ||
-        key == WXK_NUMPAD_PAGEDOWN ||
-        key == WXK_NUMPAD_PAGEUP ||
-        key == WXK_NUMPAD_HOME ||
-        key == WXK_NUMPAD_END ||
-        key == WXK_DELETE ||
-        key == WXK_NUMPAD_DELETE ||
-        key == WXK_TAB ||
-        key == WXK_RETURN ||
-        key == WXK_NUMPAD_ENTER ||
-        key == WXK_SPACE ||
-        key == WXK_NUMPAD_SPACE
-    ) {
-        event.Skip();
-    }
-}
 //----------------------------------------------------------------------------
 
-void TransactionListCtrl::OnSelectAll(wxCommandEvent& WXUNUSED(event))
+void TransactionListCtrl::onSelectAll(wxCommandEvent& WXUNUSED(event))
 {
     m_selected_id.clear();
     SetEvtHandlerEnabled(false);
@@ -1044,13 +1551,13 @@ void TransactionListCtrl::OnSelectAll(wxCommandEvent& WXUNUSED(event))
     setExtraTransactionData(GetSelectedItemCount() == 1);
 }
 
-void TransactionListCtrl::OnCopy(wxCommandEvent& WXUNUSED(event))
+void TransactionListCtrl::onCopy(wxCommandEvent& WXUNUSED(event))
 {
     // we can't copy deleted items or there is nothing to copy
     if (m_cp->isDeletedTrans() || GetSelectedItemCount() < 1) return;
 
     // collect the selected transactions for copy
-    FindSelectedTransactions();
+    findSelectedTransactions();
     m_selectedForCopy = m_selected_id;
 
     if (wxTheClipboard->Open()) {
@@ -1072,70 +1579,27 @@ void TransactionListCtrl::OnCopy(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void TransactionListCtrl::OnDuplicateTransaction(wxCommandEvent& WXUNUSED(event))
-{
-    // we can only duplicate a single transaction
-    if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    mmTransDialog dlg(this, m_cp->m_account_id, {id.first, id.second != 0}, true);
-    if (dlg.ShowModal() != wxID_CANCEL) {
-        m_selected_id.clear();
-        m_pasted_id.push_back({dlg.GetTransactionID(), 0});
-        m_cp->mmPlayTransactionSound();
-        refreshVisualList();
-    }
-    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
-}
-
-void TransactionListCtrl::OnEnterScheduled(wxCommandEvent& WXUNUSED(event))
-{
-    if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    if (id.second == 1) {
-        mmBDDialog dlg(this, id.first, false, true);
-        if ( dlg.ShowModal() == wxID_OK ) {
-            refreshVisualList();
-        }
-    }
-}
-
-void TransactionListCtrl::OnSkipScheduled(wxCommandEvent& WXUNUSED(event))
-{
-    if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    if (id.second == 1) {
-        Model_Billsdeposits::instance().completeBDInSeries(id.first);
-        refreshVisualList();
-    }
-}
-
-void TransactionListCtrl::OnPaste(wxCommandEvent& WXUNUSED(event))
+void TransactionListCtrl::onPaste(wxCommandEvent& WXUNUSED(event))
 {
     // we can't paste with multiple accounts open, deleted items, or if there is nothing to paste
     if (!m_cp->isAccount() || m_selectedForCopy.size() < 1)
         return;
     
-    FindSelectedTransactions();
+    findSelectedTransactions();
     Model_Checking::instance().Savepoint();
     m_pasted_id.clear();    // make sure the list is empty before we paste
     for (const auto& id : m_selectedForCopy) {
         if (!id.second) {
             Model_Checking::Data* tran = Model_Checking::instance().get(id.first);
             if (Model_Checking::foreignTransaction(*tran)) continue;
-            OnPaste(tran);
+            onPaste(tran);
         }
     }
     Model_Checking::instance().ReleaseSavepoint();
     refreshVisualList();
 }
 
-int64 TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
+int64 TransactionListCtrl::onPaste(Model_Checking::Data* tran)
 {
     wxASSERT(m_cp->isAccount());
 
@@ -1204,486 +1668,55 @@ int64 TransactionListCtrl::OnPaste(Model_Checking::Data* tran)
     return transactionID;
 }
 
-void TransactionListCtrl::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))
+void TransactionListCtrl::onDuplicateTransaction(wxCommandEvent& WXUNUSED(event))
 {
-    // we can only open a single transaction
+    // we can only duplicate a single transaction
     if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
+    findSelectedTransactions();
     Fused_Transaction::IdRepeat id = m_selected_id[0];
 
-    const wxString refType = !id.second ?
-        Model_Attachment::REFTYPE_STR_TRANSACTION :
-        Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
-    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, refType, id.first);
-    refreshVisualList();
-}
-//----------------------------------------------------------------------------
-
-void TransactionListCtrl::OnListKeyDown(wxListEvent& event)
-{
-    if (wxGetKeyState(WXK_COMMAND) || wxGetKeyState(WXK_ALT) || wxGetKeyState(WXK_CONTROL))
-        return event.Skip();
-
-    int key = event.GetKeyCode();
-    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
-
-    if (!m_cp->isDeletedTrans()) {
-        if (key == wxKeyCode('R')) {
-            // Reconciled
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKRECONCILED);
-            OnMarkTransaction(evt);
-        }
-        else if (key == wxKeyCode('U')) {
-            // Unreconciled
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKUNRECONCILED);
-            OnMarkTransaction(evt);
-        }
-        else if (key == wxKeyCode('F')) {
-            // Follow Up
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARK_ADD_FLAG_FOLLOWUP);
-            OnMarkTransaction(evt);
-        }
-        else if (key == wxKeyCode('D')) {
-            // Duplicate
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKDUPLICATE);
-            OnMarkTransaction(evt);
-        }
-        else if (key == wxKeyCode('V')) {
-            // Void
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_MARKVOID);
-            OnMarkTransaction(evt);
-        }
-        else if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE)
-        {
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_DELETE2);
-            OnDeleteTransaction(evt);
-        }
-        else {
-            event.Skip();
-            return;
-        }
-    }
-    else {
-        if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE) {
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_DELETE2);
-            OnDeleteTransaction(evt);
-        }
-        else if (key == wxKeyCode('R')) {
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, MENU_TREEPOPUP_RESTORE);
-            OnRestoreTransaction(evt);
-        }
-        else {
-            event.Skip();
-            return;
-        }
-    }
-}
-//----------------------------------------------------------------------------
-
-void TransactionListCtrl::OnRestoreViewedTransaction(wxCommandEvent&)
-{
-    wxMessageDialog msgDlg(
-        this,
-        _("Do you want to restore all of the transactions shown?"),
-        _("Confirm Transaction Restore"),
-        wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
-    );
-    if (msgDlg.ShowModal() == wxID_YES) {
-        std::set<std::pair<wxString, int64>> assetStockAccts;
-        for (const auto& tran : this->m_trans) {
-            if (tran.m_repeat_num) continue;
-            Model_Checking::Data* trx = Model_Checking::instance().get(tran.TRANSID);
-            trx->DELETEDTIME.Clear();
-            Model_Checking::instance().save(trx);
-            Model_Translink::Data_Set translink = Model_Translink::instance().find(
-                Model_Translink::CHECKINGACCOUNTID(trx->TRANSID)
-            );
-            if (!translink.empty()) {
-                assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
-            }
-        }
-        if (!assetStockAccts.empty()) {
-            for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset")
-                    Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
-                else if (i.first == "Stock")
-                    Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
-            }
-        }
-    }
-    
-    refreshVisualList();
-    m_cp->m_frame->RefreshNavigationTree();
-}
-
-void TransactionListCtrl::OnRestoreTransaction(wxCommandEvent& WXUNUSED(event))
-{
-    // check if any transactions selected
-    int sel = GetSelectedItemCount();
-    if (sel < 1) return;
-
-    FindSelectedTransactions();
-
-    //ask if they want to restore
-    const wxString text = wxString::Format(
-        wxPLURAL(
-            "Do you want to restore the selected transaction?",
-            "Do you want to restore the %i selected transactions?", sel
-        ),
-        sel
-    );
-
-    wxMessageDialog msgDlg(
-        this,
-        text,
-        _("Confirm Transaction Restore"),
-        wxYES_NO | wxYES_DEFAULT | wxICON_WARNING
-    );
-
-    if (msgDlg.ShowModal() == wxID_YES) {
-        std::set<std::pair<wxString, int64>> assetStockAccts;
-        for (const auto& id : m_selected_id) {
-            if (!id.second) {
-                Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
-                trx->DELETEDTIME.Clear();
-                Model_Checking::instance().save(trx);
-                Model_Translink::Data_Set translink = Model_Translink::instance().find(
-                    Model_Translink::CHECKINGACCOUNTID(trx->TRANSID)
-                );
-                if (!translink.empty()) {
-                    assetStockAccts.insert(std::make_pair(
-                        translink.at(0).LINKTYPE,
-                        translink.at(0).LINKRECORDID
-                    ));
-                }
-            }
-        }
-        m_selected_id.clear();
-        if (!assetStockAccts.empty()) {
-            for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset")
-                    Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
-                else if (i.first == "Stock")
-                    Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
-            }
-        }
-    }
-
-    refreshVisualList();
-    m_cp->m_frame->RefreshNavigationTree();
-}
-
-void TransactionListCtrl::OnDeleteViewedTransaction(wxCommandEvent& event)
-{
-    auto i = event.GetId();
-    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
-
-    if (i == MENU_TREEPOPUP_DELETE_VIEWED) {
-        wxString text = !(m_cp->isDeletedTrans() || retainDays == 0)
-            ? _("Do you want to delete all the transactions shown?")
-            : _("Do you want to permanently delete all the transactions shown?");
-
-        text += "\n\n";
-        text += !(m_cp->isDeletedTrans() || retainDays == 0)
-            ? _("Deleted transactions will be temporarily stored and can be restored from the Deleted Transactions view.")
-            : _("Unable to undo this action.");
-
-        wxMessageDialog msgDlg(this
-            , text
-            , _("Confirm Transaction Deletion")
-            , wxYES_NO | wxNO_DEFAULT | (m_cp->isDeletedTrans() ? wxICON_ERROR : wxICON_WARNING));
-        if (msgDlg.ShowModal() == wxID_YES) {
-            DeleteTransactionsByStatus("");
-        }
-    }
-    else if (i == MENU_TREEPOPUP_DELETE_FLAGGED) {
-        wxMessageDialog msgDlg(this
-            , wxString::Format(_u("Do you want to delete all the “%s” transactions shown?"), _("Follow Up"))
-            , _("Confirm Transaction Deletion")
-            , wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
-        if (msgDlg.ShowModal() == wxID_YES) {
-            DeleteTransactionsByStatus(Model_Checking::STATUS_STR_FOLLOWUP);
-        }
-    }
-    else if (i == MENU_TREEPOPUP_DELETE_UNRECONCILED) {
-        wxMessageDialog msgDlg(this
-            , wxString::Format(_u("Do you want to delete all the “%s” transactions shown?"), _("Unreconciled"))
-            , _("Confirm Transaction Deletion")
-            , wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
-        if (msgDlg.ShowModal() == wxID_YES) {
-            DeleteTransactionsByStatus(Model_Checking::STATUS_STR_NONE);
-        }
-    }
-    refreshVisualList();
-    m_cp->m_frame->RefreshNavigationTree();
-}
-
-void TransactionListCtrl::DeleteTransactionsByStatus(const wxString& status)
-{
-    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
-    wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
-    std::set<std::pair<wxString, int64>> assetStockAccts;
-    const auto s = Model_Checking::status_key(status);
-    Model_Checking::instance().Savepoint();
-    Model_Attachment::instance().Savepoint();
-    Model_Splittransaction::instance().Savepoint();
-    Model_CustomFieldData::instance().Savepoint();
-    for (const auto& tran : this->m_trans) {
-        if (tran.m_repeat_num) continue;
-        if (tran.STATUS == s || (s.empty() && status.empty())) {
-            if (m_cp->isDeletedTrans() || retainDays == 0) {
-                // remove also removes any split transactions, translink entries, attachments, and custom field data
-                Model_Checking::instance().remove(tran.TRANSID);
-            }
-            else {
-                Model_Checking::Data* trx = Model_Checking::instance().get(tran.TRANSID);
-                trx->DELETEDTIME = deletionTime;
-                Model_Checking::instance().save(trx);
-                Model_Translink::Data_Set translink = Model_Translink::instance().find(Model_Translink::CHECKINGACCOUNTID(trx->TRANSID));
-                if (!translink.empty()) {
-                    assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
-                }
-            }
-        }
-    }
-
-    if (!assetStockAccts.empty()) {
-        for (const auto& i : assetStockAccts) {
-            if (i.first == "Asset") Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
-            else if (i.first == "Stock") Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
-        }
-    }
-
-    Model_Splittransaction::instance().ReleaseSavepoint();
-    Model_Attachment::instance().ReleaseSavepoint();
-    Model_Checking::instance().ReleaseSavepoint();
-    Model_CustomFieldData::instance().ReleaseSavepoint();
-}
-
-
-void TransactionListCtrl::OnDeleteTransaction(wxCommandEvent& WXUNUSED(event))
-{
-    // check if any transactions selected
-    int sel = GetSelectedItemCount();
-    if (sel < 1) return;
-
-    FindSelectedTransactions();
-    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
-
-    //ask if they want to delete
-    wxString text = (m_cp->isDeletedTrans() || retainDays == 0)?
-        wxString::Format(wxPLURAL("Do you want to permanently delete the selected transaction?"
-        , "Do you want to permanently delete the %i selected transactions?", sel)
-        , sel)
-        :
-        wxString::Format(wxPLURAL("Do you want to delete the selected transaction?"
-            , "Do you want to delete the %i selected transactions?", sel)
-            , sel);
-    text += "\n\n";
-    text += ((m_cp->isDeletedTrans() || retainDays == 0) ? _("Unable to undo this action.")
-        : _("Deleted transactions will be temporarily stored and can be restored from the Deleted Transactions view."));
-
-    wxMessageDialog msgDlg(this
-        , text
-        , _("Confirm Transaction Deletion")
-        , wxYES_NO | wxYES_DEFAULT | (m_cp->isDeletedTrans() ? wxICON_ERROR : wxICON_WARNING));
-
-    if (msgDlg.ShowModal() == wxID_YES) {
-        wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
-        std::set<std::pair<wxString, int64>> assetStockAccts;
-        Model_Checking::instance().Savepoint();
-        Model_Attachment::instance().Savepoint();
-        Model_Splittransaction::instance().Savepoint();
-        Model_CustomFieldData::instance().Savepoint();
-        for (const auto& id : m_selected_id) {
-            if (id.second) continue;
-            Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
-
-            if (TransactionLocked(trx->ACCOUNTID, trx->TRANSDATE)) {
-                continue;
-            }
-
-            if (m_cp->isDeletedTrans() || retainDays == 0) {
-                // remove also removes split transactions, translink entries, attachments, and custom field data
-                Model_Checking::instance().remove(id.first);
-            }
-            else {
-                trx->DELETEDTIME = deletionTime;
-                Model_Checking::instance().save(trx);
-                Model_Translink::Data_Set translink = Model_Translink::instance().find(Model_Translink::CHECKINGACCOUNTID(trx->TRANSID));
-                if (!translink.empty()) {
-                    assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
-                }
-            }
-            m_selectedForCopy.erase(std::remove(m_selectedForCopy.begin(), m_selectedForCopy.end(), id)
-              , m_selectedForCopy.end());
-        }
-        m_selected_id.clear();
-        Model_CustomFieldData::instance().ReleaseSavepoint();
-        Model_Splittransaction::instance().ReleaseSavepoint();
-        Model_Attachment::instance().ReleaseSavepoint();
-        Model_Checking::instance().ReleaseSavepoint();
-
-        if (!assetStockAccts.empty()) {
-            for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset") Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
-                else if (i.first == "Stock") Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
-            }
-        }
-    }
-    refreshVisualList();
-    m_cp->m_frame->RefreshNavigationTree();
-}
-
-//----------------------------------------------------------------------------
-bool TransactionListCtrl::TransactionLocked(int64 accountID, const wxString& transdate)
-{
-    Model_Account::Data* account = Model_Account::instance().get(accountID);
-    if (Model_Account::BoolOf(account->STATEMENTLOCKED)) {
-        wxDateTime transaction_date;
-        if (transaction_date.ParseDate(transdate)) {
-            if (transaction_date <= Model_Account::DateOf(account->STATEMENTDATE)) {
-                wxMessageBox(wxString::Format(
-                    _("Locked transaction to date: %s\n\n"
-                      "Reconciled transactions.")
-                    , mmGetDateTimeForDisplay(account->STATEMENTDATE))
-                    , _("MMEX Transaction Check"), wxOK | wxICON_WARNING);
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-bool TransactionListCtrl::CheckForClosedAccounts()
-{
-    int closedTrx = 0;
-    for (const auto& id : m_selected_id) {
-        Fused_Transaction::Data tran = !id.second ?
-            Fused_Transaction::Data(*Model_Checking::instance().get(id.first)) :
-            Fused_Transaction::Data(*Model_Billsdeposits::instance().get(id.first));
-        Model_Account::Data* account = Model_Account::instance().get(tran.ACCOUNTID);
-        if (account && Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account)) {
-            closedTrx++;
-            continue;
-        }
-        Model_Account::Data* to_account = Model_Account::instance().get(tran.TOACCOUNTID);
-        if (to_account && Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account))
-            closedTrx++;
-    }
-
-    if (!closedTrx)
-        return true;
-    else {
-        const wxString text = wxString::Format(
-            wxPLURAL("You are about to edit a transaction involving an account that is closed."
-            , "The edit will affect %i transactions involving an account that is closed.", GetSelectedItemCount())
-            , closedTrx) + "\n\n" + _("Do you want to perform the edit?");
-        if (wxMessageBox(text, _("Closed Account Check"), wxYES_NO | wxICON_WARNING) == wxYES)
-            return true;
-    }
-    return false;
-}
-
-void TransactionListCtrl::OnEditTransaction(wxCommandEvent& /*event*/)
-{
-    // check if anything to edit
-    if (GetSelectedItemCount() < 1) return;
-    FindSelectedTransactions();
-
-    // edit multiple transactions
-    if (m_selected_id.size() > 1) {
-        std::vector<int64> transid;
-        for (const auto& id : m_selected_id)
-            if (!id.second)
-                transid.push_back(id.first);
-        if (transid.size() == 0) return;
-        if (!CheckForClosedAccounts()) return;
-        transactionsUpdateDialog dlg(this, transid);
-        if (dlg.ShowModal() == wxID_OK)
-            refreshVisualList();
-        return;
-    }
-
-    // edit single transaction
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-    if (!id.second) {
-        Model_Checking::Data* checking_entry = Model_Checking::instance().get(id.first);
-        if (TransactionLocked(checking_entry->ACCOUNTID, checking_entry->TRANSDATE))
-            return;
-
-        if (Model_Checking::foreignTransaction(*checking_entry)) {
-            Model_Translink::Data translink = Model_Translink::TranslinkRecord(id.first);
-            if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_STOCK) {
-                ShareTransactionDialog dlg(this, &translink, checking_entry);
-                if (dlg.ShowModal() == wxID_OK)
-                    refreshVisualList();
-            }
-            else if (translink.LINKTYPE == Model_Attachment::REFTYPE_STR_ASSET) {
-                mmAssetDialog dlg(this, m_cp->m_frame, &translink, checking_entry);
-                if (dlg.ShowModal() == wxID_OK)
-                    refreshVisualList();
-            }
-            else {
-                wxASSERT(false);
-            }
-        }
-        else {
-            mmTransDialog dlg(this, m_cp->m_account_id, {id.first, false});
-            if (dlg.ShowModal() != wxID_CANCEL)
-                refreshVisualList();
-        }
-    }
-    else {
-        mmBDDialog dlg(this, id.first, false, false);
-        if ( dlg.ShowModal() == wxID_OK )
-            refreshVisualList();
-    }
-    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
-}
-
-void TransactionListCtrl::OnNewTransaction(wxCommandEvent& event)
-{
-    int id = event.GetId();
-    int type;
-
-    switch (id) {
-    case MENU_TREEPOPUP_WITHDRAWAL:
-        type = Model_Checking::TYPE_ID_WITHDRAWAL;
-        break;
-    case MENU_TREEPOPUP_DEPOSIT:
-        type = Model_Checking::TYPE_ID_DEPOSIT;
-        break;
-    case MENU_TREEPOPUP_TRANSFER:
-        type = Model_Checking::TYPE_ID_TRANSFER;
-        break;
-    default:
-        type = Model_Checking::TYPE_ID_WITHDRAWAL;
-        break;
-    }
-
-    mmTransDialog dlg(this, m_cp->m_account_id, {0, false}, false, type);
-    int i = dlg.ShowModal();
-    if (i != wxID_CANCEL) {
+    mmTransDialog dlg(this, m_cp->m_account_id, {id.first, id.second != 0}, true);
+    if (dlg.ShowModal() != wxID_CANCEL) {
         m_selected_id.clear();
         m_pasted_id.push_back({dlg.GetTransactionID(), 0});
         m_cp->mmPlayTransactionSound();
         refreshVisualList();
+    }
+    m_topItemIndex = GetTopItem() + GetCountPerPage() - 1;
+}
 
-        if (i == wxID_NEW) {
-            OnNewTransaction(event);
+void TransactionListCtrl::onEnterScheduled(wxCommandEvent& WXUNUSED(event))
+{
+    if (GetSelectedItemCount() != 1) return;
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
+
+    if (id.second == 1) {
+        mmBDDialog dlg(this, id.first, false, true);
+        if ( dlg.ShowModal() == wxID_OK ) {
+            refreshVisualList();
         }
     }
 }
 
-//----------------------------------------------------------------------------
+void TransactionListCtrl::onSkipScheduled(wxCommandEvent& WXUNUSED(event))
+{
+    if (GetSelectedItemCount() != 1) return;
+    findSelectedTransactions();
+    Fused_Transaction::IdRepeat id = m_selected_id[0];
 
-void TransactionListCtrl::OnSetUserColour(wxCommandEvent& event)
+    if (id.second == 1) {
+        Model_Billsdeposits::instance().completeBDInSeries(id.first);
+        refreshVisualList();
+    }
+}
+
+void TransactionListCtrl::onSetUserColour(wxCommandEvent& event)
 {
     if (m_cp->isDeletedTrans())
         return;
     
-    FindSelectedTransactions();
+    findSelectedTransactions();
     int user_color_id = event.GetId();
     user_color_id -= MENU_ON_SET_UDC0;
     wxLogDebug("id: %i", user_color_id);
@@ -1712,309 +1745,22 @@ void TransactionListCtrl::OnSetUserColour(wxCommandEvent& event)
 
     refreshVisualList();
 }
-//----------------------------------------------------------------------------
 
-void TransactionListCtrl::refreshVisualList(bool filter)
+void TransactionListCtrl::onOpenAttachment(wxCommandEvent& WXUNUSED(event))
 {
-    wxLogDebug("refreshVisualList: %i selected, filter: %d", GetSelectedItemCount(), filter);
-
-    // Grab the selected transactions unless we have freshly pasted transactions in which case use them
-    if (m_pasted_id.empty()) {
-        FindSelectedTransactions();
-    }
-    else {
-        m_selected_id.clear();
-        m_selected_id.insert(std::end(m_selected_id), std::begin(m_pasted_id), std::end(m_pasted_id));
-        m_pasted_id.clear();    // Now clear them
-    }
-
-    m_today = Option::instance().UseTransDateTime() ?
-        wxDateTime::Now().FormatISOCombined() :
-        wxDateTime(23, 59, 59, 999).FormatISOCombined();
-    this->SetEvtHandlerEnabled(false);
-    Hide();
-
-    // decide whether top or down icon needs to be shown
-    setColumnImage(g_sortcol, g_asc ? mmCheckingPanel::ICON_DESC : mmCheckingPanel::ICON_ASC);
-    if (filter)
-        m_cp->filterTable();
-    SetItemCount(m_trans.size());
-    Show();
-    sortTable();
-    markSelectedTransaction();
-
-    long i = static_cast<long>(m_trans.size());
-    if (m_topItemIndex > i || m_topItemIndex < 0)
-        m_topItemIndex = g_asc ? i - 1 : 0;
-
-    i = 0;
-    for(const auto& entry : m_trans) {
-        int64 id = !entry.m_repeat_num ? entry.TRANSID : entry.m_bdid;
-        for (const auto& item : m_selected_id) {
-            if (item.first == id && item.second == entry.m_repeat_num) {
-                SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
-                SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
-                EnsureVisible(i);
-            }
-        }
-        i++;
-    }
-    FindSelectedTransactions();
-
-    if (m_topItemIndex >= 0 && m_topItemIndex < i && m_selected_id.empty())
-        EnsureVisible(m_topItemIndex);
-
-    m_cp->setAccountSummary();
-    setExtraTransactionData(GetSelectedItemCount() == 1);
-    this->SetEvtHandlerEnabled(true);
-    Refresh();
-    Update();
-    SetFocus();
-}
-
-void TransactionListCtrl::OnMoveTransaction(wxCommandEvent& /*event*/)
-{
-    FindSelectedTransactions();
-    int sel = GetSelectedItemCount();
-
-    //ask if they want to move
-    const wxString text = wxString::Format(
-        wxPLURAL("Do you want to move the selected transaction?"
-            , "Do you want to move the %i selected transactions?", sel)
-        , sel);
-    wxMessageDialog msgDlg(this
-        , text
-        , _("Confirm Transaction Move")
-        , wxYES_NO | wxYES_DEFAULT | wxICON_ERROR);
-
-    if (msgDlg.ShowModal() == wxID_YES) {
-        const wxString headerMsg = wxString::Format(
-                wxPLURAL_U8("Moving transaction to…"
-                , "Moving %i transactions to…", sel)
-                , sel);
-        mmSingleChoiceDialog scd(this
-            , _("Select the destination Account ")
-            , headerMsg
-            , Model_Account::instance().all_checking_account_names());
-        if (scd.ShowModal() == wxID_OK) {
-            int64 dest_account_id = -1;
-            wxString dest_account_name = scd.GetStringSelection();
-            Model_Account::Data* dest_account = Model_Account::instance().get(dest_account_name);
-            if (dest_account)
-                dest_account_id = dest_account->ACCOUNTID;
-            else
-                return;
-            std::vector<int64> skip_trx;
-            Model_Checking::instance().Savepoint();
-            for (const auto& id : m_selected_id) {
-                if (!id.second) {
-                    Model_Checking::Data* trx = Model_Checking::instance().get(id.first);
-                    if (TransactionLocked(trx->ACCOUNTID, trx->TRANSDATE)
-                            || Model_Checking::foreignTransaction(*trx)
-                            || Model_Checking::type_id(trx->TRANSCODE) == Model_Checking::TYPE_ID_TRANSFER
-                            || trx->TRANSDATE < dest_account->INITIALDATE
-                    ) {
-                        skip_trx.push_back(trx->TRANSID);
-                    } else {
-                        trx->ACCOUNTID = dest_account_id;
-                        Model_Checking::instance().save(trx);
-                    }
-                }
-            }
-            Model_Checking::instance().ReleaseSavepoint();
-            if (!skip_trx.empty()) {
-                const wxString detail = wxString::Format("%s\n%s: %zu\n%s: %zu"
-                                , _("This is due to some elements of the transaction or account detail not allowing the move")
-                                , _("Moved"), m_selected_id.size() - skip_trx.size()
-                                , _("Not moved"), skip_trx.size());
-                mmErrorDialogs::MessageWarning(this
-                    , detail
-                    , _("Unable to move some transactions."));
-            }
-            //TODO: enable report to detail transactions that are unable to be moved
-            refreshVisualList();
-        }
-    }
-}
-
-//----------------------------------------------------------------------------
-void TransactionListCtrl::OnViewOtherAccount(wxCommandEvent& /*event*/)
-{
-    // we can only get here for a single transfer transaction
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    Fused_Transaction::Full_Data tran = !id.second ?
-        Fused_Transaction::Full_Data(*Model_Checking::instance().get(id.first)) :
-        Fused_Transaction::Full_Data(*Model_Billsdeposits::instance().get(id.first));
-
-    int64 gotoAccountID = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTID : tran.ACCOUNTID;
-    wxString gotoAccountName = (m_cp->m_account_id == tran.ACCOUNTID) ? tran.TOACCOUNTNAME : tran.ACCOUNTNAME;   
-
-    m_cp->m_frame->setNavTreeAccount(gotoAccountName);
-    m_cp->m_frame->setGotoAccountID(gotoAccountID, id);
-    wxCommandEvent event(wxEVT_COMMAND_MENU_SELECTED, MENU_GOTOACCOUNT);
-    m_cp->m_frame->GetEventHandler()->AddPendingEvent(event);
-}
-
-//----------------------------------------------------------------------------
-void TransactionListCtrl::OnViewSplitTransaction(wxCommandEvent& /*event*/)
-{
-    // we can only view a single transaction
+    // we can only open a single transaction
     if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    m_cp->DisplaySplitCategories({id.first, id.second != 0});
-}
-
-//----------------------------------------------------------------------------
-void TransactionListCtrl::OnOrganizeAttachments(wxCommandEvent& /*event*/)
-{
-    // we only support a single transaction
-    if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
+    findSelectedTransactions();
     Fused_Transaction::IdRepeat id = m_selected_id[0];
 
     const wxString refType = !id.second ?
         Model_Attachment::REFTYPE_STR_TRANSACTION :
         Model_Attachment::REFTYPE_STR_BILLSDEPOSIT;
-    mmAttachmentDialog dlg(this, refType, id.first);
-    dlg.ShowModal();
+    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, refType, id.first);
     refreshVisualList();
 }
 
 //----------------------------------------------------------------------------
-void TransactionListCtrl::OnCreateReoccurance(wxCommandEvent& /*event*/)
-{
-     // we only support a single transaction
-    if (GetSelectedItemCount() != 1) return;
-    FindSelectedTransactions();
-    Fused_Transaction::IdRepeat id = m_selected_id[0];
-
-    if (!id.second) {
-        mmBDDialog dlg(this, 0, false, false);
-        dlg.SetDialogParameters(id.first);
-        if (dlg.ShowModal() == wxID_OK)
-            wxMessageBox(_("Scheduled transaction saved."));
-    }
-}
-
-//----------------------------------------------------------------------------
-
-void TransactionListCtrl::markSelectedTransaction()
-{
-    long i = 0;
-    for (const auto & tran : m_trans) {
-        Fused_Transaction::IdRepeat id = { !tran.m_repeat_num ? tran.TRANSID : tran.m_bdid,
-            tran.m_repeat_num };
-        //reset any selected items in the list
-        if (GetItemState(i, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED)
-            SetItemState(i, 0, wxLIST_STATE_SELECTED);
-        if (!m_selected_id.empty()) {
-            // discover where the transaction has ended up in the list
-            if (g_asc) {
-                if (m_topItemIndex < i && id == m_selected_id.back())
-                    m_topItemIndex = i;
-            } else {
-                if (m_topItemIndex > i && id == m_selected_id.back())
-                    m_topItemIndex = i;
-            }
-        }
-        ++i;
-    }
-
-    if (m_trans.empty()) return;
-
-    if (m_selected_id.empty()) {
-        i = static_cast<long>(m_trans.size()) - 1;
-        if (!g_asc)
-            i = 0;
-        EnsureVisible(i);
-    }
-}
-
-void TransactionListCtrl::markItem(long selectedItem)
-{
-    //First of all any items should be unselected
-    long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-    if (cursel != wxNOT_FOUND)
-        SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
-
-    //Then finded item will be selected
-    SetItemState(selectedItem, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
-    EnsureVisible(selectedItem);
-    return;
-}
-
-void TransactionListCtrl::doSearchText(const wxString& value)
-{
-    const wxString pattern = value.Lower().Append("*");
-
-    long last = static_cast<long>(GetItemCount() - 1);
-    if (m_selected_id.size() > 1) {
-        SetEvtHandlerEnabled(false);
-        for (long i = 0; i < last; i++) {
-            long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-            if (cursel != wxNOT_FOUND)
-                SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
-        }
-        SetEvtHandlerEnabled(true);
-    }
-
-    long selectedItem = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-    if (selectedItem < 0 || selectedItem > last) //nothing selected
-        selectedItem = g_asc ? last + 1  : -1;
-
-    while (true) {
-        g_asc ? selectedItem-- : selectedItem++;
-        if (selectedItem < 0 || selectedItem >= static_cast<long>(m_trans.size()))
-            break;
-
-        wxString test1 = Model_Currency::fromString2CLocale(value);
-        double v;
-        if (test1.ToCDouble(&v)) {
-            try {
-                double amount = m_trans.at(selectedItem).TRANSAMOUNT;
-                double to_trans_amount = m_trans.at(selectedItem).TOTRANSAMOUNT;
-                if (v == amount || v == to_trans_amount) {
-                    return markItem(selectedItem);
-                }
-            }
-            catch (std::exception & ex) {
-                wxLogDebug("%s | row invalid %ld", ex.what(), selectedItem);
-            }
-
-        }
-
-        for (const auto& t : {
-            COL_NOTES, COL_NUMBER, COL_PAYEE_STR, COL_CATEGORY, COL_DATE, COL_TAGS,
-            COL_DELETEDTIME, COL_UDFC01, COL_UDFC02, COL_UDFC03, COL_UDFC04, COL_UDFC05
-        }) {
-            const auto test = getItem(selectedItem, t, true).Lower();
-            if (test.empty())
-                continue;
-            if (test.Matches(pattern)) {
-                return markItem(selectedItem);
-            }
-        }
-
-        for (const auto& entry : m_trans.at(selectedItem).ATTACHMENT_DESCRIPTION) {
-            wxString test = entry.Lower();
-            if (test.Matches(pattern)) {
-                return markItem(selectedItem);
-            }
-        }
-
-    }
-
-    wxLogDebug("Searching finished");
-    selectedItem = g_asc ? last : 0;
-    long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-    SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
-    EnsureVisible(selectedItem);
-}
 
 wxString UDFCFormatHelper(Model_CustomField::TYPE_ID type, wxString data)
 {
@@ -2155,7 +1901,59 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
     return value;
 }
 
-void TransactionListCtrl::FindSelectedTransactions()
+void TransactionListCtrl::setColumnImage(int col, int image)
+{
+    wxListItem item;
+    item.SetMask(wxLIST_MASK_IMAGE);
+    item.SetImage(image);
+
+    SetColumn(col, item);
+}
+
+void TransactionListCtrl::setExtraTransactionData(const bool single)
+{
+    int repeat_num = 0;
+    bool isForeign = false;
+    if (single) {
+        Fused_Transaction::IdRepeat id = m_selected_id[0];
+        Fused_Transaction::Data tran = !id.second ?
+            Fused_Transaction::Data(*Model_Checking::instance().get(id.first)) :
+            Fused_Transaction::Data(*Model_Billsdeposits::instance().get(id.first));
+        if (Model_Checking::foreignTransaction(tran))
+            isForeign = true;
+        repeat_num = id.second;
+    }
+    m_cp->updateExtraTransactionData(single, repeat_num, isForeign);
+}
+
+void TransactionListCtrl::markItem(long selectedItem)
+{
+    //First of all any items should be unselected
+    long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    if (cursel != wxNOT_FOUND)
+        SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+
+    //Then finded item will be selected
+    SetItemState(selectedItem, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+    EnsureVisible(selectedItem);
+    return;
+}
+
+void TransactionListCtrl::setSelectedId(Fused_Transaction::IdRepeat sel_id)
+{ 
+    int i = 0;
+    for (const auto& fused : m_trans) {
+        if (fused.m_repeat_num == sel_id.first && fused.TRANSID == sel_id.first) {
+            SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+            SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+            m_topItemIndex = i;
+            break;
+        }
+        i++;
+    }
+}
+
+void TransactionListCtrl::findSelectedTransactions()
 {
     // find the selected transactions
     long x = 0;
@@ -2172,16 +1970,207 @@ void TransactionListCtrl::FindSelectedTransactions()
     }
 }
 
-void TransactionListCtrl::setSelectedID(Fused_Transaction::IdRepeat sel_id)
-{ 
-    int i = 0;
-    for (const auto& fused : m_trans) {
-        if (fused.m_repeat_num == sel_id.first && fused.TRANSID == sel_id.first) {
-            SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
-            SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
-            m_topItemIndex = i;
-            break;
+int TransactionListCtrl::getColumnFromPosition(int xPos)
+{
+    int column = 0;
+    int x = -GetScrollPos(wxHORIZONTAL);
+    for (column = 0; column < GetColumnCount(); column++) {
+        x += GetColumnWidth(column);
+        if (x >= xPos) break;
+    }
+    if (!(column < GetColumnCount())) return -1;
+    return column;
+}
+
+void TransactionListCtrl::doSearchText(const wxString& value)
+{
+    const wxString pattern = value.Lower().Append("*");
+
+    long last = static_cast<long>(GetItemCount() - 1);
+    if (m_selected_id.size() > 1) {
+        SetEvtHandlerEnabled(false);
+        for (long i = 0; i < last; i++) {
+            long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+            if (cursel != wxNOT_FOUND)
+                SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
         }
-        i++;
+        SetEvtHandlerEnabled(true);
+    }
+
+    long selectedItem = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+
+    if (selectedItem < 0 || selectedItem > last) //nothing selected
+        selectedItem = g_sortAsc1 ? last + 1  : -1;
+
+    while (true) {
+        g_sortAsc1 ? selectedItem-- : selectedItem++;
+        if (selectedItem < 0 || selectedItem >= static_cast<long>(m_trans.size()))
+            break;
+
+        wxString test1 = Model_Currency::fromString2CLocale(value);
+        double v;
+        if (test1.ToCDouble(&v)) {
+            try {
+                double amount = m_trans.at(selectedItem).TRANSAMOUNT;
+                double to_trans_amount = m_trans.at(selectedItem).TOTRANSAMOUNT;
+                if (v == amount || v == to_trans_amount) {
+                    return markItem(selectedItem);
+                }
+            }
+            catch (std::exception & ex) {
+                wxLogDebug("%s | row invalid %ld", ex.what(), selectedItem);
+            }
+
+        }
+
+        for (const auto& t : {
+            COL_NOTES, COL_NUMBER, COL_PAYEE_STR, COL_CATEGORY, COL_DATE, COL_TAGS,
+            COL_DELETEDTIME, COL_UDFC01, COL_UDFC02, COL_UDFC03, COL_UDFC04, COL_UDFC05
+        }) {
+            const auto test = getItem(selectedItem, t, true).Lower();
+            if (test.empty())
+                continue;
+            if (test.Matches(pattern)) {
+                return markItem(selectedItem);
+            }
+        }
+
+        for (const auto& entry : m_trans.at(selectedItem).ATTACHMENT_DESCRIPTION) {
+            wxString test = entry.Lower();
+            if (test.Matches(pattern)) {
+                return markItem(selectedItem);
+            }
+        }
+
+    }
+
+    wxLogDebug("Searching finished");
+    selectedItem = g_sortAsc1 ? last : 0;
+    long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+    EnsureVisible(selectedItem);
+}
+
+void TransactionListCtrl::markSelectedTransaction()
+{
+    long i = 0;
+    for (const auto & tran : m_trans) {
+        Fused_Transaction::IdRepeat id = { !tran.m_repeat_num ? tran.TRANSID : tran.m_bdid,
+            tran.m_repeat_num };
+        //reset any selected items in the list
+        if (GetItemState(i, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED)
+            SetItemState(i, 0, wxLIST_STATE_SELECTED);
+        if (!m_selected_id.empty()) {
+            // discover where the transaction has ended up in the list
+            if (g_sortAsc1) {
+                if (m_topItemIndex < i && id == m_selected_id.back())
+                    m_topItemIndex = i;
+            } else {
+                if (m_topItemIndex > i && id == m_selected_id.back())
+                    m_topItemIndex = i;
+            }
+        }
+        ++i;
+    }
+
+    if (m_trans.empty()) return;
+
+    if (m_selected_id.empty()) {
+        i = static_cast<long>(m_trans.size()) - 1;
+        if (!g_sortAsc1)
+            i = 0;
+        EnsureVisible(i);
     }
 }
+
+void TransactionListCtrl::deleteTransactionsByStatus(const wxString& status)
+{
+    int retainDays = Model_Setting::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
+    wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
+    std::set<std::pair<wxString, int64>> assetStockAccts;
+    const auto s = Model_Checking::status_key(status);
+    Model_Checking::instance().Savepoint();
+    Model_Attachment::instance().Savepoint();
+    Model_Splittransaction::instance().Savepoint();
+    Model_CustomFieldData::instance().Savepoint();
+    for (const auto& tran : this->m_trans) {
+        if (tran.m_repeat_num) continue;
+        if (tran.STATUS == s || (s.empty() && status.empty())) {
+            if (m_cp->isDeletedTrans() || retainDays == 0) {
+                // remove also removes any split transactions, translink entries, attachments, and custom field data
+                Model_Checking::instance().remove(tran.TRANSID);
+            }
+            else {
+                Model_Checking::Data* trx = Model_Checking::instance().get(tran.TRANSID);
+                trx->DELETEDTIME = deletionTime;
+                Model_Checking::instance().save(trx);
+                Model_Translink::Data_Set translink = Model_Translink::instance().find(Model_Translink::CHECKINGACCOUNTID(trx->TRANSID));
+                if (!translink.empty()) {
+                    assetStockAccts.insert(std::make_pair(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID));
+                }
+            }
+        }
+    }
+
+    if (!assetStockAccts.empty()) {
+        for (const auto& i : assetStockAccts) {
+            if (i.first == "Asset") Model_Translink::UpdateAssetValue(Model_Asset::instance().get(i.second));
+            else if (i.first == "Stock") Model_Translink::UpdateStockValue(Model_Stock::instance().get(i.second));
+        }
+    }
+
+    Model_Splittransaction::instance().ReleaseSavepoint();
+    Model_Attachment::instance().ReleaseSavepoint();
+    Model_Checking::instance().ReleaseSavepoint();
+    Model_CustomFieldData::instance().ReleaseSavepoint();
+}
+
+bool TransactionListCtrl::checkForClosedAccounts()
+{
+    int closedTrx = 0;
+    for (const auto& id : m_selected_id) {
+        Fused_Transaction::Data tran = !id.second ?
+            Fused_Transaction::Data(*Model_Checking::instance().get(id.first)) :
+            Fused_Transaction::Data(*Model_Billsdeposits::instance().get(id.first));
+        Model_Account::Data* account = Model_Account::instance().get(tran.ACCOUNTID);
+        if (account && Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account)) {
+            closedTrx++;
+            continue;
+        }
+        Model_Account::Data* to_account = Model_Account::instance().get(tran.TOACCOUNTID);
+        if (to_account && Model_Account::STATUS_ID_CLOSED == Model_Account::status_id(account))
+            closedTrx++;
+    }
+
+    if (!closedTrx)
+        return true;
+    else {
+        const wxString text = wxString::Format(
+            wxPLURAL("You are about to edit a transaction involving an account that is closed."
+            , "The edit will affect %i transactions involving an account that is closed.", GetSelectedItemCount())
+            , closedTrx) + "\n\n" + _("Do you want to perform the edit?");
+        if (wxMessageBox(text, _("Closed Account Check"), wxYES_NO | wxICON_WARNING) == wxYES)
+            return true;
+    }
+    return false;
+}
+
+bool TransactionListCtrl::checkTransactionLocked(int64 accountID, const wxString& transdate)
+{
+    Model_Account::Data* account = Model_Account::instance().get(accountID);
+    if (Model_Account::BoolOf(account->STATEMENTLOCKED)) {
+        wxDateTime transaction_date;
+        if (transaction_date.ParseDate(transdate)) {
+            if (transaction_date <= Model_Account::DateOf(account->STATEMENTDATE)) {
+                wxMessageBox(wxString::Format(
+                    _("Locked transaction to date: %s\n\n"
+                      "Reconciled transactions.")
+                    , mmGetDateTimeForDisplay(account->STATEMENTDATE))
+                    , _("MMEX Transaction Check"), wxOK | wxICON_WARNING);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -31,18 +31,16 @@ class mmCheckingPanel;
 class TransactionListCtrl : public mmListCtrl
 {
 public:
-    TransactionListCtrl(mmCheckingPanel* cp
-        , wxWindow* parent
-        , const wxWindowID id = wxID_ANY);
-
+    TransactionListCtrl(
+        mmCheckingPanel* cp,
+        wxWindow* parent,
+        const wxWindowID id = wxID_ANY
+    );
     ~TransactionListCtrl();
 
-    Fused_Transaction::Full_Data_Set m_trans;
-    void markSelectedTransaction();
-    void DeleteTransactionsByStatus(const wxString& status);
-    void resetColumns();
+private:
+    friend class mmCheckingPanel;
 
-public:
     enum EColumn
     {
         COL_IMGSTATUS = 0,
@@ -72,62 +70,10 @@ public:
         COL_def_sort = COL_DATE, // don't omit any columns before this
         COL_def_sort2 = COL_ID 
     };
-    EColumn toEColumn(const unsigned long col);
 
-    EColumn g_sortcol = COL_def_sort; // index of primary column to sort by
-    EColumn prev_g_sortcol = COL_def_sort2; // index of secondary column to sort by
-    bool g_asc = true; // asc\desc sorting for primary sort column
-    bool prev_g_asc = true; // asc\desc sorting for secondary sort column
-
-    bool getSortOrder() const;
-    EColumn getSortColumn() const { return m_sortCol; }
-
-    void setSortOrder(bool asc) { m_asc = asc; }
-    void setSortColumn(EColumn col) { m_sortCol = col; }
-    void setVisibleItemIndex(long v);
-
-    void setColumnImage(EColumn col, int image);
-public:
-    void OnNewTransaction(wxCommandEvent& event);
-    void OnDeleteTransaction(wxCommandEvent& event);
-    void OnRestoreTransaction(wxCommandEvent& event);
-    void OnDeleteViewedTransaction(wxCommandEvent& event);
-    void OnRestoreViewedTransaction(wxCommandEvent&);
-    void OnEditTransaction(wxCommandEvent& event);
-    void OnDuplicateTransaction(wxCommandEvent& event);
-    void OnEnterScheduled(wxCommandEvent& event);
-    void OnSkipScheduled(wxCommandEvent& event);
-    void OnSetUserColour(wxCommandEvent& event);
-    void OnMoveTransaction(wxCommandEvent& event);
-    void OnOpenAttachment(wxCommandEvent& event);
-    void OnViewOtherAccount(wxCommandEvent& event);
-    // Displays the split categories for the selected transaction
-    void OnViewSplitTransaction(wxCommandEvent& event);
-    void OnOrganizeAttachments(wxCommandEvent& event);
-    void OnCreateReoccurance(wxCommandEvent& event);
-    void refreshVisualList(bool filter = true);
-    void sortTable();
-public:
-    std::vector<Fused_Transaction::IdRepeat> getSelectedForCopy() const;
-    std::vector<Fused_Transaction::IdRepeat> getSelectedId() const;
-    void setSelectedID(Fused_Transaction::IdRepeat sel_id);
-    void doSearchText(const wxString& value);
-    /* Getter for Virtual List Control */
-    const wxString getItem(long item, long column, bool realenum = false) const;
-
-protected:
-    /* Sort Columns */
-    virtual void OnColClick(wxListEvent& event);
-
-private:
-    void markItem(long selectedItem);
-
-    std::vector<Fused_Transaction::IdRepeat> m_selectedForCopy; // the copied transactions (held for pasting)
-    std::vector<Fused_Transaction::IdRepeat> m_pasted_id;       // the last pasted transactions
-    std::vector<Fused_Transaction::IdRepeat> m_selected_id;     // the selected transactions
     enum
     {
-        MENU_TREEPOPUP_MARKRECONCILED = wxID_HIGHEST + 150,
+        MENU_TREEPOPUP_MARKRECONCILED = wxID_HIGHEST + 200,
         MENU_TREEPOPUP_MARKUNRECONCILED,
         MENU_TREEPOPUP_MARKVOID,
         MENU_TREEPOPUP_MARK_ADD_FLAG_FOLLOWUP,
@@ -154,14 +100,14 @@ private:
         MENU_ON_ENTER_SCHEDULED,
         MENU_ON_SKIP_SCHEDULED,
 
-        MENU_ON_SET_UDC0, //Default color
-        MENU_ON_SET_UDC1, //User defined color 1
-        MENU_ON_SET_UDC2, //User defined color 2
-        MENU_ON_SET_UDC3, //User defined color 3
-        MENU_ON_SET_UDC4, //User defined color 4
-        MENU_ON_SET_UDC5, //User defined color 5
-        MENU_ON_SET_UDC6, //User defined color 6
-        MENU_ON_SET_UDC7, //User defined color 7
+        MENU_ON_SET_UDC0, // default color
+        MENU_ON_SET_UDC1, // user-defined color 1
+        MENU_ON_SET_UDC2, // user-defined color 2
+        MENU_ON_SET_UDC3, // user-defined color 3
+        MENU_ON_SET_UDC4, // user-defined color 4
+        MENU_ON_SET_UDC5, // user-defined color 5
+        MENU_ON_SET_UDC6, // user-defined color 6
+        MENU_ON_SET_UDC7, // user-defined color 7
 
         MENU_TREEPOPUP_WITHDRAWAL,
         MENU_TREEPOPUP_DEPOSIT,
@@ -176,72 +122,133 @@ private:
         MENU_TREEPOPUP_RESTORE_VIEWED,
         ID_PANEL_CHECKING_STATIC_BITMAP_VIEW,
     };
+
 private:
-    DECLARE_NO_COPY_CLASS(TransactionListCtrl)
-    wxDECLARE_EVENT_TABLE();
-
-    mmCheckingPanel* m_cp = nullptr;
-
-    wxSharedPtr<wxListItemAttr> m_attr1;  // style1
-    wxSharedPtr<wxListItemAttr> m_attr2;  // style2
-    wxSharedPtr<wxListItemAttr> m_attr3;  // style, for future dates
-    wxSharedPtr<wxListItemAttr> m_attr4;  // style, for future dates
-    wxSharedPtr<wxListItemAttr> m_attr11; // user defined style 1
-    wxSharedPtr<wxListItemAttr> m_attr12; // user defined style 2
-    wxSharedPtr<wxListItemAttr> m_attr13; // user defined style 3
-    wxSharedPtr<wxListItemAttr> m_attr14; // user defined style 4
-    wxSharedPtr<wxListItemAttr> m_attr15; // user defined style 5
-    wxSharedPtr<wxListItemAttr> m_attr16; // user defined style 6
-    wxSharedPtr<wxListItemAttr> m_attr17; // user defined style 7
-
-    /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long column) const;
-    virtual int OnGetItemColumnImage(long item, long column) const;
-    virtual wxListItemAttr* OnGetItemAttr(long item) const;
-
-    void OnMouseRightClick(wxMouseEvent& event);
-    void OnListLeftClick(wxMouseEvent& event);
-    void OnListItemSelected(wxListEvent&);
-    void OnListItemDeSelected(wxListEvent&);
-    void OnListItemActivated(wxListEvent& event);
-    void OnMarkTransaction(wxCommandEvent& event);
-    void OnListKeyDown(wxListEvent& event);
-    void OnChar(wxKeyEvent& event);
-    void OnSelectAll(wxCommandEvent& WXUNUSED(event));
-    void OnCopy(wxCommandEvent& WXUNUSED(event));
-    void OnPaste(wxCommandEvent& WXUNUSED(event));
-    void OnListItemFocused(wxListEvent& WXUNUSED(event));
-    int64 OnPaste(Model_Checking::Data* tran);
-
-    bool TransactionLocked(int64 AccountID, const wxString& transdate);
-    void FindSelectedTransactions();
-    bool CheckForClosedAccounts();
-    void setExtraTransactionData(const bool single);
-    template<class Compare>
-    void SortBy(Compare comp, bool ascend);
-    void SortTransactions(int sortcol, bool ascend);
-    void findInAllTransactions(wxCommandEvent&);
-    void OnCopyText(wxCommandEvent&);
-    int getColumnFromPosition(int xPos);
-private:
-    /* The topmost visible item - this will be used to set
-    where to display the list again after refresh */
-    long m_topItemIndex = -1;
-    EColumn m_sortCol = COL_def_sort;
+    Fused_Transaction::Full_Data_Set m_trans;
+    long m_topItemIndex = -1; // where to display the list again after refresh
+    int g_sortCol1 = COL_def_sort;  // 0-based number of primary sorting column
+    int g_sortCol2 = COL_def_sort2; // 0-based number of secondary sorting column
+    bool g_sortAsc1 = true;         // asc/desc order for primary sorting column
+    bool g_sortAsc2 = true;         // asc/desc order for secondary sorting column
     wxString m_today;
     bool m_firstSort = true;
     wxString rightClickFilter_;
     wxString copyText_;
+    std::vector<Fused_Transaction::IdRepeat> m_selectedForCopy; // copied transactions
+    std::vector<Fused_Transaction::IdRepeat> m_pasted_id;       // last pasted transactions
+    std::vector<Fused_Transaction::IdRepeat> m_selected_id;     // selected transactions
+
+    DECLARE_NO_COPY_CLASS(TransactionListCtrl)
+    wxDECLARE_EVENT_TABLE();
+    mmCheckingPanel* m_cp = nullptr;
+    wxSharedPtr<wxListItemAttr> m_attr1;  // style 1
+    wxSharedPtr<wxListItemAttr> m_attr2;  // style 2
+    wxSharedPtr<wxListItemAttr> m_attr3;  // style 3 (reserved)
+    wxSharedPtr<wxListItemAttr> m_attr4;  // style 4 (reserved)
+    wxSharedPtr<wxListItemAttr> m_attr11; // user-defined style 1
+    wxSharedPtr<wxListItemAttr> m_attr12; // user-defined style 2
+    wxSharedPtr<wxListItemAttr> m_attr13; // user-defined style 3
+    wxSharedPtr<wxListItemAttr> m_attr14; // user-defined style 4
+    wxSharedPtr<wxListItemAttr> m_attr15; // user-defined style 5
+    wxSharedPtr<wxListItemAttr> m_attr16; // user-defined style 6
+    wxSharedPtr<wxListItemAttr> m_attr17; // user-defined style 7
+
+private:
+    void resetColumns();
+    void refreshVisualList(bool filter = true);
+    void sortTable();
+    template<class Compare>
+    void sortBy(Compare comp, bool ascend);
+    void sortTransactions(int sortcol, bool ascend);
+
+private:
+    // required overrides for virtual style list control
+    virtual wxString OnGetItemText(long item, long column) const;
+    virtual int OnGetItemColumnImage(long item, long column) const;
+    virtual wxListItemAttr* OnGetItemAttr(long item) const;
+
+protected:
+    virtual void OnColClick(wxListEvent& event);
+
+private:
+    void onChar(wxKeyEvent& event);
+    void onListLeftClick(wxMouseEvent& event);
+    void onMouseRightClick(wxMouseEvent& event);
+
+    void onListItemActivated(wxListEvent& event);
+    void onListItemSelected(wxListEvent&);
+    void onListItemDeSelected(wxListEvent&);
+    void onListItemFocused(wxListEvent& WXUNUSED(event));
+    void onListKeyDown(wxListEvent& event);
+
+    void onNewTransaction(wxCommandEvent& event);
+    void onDeleteTransaction(wxCommandEvent& event);
+    void onRestoreTransaction(wxCommandEvent& event);
+    void onRestoreViewedTransaction(wxCommandEvent&);
+    void onEditTransaction(wxCommandEvent& event);
+    void onMoveTransaction(wxCommandEvent& event);
+    void onViewOtherAccount(wxCommandEvent& event);
+    void onViewSplitTransaction(wxCommandEvent& event);
+    void onOrganizeAttachments(wxCommandEvent& event);
+    void onCreateReoccurance(wxCommandEvent& event);
+    void onFind(wxCommandEvent&);
+    void onCopyText(wxCommandEvent&);
+    void onMarkTransaction(wxCommandEvent& event);
+    void onDeleteViewedTransaction(wxCommandEvent& event);
+
+    void onSelectAll(wxCommandEvent& WXUNUSED(event));
+    void onCopy(wxCommandEvent& WXUNUSED(event));
+    void onPaste(wxCommandEvent& WXUNUSED(event));
+    int64 onPaste(Model_Checking::Data* tran);
+    void onDuplicateTransaction(wxCommandEvent& event);
+    void onEnterScheduled(wxCommandEvent& event);
+    void onSkipScheduled(wxCommandEvent& event);
+    void onSetUserColour(wxCommandEvent& event);
+    void onOpenAttachment(wxCommandEvent& event);
+
+private:
+    const wxString getItem(long item, long column, bool realenum = false) const;
+    void setColumnImage(int col, int image);
+    void setExtraTransactionData(const bool single);
+    void markItem(long selectedItem);
+    void setSelectedId(Fused_Transaction::IdRepeat sel_id);
+    std::vector<Fused_Transaction::IdRepeat> getSelectedId() const;
+    std::vector<Fused_Transaction::IdRepeat> getSelectedForCopy() const;
+    void findSelectedTransactions();
+    void setSortOrder(bool asc);
+    bool getSortOrder() const;
+    int getColumnFromPosition(int xPos);
+    void doSearchText(const wxString& value);
+    void setVisibleItemIndex(long v);
+    void markSelectedTransaction();
+    void deleteTransactionsByStatus(const wxString& status);
+    bool checkForClosedAccounts();
+    bool checkTransactionLocked(int64 AccountID, const wxString& transdate);
 };
 
 //----------------------------------------------------------------------------
 
-inline bool TransactionListCtrl::getSortOrder() const { return m_asc; }
-inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedForCopy() const { return m_selectedForCopy; }
+inline void TransactionListCtrl::setSortOrder(bool asc)
+{
+    m_asc = asc;
+}
+inline bool TransactionListCtrl::getSortOrder() const {
+    return m_asc;
+}
 
-inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedId() const { return m_selected_id; }
+inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedId() const
+{
+    return m_selected_id;
+}
+inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedForCopy() const
+{
+    return m_selectedForCopy;
+}
 
-inline void TransactionListCtrl::setVisibleItemIndex(long v) { m_topItemIndex = v; }
+inline void TransactionListCtrl::setVisibleItemIndex(long v)
+{
+    m_topItemIndex = v;
+}
 
 #endif // MM_EX_CHECKING_LIST_H_
 
@@ -250,21 +257,25 @@ inline static bool SorterByUDFC01(
 ) {
     return (i.UDFC_content[0] < j.UDFC_content[0]);
 }
+
 inline static bool SorterByUDFC02(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_content[1] < j.UDFC_content[1]);
 }
+
 inline static bool SorterByUDFC03(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_content[2] < j.UDFC_content[2]);
 }
+
 inline static bool SorterByUDFC04(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_content[3] < j.UDFC_content[3]);
 }
+
 inline static bool SorterByUDFC05(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
@@ -276,23 +287,28 @@ inline static bool SorterByUDFC01_val(
 ) {
     return (i.UDFC_value[0] < j.UDFC_value[0]);
 }
+
 inline static bool SorterByUDFC02_val(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_value[1] < j.UDFC_value[1]);
 }
+
 inline static bool SorterByUDFC03_val(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_value[2] < j.UDFC_value[2]);
 }
+
 inline static bool SorterByUDFC04_val(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_value[3] < j.UDFC_value[3]);
 }
+
 inline static bool SorterByUDFC05_val(
     const Model_Checking::Full_Data& i, const Model_Checking::Full_Data& j
 ) {
     return (i.UDFC_value[4] < j.UDFC_value[4]);
 }
+

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -26,6 +26,7 @@ Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
 #include "mmpanelbase.h"
 #include "constants.h"
 #include "fusedtransaction.h"
+#include "reports/mmDateRange.h"
 #include "model/Model_Account.h"
 #include <map>
 //----------------------------------------------------------------------------
@@ -49,10 +50,6 @@ public:
         ICON_ASC,
     };
 
-    static wxArrayString FILTER_STR;
-    static const wxString FILTER_STR_ALL;
-    static const wxString FILTER_STR_DIALOG;
-
 public:
     mmCheckingPanel(
         mmGUIFrame* frame,
@@ -67,77 +64,69 @@ public:
     bool isDeletedTrans() const;
     bool isGroup() const;
     bool isAccount() const;
+    wxString sortPrefix() const;
 
-    void DisplayAccountDetails(int64 account_id = -1);
-        // Refresh account screen with new details
-    void DisplaySplitCategories(Fused_Transaction::IdB fused_id);
-        // Display the split categories for the selected transaction.
-
-    void SetSelectedTransaction(Fused_Transaction::IdRepeat fused_id);
-
-    void RefreshList();
-    void ResetColumnView();
-
+    void loadAccount(int64 account_id = -1);
+    void refreshList();
     wxString BuildPage() const;
+    void resetColumnView();
+    void setSelectedTransaction(Fused_Transaction::IdRepeat fused_id);
+    void displaySplitCategories(Fused_Transaction::IdB fused_id);
 
 private:
     friend class TransactionListCtrl; // needs access to m_core, initdb_, ...
 
-    enum ID_TRX
-    {
-        ID_TRX_FILTER = wxID_HIGHEST + 50,
-        ID_TRX_SCHEDULED
-    };
-
     enum FILTER_ID
     {
-        FILTER_ID_ALL = 0,
-        FILTER_ID_TODAY,
-        FILTER_ID_CURRENTMONTH,
-        FILTER_ID_LAST30,
-        FILTER_ID_LAST90,
-        FILTER_ID_LASTMONTH,
-        FILTER_ID_LAST3MONTHS,
-        FILTER_ID_LAST12MONTHS,
-        FILTER_ID_CURRENTYEAR,
-        FILTER_ID_CURRENTFINYEAR,
-        FILTER_ID_LASTYEAR,
-        FILTER_ID_LASTFINYEAR,
-        FILTER_ID_STATEMENTDATE,
-        FILTER_ID_DIALOG,
-        FILTER_ID_MAX,
+        FILTER_ID_DATE = 0,
+        FILTER_ID_ADVANCED,
+        FILTER_ID_size
     };
 
-    static const std::vector<std::pair<FILTER_ID, wxString> > FILTER_CHOICES;
-    static wxArrayString filter_str_all();
-    static void mmPlayTransactionSound();
+    enum
+    {
+        mmID_FILTER = wxID_HIGHEST + 50,
+        mmID_FILTER_DATE_MIN,
+        mmID_FILTER_DATE_MAX = mmID_FILTER_DATE_MIN + 99,
+        mmID_FILTER_ADVANCED,
+        mmID_EDIT_DATE_RANGES,
+        mmID_SCHEDULED,
+    };
+
+    static const std::vector<std::pair<FILTER_ID, wxString> > FILTER_NAME;
+    static const wxString FILTER_NAME_DATE;
+    static const wxString FILTER_NAME_ADVANCED;
 
 private:
+    // set by constructor or loadAccount()
     int64 m_checking_id = -1;
         //  1..   : single account with id m_checking_id
         // -1     : all transactions
         // -2     : deleted transactions
         // -3     : favorite accounts
         // -(4+X) : accounts of type X
-    int m_filter_id;
-    bool m_scheduled_enable;
-    bool m_scheduled_selected;
-    bool m_transFilterActive = false;
-    wxString m_sortSaveTitle;  // Used for saving sort settings
-    wxString m_begin_date;
-    wxString m_end_date;
-    double m_account_flow = 0.0;
-    double m_account_balance = 0.0;
-    double m_account_reconciled = 0.0;
-    bool m_show_reconciled;
-    bool m_show_tips = false;
-    TransactionListCtrl* m_listCtrlAccount = nullptr;
-
     int64 m_account_id = -1;                    // applicable if m_checking_id >= 1
     int m_account_type = -1;                    // applicable if m_checking_id <= -4
     std::set<int64> m_group_ids = {};           // applicable if m_checking_id <= -3
     Model_Account::Data* m_account = nullptr;   // non-null if m_checking_id >= 1
     Model_Currency::Data* m_currency = nullptr; // currency of m_account, or base currency
+    std::vector<DateRange2::Spec> m_date_range_a = {};
+    int m_date_range_m = -1;
+
+    // set by gui
+    FILTER_ID m_filter_id;
+    DateRange2 m_date_range = DateRange2();
+    bool m_scheduled_enable;
+    bool m_scheduled_selected;
+
+    // calculated by filterList(); applicable if isAccount()
+    double m_flow = 0.0;
+    double m_balance = 0.0;
+    double m_reconciled_balance = 0.0;
+    bool m_show_reconciled;
+
+    // set by showTips()
+    bool m_show_tips = false;
 
     wxDECLARE_EVENT_TABLE();
     mmGUIFrame* m_frame = nullptr;
@@ -157,54 +146,65 @@ private:
     wxStaticText* m_header_balance = nullptr;
     wxStaticText* m_info_panel = nullptr;
     wxStaticText* m_info_panel_mini = nullptr;
-    wxSharedPtr<mmFilterTransactionsDialog> m_trans_filter_dlg;
     wxVector<wxBitmapBundle> m_images;
+    TransactionListCtrl* m_listCtrlAccount = nullptr;
+    wxSharedPtr<mmFilterTransactionsDialog> m_trans_filter_dlg;
 
 private:
-    wxString GetPanelTitle() const;
-
-    bool Create(
+    bool create(
         wxWindow* parent,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = wxTAB_TRAVERSAL | wxNO_BORDER,
         const wxString& name = "mmCheckingPanel" 
     );
-
-    void initFilterChoices();
-    void updateFilterState();
-    void saveFilterChoices();
-    void setAccountSummary();
+    void createControls();
+    void updateHeader();
+    void updateFilter();
+    void updateFilterTooltip();
+    void setFilterDate(DateRange2::Spec& spec);
+    void setFilterAdvanced();
+    void loadFilterSettings();
+    void saveFilterSettings();
+    void filterList();
     void sortTable();
-    void filterTable();
-    void CreateControls();
-
-    /* updates the checking panel data */
+    void updateExtraTransactionData(bool single, int repeat_num, bool foreign);
+    void enableButtons(bool edit, bool dup, bool del, bool enter, bool skip, bool attach);
     void showTips();
     void showTips(const wxString& tip);
     void updateScheduledToolTip();
-    void updateExtraTransactionData(bool single, int repeat_num, bool foreign);
-    void enableButtons(bool edit, bool dup, bool del, bool enter, bool skip, bool attach);
 
-    void OnNewTransaction(wxCommandEvent& event);
-    void OnEditTransaction(wxCommandEvent& event);
-    void OnDuplicateTransaction(wxCommandEvent& event);
-    void OnRestoreTransaction(wxCommandEvent& event);
-    void OnDeleteTransaction(wxCommandEvent& event);
-    void OnEnterScheduled(wxCommandEvent& event);
-    void OnSkipScheduled(wxCommandEvent& event);
-    void OnOpenAttachment(wxCommandEvent& event);
-    void OnMoveTransaction(wxCommandEvent& event);
-    void OnMouseLeftDown(wxCommandEvent& event);
-    void OnButtonRightDown(wxMouseEvent& event);
-    void OnViewPopupSelected(wxCommandEvent& event);
-    void OnScheduled(wxCommandEvent& event);
-    void OnSearchTxtEntered(wxCommandEvent& event);
+    void onFilterPopup(wxCommandEvent& event);
+    void onFilterDate(wxCommandEvent& event);
+    void onFilterAdvanced(wxCommandEvent& event);
+    void onEditDateRanges(wxCommandEvent& event);
+    void onScheduled(wxCommandEvent& event);
+    void onNewTransaction(wxCommandEvent& event);
+    void onEditTransaction(wxCommandEvent& event);
+    void onDeleteTransaction(wxCommandEvent& event);
+    void onRestoreTransaction(wxCommandEvent& event);
+    void onDuplicateTransaction(wxCommandEvent& event);
+    void onMoveTransaction(wxCommandEvent& event);
+    void onEnterScheduled(wxCommandEvent& event);
+    void onSkipScheduled(wxCommandEvent& event);
+    void onOpenAttachment(wxCommandEvent& event);
+    void onSearchTxtEntered(wxCommandEvent& event);
+    void onButtonRightDown(wxMouseEvent& event);
+
+    wxString getPanelTitle() const;
+    static void mmPlayTransactionSound();
 };
 
 inline bool mmCheckingPanel::isAllTrans() const { return m_checking_id == -1; }
 inline bool mmCheckingPanel::isDeletedTrans() const { return m_checking_id == -2; }
 inline bool mmCheckingPanel::isGroup() const { return m_checking_id <= -3; }
 inline bool mmCheckingPanel::isAccount() const { return m_checking_id >= 1; }
+inline wxString mmCheckingPanel::sortPrefix() const {
+    return
+        isAllTrans() ? "ALLTRANS" :
+        isDeletedTrans() ? "DELETED" :
+        isGroup() ? "MULTI" :
+        "CHECK";
+}
 
 #endif // MM_EX_CHECKINGPANEL_H_

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2956,7 +2956,7 @@ void mmGUIFrame::refreshPanelData()
         createHomePage();
         break;
     case mmID_CHECKING:
-        wxDynamicCast(panelCurrent_, mmCheckingPanel)->RefreshList();
+        wxDynamicCast(panelCurrent_, mmCheckingPanel)->refreshList();
         break;
     case mmID_STOCKS:
         wxDynamicCast(panelCurrent_, mmStocksPanel)->RefreshList();
@@ -3115,7 +3115,7 @@ void mmGUIFrame::OnOptions(wxCommandEvent& /*event*/)
         // Reset columns of the checking panel in case the time columns was added/removed
         int id = panelCurrent_->GetId();
         if (id == mmID_CHECKING)
-            wxDynamicCast(panelCurrent_, mmCheckingPanel)->ResetColumnView();
+            wxDynamicCast(panelCurrent_, mmCheckingPanel)->resetColumnView();
 
         const wxString& sysMsg = _("Settings have been updated.") + "\n\n"
             + _("Some settings take effect only after an application restart.");
@@ -3507,9 +3507,9 @@ void mmGUIFrame::createCheckingPage(int64 checking_id, const std::vector<int64> 
             (checking_id == -2 && cp->isDeletedTrans()) ||
             (checking_id >= 1 && cp->isAccount() && newCreditDisplayed == creditDisplayed_)
         ) {
-            cp->RefreshList();
+            cp->refreshList();
             if (cp->isAccount())
-                cp->DisplayAccountDetails(checking_id);
+                cp->loadAccount(checking_id);
             done = true;
         }
     }
@@ -3533,7 +3533,7 @@ void mmGUIFrame::createCheckingPage(int64 checking_id, const std::vector<int64> 
     menuPrintingEnable(true);
     if (checking_id >= 1 && gotoTransID_.first > 0) {
         mmCheckingPanel* cp = wxDynamicCast(panelCurrent_, mmCheckingPanel);
-        cp->SetSelectedTransaction(gotoTransID_);
+        cp->setSelectedTransaction(gotoTransID_);
         gotoTransID_ = { -1, 0 };
     }
     m_nav_tree_ctrl->SetEvtHandlerEnabled(true);

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -69,9 +69,15 @@ wxListItemAttr* mmListCtrl::OnGetItemAttr(long row) const
     return (row % 2) ? attr2_.get() : attr1_.get();
 }
 
-int mmListCtrl::GetRealColumn(int col)
+int mmListCtrl::GetRealColumn(int col_order) const
 {
-    return (0 == m_real_columns.size()) ? col : m_real_columns[col];
+    return m_real_columns.empty() ? col_order : m_real_columns[col_order];
+}
+
+int mmListCtrl::GetColumnOrder(int col_id) const
+{
+    return m_real_columns.empty() ? col_id :
+        std::find(m_real_columns.begin(), m_real_columns.end(), col_id) - m_real_columns.begin();
 }
 
 wxString mmListCtrl::BuildPage(const wxString &title) const
@@ -305,7 +311,7 @@ void mmListCtrl::OnHeaderReset(wxCommandEvent& WXUNUSED(event))
         }
     }
     wxListEvent e;
-    e.SetId(MENU_HEADER_SORT);
+    e.SetId(MENU_HEADER_RESET);
     m_ColumnHeaderNbr = m_default_sort_column;
     m_asc = true;
     OnColClick(e);

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -75,7 +75,8 @@ protected:
     void OnHeaderSort(wxCommandEvent& event);
     void OnHeaderReset(wxCommandEvent& WXUNUSED(event));
     void OnHeaderMove(wxCommandEvent& WXUNUSED(event), int direction);
-    int GetRealColumn(int col);
+    int GetRealColumn(int col_order) const;
+    int GetColumnOrder(int col_id) const;
     int m_ColumnHeaderNbr = -1;
     enum {
         HEADER = 0,

--- a/src/model/Model_Infotable.cpp
+++ b/src/model/Model_Infotable.cpp
@@ -197,6 +197,25 @@ void Model_Infotable::setDate(const wxString& key, const wxDateTime& newValue)
 }
 
 //-------------------------------------------------------------------
+// Jdoc
+void Model_Infotable::setJdoc(const wxString& key, Document& newValue)
+{
+    wxString j_str = JSON_PrettyFormated(newValue);
+    setRaw(key, j_str);
+}
+void Model_Infotable::setJdoc(const wxString& key, StringBuffer& newValue)
+{
+    wxString j_str = wxString::FromUTF8(newValue.GetString());
+    setRaw(key, j_str);
+}
+Document Model_Infotable::getJdoc(const wxString& key, const wxString& defaultValue)
+{
+    Document j_doc;
+    wxString j_str = getRaw(key, defaultValue);
+    j_doc.Parse(j_str.utf8_str());
+    return j_doc;
+}
+
 // ArrayString
 void Model_Infotable::setArrayString(const wxString& key, const wxArrayString& a)
 {

--- a/src/model/Model_Infotable.h
+++ b/src/model/Model_Infotable.h
@@ -23,6 +23,7 @@
 #include "Model.h"
 #include "db/DB_Table_Infotable_V1.h"
 #include "defs.h"
+#include "util.h"
 
 class Model_Infotable : public Model<DB_Table_INFOTABLE_V1>
 {
@@ -66,6 +67,10 @@ public:
     const wxColour getColour(const wxString& key, const wxColour& defaultValue = wxColour(255, 255, 255));
 
     void setDate(const wxString& key, const wxDateTime& newValue);
+
+    void setJdoc(const wxString& key, Document& newValue);
+    void setJdoc(const wxString& key, StringBuffer& newValue);
+    Document getJdoc(const wxString& key, const wxString& defaultValue);
 
     void setArrayString(const wxString& key, const wxArrayString& a);
     const wxArrayString getArrayString(const wxString& key, bool sort = false);

--- a/src/model/Model_Setting.cpp
+++ b/src/model/Model_Setting.cpp
@@ -256,16 +256,6 @@ wxString Model_Setting::getTheme()
     return getString("THEME", "default");
 }
 
-// VIEWTRANSACTIONS
-void Model_Setting::setViewTransactions(const wxString& value)
-{
-    setString("VIEWTRANSACTIONS", value);
-}
-wxString Model_Setting::getViewTransactions()
-{
-    return getString("VIEWTRANSACTIONS", mmCheckingPanel::FILTER_STR_ALL);
-}
-
 // LASTFILENAME
 wxString Model_Setting::getLastDbPath()
 {

--- a/src/model/Model_Setting.h
+++ b/src/model/Model_Setting.h
@@ -84,9 +84,6 @@ public:
     void setTheme(const wxString& newValue);
     wxString getTheme();
 
-    void setViewTransactions(const wxString& newValue);
-    wxString getViewTransactions();
-    
     wxString getLastDbPath();
 
 public:

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -627,7 +627,7 @@ void Option::parseCheckingRange()
         }
         wxString name = wxGetTranslation(range.second);
         DateRange2::Spec spec;
-        if (!spec.parseSpec(range.first, range.second))
+        if (!spec.parseSpec(label, name))
             continue;
         m_checking_range_a.push_back(spec);
     }

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -82,14 +82,24 @@ inline const wxString mmGetMonthName(const wxDateTime::Month& month)
     return MONTHS[static_cast<int>(month)];
 }
 
+inline wxString dateTimeISO(wxDateTime dateTime)
+{
+    return (dateTime == wxInvalidDateTime) ? "" : dateTime.FormatISOCombined();
+}
+
 inline wxString dateISO(wxDateTime date)
 {
     return (date == wxInvalidDateTime) ? "" : date.FormatISODate();
 }
 
-inline wxString dateTimeISO(wxDateTime dateTime)
+inline wxString dateISOStart(wxDateTime date)
 {
-    return (dateTime == wxInvalidDateTime) ? "" : dateTime.FormatISOCombined();
+    return dateISO(date).append("");
+}
+
+inline wxString dateISOEnd(wxDateTime date)
+{
+    return dateISO(date).append("~");
 }
 
 bool mmParseISODate(const wxString& in_str, wxDateTime& out_date);

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -399,13 +399,16 @@ void StocksListCtrl::OnListItemActivated(wxListEvent& event)
 void StocksListCtrl::OnColClick(wxListEvent& event)
 {
     int ColumnNr;
-    if (event.GetId() != MENU_HEADER_SORT)
+    if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
         ColumnNr = event.GetColumn();
     else
         ColumnNr = m_ColumnHeaderNbr;
     if (0 >= ColumnNr || ColumnNr >= getColumnsNumber()) return;
 
-    if (m_selected_col == ColumnNr && event.GetId() != MENU_HEADER_SORT) m_asc = !m_asc;
+    if (m_selected_col == ColumnNr &&
+        event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
+    )
+        m_asc = !m_asc;
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,22 +48,46 @@
 
 using namespace rapidjson;
 
+// Return a JSON formatted string in readable form
 wxString JSON_PrettyFormated(rapidjson::Document& j_doc)
 {
     StringBuffer j_buffer;
     PrettyWriter<StringBuffer> j_writer(j_buffer);
     j_doc.Accept(j_writer);
-
     return wxString::FromUTF8(j_buffer.GetString());
 }
 
+// Returns a JSON formatted string from RapidJson DOM
 wxString JSON_Formated(rapidjson::Document& j_doc)
 {
     StringBuffer j_buffer;
     Writer<StringBuffer> j_writer(j_buffer);
     j_doc.Accept(j_writer);
-
     return wxString::FromUTF8(j_buffer.GetString());
+}
+
+// Get a string value from RapidJson DOM
+bool JSON_GetStringValue(Document& j_doc, const MemoryStream::Ch* name, wxString& value)
+{
+    if (!j_doc.HasMember(name))
+        return false;
+    Value& j_value = j_doc[name];
+    if (!j_value.IsString())
+        return false;
+    value = wxString::FromUTF8(j_value.GetString());
+    return true;
+}
+
+// Get a bool value from RapidJson DOM
+bool JSON_GetBoolValue(Document& j_doc, const MemoryStream::Ch* name, bool& value)
+{
+    if (!j_doc.HasMember(name))
+        return false;
+    Value& j_value = j_doc[name];
+    if (!j_value.IsBool())
+        return false;
+    value = j_value.GetBool();
+    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/util.h
+++ b/src/util.h
@@ -33,10 +33,10 @@
 
 class mmGUIApp;
 
-//Returns a JSON formatted string in readable form
 wxString JSON_PrettyFormated(rapidjson::Document& j_doc);
-//Returns a JSON formatted string from RapidJson DOM
 wxString JSON_Formated(rapidjson::Document& j_doc);
+bool JSON_GetStringValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, wxString& value);
+bool JSON_GetBoolValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, bool& value);
 
 struct ValuePair
 {


### PR DESCRIPTION
## Database changes

- Deprecate Infotable `CHECK_FILTER_ID_*`.

- Add Infotable `CHECK_FILTER_*` (JSON string), with fields:
  - FILTER (string) is one of: Date, Advanced
  - DATE (string) is a date range spec (label; name)
  - SCHEDULED (bool)

## Changes in `primitive.h`

- Add `dateISOStart()`, `dateISOEnd()`.

## Changes in `util.{h,cpp}`

- Add `JSON_GetStringValue()`, `JSON_GetBoolValue()`.

## Changes in `DateRange2`

- Add `Spec::hasPeriodS()`, `Spec::getLabelName()`.

- Add `getLabel()`, `getName()`, `getLabelName()`, `checking_start_str()`, `checking_end_str()`, `checking_tooltip()`.

## Changes in `Model_Infotable`

- Add `setJdoc()`, `getJdoc()`.

## Changes in `Model_Setting`

- Remove `setViewTransactions()`, `getViewTransactions()`. Deprecate unused `VIEWTRANSACTIONS`.

## Changes in `mmListCtrl`

- Add `GetColumnOrder()`.

## Refactor `mmFilterTransactionsDialog`

- Rename `mmGetJsonSetings()` -> `mmGetJsonSettings().`

## Changes in `mmCheckingPanel`

- Reorder class members (consistent order in .h and .cpp).

- Rename several variable and functions (e.g., lowercase first letter).

- Remove `FILTER_CHOICES`, `FILTER_STR`, `FILTER_STR_*`, `filter_str_all()`.

- Add `FILTER_NAME`, `FILTER_NAME_*`.

- Changes in enum `FILTER_ID`, `ID_TRX`.

- Add `m_date_range_a`, `m_date_range_m`, `m_date_range`.

- Remove `m_begin_date`, `m_end_date`, `m_transFilterActive`, `m_sortSaveTitle`.

- Rename `m_account_flow` -> `m_flow`, `m_account_balance` -> `m_balance`, `m_account_reconciled` -> `m_reconciled_balance`.

- Remove `m_sortSaveTitle`. Add `sortPrefix()`.

- Rename and refine `DisplayAccountDetails()` -> `loadAccount()`.

- Rename `filterTable()` -> `filterList()`.

- Rename and refine `OnMouseLeftDown()` -> `onFilterPopup()`.

- Remove `OnViewPopupSelected()`. Add `onFilterAdvanced()`, `onFilterDate()`.

- Add `updateFilterTooltip()`, `setFilterDate()`, `setFilterAdvanced()`.

- Rename and refine `initFilterChoices()` -> `loadFilterSettings()`, `saveFilterChoices()` -> `saveFilterSettings()`, `updateFilterState()` -> `updateFilter()`, `setAccountSummary()` -> `updateHeader()`.

## Changes in `TransactionListCtrl`

- Reorder class members (consistent order in .h and .cpp).

- Rename several variable and functions (e.g., lowercase first letter).

- Rename EColumn `g_sortcol` -> int `g_sortCol1`, EColumn `prev_g_sortcol` -> int `g_sortCol2`, `g_asc` -> `g_sortAsc1`, `prev_g_asc` -> `g_sortAsc2`.

- Remove `m_sortCol`, `setSortColumn()`, `toEColumn()`.

- Rename `findInAllTransactions()` -> `onFind()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7224)
<!-- Reviewable:end -->
