### PR TITLE
refine mmListCtrl (part 2)

### DIFF
--- a/src/assetspanel.h
+++ b/src/assetspanel.h
@@ -27,27 +27,38 @@ class wxButton;
 /* Custom ListCtrl class that implements virtual LC style */
 class mmAssetsListCtrl: public mmListCtrl
 {
-    DECLARE_NO_COPY_CLASS(mmAssetsListCtrl)
-    wxDECLARE_EVENT_TABLE();
-
 public:
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_ICON = 0,
-        LIST_COL_ID,
-        LIST_COL_NAME,
-        LIST_COL_DATE,
-        LIST_COL_TYPE,
-        LIST_COL_VALUE_INITIAL,
-        LIST_COL_VALUE_CURRENT,
-        LIST_COL_NOTES,
-        LIST_COL_size, // number of columns
+        LISTCOL_ID_ICON = 0,
+        LISTCOL_ID_ID,
+        LISTCOL_ID_NAME,
+        LISTCOL_ID_DATE,
+        LISTCOL_ID_TYPE,
+        LISTCOL_ID_VALUE_INITIAL,
+        LISTCOL_ID_VALUE_CURRENT,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_size, // number of columns
     };
 
 private:
-    static const std::vector<ListColumnInfo> col_info_all();
-    int col_size() { return LIST_COL_size; }
-    int col_sort() { return LIST_COL_DATE; }
+    DECLARE_NO_COPY_CLASS(mmAssetsListCtrl)
+    wxDECLARE_EVENT_TABLE();
+    enum {
+        MENU_TREEPOPUP_NEW = wxID_HIGHEST + 1200,
+        MENU_TREEPOPUP_ADDTRANS,
+        MENU_TREEPOPUP_VIEWTRANS,
+        MENU_TREEPOPUP_GOTOACCOUNT,
+        MENU_TREEPOPUP_EDIT,
+        MENU_TREEPOPUP_DELETE,
+        MENU_ON_DUPLICATE_TRANSACTION,
+        MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS,
+    };
+
+private:
+    static const std::vector<ListColumnInfo> LISTCOL_INFO;
+    mmAssetsPanel* m_panel = nullptr;
+    long m_selected_row = -1;
 
 public:
     mmAssetsListCtrl(mmAssetsPanel* cp, wxWindow *parent, wxWindowID winid = wxID_ANY);
@@ -68,10 +79,8 @@ protected:
     virtual void OnColClick(wxListEvent& event);
 
 private:
-    mmAssetsPanel* m_panel = nullptr;
-
     /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long column) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const;
     virtual int OnGetItemImage(long item) const;
 
     void OnMouseRightClick(wxMouseEvent& event);
@@ -81,17 +90,6 @@ private:
     void OnListItemSelected(wxListEvent& event);
     void OnEndLabelEdit(wxListEvent& event);
     bool EditAsset(Model_Asset::Data* pEntry);
-
-    enum {
-        MENU_TREEPOPUP_NEW = wxID_HIGHEST + 1200,
-        MENU_TREEPOPUP_ADDTRANS,
-        MENU_TREEPOPUP_VIEWTRANS,
-        MENU_TREEPOPUP_GOTOACCOUNT,
-        MENU_TREEPOPUP_EDIT,
-        MENU_TREEPOPUP_DELETE,
-        MENU_ON_DUPLICATE_TRANSACTION,
-        MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS,
-    };
 };
 
 class mmAssetsPanel : public mmPanelBase
@@ -117,12 +115,12 @@ public:
 
     void updateExtraAssetData(int selIndex);
     int initVirtualListControl(int64 trx_id = -1, int col = 0, bool asc = true);
-    wxString getItem(long item, long column);
+    wxString getItem(long item, int col_id);
 
     Model_Asset::Data_Set m_assets;
     Model_Asset::TYPE_ID m_filter_type;
 
-    wxString BuildPage() const { return m_listCtrlAssets->BuildPage(_t("Assets")); }
+    wxString BuildPage() const { return m_lc->BuildPage(_t("Assets")); }
 
     void AddAssetTrans(const int selected_index);
     void ViewAssetTrans(const int selected_index);
@@ -133,7 +131,7 @@ private:
     void enableEditDeleteButtons(bool enable);
     void OnSearchTxtEntered(wxCommandEvent& event);
     
-    mmAssetsListCtrl* m_listCtrlAssets = nullptr;
+    mmAssetsListCtrl* m_lc = nullptr;
     wxButton* m_bitmapTransFilter = nullptr;
     wxStaticText* header_text_ = nullptr;
 
@@ -155,7 +153,7 @@ private:
     void OnViewAssetTrans(wxCommandEvent& event);
 
     void OnViewPopupSelected(wxCommandEvent& event);
-    void sortTable();
+    void sortList();
     void SetAccountParameters(const Model_Account::Data* account);
 
 private:
@@ -166,4 +164,4 @@ private:
     };
 };
 
-inline void mmAssetsPanel::RefreshList(){ m_listCtrlAssets->doRefreshItems(); }
+inline void mmAssetsPanel::RefreshList(){ m_lc->doRefreshItems(); }

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -66,68 +66,67 @@ const wxString BILLSDEPOSITS_REPEATS[] =
     _n("Monthly (last business day)")
 };
 
-/*******************************************************/
 wxBEGIN_EVENT_TABLE(mmBillsDepositsPanel, wxPanel)
-EVT_BUTTON(wxID_NEW, mmBillsDepositsPanel::OnNewBDSeries)
-EVT_BUTTON(wxID_EDIT, mmBillsDepositsPanel::OnEditBDSeries)
-EVT_BUTTON(wxID_DUPLICATE, mmBillsDepositsPanel::OnDuplicateBDSeries)
-EVT_BUTTON(wxID_DELETE, mmBillsDepositsPanel::OnDeleteBDSeries)
-EVT_BUTTON(wxID_PASTE, mmBillsDepositsPanel::OnEnterBDTransaction)
-EVT_BUTTON(wxID_IGNORE, mmBillsDepositsPanel::OnSkipBDTransaction)
-EVT_BUTTON(wxID_FILE, mmBillsDepositsPanel::OnOpenAttachment)
-EVT_BUTTON(wxID_FILE2, mmBillsDepositsPanel::OnFilterTransactions)
+    EVT_BUTTON(wxID_NEW,       mmBillsDepositsPanel::OnNewBDSeries)
+    EVT_BUTTON(wxID_EDIT,      mmBillsDepositsPanel::OnEditBDSeries)
+    EVT_BUTTON(wxID_DUPLICATE, mmBillsDepositsPanel::OnDuplicateBDSeries)
+    EVT_BUTTON(wxID_DELETE,    mmBillsDepositsPanel::OnDeleteBDSeries)
+    EVT_BUTTON(wxID_PASTE,     mmBillsDepositsPanel::OnEnterBDTransaction)
+    EVT_BUTTON(wxID_IGNORE,    mmBillsDepositsPanel::OnSkipBDTransaction)
+    EVT_BUTTON(wxID_FILE,      mmBillsDepositsPanel::OnOpenAttachment)
+    EVT_BUTTON(wxID_FILE2,     mmBillsDepositsPanel::OnFilterTransactions)
 wxEND_EVENT_TABLE()
-/*******************************************************/
+
 wxBEGIN_EVENT_TABLE(billsDepositsListCtrl, mmListCtrl)
-EVT_LIST_ITEM_ACTIVATED(wxID_ANY,   billsDepositsListCtrl::OnListItemActivated)
-EVT_RIGHT_DOWN(billsDepositsListCtrl::OnItemRightClick)
-EVT_LEFT_DOWN(billsDepositsListCtrl::OnListLeftClick)
-EVT_LIST_ITEM_SELECTED(wxID_ANY, billsDepositsListCtrl::OnListItemSelected)
+    EVT_LEFT_DOWN(billsDepositsListCtrl::OnListLeftClick)
+    EVT_RIGHT_DOWN(billsDepositsListCtrl::OnItemRightClick)
 
-EVT_MENU(MENU_TREEPOPUP_NEW,              billsDepositsListCtrl::OnNewBDSeries)
-EVT_MENU(MENU_TREEPOPUP_EDIT,             billsDepositsListCtrl::OnEditBDSeries)
-EVT_MENU(MENU_TREEPOPUP_DUPLICATE,        billsDepositsListCtrl::OnDuplicateBDSeries)
-EVT_MENU(MENU_TREEPOPUP_DELETE,           billsDepositsListCtrl::OnDeleteBDSeries)
-EVT_MENU(MENU_POPUP_BD_ENTER_OCCUR,       billsDepositsListCtrl::OnEnterBDTransaction)
-EVT_MENU(MENU_POPUP_BD_SKIP_OCCUR,        billsDepositsListCtrl::OnSkipBDTransaction)
-EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, billsDepositsListCtrl::OnOrganizeAttachments)
-EVT_MENU_RANGE(MENU_ON_SET_UDC0, MENU_ON_SET_UDC7, billsDepositsListCtrl::OnSetUserColour)
+    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, billsDepositsListCtrl::OnListItemActivated)
+    EVT_LIST_ITEM_SELECTED(wxID_ANY,  billsDepositsListCtrl::OnListItemSelected)
+    EVT_LIST_KEY_DOWN(wxID_ANY,       billsDepositsListCtrl::OnListKeyDown)
 
-EVT_LIST_KEY_DOWN(wxID_ANY,   billsDepositsListCtrl::OnListKeyDown)
+    EVT_MENU(MENU_TREEPOPUP_NEW,                  billsDepositsListCtrl::OnNewBDSeries)
+    EVT_MENU(MENU_TREEPOPUP_EDIT,                 billsDepositsListCtrl::OnEditBDSeries)
+    EVT_MENU(MENU_TREEPOPUP_DUPLICATE,            billsDepositsListCtrl::OnDuplicateBDSeries)
+    EVT_MENU(MENU_TREEPOPUP_DELETE,               billsDepositsListCtrl::OnDeleteBDSeries)
+    EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, billsDepositsListCtrl::OnOrganizeAttachments)
+    EVT_MENU(MENU_POPUP_BD_ENTER_OCCUR,           billsDepositsListCtrl::OnEnterBDTransaction)
+    EVT_MENU(MENU_POPUP_BD_SKIP_OCCUR,            billsDepositsListCtrl::OnSkipBDTransaction)
+    EVT_MENU_RANGE(
+        MENU_ON_SET_UDC0, MENU_ON_SET_UDC7,
+        billsDepositsListCtrl::OnSetUserColour
+    )
 wxEND_EVENT_TABLE()
-/*******************************************************/
 
-const std::vector<ListColumnInfo> billsDepositsListCtrl::col_info_all()
-{
-    return {
-        { " ",              25,                        wxLIST_FORMAT_LEFT,  false },
-        { _t("ID"),          wxLIST_AUTOSIZE,           wxLIST_FORMAT_RIGHT, true },
-        { _t("Date Paid"),   wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Date Due"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Account"),     wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Payee"),       wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Status"),      wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Category"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Tags"),        200,                       wxLIST_FORMAT_LEFT,  true },
-        { _t("Type"),        wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Amount"),      wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Frequency"),   wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Repetitions"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Autorepeat"),  wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Payment"),     wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Number"),      wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Notes"),       150,                       wxLIST_FORMAT_LEFT,  true },
-    };
-}
+const std::vector<ListColumnInfo> billsDepositsListCtrl::LISTCOL_INFO = {
+    { LISTCOL_ID_ICON,         true, _n("Icon"),        25,  _FL, false },
+    { LISTCOL_ID_ID,           true, _n("ID"),          _WA, _FR, true },
+    { LISTCOL_ID_PAYMENT_DATE, true, _n("Date Paid"),   _WH, _FL, true },
+    { LISTCOL_ID_DUE_DATE,     true, _n("Date Due"),    _WH, _FL, true },
+    { LISTCOL_ID_ACCOUNT,      true, _n("Account"),     _WH, _FL, true },
+    { LISTCOL_ID_PAYEE,        true, _n("Payee"),       _WH, _FL, true },
+    { LISTCOL_ID_STATUS,       true, _n("Status"),      _WH, _FL, true },
+    { LISTCOL_ID_CATEGORY,     true, _n("Category"),    _WH, _FL, true },
+    { LISTCOL_ID_TAGS,         true, _n("Tags"),        200, _FL, true },
+    { LISTCOL_ID_TYPE,         true, _n("Type"),        _WH, _FL, true },
+    { LISTCOL_ID_AMOUNT,       true, _n("Amount"),      _WH, _FR, true },
+    { LISTCOL_ID_FREQUENCY,    true, _n("Frequency"),   _WH, _FL, true },
+    { LISTCOL_ID_REPEATS,      true, _n("Repetitions"), _WH, _FR, true },
+    { LISTCOL_ID_AUTO,         true, _n("Autorepeat"),  _WH, _FL, true },
+    { LISTCOL_ID_DAYS,         true, _n("Payment"),     _WH, _FL, true },
+    { LISTCOL_ID_NUMBER,       true, _n("Number"),      _WH, _FL, true },
+    { LISTCOL_ID_NOTES,        true, _n("Notes"),       150, _FL, true },
+};
 
-billsDepositsListCtrl::billsDepositsListCtrl(mmBillsDepositsPanel* bdp, wxWindow *parent, wxWindowID winid)
-    : mmListCtrl(parent, winid)
-    , m_bdp(bdp)
+billsDepositsListCtrl::billsDepositsListCtrl(
+    mmBillsDepositsPanel* bdp, wxWindow *parent, wxWindowID winid
+) :
+    mmListCtrl(parent, winid),
+    m_bdp(bdp)
 {
     mmThemeMetaColour(this, meta::COLOR_LISTPANEL);
 
-    const wxAcceleratorEntry entries[] =
-    {
+    const wxAcceleratorEntry entries[] = {
         wxAcceleratorEntry(wxACCEL_CTRL, 'N', MENU_TREEPOPUP_NEW),
         wxAcceleratorEntry(wxACCEL_CTRL, 'E', MENU_TREEPOPUP_EDIT),
         wxAcceleratorEntry(wxACCEL_CTRL, 'U', MENU_TREEPOPUP_DUPLICATE),
@@ -141,23 +140,16 @@ billsDepositsListCtrl::billsDepositsListCtrl(mmBillsDepositsPanel* bdp, wxWindow
         wxAcceleratorEntry(wxACCEL_CTRL, '6', MENU_ON_SET_UDC6),
         wxAcceleratorEntry(wxACCEL_CTRL, '7', MENU_ON_SET_UDC7)
     };
-
     wxAcceleratorTable tab(sizeof(entries) / sizeof(*entries), entries);
     SetAcceleratorTable(tab);
 
-    // load the global variables
-    m_selected_col = Model_Setting::instance().getInt("BD_SORT_COL", col_sort());
-    m_asc = Model_Setting::instance().getBool("BD_ASC", true);
-
-    m_columns = col_info_all();
-    for (int i = 0; i < LIST_COL_size; ++i)
-        m_column_order.push_back(i);
-    m_col_width_fmt = "BD_COL%d_WIDTH";
-    m_col_type_str = "BD";
-    m_default_sort_column = col_sort();
-
+    o_col_order_prefix = "BD";
+    o_col_width_prefix = "BD_COL";
+    o_sort_prefix = "BD";
+    m_col_id_info = LISTCOL_INFO;
+    m_col_nr_id = ListColumnInfo::getId(LISTCOL_INFO);
+    m_sort_col_id = { col_sort() };
     createColumns();
-
 }
 
 billsDepositsListCtrl::~billsDepositsListCtrl()
@@ -167,26 +159,27 @@ billsDepositsListCtrl::~billsDepositsListCtrl()
 
 void billsDepositsListCtrl::OnColClick(wxListEvent& event)
 {
-    int ColumnNr;
+    int col_nr;
     if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
-        ColumnNr = event.GetColumn();
+        col_nr = event.GetColumn();
     else
-        ColumnNr = m_ColumnHeaderNbr;
-    if (0 > ColumnNr || ColumnNr >= m_bdp->getColumnsNumber() || ColumnNr == 0) return;
+        col_nr = m_col_nr;
+    if (!isValidColNr(col_nr) || col_nr == 0)
+        return;
 
-    if (m_selected_col == ColumnNr &&
+    if (getSortColNr() == col_nr &&
         event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
-    ) m_asc = !m_asc;
+    )
+        m_sort_asc[0] = !m_sort_asc[0];
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);
     item.SetImage(-1);
-    SetColumn(m_selected_col, item);
+    SetColumn(getSortColNr(), item);
 
-    m_selected_col = ColumnNr;
+    m_sort_col_id[0] = getColId(col_nr);
 
-    Model_Setting::instance().setBool("BD_ASC", m_asc);
-    Model_Setting::instance().setInt("BD_SORT_COL", m_selected_col);
+    savePreferences();
 
     if (m_selected_row >= 0)
         refreshVisualList(m_bdp->initVirtualListControl(m_bdp->bills_[m_selected_row].BDID));
@@ -276,15 +269,15 @@ void mmBillsDepositsPanel::CreateControls()
     images.push_back(mmBitmapBundle(png::UPARROW));
     images.push_back(mmBitmapBundle(png::DOWNARROW));
 
-    listCtrlAccount_ = new billsDepositsListCtrl(this, itemSplitterWindowBillsDeposit);
+    m_lc = new billsDepositsListCtrl(this, itemSplitterWindowBillsDeposit);
 
-    listCtrlAccount_->SetSmallImages(images);
+    m_lc->SetSmallImages(images);
 
     wxPanel* bdPanel = new wxPanel(itemSplitterWindowBillsDeposit, wxID_ANY
         , wxDefaultPosition, wxDefaultSize, wxNO_BORDER | wxTAB_TRAVERSAL);
     mmThemeMetaColour(bdPanel, meta::COLOR_LISTPANEL);
 
-    itemSplitterWindowBillsDeposit->SplitHorizontally(listCtrlAccount_, bdPanel);
+    itemSplitterWindowBillsDeposit->SplitHorizontally(m_lc, bdPanel);
     itemSplitterWindowBillsDeposit->SetMinimumPaneSize(100);
     itemSplitterWindowBillsDeposit->SetSashGravity(1.0);
     itemBoxSizer9->Add(itemSplitterWindowBillsDeposit, g_flagsExpandBorder1);
@@ -345,12 +338,12 @@ void mmBillsDepositsPanel::CreateControls()
 
 int mmBillsDepositsPanel::initVirtualListControl(int64 id)
 {
-    listCtrlAccount_->DeleteAllItems();
+    m_lc->DeleteAllItems();
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);
-    item.SetImage(listCtrlAccount_->m_asc ? ICON_UPARROW : ICON_DOWNARROW);
-    listCtrlAccount_->SetColumn(listCtrlAccount_->m_selected_col, item);
+    item.SetImage(m_lc->getSortAsc() ? ICON_UPARROW : ICON_DOWNARROW);
+    m_lc->SetColumn(m_lc->getSortColNr(), item);
 
     bills_.clear();
     const auto split = Model_Budgetsplittransaction::instance().get_all();
@@ -364,7 +357,7 @@ int mmBillsDepositsPanel::initVirtualListControl(int64 id)
         bills_.push_back(r);
     }
 
-    sortTable();
+    sortList();
 
     int cnt = 0, selected_item = -1;
     for (const auto& entry: bills_)
@@ -377,45 +370,45 @@ int mmBillsDepositsPanel::initVirtualListControl(int64 id)
         ++cnt;
     }
 
-    listCtrlAccount_->SetItemCount(static_cast<long>(bills_.size()));
+    m_lc->SetItemCount(static_cast<long>(bills_.size()));
     return selected_item;
 }
 
 void mmBillsDepositsPanel::OnNewBDSeries(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnNewBDSeries(event);
+    m_lc->OnNewBDSeries(event);
 }
 
 void mmBillsDepositsPanel::OnEditBDSeries(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnEditBDSeries(event);
+    m_lc->OnEditBDSeries(event);
 }
 
 void mmBillsDepositsPanel::OnDuplicateBDSeries(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnDuplicateBDSeries(event);
+    m_lc->OnDuplicateBDSeries(event);
 }
 
 void mmBillsDepositsPanel::OnDeleteBDSeries(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnDeleteBDSeries(event);
+    m_lc->OnDeleteBDSeries(event);
 }
 
 void mmBillsDepositsPanel::OnEnterBDTransaction(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnEnterBDTransaction(event);
+    m_lc->OnEnterBDTransaction(event);
 }
 
 void mmBillsDepositsPanel::OnSkipBDTransaction(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnSkipBDTransaction(event);
-    listCtrlAccount_->SetFocus();
+    m_lc->OnSkipBDTransaction(event);
+    m_lc->SetFocus();
 }
 
 void mmBillsDepositsPanel::OnOpenAttachment(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnOpenAttachment(event);
-    listCtrlAccount_->SetFocus();
+    m_lc->OnOpenAttachment(event);
+    m_lc->SetFocus();
 }
 
 /*******************************************************/
@@ -457,35 +450,33 @@ void billsDepositsListCtrl::OnItemRightClick(wxMouseEvent& event)
     this->SetFocus();
 }
 
-wxString mmBillsDepositsPanel::getItem(long item, long column)
+wxString mmBillsDepositsPanel::getItem(long item, int col_id)
 {
     const Model_Billsdeposits::Full_Data& bill = this->bills_.at(item);
-    switch (column)
-    {
-    case billsDepositsListCtrl::LIST_COL_ID:
+    switch (col_id) {
+    case billsDepositsListCtrl::LISTCOL_ID_ID:
         return wxString::Format("%lld", bill.BDID).Trim();
-    case billsDepositsListCtrl::LIST_COL_PAYMENT_DATE:
+    case billsDepositsListCtrl::LISTCOL_ID_PAYMENT_DATE:
         return mmGetDateTimeForDisplay(bill.TRANSDATE);
-    case billsDepositsListCtrl::LIST_COL_DUE_DATE:
+    case billsDepositsListCtrl::LISTCOL_ID_DUE_DATE:
         return mmGetDateTimeForDisplay(bill.NEXTOCCURRENCEDATE);
-    case billsDepositsListCtrl::LIST_COL_ACCOUNT:
+    case billsDepositsListCtrl::LISTCOL_ID_ACCOUNT:
         return bill.ACCOUNTNAME;
-    case billsDepositsListCtrl::LIST_COL_PAYEE:
+    case billsDepositsListCtrl::LISTCOL_ID_PAYEE:
         return bill.real_payee_name();
-    case billsDepositsListCtrl::LIST_COL_STATUS:
+    case billsDepositsListCtrl::LISTCOL_ID_STATUS:
         return bill.STATUS;
-    case billsDepositsListCtrl::LIST_COL_CATEGORY:
+    case billsDepositsListCtrl::LISTCOL_ID_CATEGORY:
         return bill.CATEGNAME;
-    case billsDepositsListCtrl::LIST_COL_TAGS:
+    case billsDepositsListCtrl::LISTCOL_ID_TAGS:
         return bill.TAGNAMES;
-    case billsDepositsListCtrl::LIST_COL_TYPE:
+    case billsDepositsListCtrl::LISTCOL_ID_TYPE:
         return wxGetTranslation(bill.TRANSCODE);
-    case billsDepositsListCtrl::LIST_COL_AMOUNT:
+    case billsDepositsListCtrl::LISTCOL_ID_AMOUNT:
         return Model_Account::toCurrency(bill.TRANSAMOUNT, Model_Account::instance().get(bill.ACCOUNTID));
-    case billsDepositsListCtrl::LIST_COL_FREQUENCY:
+    case billsDepositsListCtrl::LISTCOL_ID_FREQUENCY:
         return GetFrequency(&bill);
-    case billsDepositsListCtrl::LIST_COL_REPEATS:
-    {
+    case billsDepositsListCtrl::LISTCOL_ID_REPEATS: {
         int numRepeats = GetNumRepeats(&bill);
         if (numRepeats > 0)
             return wxString::Format("%i", numRepeats).Trim();
@@ -494,8 +485,7 @@ wxString mmBillsDepositsPanel::getItem(long item, long column)
         else
             return L"\x2015";  // HORIZONTAL BAR
     }
-    case billsDepositsListCtrl::LIST_COL_AUTO:
-    {
+    case billsDepositsListCtrl::LISTCOL_ID_AUTO: {
         int autoExecute = bill.REPEATS.GetValue() / BD_REPEATS_MULTIPLEX_BASE;
         wxString repeatSTR =
             (autoExecute == Model_Billsdeposits::REPEAT_AUTO_SILENT) ? _t("Automated") :
@@ -503,12 +493,11 @@ wxString mmBillsDepositsPanel::getItem(long item, long column)
             _t("Manual");
         return repeatSTR;
     }
-    case billsDepositsListCtrl::LIST_COL_DAYS:
+    case billsDepositsListCtrl::LISTCOL_ID_DAYS:
         return GetRemainingDays(&bill);
-    case billsDepositsListCtrl::LIST_COL_NUMBER:
+    case billsDepositsListCtrl::LISTCOL_ID_NUMBER:
         return bill.TRANSACTIONNUMBER;
-    case billsDepositsListCtrl::LIST_COL_NOTES:
-    {
+    case billsDepositsListCtrl::LISTCOL_ID_NOTES: {
         wxString value = bill.NOTES;
         value.Replace("\n", " ");
         if (Model_Attachment::NrAttachments(Model_Attachment::REFTYPE_NAME_BILLSDEPOSIT, bill.BDID))
@@ -571,9 +560,9 @@ const wxString mmBillsDepositsPanel::GetRemainingDays(const Model_Billsdeposits:
     return text;
 }
 
-wxString billsDepositsListCtrl::OnGetItemText(long item, long column) const
+wxString billsDepositsListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return m_bdp->getItem(item, m_column_order[column]);
+    return m_bdp->getItem(item, getColId(static_cast<int>(col_nr)));
 }
 
 void billsDepositsListCtrl::OnListItemSelected(wxListEvent& event)
@@ -765,39 +754,39 @@ void mmBillsDepositsPanel::enableEditDeleteButtons(bool en)
     m_infoTextMini->ClearBackground();
 }
 
-void mmBillsDepositsPanel::sortTable()
+void mmBillsDepositsPanel::sortList()
 {
     std::sort(bills_.begin(), bills_.end());
-    switch (listCtrlAccount_->m_selected_col)
+    switch (m_lc->getSortColId())
     {
-    case billsDepositsListCtrl::LIST_COL_ID:
+    case billsDepositsListCtrl::LISTCOL_ID_ID:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByBDID());
         break;
-    case billsDepositsListCtrl::LIST_COL_PAYMENT_DATE:
+    case billsDepositsListCtrl::LISTCOL_ID_PAYMENT_DATE:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByTRANSDATE());
         break;
-    case billsDepositsListCtrl::LIST_COL_DUE_DATE:
+    case billsDepositsListCtrl::LISTCOL_ID_DUE_DATE:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByNEXTOCCURRENCEDATE());
         break;
-    case billsDepositsListCtrl::LIST_COL_ACCOUNT:
+    case billsDepositsListCtrl::LISTCOL_ID_ACCOUNT:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByACCOUNTNAME());
         break;
-    case billsDepositsListCtrl::LIST_COL_PAYEE:
+    case billsDepositsListCtrl::LISTCOL_ID_PAYEE:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByPAYEENAME());
         break;
-    case billsDepositsListCtrl::LIST_COL_STATUS:
+    case billsDepositsListCtrl::LISTCOL_ID_STATUS:
         std::stable_sort(bills_.begin(), bills_.end(), SorterBySTATUS());
         break;
-    case billsDepositsListCtrl::LIST_COL_CATEGORY:
+    case billsDepositsListCtrl::LISTCOL_ID_CATEGORY:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByCATEGNAME());
         break;
-    case billsDepositsListCtrl::LIST_COL_TYPE:
+    case billsDepositsListCtrl::LISTCOL_ID_TYPE:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByTRANSCODE());
         break;
-    case billsDepositsListCtrl::LIST_COL_AMOUNT:
+    case billsDepositsListCtrl::LISTCOL_ID_AMOUNT:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByTRANSAMOUNT());
         break;
-    case billsDepositsListCtrl::LIST_COL_FREQUENCY:
+    case billsDepositsListCtrl::LISTCOL_ID_FREQUENCY:
         std::stable_sort(bills_.begin(), bills_.end()
             , [&](const Model_Billsdeposits::Full_Data& x, const Model_Billsdeposits::Full_Data& y)
         {
@@ -806,7 +795,7 @@ void mmBillsDepositsPanel::sortTable()
             return x_text < y_text;
         });
         break;
-    case billsDepositsListCtrl::LIST_COL_REPEATS:
+    case billsDepositsListCtrl::LISTCOL_ID_REPEATS:
         std::stable_sort(bills_.begin(), bills_.end()
             , [&](const Model_Billsdeposits::Full_Data& x, const Model_Billsdeposits::Full_Data& y)
         {
@@ -819,7 +808,7 @@ void mmBillsDepositsPanel::sortTable()
                 return xn == Model_Billsdeposits::REPEAT_NUM_INFINITY && yn == Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
         });
         break;
-    case billsDepositsListCtrl::LIST_COL_DAYS:
+    case billsDepositsListCtrl::LISTCOL_ID_DAYS:
         std::stable_sort(bills_.begin(), bills_.end()
             , [&](const Model_Billsdeposits::Data& x, const Model_Billsdeposits::Data& y)
         {
@@ -851,13 +840,13 @@ void mmBillsDepositsPanel::sortTable()
             return ((!x_useText && !y_useText) ? x_num < y_num : x_text < y_text);
         });
         break;
-    case billsDepositsListCtrl::LIST_COL_NOTES:
+    case billsDepositsListCtrl::LISTCOL_ID_NOTES:
         std::stable_sort(bills_.begin(), bills_.end(), SorterByNOTES());
         break;
     default:
         break;
     }
-    if (!listCtrlAccount_->m_asc) std::reverse(bills_.begin(), bills_.end());
+    if (!m_lc->getSortAsc()) std::reverse(bills_.begin(), bills_.end());
 }
 
 wxString mmBillsDepositsPanel::tips()
@@ -953,7 +942,7 @@ void billsDepositsListCtrl::OnSetUserColour(wxCommandEvent& event)
 
 void mmBillsDepositsPanel::RefreshList()
 {
-    listCtrlAccount_->RefreshList();
+    m_lc->RefreshList();
 }
 
 void mmBillsDepositsPanel::OnFilterTransactions(wxCommandEvent& WXUNUSED(event))
@@ -975,7 +964,7 @@ void mmBillsDepositsPanel::OnFilterTransactions(wxCommandEvent& WXUNUSED(event))
 
 wxString  mmBillsDepositsPanel::BuildPage() const
 {
-    return listCtrlAccount_->BuildPage(_t("Scheduled Transactions"));
+    return m_lc->BuildPage(_t("Scheduled Transactions"));
 }
 
 void mmBillsDepositsPanel::do_delete_custom_values(int64 id)

--- a/src/billsdepositspanel.h
+++ b/src/billsdepositspanel.h
@@ -35,31 +35,32 @@ class billsDepositsListCtrl: public mmListCtrl
     wxDECLARE_EVENT_TABLE();
 
 public:
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_ICON = 0,
-        LIST_COL_ID,
-        LIST_COL_PAYMENT_DATE,
-        LIST_COL_DUE_DATE,
-        LIST_COL_ACCOUNT,
-        LIST_COL_PAYEE,
-        LIST_COL_STATUS,
-        LIST_COL_CATEGORY,
-        LIST_COL_TAGS,
-        LIST_COL_TYPE,
-        LIST_COL_AMOUNT,
-        LIST_COL_FREQUENCY,
-        LIST_COL_REPEATS,
-        LIST_COL_AUTO,
-        LIST_COL_DAYS,
-        LIST_COL_NUMBER,
-        LIST_COL_NOTES,
-        LIST_COL_size, // number of columns
+        LISTCOL_ID_ICON = 0,
+        LISTCOL_ID_ID,
+        LISTCOL_ID_PAYMENT_DATE,
+        LISTCOL_ID_DUE_DATE,
+        LISTCOL_ID_ACCOUNT,
+        LISTCOL_ID_PAYEE,
+        LISTCOL_ID_STATUS,
+        LISTCOL_ID_CATEGORY,
+        LISTCOL_ID_TAGS,
+        LISTCOL_ID_TYPE,
+        LISTCOL_ID_AMOUNT,
+        LISTCOL_ID_FREQUENCY,
+        LISTCOL_ID_REPEATS,
+        LISTCOL_ID_AUTO,
+        LISTCOL_ID_DAYS,
+        LISTCOL_ID_NUMBER,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_size, // number of columns
     };
 
 private:
-    static const std::vector<ListColumnInfo> col_info_all();
-    int col_sort();
+    static const std::vector<ListColumnInfo> LISTCOL_INFO;
+    mmBillsDepositsPanel* m_bdp;
+    long m_selected_row = -1;
 
 public:
     billsDepositsListCtrl(mmBillsDepositsPanel* bdp, wxWindow *parent, wxWindowID winid = wxID_ANY);
@@ -80,8 +81,11 @@ protected:
     virtual wxListItemAttr *OnGetItemAttr(long item) const;
 
 private:
+    static int col_sort();
+    void refreshVisualList(int selected_index = -1);
+
     /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long column) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const;
     virtual int OnGetItemImage(long item) const;
 
     void OnItemRightClick(wxMouseEvent& event);
@@ -92,10 +96,6 @@ private:
     void OnListKeyDown(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
     void OnSetUserColour(wxCommandEvent& event);
-
-    void refreshVisualList(int selected_index = -1);
-
-    mmBillsDepositsPanel* m_bdp;
 };
 
 class mmBillsDepositsPanel : public mmPanelBase
@@ -129,9 +129,8 @@ public:
     /* updates the Repeating transactions panel data */
     int initVirtualListControl(int64 id = -1);
     /* Getter for Virtual List Control */
-    wxString getItem(long item, long column);
+    wxString getItem(long item, int col_id);
     void RefreshList();
-    int getColumnsNumber();
 
     const wxString GetFrequency(const Model_Billsdeposits::Data* item) const;
     int GetNumRepeats(const Model_Billsdeposits::Data* item) const;
@@ -162,12 +161,12 @@ private:
 
     //void OnViewPopupSelected(wxCommandEvent& event);
 
-    void sortTable();
+    void sortList();
     wxString tips();
 
 private:
     wxSharedPtr<mmFilterTransactionsDialog> transFilterDlg_;
-    billsDepositsListCtrl* listCtrlAccount_ = nullptr;
+    billsDepositsListCtrl* m_lc = nullptr;
     wxStaticText* m_infoText = nullptr;
     wxStaticText* m_infoTextMini = nullptr;
     wxDate m_today;
@@ -179,9 +178,8 @@ private:
     wxArrayString tips_;
 };
 
-inline int billsDepositsListCtrl::col_sort() { return LIST_COL_PAYMENT_DATE; }
+inline int billsDepositsListCtrl::col_sort() { return LISTCOL_ID_PAYMENT_DATE; }
 
 inline wxDate mmBillsDepositsPanel::getToday() const { return m_today; }
-inline int mmBillsDepositsPanel::getColumnsNumber() { return billsDepositsListCtrl::LIST_COL_size; }
 
 #endif

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -53,41 +53,25 @@ static const wxString VIEW_INCOME   = _n("View Income Budget Categories");
 static const wxString VIEW_EXPENSE  = _n("View Expense Budget Categories");
 static const wxString VIEW_SUMM     = _n("View Budget Category Summary");
 
-/*******************************************************/
 wxBEGIN_EVENT_TABLE(mmBudgetingPanel, wxPanel)
-EVT_BUTTON(wxID_FILE2, mmBudgetingPanel::OnMouseLeftDown)
-EVT_MENU(wxID_ANY, mmBudgetingPanel::OnViewPopupSelected)
+    EVT_BUTTON(wxID_FILE2, mmBudgetingPanel::OnMouseLeftDown)
+    EVT_MENU(wxID_ANY,     mmBudgetingPanel::OnViewPopupSelected)
 wxEND_EVENT_TABLE()
-/*******************************************************/
+
 wxBEGIN_EVENT_TABLE(budgetingListCtrl, mmListCtrl)
-EVT_LIST_ITEM_SELECTED(wxID_ANY, budgetingListCtrl::OnListItemSelected)
-EVT_LIST_ITEM_ACTIVATED(wxID_ANY, budgetingListCtrl::OnListItemActivated)
+    EVT_LIST_ITEM_SELECTED(wxID_ANY,  budgetingListCtrl::OnListItemSelected)
+    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, budgetingListCtrl::OnListItemActivated)
 wxEND_EVENT_TABLE()
-/*******************************************************/
 
-const std::vector<ListColumnInfo> budgetingListCtrl::col_info_all()
-{
-    return {
-        { _t("Icon"),      wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  false },
-        { _t("Category"),  wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Frequency"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Amount"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Estimated"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Actual"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Notes"),     wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-    };
-}
-
-void budgetingListCtrl::createColumns_()
-{
-    InsertColumn(LIST_COL_ICON, (" "));
-    InsertColumn(LIST_COL_CATEGORY, m_columns[LIST_COL_CATEGORY].header);
-    InsertColumn(LIST_COL_FREQUENCY, m_columns[LIST_COL_FREQUENCY].header);
-    InsertColumn(LIST_COL_AMOUNT, m_columns[LIST_COL_AMOUNT].header, wxLIST_FORMAT_RIGHT);
-    InsertColumn(LIST_COL_ESTIMATED, m_columns[LIST_COL_ESTIMATED].header, wxLIST_FORMAT_RIGHT);
-    InsertColumn(LIST_COL_ACTUAL, m_columns[LIST_COL_ACTUAL].header, wxLIST_FORMAT_RIGHT);
-    InsertColumn(LIST_COL_NOTES, m_columns[LIST_COL_NOTES].header, wxLIST_FORMAT_LEFT);
-}
+const std::vector<ListColumnInfo> budgetingListCtrl::LISTCOL_INFO = {
+    { LISTCOL_ID_ICON,      true, _n("Icon"),      _WH, _FL, false },
+    { LISTCOL_ID_CATEGORY,  true, _n("Category"),  _WH, _FL, false },
+    { LISTCOL_ID_FREQUENCY, true, _n("Frequency"), _WH, _FL, false },
+    { LISTCOL_ID_AMOUNT,    true, _n("Amount"),    _WH, _FR, false },
+    { LISTCOL_ID_ESTIMATED, true, _n("Estimated"), _WH, _FR, false },
+    { LISTCOL_ID_ACTUAL,    true, _n("Actual"),    _WH, _FR, false },
+    { LISTCOL_ID_NOTES,     true, _n("Notes"),     _WH, _FL, false },
+};
 
 mmBudgetingPanel::mmBudgetingPanel(int64 budgetYearID
     , wxWindow *parent, mmGUIFrame *frame
@@ -95,7 +79,7 @@ mmBudgetingPanel::mmBudgetingPanel(int64 budgetYearID
     , const wxPoint& pos, const wxSize& size
     , long style, const wxString& name)
     : m_frame(frame)
-    , listCtrlBudget_(nullptr)
+    , m_lc(nullptr)
     , budgetYearID_(budgetYearID)
 {
     Create(parent, winid, pos, size, style, name);
@@ -115,7 +99,7 @@ bool mmBudgetingPanel::Create(wxWindow *parent
 
     initVirtualListControl();
     if (!budget_.empty())
-        listCtrlBudget_->EnsureVisible(0);
+        m_lc->EnsureVisible(0);
 
     this->windowsFreezeThaw();
     Model_Usage::instance().pageview(this);
@@ -153,10 +137,10 @@ void mmBudgetingPanel::OnViewPopupSelected(wxCommandEvent& event)
 void mmBudgetingPanel::RefreshList()
 {
     initVirtualListControl();
-    listCtrlBudget_->Refresh();
-    listCtrlBudget_->Update();
+    m_lc->Refresh();
+    m_lc->Update();
     if (!budget_.empty())
-        listCtrlBudget_->EnsureVisible(0);
+        m_lc->EnsureVisible(0);
 }
 
 void mmBudgetingPanel::OnMouseLeftDown(wxCommandEvent& event)
@@ -281,34 +265,29 @@ void mmBudgetingPanel::CreateControls()
     images.push_back(mmBitmapBundle(png::VOID_STAT));
     images.push_back(mmBitmapBundle(png::FOLLOW_UP));
 
-    listCtrlBudget_ = new budgetingListCtrl(this, this, wxID_ANY);
+    m_lc = new budgetingListCtrl(this, this, wxID_ANY);
+    m_lc->SetSmallImages(images);
+    m_lc->createColumns();
 
-    listCtrlBudget_->SetSmallImages(images);
-    listCtrlBudget_->createColumns_();
-
-    /* Get data from inidb */
-    for (int i = 0; i < listCtrlBudget_->GetColumnCount(); ++i)
-    {
-        int col_width = Model_Setting::instance().getInt(wxString::Format(listCtrlBudget_->m_col_width_fmt, i)
-            , listCtrlBudget_->m_columns[i].width);
-        listCtrlBudget_->SetColumnWidth(i, col_width);
-    }
-    itemBoxSizer2->Add(listCtrlBudget_.get(), 1, wxGROW | wxALL, 1);
+    itemBoxSizer2->Add(m_lc.get(), 1, wxGROW | wxALL, 1);
 }
 
-budgetingListCtrl::budgetingListCtrl(mmBudgetingPanel* cp, wxWindow *parent, const wxWindowID id)
-    : mmListCtrl(parent, id)
-    , attr3_(new wxListItemAttr(wxNullColour, mmThemeMetaColour(meta::COLOR_LISTTOTAL), wxNullFont))
-    , cp_(cp)
+budgetingListCtrl::budgetingListCtrl(
+    mmBudgetingPanel* cp, wxWindow *parent, const wxWindowID id
+) :
+    mmListCtrl(parent, id),
+    attr3_(new wxListItemAttr(
+        wxNullColour, mmThemeMetaColour(meta::COLOR_LISTTOTAL), wxNullFont
+    )),
+    cp_(cp)
 {
     mmThemeMetaColour(this, meta::COLOR_LISTPANEL);
 
-    m_columns = col_info_all();
-    m_col_width_fmt = "BUDGET_COL%d_WIDTH";
-    m_col_type_str = "BUDGET";
+    m_col_id_info = LISTCOL_INFO;
+    o_col_width_prefix = "BUDGET_COL";
 }
 
-void mmBudgetingPanel::sortTable()
+void mmBudgetingPanel::sortList()
 {
     //TODO: Sort budget panel
 }
@@ -490,7 +469,7 @@ void mmBudgetingPanel::initVirtualListControl()
                         {
                             budget_.push_back(std::make_pair(-1, subcats[totals_queue.back()].CATEGID));
                             size_t transCatTotalIndex = budget_.size() - 1;
-                            listCtrlBudget_->RefreshItem(transCatTotalIndex);
+                            m_lc->RefreshItem(transCatTotalIndex);
                         }
                         totals_queue.pop_back();
                     }
@@ -503,7 +482,7 @@ void mmBudgetingPanel::initVirtualListControl()
                     {
                         budget_.push_back(std::make_pair(-1, subcats[totals_queue.back()].CATEGID));
                         size_t transCatTotalIndex = budget_.size() - 1;
-                        listCtrlBudget_->RefreshItem(transCatTotalIndex);
+                        m_lc->RefreshItem(transCatTotalIndex);
                     }
                     totals_queue.pop_back();
                 }
@@ -515,11 +494,11 @@ void mmBudgetingPanel::initVirtualListControl()
         {
             budget_.push_back(std::make_pair(-1, category.CATEGID));
             size_t transCatTotalIndex = budget_.size() - 1;
-            listCtrlBudget_->RefreshItem(transCatTotalIndex);
+            m_lc->RefreshItem(transCatTotalIndex);
         }
     }
 
-    listCtrlBudget_->SetItemCount(budget_.size());
+    m_lc->SetItemCount(budget_.size());
 
     wxString est_amount, act_amount, diff_amount;
     est_amount = Model_Currency::toCurrency(estIncome);
@@ -571,14 +550,12 @@ void budgetingListCtrl::OnListItemSelected(wxListEvent& event)
     selectedIndex_ = event.GetIndex();
 }
 
-wxString mmBudgetingPanel::getItem(long item, long column)
+wxString mmBudgetingPanel::getItem(long item, int col_id)
 {
-    switch (column)
-    {
-    case budgetingListCtrl::LIST_COL_ICON:
+    switch (col_id) {
+    case budgetingListCtrl::LISTCOL_ID_ICON:
         return " ";
-    case budgetingListCtrl::LIST_COL_CATEGORY:
-    {
+    case budgetingListCtrl::LISTCOL_ID_CATEGORY: {
         Model_Category::Data* category = Model_Category::instance().get(budget_[item].first > 0
             ? budget_[item].first : budget_[item].second);
         if (category) {
@@ -590,56 +567,45 @@ wxString mmBudgetingPanel::getItem(long item, long column)
         }
         return wxEmptyString;
     }
-    case budgetingListCtrl::LIST_COL_FREQUENCY:
-    {
-        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second)
-        {
+    case budgetingListCtrl::LISTCOL_ID_FREQUENCY: {
+        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second) {
             Model_Budget::PERIOD_ID period = budgetPeriod_[budget_[item].first];
             return wxGetTranslation(Model_Budget::period_name(period));
         }
         return wxEmptyString;
     }
-    case budgetingListCtrl::LIST_COL_AMOUNT:
-    {
-        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second)
-        {
+    case budgetingListCtrl::LISTCOL_ID_AMOUNT: {
+        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second) {
             double amt = budgetAmt_[budget_[item].first];
             return Model_Currency::toCurrency(amt);
         }
         return wxEmptyString;
     }
-    case budgetingListCtrl::LIST_COL_ESTIMATED:
-    {
-        if (budget_[item].first < 0)
-        {
+    case budgetingListCtrl::LISTCOL_ID_ESTIMATED: {
+        if (budget_[item].first < 0) {
             double estimated = budgetTotals_[budget_[item].second].first;
             return Model_Currency::toCurrency(estimated);
         }
-        else if (displayDetails_[budget_[item].first].second)
-        {
+        else if (displayDetails_[budget_[item].first].second) {
             double estimated = getEstimate(budget_[item].first);
             return Model_Currency::toCurrency(estimated);
         }
         return wxEmptyString;
     }
-    case budgetingListCtrl::LIST_COL_ACTUAL:
-    {
-        if (budget_[item].first < 0)
-        {
+    case budgetingListCtrl::LISTCOL_ID_ACTUAL: {
+        if (budget_[item].first < 0) {
             double actual = budgetTotals_[budget_[item].second].second;
             return Model_Currency::toCurrency(actual);
         }
-        else if (displayDetails_[budget_[item].first].second)
-        {
+        else if (displayDetails_[budget_[item].first].second) {
             double actual = categoryStats_[budget_[item].second >= 0 ? budget_[item].second
                 : budget_[item].first][0];
             return Model_Currency::toCurrency(actual);
         }
         return wxEmptyString;
     }
-    case budgetingListCtrl::LIST_COL_NOTES:
-        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second)
-        {
+    case budgetingListCtrl::LISTCOL_ID_NOTES:
+        if (budget_[item].first >= 0 && displayDetails_[budget_[item].first].second) {
             wxString value = budgetNotes_[budget_[item].second >= 0 ? budget_[item].second
                 : budget_[item].first];
             value.Replace("\n", " ");
@@ -690,9 +656,9 @@ int mmBudgetingPanel::GetItemImage(long item) const
     }
 }
 
-wxString budgetingListCtrl::OnGetItemText(long item, long column) const
+wxString budgetingListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return cp_->getItem(item, column);
+    return cp_->getItem(item, getColId(static_cast<int>(col_nr)));
 }
 
 wxListItemAttr* budgetingListCtrl::OnGetItemAttr(long item) const
@@ -747,8 +713,8 @@ void mmBudgetingPanel::OnListItemActivated(int selectedIndex)
     if (dlg.ShowModal() == wxID_OK)
     {
         initVirtualListControl();
-        listCtrlBudget_->Refresh();
-        listCtrlBudget_->Update();
-        listCtrlBudget_->EnsureVisible(selectedIndex);
+        m_lc->Refresh();
+        m_lc->Update();
+        m_lc->EnsureVisible(selectedIndex);
     }
 }

--- a/src/budgetingpanel.h
+++ b/src/budgetingpanel.h
@@ -35,28 +35,27 @@ class budgetingListCtrl : public mmListCtrl
     wxDECLARE_EVENT_TABLE();
 
 public:
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_ICON = 0,
-        LIST_COL_CATEGORY,
-        LIST_COL_FREQUENCY,
-        LIST_COL_AMOUNT,
-        LIST_COL_ESTIMATED,
-        LIST_COL_ACTUAL,
-        LIST_COL_NOTES,
-        LIST_COL_size, // number of columns
+        LISTCOL_ID_ICON = 0,
+        LISTCOL_ID_CATEGORY,
+        LISTCOL_ID_FREQUENCY,
+        LISTCOL_ID_AMOUNT,
+        LISTCOL_ID_ESTIMATED,
+        LISTCOL_ID_ACTUAL,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_size, // number of columns
     };
 
 private:
-    static const std::vector<ListColumnInfo> col_info_all();
+    static const std::vector<ListColumnInfo> LISTCOL_INFO;
 
 public:
     budgetingListCtrl(mmBudgetingPanel* cp, wxWindow *parent, const wxWindowID id);
-    void createColumns_();
 
 public:
     /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long column) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const;
     virtual wxListItemAttr *OnGetItemAttr(long item) const;
     virtual int OnGetItemImage(long item) const;
 
@@ -87,7 +86,7 @@ public:
     void initVirtualListControl();
 
     /* Getter for Virtual List Control */
-    wxString getItem(long item, long column);
+    wxString getItem(long item, int col_id);
 
     void DisplayBudgetingDetails(int64 budgetYearID);
     int64 GetBudgetYearID()
@@ -107,7 +106,7 @@ public:
 
     void RefreshList();
 
-    wxString BuildPage() const { return listCtrlBudget_->BuildPage(GetPanelTitle()); }
+    wxString BuildPage() const { return m_lc->BuildPage(GetPanelTitle()); }
 
 private:
     enum EIcons
@@ -126,7 +125,7 @@ private:
     std::map<int64, wxString> budgetNotes_;
     std::map<int64, std::map<int,double> > categoryStats_;
     bool monthlyBudget_;
-    wxSharedPtr<budgetingListCtrl> listCtrlBudget_;
+    wxSharedPtr<budgetingListCtrl> m_lc;
     wxString currentView_;
     int64 budgetYearID_;
     wxString m_monthName;
@@ -147,7 +146,7 @@ private:
         , const wxString& name = "mmBudgetingPanel");
 
     void CreateControls();
-    void sortTable();
+    void sortList();
     bool DisplayEntryAllowed(int64 categoryID, int64 subcategoryID);
     void UpdateBudgetHeading();
     double getEstimate(int64 category) const;

--- a/src/daterange2.cpp
+++ b/src/daterange2.cpp
@@ -34,7 +34,7 @@ DateRange2::PERIOD_LABEL_ID_t DateRange2::PERIOD_LABEL_ID = make_period_label_id
 DateRange2::PERIOD_LABEL_ID_t DateRange2::make_period_label_id()
 {
     PERIOD_LABEL_ID_t period_label_id;
-    for (int i = 0; i < int(sizeof(PERIOD_INFO)/sizeof(PERIOD_INFO[0])); ++i) {
+    for (int i = 0; i < static_cast<int>(sizeof(PERIOD_INFO)/sizeof(PERIOD_INFO[0])); ++i) {
         char c = PERIOD_INFO[i].label[0];
         period_label_id[c] = PERIOD_INFO[i].id;
     }
@@ -513,7 +513,7 @@ bool DateRange2::debug()
     wxLogDebug("{{{ DateRange2::debug()");
 
     // check order in PERIOD_INFO
-    for (int i = 0; i < int(sizeof(PERIOD_INFO)/sizeof(PERIOD_INFO[0])); i++) {
+    for (int i = 0; i < static_cast<int>(sizeof(PERIOD_INFO)/sizeof(PERIOD_INFO[0])); i++) {
         wxASSERT_MSG(PERIOD_INFO[i].id == i, "Wrong order in DateRange2::PERIOD_INFO");
     }
 
@@ -552,7 +552,7 @@ bool DateRange2::debug()
         { "-1 M, Q .. Y", "2024-12-01", "2025-01-31" },
         { "W, -1..+1 Q",  "2024-10-28", "2025-05-04" },
     };
-    for (int i = 0; i < int(sizeof(checking)/sizeof(checking[0])); ++i) {
+    for (int i = 0; i < static_cast<int>(sizeof(checking)/sizeof(checking[0])); ++i) {
         wxString spec = checking[i].spec;
         //wxLogDebug("checking[%d] [%s]", i, spec);
         if (!dr.parseSpec(spec)) {

--- a/src/general_report_manager.cpp
+++ b/src/general_report_manager.cpp
@@ -1095,14 +1095,14 @@ void mmGeneralReportManager::showHelp()
     browser_->LoadURL(url);
 }
 
-wxString mmGeneralReportManager::OnGetItemText(long item, long column) const
+wxString mmGeneralReportManager::OnGetItemText(long item, long col_nr) const
 {
-    return m_sqlQueryData.at(item).at(column);
+    return m_sqlQueryData.at(item).at(col_nr);
 }
 
-wxString sqlListCtrl::OnGetItemText(long item, long column) const
+wxString sqlListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return m_grm->OnGetItemText(item, column);
+    return m_grm->OnGetItemText(item, col_nr);
 }
 
 void mmGeneralReportManager::OnClose(wxCommandEvent& WXUNUSED(event))

--- a/src/general_report_manager.h
+++ b/src/general_report_manager.h
@@ -38,9 +38,8 @@ class sqlListCtrl : public mmListCtrl
     wxDECLARE_NO_COPY_CLASS(sqlListCtrl);
 public:
 
-    sqlListCtrl(mmGeneralReportManager *grm, wxWindow *parent
-        , const wxWindowID id);
-    virtual wxString OnGetItemText(long item, long column) const;
+    sqlListCtrl(mmGeneralReportManager *grm, wxWindow *parent, const wxWindowID id);
+    virtual wxString OnGetItemText(long item, long col_nr) const;
 private:
     mmGeneralReportManager* m_grm;
 };
@@ -56,7 +55,7 @@ public:
     ~mmGeneralReportManager();
 
     mmGeneralReportManager(wxWindow* parent, wxSQLite3Database* db);
-    wxString OnGetItemText(long item, long column) const;
+    wxString OnGetItemText(long item, long col_nr) const;
 
 private:
     bool Create(wxWindow* parent

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -83,16 +83,16 @@ bool mmQIFImportDialog::Create(wxWindow* parent, wxWindowID id, const wxString& 
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
     wxDialog::Create(parent, id, caption, pos, size, style);
 
-    ColName_[LIST_COL_ID] = "#";
-    ColName_[LIST_COL_ACCOUNT] = _t("Account");
-    ColName_[LIST_COL_DATE] = _t("Date");
-    ColName_[LIST_COL_NUMBER] = _t("Number");
-    ColName_[LIST_COL_PAYEE] = _t("Payee");
-    ColName_[LIST_COL_TYPE] = _t("Type");
-    ColName_[LIST_COL_CATEGORY] = _t("Category");
-    ColName_[LIST_COL_TAGS] = _t("Tags");
-    ColName_[LIST_COL_VALUE] = _t("Value");
-    ColName_[LIST_COL_NOTES] = _t("Notes");
+    ColName_[LISTCOL_ID_ID] = "#";
+    ColName_[LISTCOL_ID_ACCOUNT] = _t("Account");
+    ColName_[LISTCOL_ID_DATE] = _t("Date");
+    ColName_[LISTCOL_ID_NUMBER] = _t("Number");
+    ColName_[LISTCOL_ID_PAYEE] = _t("Payee");
+    ColName_[LISTCOL_ID_TYPE] = _t("Type");
+    ColName_[LISTCOL_ID_CATEGORY] = _t("Category");
+    ColName_[LISTCOL_ID_TAGS] = _t("Tags");
+    ColName_[LISTCOL_ID_VALUE] = _t("Value");
+    ColName_[LISTCOL_ID_NOTES] = _t("Notes");
 
     CreateControls();
     if (m_FileNameStr != wxEmptyString)
@@ -224,16 +224,16 @@ void mmQIFImportDialog::CreateControls()
 
     dataListBox_ = new wxDataViewListCtrl(data_tab, wxID_ANY);
     dataListBox_->SetMinSize(wxSize(100, 200));
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_ID], wxDATAVIEW_CELL_INERT, 40, wxALIGN_RIGHT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_ACCOUNT], wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_DATE], wxDATAVIEW_CELL_INERT, 90, wxALIGN_RIGHT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_NUMBER], wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_PAYEE], wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_TYPE], wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_CATEGORY], wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_TAGS], wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_VALUE], wxDATAVIEW_CELL_INERT, 100, wxALIGN_RIGHT);
-    dataListBox_->AppendTextColumn(ColName_[LIST_COL_NOTES], wxDATAVIEW_CELL_INERT, 300, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_ID], wxDATAVIEW_CELL_INERT, 40, wxALIGN_RIGHT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_ACCOUNT], wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_DATE], wxDATAVIEW_CELL_INERT, 90, wxALIGN_RIGHT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_NUMBER], wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_PAYEE], wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_TYPE], wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_CATEGORY], wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_TAGS], wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_VALUE], wxDATAVIEW_CELL_INERT, 100, wxALIGN_RIGHT);
+    dataListBox_->AppendTextColumn(ColName_[LISTCOL_ID_NOTES], wxDATAVIEW_CELL_INERT, 300, wxALIGN_LEFT);
     data_sizer->Add(dataListBox_, g_flagsExpand);
 
     //Accounts

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -127,19 +127,19 @@ private:
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;
     bool payeeRegExInitialized_ = false;
 
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_ID = 0,
-        LIST_COL_ACCOUNT,
-        LIST_COL_DATE,
-        LIST_COL_NUMBER,
-        LIST_COL_PAYEE,
-        LIST_COL_TYPE,
-        LIST_COL_CATEGORY,
-        LIST_COL_TAGS,
-        LIST_COL_VALUE,
-        LIST_COL_NOTES,
-        LIST_COL_size, // number of columns
+        LISTCOL_ID_ID = 0,
+        LISTCOL_ID_ACCOUNT,
+        LISTCOL_ID_DATE,
+        LISTCOL_ID_NUMBER,
+        LISTCOL_ID_PAYEE,
+        LISTCOL_ID_TYPE,
+        LISTCOL_ID_CATEGORY,
+        LISTCOL_ID_TAGS,
+        LISTCOL_ID_VALUE,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_size, // number of columns
     };
     enum {
         ID_ACCOUNT = wxID_HIGHEST + 1

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -92,6 +92,32 @@ wxBEGIN_EVENT_TABLE(TransactionListCtrl, mmListCtrl)
     )
 wxEND_EVENT_TABLE();
 
+const std::vector<ListColumnInfo> TransactionListCtrl::LISTCOL_INFO = {
+    { LISTCOL_ID_ICON,        true, _n("Icon"),         25,  _FC, false },
+    { LISTCOL_ID_ID,          true, _n("ID"),           _WA, _FR, true },
+    { LISTCOL_ID_DATE,        true, _n("Date"),         112, _FL, true },
+    { LISTCOL_ID_TIME,        true, _n("Time"),         70,  _FL, true },
+    { LISTCOL_ID_NUMBER,      true, _n("Number"),       70,  _FL, true },
+    { LISTCOL_ID_ACCOUNT,     true, _n("Account"),      100, _FL, true },
+    { LISTCOL_ID_PAYEE_STR,   true, _n("Payee"),        150, _FL, true },
+    { LISTCOL_ID_STATUS,      true, _n("Status"),       _WH, _FC, true },
+    { LISTCOL_ID_CATEGORY,    true, _n("Category"),     150, _FL, true },
+    { LISTCOL_ID_TAGS,        true, _n("Tags"),         250, _FL, true },
+    { LISTCOL_ID_WITHDRAWAL,  true, _n("Withdrawal"),   _WH, _FR, true },
+    { LISTCOL_ID_DEPOSIT,     true, _n("Deposit"),      _WH, _FR, true },
+    { LISTCOL_ID_BALANCE,     true, _n("Balance"),      _WH, _FR, true },
+    { LISTCOL_ID_CREDIT,      true, _n("Credit"),       _WH, _FR, true },
+    { LISTCOL_ID_NOTES,       true, _n("Notes"),        250, _FL, true },
+    { LISTCOL_ID_DELETEDTIME, true, _n("Deleted On"),   _WA, _FL, true },
+    { LISTCOL_ID_UDFC01,      false, "",                100, _FL, true },
+    { LISTCOL_ID_UDFC02,      false, "",                100, _FL, true },
+    { LISTCOL_ID_UDFC03,      false, "",                100, _FL, true },
+    { LISTCOL_ID_UDFC04,      false, "",                100, _FL, true },
+    { LISTCOL_ID_UDFC05,      false, "",                100, _FL, true },
+    { LISTCOL_ID_UPDATEDTIME, true, _n("Last Updated"), _WA, _FL, true },
+    { LISTCOL_ID_SN,          true, _n("SN"),           _WA, _FR, true },
+};
+
 //----------------------------------------------------------------------------
 
 TransactionListCtrl::TransactionListCtrl(
@@ -181,25 +207,25 @@ TransactionListCtrl::TransactionListCtrl(
         wxAcceleratorEntry(wxACCEL_CTRL, '6', MENU_ON_SET_UDC6),
         wxAcceleratorEntry(wxACCEL_CTRL, '7', MENU_ON_SET_UDC7)
     };
-
     wxAcceleratorTable tab(sizeof(entries) / sizeof(*entries), entries);
     SetAcceleratorTable(tab);
 
     // V2 used as now maps to real column names and this resets everything to default
     // to avoid strange column widths when this code version is first
-    // TODO: isDeletedTrans(), isGroup()
-    m_col_width_fmt = m_cp->isAllTrans() ? "ALLTRANS_COLV2%d_WIDTH" : "CHECK2_COLV2%d_WIDTH";
-    if (m_cp->isAllTrans()) {
-        m_col_type_str = "ALLTRANS";
+    if (m_cp->m_account) {
+        o_col_order_prefix = m_cp->m_account->ACCOUNTTYPE.Upper();
+        o_col_order_prefix.Replace(" ", "_");
+        o_col_width_prefix = "CHECK2_COLV2";
     }
-    else if (m_cp->m_account) {
-        m_col_type_str = m_cp->m_account->ACCOUNTTYPE.Upper();
-        m_col_type_str.Replace(" ", "_");
+    else {
+        o_col_order_prefix = "ALLTRANS";
+        o_col_width_prefix = "ALLTRANS_COLV2";
     }
+    o_sort_prefix = m_cp->sortPrefix();
+    getColumnsInfo();
+    m_sort_col_id = { LISTCOL_ID_def_sort1, LISTCOL_ID_def_sort2 };
+    createColumns();
 
-    resetColumns();
-
-    m_default_sort_column = LIST_COL_def_sort1;
     m_today = Option::instance().UseTransDateTime() ?
         wxDateTime::Now().FormatISOCombined() :
         wxDateTime(23, 59, 59, 999).FormatISOCombined();
@@ -212,88 +238,55 @@ TransactionListCtrl::~TransactionListCtrl()
 
 //----------------------------------------------------------------------------
 
-void TransactionListCtrl::resetColumns()
+void TransactionListCtrl::getColumnsInfo()
 {
-    m_columns.clear();
-    m_columns.push_back({" ", 25, wxLIST_FORMAT_CENTER, false});
-    m_columns.push_back({_t("SN"), wxLIST_AUTOSIZE, wxLIST_FORMAT_RIGHT, true});
-    m_columns.push_back({_t("ID"), wxLIST_AUTOSIZE, wxLIST_FORMAT_RIGHT, true});
-    m_columns.push_back({_t("Date"), 112, wxLIST_FORMAT_LEFT, true});
+    m_col_id_info = LISTCOL_INFO;
 
-    m_column_order.clear();
-    m_column_order.push_back(LIST_COL_IMGSTATUS);
-    m_column_order.push_back(LIST_COL_SN);
-    m_column_order.push_back(LIST_COL_ID);
-    m_column_order.push_back(LIST_COL_DATE);
-
-    if (Option::instance().UseTransDateTime()) {
-        m_columns.push_back({_t("Time"), 70, wxLIST_FORMAT_LEFT, true});
-        m_column_order.push_back(LIST_COL_TIME);
-    }
-
-    m_columns.push_back({_t("Number"), 70, wxLIST_FORMAT_LEFT, true});
-    m_column_order.push_back(LIST_COL_NUMBER);
-
-    if (!m_cp->isAccount()) {
-        m_columns.push_back({_t("Account"), 100, wxLIST_FORMAT_LEFT, true});
-        m_column_order.push_back(LIST_COL_ACCOUNT);
-    }
-
-    m_columns.push_back({_t("Payee"), 150, wxLIST_FORMAT_LEFT, true});
-    m_columns.push_back({_t("Status"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_CENTER, true});
-    m_columns.push_back({_t("Category"), 150, wxLIST_FORMAT_LEFT, true});
-    m_columns.push_back({_t("Tags"), 250, wxLIST_FORMAT_LEFT, true});
-    m_columns.push_back({_t("Withdrawal"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true});
-    m_columns.push_back({_t("Deposit"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true});
-
-    m_column_order.push_back(LIST_COL_PAYEE_STR);
-    m_column_order.push_back(LIST_COL_STATUS);
-    m_column_order.push_back(LIST_COL_CATEGORY);
-    m_column_order.push_back(LIST_COL_TAGS);
-    m_column_order.push_back(LIST_COL_WITHDRAWAL);
-    m_column_order.push_back(LIST_COL_DEPOSIT);
-
+    m_col_nr_id.clear();
+    m_col_nr_id.push_back(LISTCOL_ID_ICON);
+    m_col_nr_id.push_back(LISTCOL_ID_SN);
+    m_col_nr_id.push_back(LISTCOL_ID_ID);
+    m_col_nr_id.push_back(LISTCOL_ID_DATE);
+    if (Option::instance().UseTransDateTime())
+        m_col_nr_id.push_back(LISTCOL_ID_TIME);
+    m_col_nr_id.push_back(LISTCOL_ID_NUMBER);
+    if (!m_cp->isAccount())
+        m_col_nr_id.push_back(LISTCOL_ID_ACCOUNT);
+    m_col_nr_id.push_back(LISTCOL_ID_PAYEE_STR);
+    m_col_nr_id.push_back(LISTCOL_ID_STATUS);
+    m_col_nr_id.push_back(LISTCOL_ID_CATEGORY);
+    m_col_nr_id.push_back(LISTCOL_ID_TAGS);
+    m_col_nr_id.push_back(LISTCOL_ID_WITHDRAWAL);
+    m_col_nr_id.push_back(LISTCOL_ID_DEPOSIT);
     if (m_cp->isAccount()) {
-        m_columns.push_back({_t("Balance"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true});
-        m_column_order.push_back(LIST_COL_BALANCE);
-        if (m_cp->m_account->CREDITLIMIT != 0) {
-            m_columns.push_back({_t("Credit"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true});
-            m_column_order.push_back(LIST_COL_CREDIT);
-        }
+        m_col_nr_id.push_back(LISTCOL_ID_BALANCE);
+        if (m_cp->m_account->CREDITLIMIT != 0)
+            m_col_nr_id.push_back(LISTCOL_ID_CREDIT);
     }
+    m_col_nr_id.push_back(LISTCOL_ID_NOTES);
+    if (m_cp->isDeletedTrans())
+        m_col_nr_id.push_back(LISTCOL_ID_DELETEDTIME);
 
-    m_columns.push_back({_t("Notes"), 250, wxLIST_FORMAT_LEFT, true});
-    m_column_order.push_back(LIST_COL_NOTES);
-
-    if (m_cp->isDeletedTrans()) {
-        m_columns.push_back({_t("Deleted On"), wxLIST_AUTOSIZE, wxLIST_FORMAT_LEFT, true});
-        m_column_order.push_back(LIST_COL_DELETEDTIME);
-    }
-
-    int i = LIST_COL_UDFC01;
     const auto& ref_type = Model_Attachment::REFTYPE_NAME_TRANSACTION;
+    int col_id = LISTCOL_ID_UDFC01;
     for (const auto& udfc_entry : Model_CustomField::UDFC_FIELDS()) {
+        if (col_id > LISTCOL_ID_UDFC05) break;
         if (udfc_entry.empty()) continue;
+
         const auto& name = Model_CustomField::getUDFCName(ref_type, udfc_entry);
         if (!name.IsEmpty() && name != udfc_entry) {
+            m_col_id_info[col_id].header = name;
             const auto& type = Model_CustomField::getUDFCType(ref_type, udfc_entry);
-            int align;
             if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-                align = wxLIST_FORMAT_RIGHT;
+                m_col_id_info[col_id].format = _FR;
             else if (type == Model_CustomField::TYPE_ID_BOOLEAN)
-                align = wxLIST_FORMAT_CENTER;
-            else
-                align = wxLIST_FORMAT_LEFT;
-            m_columns.push_back({name, 100, align, true});
-            m_column_order.push_back(static_cast<LIST_COL>(i));
+                m_col_id_info[col_id].format = _FC;
+            m_col_nr_id.push_back(col_id);
         }
-        i++;
+        col_id++;
     }
 
-    m_columns.push_back({_t("Last Updated"), wxLIST_AUTOSIZE, wxLIST_FORMAT_LEFT, true});
-    m_column_order.push_back(LIST_COL_UPDATEDTIME);
-
-    createColumns();
+    m_col_nr_id.push_back(LISTCOL_ID_UPDATEDTIME);
 }
 
 void TransactionListCtrl::refreshVisualList(bool filter)
@@ -317,17 +310,20 @@ void TransactionListCtrl::refreshVisualList(bool filter)
     Hide();
 
     // decide whether top or down icon needs to be shown
-    setColumnImage(g_sortCol1, g_sortAsc1 ? mmCheckingPanel::ICON_DESC : mmCheckingPanel::ICON_ASC);
+    setColumnImage(
+        getSortColNr(0),
+        getSortAsc(0) ? mmCheckingPanel::ICON_DESC : mmCheckingPanel::ICON_ASC
+    );
     if (filter)
         m_cp->filterList();
     SetItemCount(m_trans.size());
     Show();
-    sortTable();
+    sortList();
     markSelectedTransaction();
 
     long i = static_cast<long>(m_trans.size());
     if (m_topItemIndex > i || m_topItemIndex < 0)
-        m_topItemIndex = g_sortAsc1 ? i - 1 : 0;
+        m_topItemIndex = getSortAsc(0) ? i - 1 : 0;
 
     i = 0;
     for(const auto& entry : m_trans) {
@@ -354,25 +350,25 @@ void TransactionListCtrl::refreshVisualList(bool filter)
     SetFocus();
 }
 
-void TransactionListCtrl::sortTable()
+void TransactionListCtrl::sortList()
 {
     if (m_trans.empty()) return;
 
-    sortTransactions(g_sortCol2, g_sortAsc2);
-    sortTransactions(g_sortCol1, g_sortAsc1);
+    sortTransactions(getSortColId(1), getSortAsc(1));
+    sortTransactions(getSortColId(0), getSortAsc(0));
 
     wxString sortText = wxString::Format(
-        "%s: %s %s / %s %s", _t("Sort Order"),
-        m_columns[g_sortCol1].header, g_sortAsc1 ? L"\u25B2" : L"\u25BC",
-        m_columns[g_sortCol2].header, g_sortAsc2 ? L"\u25B2" : L"\u25BC"
+        "%s:  %s %s / %s %s", _t("Sorted by"),
+        getColHeader(getSortColId(0), true), getSortAsc(0) ? L"\u25B2" : L"\u25BC",
+        getColHeader(getSortColId(1), true), getSortAsc(1) ? L"\u25B2" : L"\u25BC"
     );
     m_cp->m_header_sortOrder->SetLabelText(sortText);
 
-    if (m_column_order[g_sortCol1] == LIST_COL_SN)
+    if (getSortColId(0) == LISTCOL_ID_SN)
         m_cp->showTips(_t("SN (Sequence Number) has the same order as Date/ID (or Date/Time/ID if Time is enabled)."));
-    else if (m_column_order[g_sortCol1] == LIST_COL_ID)
+    else if (getSortColId(0) == LISTCOL_ID_ID)
         m_cp->showTips(_t("ID (identification number) is increasing with the time of creation in the database."));
-    else if (m_column_order[g_sortCol1] == LIST_COL_BALANCE)
+    else if (getSortColId(0) == LISTCOL_ID_BALANCE)
         m_cp->showTips(_t("Balance is calculated in the order of SN (Sequence Number)."));
 
     RefreshItems(0, m_trans.size() - 1);
@@ -387,96 +383,96 @@ void TransactionListCtrl::sortBy(Compare comp, bool ascend)
         std::stable_sort(this->m_trans.rbegin(), this->m_trans.rend(), comp);
 }
 
-void TransactionListCtrl::sortTransactions(int sortcol, bool ascend)
+void TransactionListCtrl::sortTransactions(int col_id, bool ascend)
 {
     const auto& ref_type = Model_Attachment::REFTYPE_NAME_TRANSACTION;
     Model_CustomField::TYPE_ID type;
 
-    switch (m_column_order[sortcol]) {
-    case TransactionListCtrl::LIST_COL_SN:
+    switch (col_id) {
+    case TransactionListCtrl::LISTCOL_ID_SN:
         sortBy(Fused_Transaction::SorterByFUSEDTRANSSN(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_ID:
+    case TransactionListCtrl::LISTCOL_ID_ID:
         sortBy(Fused_Transaction::SorterByFUSEDTRANSID(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_NUMBER:
+    case TransactionListCtrl::LISTCOL_ID_NUMBER:
         sortBy(Model_Checking::SorterByNUMBER(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_ACCOUNT:
+    case TransactionListCtrl::LISTCOL_ID_ACCOUNT:
         sortBy(SorterByACCOUNTNAME(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_PAYEE_STR:
+    case TransactionListCtrl::LISTCOL_ID_PAYEE_STR:
         sortBy(SorterByPAYEENAME(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_STATUS:
+    case TransactionListCtrl::LISTCOL_ID_STATUS:
         sortBy(SorterBySTATUS(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_CATEGORY:
+    case TransactionListCtrl::LISTCOL_ID_CATEGORY:
         sortBy(SorterByCATEGNAME(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_TAGS:
+    case TransactionListCtrl::LISTCOL_ID_TAGS:
         sortBy(Model_Checking::SorterByTAGNAMES(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_WITHDRAWAL:
+    case TransactionListCtrl::LISTCOL_ID_WITHDRAWAL:
         sortBy(Model_Checking::SorterByWITHDRAWAL(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_DEPOSIT:
+    case TransactionListCtrl::LISTCOL_ID_DEPOSIT:
         sortBy(Model_Checking::SorterByDEPOSIT(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_BALANCE:
+    case TransactionListCtrl::LISTCOL_ID_BALANCE:
         sortBy(Model_Checking::SorterByBALANCE(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_CREDIT:
+    case TransactionListCtrl::LISTCOL_ID_CREDIT:
         sortBy(Model_Checking::SorterByBALANCE(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_NOTES:
+    case TransactionListCtrl::LISTCOL_ID_NOTES:
         sortBy(SorterByNOTES(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_DATE:
+    case TransactionListCtrl::LISTCOL_ID_DATE:
         sortBy(Model_Checking::SorterByTRANSDATE_DATE(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_TIME:
+    case TransactionListCtrl::LISTCOL_ID_TIME:
         sortBy(Model_Checking::SorterByTRANSDATE_TIME(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_DELETEDTIME:
+    case TransactionListCtrl::LISTCOL_ID_DELETEDTIME:
         sortBy(SorterByDELETEDTIME(), ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UDFC01:
+    case TransactionListCtrl::LISTCOL_ID_UDFC01:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC01");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             sortBy(SorterByUDFC01_val, ascend);
         else
             sortBy(SorterByUDFC01, ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UDFC02:
+    case TransactionListCtrl::LISTCOL_ID_UDFC02:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC02");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             sortBy(SorterByUDFC02_val, ascend);
         else
             sortBy(SorterByUDFC02, ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UDFC03:
+    case TransactionListCtrl::LISTCOL_ID_UDFC03:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC03");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             sortBy(SorterByUDFC03_val, ascend);
         else
             sortBy(SorterByUDFC03, ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UDFC04:
+    case TransactionListCtrl::LISTCOL_ID_UDFC04:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC04");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             sortBy(SorterByUDFC04_val, ascend);
         else
             sortBy(SorterByUDFC04, ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UDFC05:
+    case TransactionListCtrl::LISTCOL_ID_UDFC05:
         type = Model_CustomField::getUDFCType(ref_type, "UDFC05");
         if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
             sortBy(SorterByUDFC05_val, ascend);
         else
             sortBy(SorterByUDFC05, ascend);
         break;
-    case TransactionListCtrl::LIST_COL_UPDATEDTIME:
+    case TransactionListCtrl::LISTCOL_ID_UPDATEDTIME:
         sortBy(SorterByLASTUPDATEDTIME(), ascend);
         break;
     default:
@@ -486,34 +482,34 @@ void TransactionListCtrl::sortTransactions(int sortcol, bool ascend)
 
 //----------------------------------------------------------------------------
 
-wxString TransactionListCtrl::OnGetItemText(long item, long column) const
+wxString TransactionListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return getItem(item, column);
+    return getItem(item, getColId(static_cast<int>(col_nr)));
 }
 
 // Returns the icon to be shown for each transaction for the required column
-int TransactionListCtrl::OnGetItemColumnImage(long item, long column) const
+int TransactionListCtrl::OnGetItemColumnImage(long item, long col_nr) const
 {
-    if (m_trans.empty()) return -1;
+    if (m_trans.empty())
+        return -1;
 
-    int res = -1;
-    if (m_column_order[static_cast<int>(column)] == LIST_COL_IMGSTATUS) {
-        wxString status = getItem(item, LIST_COL_STATUS, true);
-        if (status.length() > 1)
-            status = status.Mid(2, 1);
-        if (status == Model_Checking::STATUS_KEY_FOLLOWUP)
-            res = mmCheckingPanel::ICON_FOLLOWUP;
-        else if (status == Model_Checking::STATUS_KEY_RECONCILED)
-            res = mmCheckingPanel::ICON_RECONCILED;
-        else if (status == Model_Checking::STATUS_KEY_VOID)
-            res = mmCheckingPanel::ICON_VOID;
-        else if (status == Model_Checking::STATUS_KEY_DUPLICATE)
-            res = mmCheckingPanel::ICON_DUPLICATE;
-        else
-            res = mmCheckingPanel::ICON_UNRECONCILED;
-    }
+    int col_id = getColId(static_cast<int>(col_nr));
+    if (col_id != LISTCOL_ID_ICON)
+        return -1;
 
-    return res;
+    wxString status = getItem(item, LISTCOL_ID_STATUS);
+    if (status.length() > 1) status = status.Mid(2, 1);
+
+    if (status == Model_Checking::STATUS_KEY_FOLLOWUP)
+        return mmCheckingPanel::ICON_FOLLOWUP;
+    else if (status == Model_Checking::STATUS_KEY_RECONCILED)
+        return mmCheckingPanel::ICON_RECONCILED;
+    else if (status == Model_Checking::STATUS_KEY_VOID)
+        return mmCheckingPanel::ICON_VOID;
+    else if (status == Model_Checking::STATUS_KEY_DUPLICATE)
+        return mmCheckingPanel::ICON_DUPLICATE;
+    else
+        return mmCheckingPanel::ICON_UNRECONCILED;
 }
 
 // Failed wxASSERT will hang application if active modal dialog presents on screen.
@@ -552,50 +548,43 @@ wxListItemAttr* TransactionListCtrl::OnGetItemAttr(long item) const
 void TransactionListCtrl::OnColClick(wxListEvent& event)
 {
     findSelectedTransactions();
-    int sortCol;
+    int col_nr;
     bool sortAsc;
     if (event.GetId() == MENU_HEADER_SORT) {
-        sortCol = m_ColumnHeaderNbr;
-        sortAsc = g_sortAsc1;
+        col_nr = m_col_nr;
+        sortAsc = m_sort_asc[0];
     }
     else if (event.GetId() == MENU_HEADER_RESET) {
-        sortCol = m_ColumnHeaderNbr;
+        col_nr = m_col_nr;
         sortAsc = true;
-        g_sortAsc1 = true;
+        m_sort_asc[0] = true;
     }
     else {
-        sortCol = event.GetColumn();
-        sortAsc = (sortCol == g_sortCol1) ? !g_sortAsc1 : g_sortAsc1;
+        col_nr = event.GetColumn();
+        sortAsc = (col_nr == getSortColNr(0)) ? !m_sort_asc[0] : m_sort_asc[0];
     }
 
-    if (sortCol < 0 || sortCol >= int(m_column_order.size()) ||
-        getColumnId(sortCol) == LIST_COL_IMGSTATUS
-    )
+    if (!isValidColNr(col_nr) || getColId(col_nr) == LISTCOL_ID_ICON)
         return;
 
-    if (sortCol != g_sortCol1) {
-        setColumnImage(g_sortCol1, -1); // clear previous column image
-        g_sortCol2 = g_sortCol1;
-        g_sortAsc2 = g_sortAsc1;
+    if (col_nr != getSortColNr(0)) {
+        setColumnImage(getSortColNr(0), -1); // clear previous column image
+        m_sort_col_id[1] = m_sort_col_id[0];
+        m_sort_asc[1] = m_sort_asc[0];
     }
-    g_sortCol1 = sortCol;
-    g_sortAsc1 = sortAsc;
+    m_sort_col_id[0] = getColId(col_nr);
+    m_sort_asc[0] = sortAsc;
 
     // #7080: Decouple DATE and ID, since SN may be used instead of ID.
     /*
     // If primary is DATE, then set secondary to ID in the same direction
-    if (getColumnId(g_sortCol1) == LIST_COL_DATE) {
-        g_sortCol2 = getColumnNr(LIST_COL_ID);
-        g_sortAsc2 = g_sortAsc1;        
+    if (getSortColId(0) == LISTCOL_ID_DATE) {
+        m_sort_col_id[1] = LISTCOL_ID_ID;
+        m_sort_asc[1] = m_sort_asc[0];        
     }
     */
 
-    // store sort settings
-    wxString prefix = m_cp->sortPrefix();
-    Model_Setting::instance().setInt(wxString::Format("%s_SORT_COL", prefix), g_sortCol1);
-    Model_Setting::instance().setInt(wxString::Format("%s_SORT_COL2", prefix), g_sortCol2);
-    Model_Setting::instance().setInt(wxString::Format("%s_ASC", prefix), (g_sortAsc1 ? 1 : 0));
-    Model_Setting::instance().setInt(wxString::Format("%s_ASC2", prefix), (g_sortAsc2 ? 1 : 0));
+    savePreferences();
 
     refreshVisualList(false);
 }
@@ -743,55 +732,56 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
         );
     }
     bool columnIsAmount = false;
-    unsigned long column = getColumnFromPosition(event.GetX());
+    unsigned long col_nr = getColumnFromPosition(event.GetX());
     int flags;
     unsigned long row = HitTest(event.GetPosition(), flags);
-    if (row < m_trans.size() && (flags & wxLIST_HITTEST_ONITEM) && column < m_columns.size()) {
+    if (row < m_trans.size() && (flags & wxLIST_HITTEST_ONITEM) && col_nr < getColNrSize()) {
+        int col_id = getColId(col_nr);
         wxString menuItemText;
         wxString refType = Model_Attachment::REFTYPE_NAME_TRANSACTION;
         wxDateTime datetime;
         wxString dateFormat = Option::instance().getDateFormat();
 
-        switch (m_column_order[column]) {
-        case LIST_COL_SN:
+        switch (col_id) {
+        case LISTCOL_ID_SN:
             copyText_ = m_trans[row].displaySN;
             break;
-        case LIST_COL_ID:
+        case LISTCOL_ID_ID:
             copyText_ = m_trans[row].displayID;
             break;
-        case LIST_COL_DATE: {
+        case LISTCOL_ID_DATE: {
             copyText_ = menuItemText = mmGetDateTimeForDisplay(m_trans[row].TRANSDATE);
             wxString strDate = Model_Checking::TRANSDATE(m_trans[row]).FormatISODate();
             rightClickFilter_ = "{\n\"DATE1\": \"" + strDate + "\",\n\"DATE2\" : \"" + strDate + "T23:59:59" + "\"\n}";
             break;
         }
-        case LIST_COL_NUMBER:
+        case LISTCOL_ID_NUMBER:
             copyText_ = menuItemText = m_trans[row].TRANSACTIONNUMBER;
             rightClickFilter_ = "{\n\"NUMBER\": \"" + menuItemText + "\"\n}";
             break;
-        case LIST_COL_ACCOUNT:
+        case LISTCOL_ID_ACCOUNT:
             copyText_ = menuItemText = m_trans[row].ACCOUNTNAME;
             rightClickFilter_ = "{\n\"ACCOUNT\": [\n\"" + menuItemText + "\"\n]\n}";
             break;
-        case LIST_COL_PAYEE_STR:
+        case LISTCOL_ID_PAYEE_STR:
             copyText_ = m_trans[row].PAYEENAME;
             if (!Model_Checking::is_transfer(m_trans[row].TRANSCODE)) {
                 menuItemText = m_trans[row].PAYEENAME;
                 rightClickFilter_ = "{\n\"PAYEE\": \"" + menuItemText + "\"\n}";
             }
             break;
-        case LIST_COL_STATUS:
+        case LISTCOL_ID_STATUS:
             copyText_ = menuItemText = Model_Checking::status_name(m_trans[row].STATUS);
             rightClickFilter_ = "{\n\"STATUS\": \"" + menuItemText + "\"\n}";
             break;
-        case LIST_COL_CATEGORY:
+        case LISTCOL_ID_CATEGORY:
             copyText_ = m_trans[row].CATEGNAME;
             if (!m_trans[row].has_split()) {
                 menuItemText = m_trans[row].CATEGNAME;
                 rightClickFilter_ = "{\n\"CATEGORY\": \"" + menuItemText + "\",\n\"SUBCATEGORYINCLUDE\": false\n}";
             }
             break;
-        case LIST_COL_TAGS:
+        case LISTCOL_ID_TAGS:
             if (!m_trans[row].has_split() && m_trans[row].has_tags()) {
                 copyText_ = menuItemText = m_trans[row].TAGNAMES;
                 // build the tag filter json
@@ -801,7 +791,7 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
                 rightClickFilter_ += "\n]\n}";
             }
             break;
-        case LIST_COL_WITHDRAWAL: {
+        case LISTCOL_ID_WITHDRAWAL: {
             columnIsAmount = true;
             Model_Account::Data* account = Model_Account::instance().get(m_trans[row].ACCOUNTID_W);
             Model_Currency::Data* currency = account ? Model_Currency::instance().get(account->CURRENCYID) : nullptr;
@@ -812,7 +802,7 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
             }
             break;
         }
-        case LIST_COL_DEPOSIT: {
+        case LISTCOL_ID_DEPOSIT: {
             columnIsAmount = true;
             Model_Account::Data* account = Model_Account::instance().get(m_trans[row].ACCOUNTID_D);
             Model_Currency::Data* currency = account ? Model_Currency::instance().get(account->CURRENCYID) : nullptr;
@@ -823,46 +813,46 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
             }
             break;
         }
-        case LIST_COL_BALANCE:
+        case LISTCOL_ID_BALANCE:
             copyText_ = Model_Currency::toString(m_trans[row].ACCOUNT_BALANCE, m_cp->m_currency);
             break;
-        case LIST_COL_CREDIT:
+        case LISTCOL_ID_CREDIT:
             copyText_ = Model_Currency::toString(
                 m_cp->m_account->CREDITLIMIT + m_trans[row].ACCOUNT_BALANCE,
                 m_cp->m_currency
             );
             break;
-        case LIST_COL_NOTES:
+        case LISTCOL_ID_NOTES:
             copyText_ = menuItemText = m_trans[row].NOTES;
             rightClickFilter_ = "{\n\"NOTES\": \"" + menuItemText + "\"\n}";
             break;
-        case LIST_COL_DELETEDTIME:
+        case LISTCOL_ID_DELETEDTIME:
             datetime.ParseISOCombined(m_trans[row].DELETEDTIME);        
             if(datetime.IsValid())
                 copyText_ = mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
             break;
-        case LIST_COL_UPDATEDTIME:
+        case LISTCOL_ID_UPDATEDTIME:
             datetime.ParseISOCombined(m_trans[row].LASTUPDATEDTIME);
             if (datetime.IsValid())
                 copyText_ = mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
             break;
-        case LIST_COL_UDFC01:
+        case LISTCOL_ID_UDFC01:
             copyText_ = menuItemText = m_trans[row].UDFC_content[0];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC01"));
             break;
-        case LIST_COL_UDFC02:
+        case LISTCOL_ID_UDFC02:
             copyText_ = menuItemText = m_trans[row].UDFC_content[1];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC02"));
             break;
-        case LIST_COL_UDFC03:
+        case LISTCOL_ID_UDFC03:
             copyText_ = menuItemText = m_trans[row].UDFC_content[2];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC03"));
             break;
-        case LIST_COL_UDFC04:
+        case LISTCOL_ID_UDFC04:
             copyText_ = menuItemText = m_trans[row].UDFC_content[3];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC04"));
             break;
-        case LIST_COL_UDFC05:
+        case LISTCOL_ID_UDFC05:
             copyText_ = menuItemText = m_trans[row].UDFC_content[4];
             rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", Model_CustomField::getUDFCID(refType, "UDFC05"));
             break;
@@ -877,7 +867,7 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
                     menuItemText = menuItemText.SubString(0, 30).Append(L"\u2026");
                 menu.Append(MENU_TREEPOPUP_FIND, wxString::Format(
                     _t("&Find all transactions with %s '%s'"),
-                    (columnIsAmount ? _t("Amount") : m_columns[column].header),
+                    (columnIsAmount ? _t("Amount") : getColHeader(col_id, true)),
                     menuItemText
                 ));
             }
@@ -1575,9 +1565,9 @@ void TransactionListCtrl::onCopy(wxCommandEvent& WXUNUSED(event))
         wxString data = "";
         for (int row = 0; row < GetItemCount(); row++) {
             if (GetItemState(row, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED) {
-                for (int column = 0; column < static_cast<int>(m_columns.size()); column++) {
-                    if (GetColumnWidth(column) > 0) {
-                        data += inQuotes(OnGetItemText(row, column), seperator);
+                for (int col_nr = 0; col_nr < getColNrSize(); ++col_nr) {
+                    if (GetColumnWidth(col_nr) > 0) {
+                        data += inQuotes(OnGetItemText(row, col_nr), seperator);
                         data += seperator;
                     }
                 }
@@ -1792,37 +1782,37 @@ wxString UDFCFormatHelper(Model_CustomField::TYPE_ID type, wxString data)
     return formattedData;
 }
 
-const wxString TransactionListCtrl::getItem(long item, long column, bool realenum) const
+const wxString TransactionListCtrl::getItem(long item, int col_id) const
 {
-    if (item < 0 || item >= static_cast<int>(m_trans.size())) return "";
-
+    if (item < 0 || item >= static_cast<int>(m_trans.size()))
+        return "";
     const Fused_Transaction::Full_Data& fused = m_trans.at(item);
 
     wxString value = wxEmptyString;
     wxDateTime datetime;
     wxString dateFormat = Option::instance().getDateFormat();
-    switch (realenum ? column : m_column_order[column]) {
-    case TransactionListCtrl::LIST_COL_SN:
+    switch (col_id) {
+    case TransactionListCtrl::LISTCOL_ID_SN:
         return fused.displaySN;
-    case TransactionListCtrl::LIST_COL_ID:
+    case TransactionListCtrl::LISTCOL_ID_ID:
         return fused.displayID;
-    case TransactionListCtrl::LIST_COL_ACCOUNT:
+    case TransactionListCtrl::LISTCOL_ID_ACCOUNT:
         return fused.ACCOUNTNAME;
-    case TransactionListCtrl::LIST_COL_DATE:
+    case TransactionListCtrl::LISTCOL_ID_DATE:
         return mmGetDateForDisplay(fused.TRANSDATE);
-    case TransactionListCtrl::LIST_COL_TIME:
+    case TransactionListCtrl::LISTCOL_ID_TIME:
         return mmGetTimeForDisplay(fused.TRANSDATE);
-    case TransactionListCtrl::LIST_COL_NUMBER:
+    case TransactionListCtrl::LISTCOL_ID_NUMBER:
         return fused.TRANSACTIONNUMBER;
-    case TransactionListCtrl::LIST_COL_CATEGORY:
+    case TransactionListCtrl::LISTCOL_ID_CATEGORY:
         return fused.CATEGNAME;
-    case TransactionListCtrl::LIST_COL_PAYEE_STR:
+    case TransactionListCtrl::LISTCOL_ID_PAYEE_STR:
         return fused.is_foreign_transfer() ?
             (Model_Checking::type_id(fused.TRANSCODE) == Model_Checking::TYPE_ID_DEPOSIT ? "< " : "> ") + fused.PAYEENAME :
             fused.PAYEENAME;
-    case TransactionListCtrl::LIST_COL_STATUS:
+    case TransactionListCtrl::LISTCOL_ID_STATUS:
         return fused.is_foreign() ? "< " + fused.STATUS : fused.STATUS;
-    case TransactionListCtrl::LIST_COL_NOTES: {
+    case TransactionListCtrl::LISTCOL_ID_NOTES: {
         value = fused.NOTES;
         if (!fused.displayID.Contains(".")) {
             for (const auto& split : fused.m_splits)
@@ -1833,7 +1823,7 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
             value.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return value.Trim(false);
     }
-    case TransactionListCtrl::LIST_COL_TAGS:
+    case TransactionListCtrl::LISTCOL_ID_TAGS:
         value = fused.TAGNAMES;
         if (!fused.displayID.Contains(".")) {
             const wxString splitRefType = Model_Attachment::REFTYPE_NAME_TRANSACTIONSPLIT;
@@ -1848,30 +1838,30 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
             }
         }
         return value.Trim();
-    case TransactionListCtrl::LIST_COL_DELETEDTIME:
+    case TransactionListCtrl::LISTCOL_ID_DELETEDTIME:
         datetime.ParseISOCombined(fused.DELETEDTIME);        
         if(!datetime.IsValid())
             return wxString("");
         return mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
-    case TransactionListCtrl::LIST_COL_UDFC01:
+    case TransactionListCtrl::LISTCOL_ID_UDFC01:
         return UDFCFormatHelper(fused.UDFC_type[0], fused.UDFC_content[0]);
-    case TransactionListCtrl::LIST_COL_UDFC02:
+    case TransactionListCtrl::LISTCOL_ID_UDFC02:
         return UDFCFormatHelper(fused.UDFC_type[1], fused.UDFC_content[1]);
-    case TransactionListCtrl::LIST_COL_UDFC03:
+    case TransactionListCtrl::LISTCOL_ID_UDFC03:
         return UDFCFormatHelper(fused.UDFC_type[2], fused.UDFC_content[2]);
-    case TransactionListCtrl::LIST_COL_UDFC04:
+    case TransactionListCtrl::LISTCOL_ID_UDFC04:
         return UDFCFormatHelper(fused.UDFC_type[3], fused.UDFC_content[3]);
-    case TransactionListCtrl::LIST_COL_UDFC05:
+    case TransactionListCtrl::LISTCOL_ID_UDFC05:
         return UDFCFormatHelper(fused.UDFC_type[4], fused.UDFC_content[4]);
-    case TransactionListCtrl::LIST_COL_UPDATEDTIME:
+    case TransactionListCtrl::LISTCOL_ID_UPDATEDTIME:
         datetime.ParseISOCombined(fused.LASTUPDATEDTIME);
         if (!datetime.IsValid())
             return wxString("");
         return mmGetDateTimeForDisplay(datetime.FromUTC().FormatISOCombined(), dateFormat + " %H:%M:%S");
     }
 
-    switch (realenum ? column : m_column_order[column]) {
-    case TransactionListCtrl::LIST_COL_WITHDRAWAL:
+    switch (col_id) {
+    case TransactionListCtrl::LISTCOL_ID_WITHDRAWAL:
         if (!m_cp->isAccount()) {
             Model_Account::Data* account = Model_Account::instance().get(fused.ACCOUNTID_W);
             Model_Currency::Data* currency = account ?
@@ -1885,7 +1875,7 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
         if (!value.IsEmpty() && Model_Checking::status_id(fused.STATUS) == Model_Checking::STATUS_ID_VOID)
             value = "* " + value;
         return value;
-    case TransactionListCtrl::LIST_COL_DEPOSIT:
+    case TransactionListCtrl::LISTCOL_ID_DEPOSIT:
         if (!m_cp->isAccount()) {
             Model_Account::Data* account = Model_Account::instance().get(fused.ACCOUNTID_D);
             Model_Currency::Data* currency = account ?
@@ -1899,9 +1889,9 @@ const wxString TransactionListCtrl::getItem(long item, long column, bool realenu
         if (!value.IsEmpty() && Model_Checking::status_id(fused.STATUS) == Model_Checking::STATUS_ID_VOID)
             value = "* " + value;
         return value;
-    case TransactionListCtrl::LIST_COL_BALANCE:
+    case TransactionListCtrl::LISTCOL_ID_BALANCE:
         return Model_Currency::toString(fused.ACCOUNT_BALANCE, m_cp->m_currency);
-    case TransactionListCtrl::LIST_COL_CREDIT:
+    case TransactionListCtrl::LISTCOL_ID_CREDIT:
         return Model_Currency::toString(
             m_cp->m_account->CREDITLIMIT + fused.ACCOUNT_BALANCE,
             m_cp->m_currency
@@ -2010,10 +2000,10 @@ void TransactionListCtrl::doSearchText(const wxString& value)
     long selectedItem = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 
     if (selectedItem < 0 || selectedItem > last) //nothing selected
-        selectedItem = g_sortAsc1 ? last + 1  : -1;
+        selectedItem = getSortAsc(0) ? last + 1  : -1;
 
     while (true) {
-        g_sortAsc1 ? selectedItem-- : selectedItem++;
+        getSortAsc(0) ? selectedItem-- : selectedItem++;
         if (selectedItem < 0 || selectedItem >= static_cast<long>(m_trans.size()))
             break;
 
@@ -2034,11 +2024,11 @@ void TransactionListCtrl::doSearchText(const wxString& value)
         }
 
         for (const auto& t : {
-            LIST_COL_NOTES, LIST_COL_NUMBER, LIST_COL_PAYEE_STR, LIST_COL_CATEGORY,
-            LIST_COL_DATE, LIST_COL_TAGS, LIST_COL_DELETEDTIME, LIST_COL_UDFC01,
-            LIST_COL_UDFC02, LIST_COL_UDFC03, LIST_COL_UDFC04, LIST_COL_UDFC05
+            LISTCOL_ID_NOTES, LISTCOL_ID_NUMBER, LISTCOL_ID_PAYEE_STR, LISTCOL_ID_CATEGORY,
+            LISTCOL_ID_DATE, LISTCOL_ID_TAGS, LISTCOL_ID_DELETEDTIME, LISTCOL_ID_UDFC01,
+            LISTCOL_ID_UDFC02, LISTCOL_ID_UDFC03, LISTCOL_ID_UDFC04, LISTCOL_ID_UDFC05
         }) {
-            const auto test = getItem(selectedItem, t, true).Lower();
+            const auto test = getItem(selectedItem, t).Lower();
             if (test.empty())
                 continue;
             if (test.Matches(pattern)) {
@@ -2056,7 +2046,7 @@ void TransactionListCtrl::doSearchText(const wxString& value)
     }
 
     wxLogDebug("Searching finished");
-    selectedItem = g_sortAsc1 ? last : 0;
+    selectedItem = getSortAsc(0) ? last : 0;
     long cursel = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
     SetItemState(cursel, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
     EnsureVisible(selectedItem);
@@ -2073,7 +2063,7 @@ void TransactionListCtrl::markSelectedTransaction()
             SetItemState(i, 0, wxLIST_STATE_SELECTED);
         if (!m_selected_id.empty()) {
             // discover where the transaction has ended up in the list
-            if (g_sortAsc1) {
+            if (getSortAsc(0)) {
                 if (m_topItemIndex < i && id == m_selected_id.back())
                     m_topItemIndex = i;
             } else {
@@ -2088,7 +2078,7 @@ void TransactionListCtrl::markSelectedTransaction()
 
     if (m_selected_id.empty()) {
         i = static_cast<long>(m_trans.size()) - 1;
-        if (!g_sortAsc1)
+        if (!getSortAsc(0))
             i = 0;
         EnsureVisible(i);
     }

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -41,36 +41,36 @@ public:
 private:
     friend class mmCheckingPanel;
 
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_IMGSTATUS = 0,
-        LIST_COL_ID,
-        LIST_COL_DATE,
-        LIST_COL_TIME,
-        LIST_COL_NUMBER,
-        LIST_COL_ACCOUNT,
-        LIST_COL_PAYEE_STR,
-        LIST_COL_STATUS,
-        LIST_COL_CATEGORY,
-        LIST_COL_TAGS,
-        LIST_COL_WITHDRAWAL,
-        LIST_COL_DEPOSIT,
-        LIST_COL_BALANCE,
-        LIST_COL_CREDIT,
-        LIST_COL_NOTES,
-        LIST_COL_DELETEDTIME,
-        LIST_COL_UDFC01,
-        LIST_COL_UDFC02,
-        LIST_COL_UDFC03,
-        LIST_COL_UDFC04,
-        LIST_COL_UDFC05,
-        LIST_COL_UPDATEDTIME,
-        LIST_COL_SN,
-        LIST_COL_size, // number of columns
-        LIST_COL_def_sort1 = LIST_COL_DATE,
-        LIST_COL_def_sort2 = LIST_COL_ID 
+        LISTCOL_ID_ICON = 0,
+        LISTCOL_ID_ID,
+        LISTCOL_ID_DATE,
+        LISTCOL_ID_TIME,
+        LISTCOL_ID_NUMBER,
+        LISTCOL_ID_ACCOUNT,
+        LISTCOL_ID_PAYEE_STR,
+        LISTCOL_ID_STATUS,
+        LISTCOL_ID_CATEGORY,
+        LISTCOL_ID_TAGS,
+        LISTCOL_ID_WITHDRAWAL,
+        LISTCOL_ID_DEPOSIT,
+        LISTCOL_ID_BALANCE,
+        LISTCOL_ID_CREDIT,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_DELETEDTIME,
+        LISTCOL_ID_UDFC01,
+        LISTCOL_ID_UDFC02,
+        LISTCOL_ID_UDFC03,
+        LISTCOL_ID_UDFC04,
+        LISTCOL_ID_UDFC05,
+        LISTCOL_ID_UPDATEDTIME,
+        LISTCOL_ID_SN,
+        LISTCOL_ID_size, // number of columns
+        LISTCOL_ID_def_sort1 = LISTCOL_ID_DATE,
+        LISTCOL_ID_def_sort2 = LISTCOL_ID_ID 
     };
-    static const std::vector<ListColumnInfo> col_info_all();
+    static const std::vector<ListColumnInfo> LISTCOL_INFO;
 
     enum
     {
@@ -127,10 +127,6 @@ private:
 private:
     Fused_Transaction::Full_Data_Set m_trans;
     long m_topItemIndex = -1; // where to display the list again after refresh
-    int g_sortCol1 = LIST_COL_def_sort1; // 0-based number of primary sorting column
-    int g_sortCol2 = LIST_COL_def_sort2; // 0-based number of secondary sorting column
-    bool g_sortAsc1 = true;         // asc/desc order for primary sorting column
-    bool g_sortAsc2 = true;         // asc/desc order for secondary sorting column
     wxString m_today;
     bool m_firstSort = true;
     wxString rightClickFilter_;
@@ -155,17 +151,17 @@ private:
     wxSharedPtr<wxListItemAttr> m_attr17; // user-defined style 7
 
 private:
-    void resetColumns();
+    void getColumnsInfo();
     void refreshVisualList(bool filter = true);
-    void sortTable();
+    void sortList();
     template<class Compare>
     void sortBy(Compare comp, bool ascend);
-    void sortTransactions(int sortcol, bool ascend);
+    void sortTransactions(int col_id, bool ascend);
 
 private:
     // required overrides for virtual style list control
-    virtual wxString OnGetItemText(long item, long column) const;
-    virtual int OnGetItemColumnImage(long item, long column) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const;
+    virtual int OnGetItemColumnImage(long item, long col_nr) const;
     virtual wxListItemAttr* OnGetItemAttr(long item) const;
 
 protected:
@@ -208,7 +204,7 @@ private:
     void onOpenAttachment(wxCommandEvent& event);
 
 private:
-    const wxString getItem(long item, long column, bool realenum = false) const;
+    const wxString getItem(long item, int col_id) const;
     void setColumnImage(int col, int image);
     void setExtraTransactionData(const bool single);
     void markItem(long selectedItem);
@@ -216,8 +212,6 @@ private:
     std::vector<Fused_Transaction::IdRepeat> getSelectedId() const;
     std::vector<Fused_Transaction::IdRepeat> getSelectedForCopy() const;
     void findSelectedTransactions();
-    void setSortOrder(bool asc);
-    bool getSortOrder() const;
     int getColumnFromPosition(int xPos);
     void doSearchText(const wxString& value);
     void setVisibleItemIndex(long v);
@@ -228,14 +222,6 @@ private:
 };
 
 //----------------------------------------------------------------------------
-
-inline void TransactionListCtrl::setSortOrder(bool asc)
-{
-    m_asc = asc;
-}
-inline bool TransactionListCtrl::getSortOrder() const {
-    return m_asc;
-}
 
 inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedId() const
 {

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -151,7 +151,7 @@ void mmCheckingPanel::loadAccount(int64 account_id)
 {
     wxASSERT (account_id >= 1);
 
-    m_listCtrlAccount->setVisibleItemIndex(-1);
+    m_lc->setVisibleItemIndex(-1);
     m_checking_id = account_id;
     m_account_id = account_id;
     m_account_type = -1;
@@ -237,35 +237,10 @@ void mmCheckingPanel::createControls()
     m_images.push_back(mmBitmapBundle(png::UPARROW));
     m_images.push_back(mmBitmapBundle(png::DOWNARROW));
 
-    m_listCtrlAccount = new TransactionListCtrl(this, splitterListFooter);
-
-    m_listCtrlAccount->SetSmallImages(m_images);
-    m_listCtrlAccount->SetNormalImages(m_images);
-
-    // load sort settings
-    wxString prefix = sortPrefix();
-    m_listCtrlAccount->g_sortCol1 = Model_Setting::instance().getInt(
-        wxString::Format("%s_SORT_COL", prefix),
-        m_listCtrlAccount->getColumnNr(m_listCtrlAccount->LIST_COL_def_sort1)
-    );
-    m_listCtrlAccount->g_sortCol2 = Model_Setting::instance().getInt(
-        wxString::Format("%s_SORT_COL2", prefix),
-        m_listCtrlAccount->getColumnNr(m_listCtrlAccount->LIST_COL_def_sort2)
-    );
-    m_listCtrlAccount->g_sortAsc1 = Model_Setting::instance().getInt(
-        wxString::Format("%s_ASC", prefix),
-        1 // default is asc order
-    ) != 0;
-    m_listCtrlAccount->g_sortAsc2 = Model_Setting::instance().getInt(
-        wxString::Format("%s_ASC2", prefix),
-        1 // default is asc order
-    ) != 0;
-
-    m_listCtrlAccount->setSortOrder(m_listCtrlAccount->g_sortAsc1);
-    m_listCtrlAccount->setColumnImage(
-        m_listCtrlAccount->g_sortCol1,
-        m_listCtrlAccount->g_sortAsc1 ? ICON_ASC : ICON_DESC // asc/desc sort mark (arrow)
-    );
+    m_lc = new TransactionListCtrl(this, splitterListFooter);
+    m_lc->SetSmallImages(m_images);
+    m_lc->SetNormalImages(m_images);
+    m_lc->setColumnImage(m_lc->getSortColNr(0), (m_lc->getSortAsc(0) ? ICON_ASC : ICON_DESC));
 
     wxPanel* panelFooter = new wxPanel(
         splitterListFooter, wxID_ANY, wxDefaultPosition, wxDefaultSize,
@@ -273,7 +248,7 @@ void mmCheckingPanel::createControls()
     );
     mmThemeMetaColour(panelFooter, meta::COLOR_LISTPANEL);
 
-    splitterListFooter->SplitHorizontally(m_listCtrlAccount, panelFooter);
+    splitterListFooter->SplitHorizontally(m_lc, panelFooter);
     splitterListFooter->SetMinimumPaneSize(100);
     splitterListFooter->SetSashGravity(1.0);
 
@@ -583,12 +558,12 @@ void mmCheckingPanel::saveFilterSettings()
 
 void mmCheckingPanel::refreshList()
 {
-    m_listCtrlAccount->refreshVisualList();
+    m_lc->refreshVisualList();
 }
 
 void mmCheckingPanel::filterList()
 {
-    m_listCtrlAccount->m_trans.clear();
+    m_lc->m_trans.clear();
 
     wxString date_start_str = m_date_range.checking_start_str();
     wxString date_end_str = m_date_range.checking_end_str();
@@ -793,7 +768,7 @@ void mmCheckingPanel::filterList()
             full_tran.displayID = wxString::Format("%s%ld", marker, full_tran.m_bdid);
 
         if (!expandSplits) {
-            m_listCtrlAccount->m_trans.push_back(full_tran);
+            m_lc->m_trans.push_back(full_tran);
             if (isAccount())
                 m_flow += account_flow;
             continue;
@@ -835,15 +810,15 @@ void mmCheckingPanel::filterList()
                 tagnames.Append(tag.first + " ");
             if (!tagnames.IsEmpty())
                 full_tran.TAGNAMES.Append((full_tran.TAGNAMES.IsEmpty() ? "" : ", ") + tagnames.Trim());
-            m_listCtrlAccount->m_trans.push_back(full_tran);
+            m_lc->m_trans.push_back(full_tran);
         }
         // }
     }
 }
 
-void mmCheckingPanel::sortTable()
+void mmCheckingPanel::sortList()
 {
-    m_listCtrlAccount->sortTable();
+    m_lc->sortList();
 }
 
 //----------------------------------------------------------------------------
@@ -861,12 +836,12 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
         );
 
         long x = -1;
-        for (x = 0; x < m_listCtrlAccount->GetItemCount(); x++) {
-            if (m_listCtrlAccount->GetItemState(x, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED)
+        for (x = 0; x < m_lc->GetItemCount(); x++) {
+            if (m_lc->GetItemState(x, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED)
                 break;
         }
 
-        Fused_Transaction::Full_Data full_tran(m_listCtrlAccount->m_trans[x]);
+        Fused_Transaction::Full_Data full_tran(m_lc->m_trans[x]);
         wxString miniStr = full_tran.info();
         //Show only first line but full string set as tooltip
         if (miniStr.Find("\n") > 1 && !miniStr.IsEmpty()) {
@@ -921,7 +896,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
     }
     else /* !single */ {
         m_info_panel_mini->SetLabelText("");
-        const auto selected = m_listCtrlAccount->getSelectedId();
+        const auto selected = m_lc->getSelectedId();
         if (selected.size() > 0) {
             bool selected_bill = false;
             for (const auto& id : selected)
@@ -943,14 +918,14 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
             wxString minDate;
             long item = -1;
             while (true) {
-                item = m_listCtrlAccount->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+                item = m_lc->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
                 if (item == -1) break;
                 if (currency)
                     flow += Model_Checking::account_flow(
-                        m_listCtrlAccount->m_trans[item],
+                        m_lc->m_trans[item],
                         m_account_id
                     );
-                wxString transdate = m_listCtrlAccount->m_trans[item].TRANSDATE;
+                wxString transdate = m_lc->m_trans[item].TRANSDATE;
                 if (minDate > transdate || minDate.empty()) minDate = transdate;
                 if (maxDate < transdate || maxDate.empty()) maxDate = transdate;
             }
@@ -1051,10 +1026,10 @@ void mmCheckingPanel::onFilterPopup(wxCommandEvent& event)
     }
 
     menu.AppendSeparator();
-    if (i < int(m_date_range_a.size())) {
+    if (i < static_cast<int>(m_date_range_a.size())) {
         wxMenu* menu_more(new wxMenu);
         menu.AppendSubMenu(menu_more, _t("More date ranges…"));
-        while (i < int(m_date_range_a.size())) {
+        while (i < static_cast<int>(m_date_range_a.size())) {
             menu_more->Append(mmID_FILTER_DATE_MIN + i, m_date_range_a[i].getName());
             i++;
         }
@@ -1070,7 +1045,7 @@ void mmCheckingPanel::onFilterPopup(wxCommandEvent& event)
 void mmCheckingPanel::onFilterDate(wxCommandEvent& event)
 {
     int i = event.GetId() - mmID_FILTER_DATE_MIN;
-    if (i < 0 || i >= int(m_date_range_a.size()))
+    if (i < 0 || i >= static_cast<int>(m_date_range_a.size()))
         return;
 
     setFilterDate(m_date_range_a[i]);
@@ -1125,56 +1100,56 @@ void mmCheckingPanel::onScheduled(wxCommandEvent&)
 
 void mmCheckingPanel::onNewTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onNewTransaction(event);
+    m_lc->onNewTransaction(event);
 }
 
 void mmCheckingPanel::onEditTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onEditTransaction(event);
-    m_listCtrlAccount->SetFocus();
+    m_lc->onEditTransaction(event);
+    m_lc->SetFocus();
 }
 
 void mmCheckingPanel::onDeleteTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onDeleteTransaction(event);
+    m_lc->onDeleteTransaction(event);
 }
 
 void mmCheckingPanel::onRestoreTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onRestoreTransaction(event);
+    m_lc->onRestoreTransaction(event);
 }
 
 void mmCheckingPanel::onDuplicateTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onDuplicateTransaction(event);
+    m_lc->onDuplicateTransaction(event);
 }
 
 void mmCheckingPanel::onMoveTransaction(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onMoveTransaction(event);
+    m_lc->onMoveTransaction(event);
 }
 
 void mmCheckingPanel::onEnterScheduled(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onEnterScheduled(event);
+    m_lc->onEnterScheduled(event);
 }
 
 void mmCheckingPanel::onSkipScheduled(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onSkipScheduled(event);
+    m_lc->onSkipScheduled(event);
 }
 
 void mmCheckingPanel::onOpenAttachment(wxCommandEvent& event)
 {
-    m_listCtrlAccount->onOpenAttachment(event);
-    m_listCtrlAccount->SetFocus();
+    m_lc->onOpenAttachment(event);
+    m_lc->SetFocus();
 }
 
 void mmCheckingPanel::onSearchTxtEntered(wxCommandEvent& event)
 {
     const wxString search_string = event.GetString();
     if (search_string.IsEmpty()) return;
-    m_listCtrlAccount->doSearchText(search_string);
+    m_lc->doSearchText(search_string);
 }
 
 void mmCheckingPanel::onButtonRightDown(wxMouseEvent& event)
@@ -1187,7 +1162,7 @@ void mmCheckingPanel::onButtonRightDown(wxMouseEvent& event)
         break;
     }
     case wxID_FILE: {
-        auto selected_id = m_listCtrlAccount->getSelectedId();
+        auto selected_id = m_lc->getSelectedId();
         if (selected_id.size() == 1) {
             const wxString refType = !selected_id[0].second ?
                 Model_Attachment::REFTYPE_NAME_TRANSACTION :
@@ -1232,21 +1207,22 @@ wxString mmCheckingPanel::getPanelTitle() const
 
 wxString mmCheckingPanel::BuildPage() const
 {
-    return m_listCtrlAccount->BuildPage((m_account ? getPanelTitle() : ""));
+    return m_lc->BuildPage((m_account ? getPanelTitle() : ""));
 }
 
 void mmCheckingPanel::resetColumnView()
 {
-    m_listCtrlAccount->DeleteAllColumns();
-    m_listCtrlAccount->resetColumns();
-    m_listCtrlAccount->refreshVisualList();
+    m_lc->DeleteAllColumns();
+    m_lc->getColumnsInfo();
+    m_lc->createColumns();
+    m_lc->refreshVisualList();
 }
 
 void mmCheckingPanel::setSelectedTransaction(Fused_Transaction::IdRepeat fused_id)
 {
-    m_listCtrlAccount->setSelectedId(fused_id);
+    m_lc->setSelectedId(fused_id);
     refreshList();
-    m_listCtrlAccount->SetFocus();
+    m_lc->SetFocus();
 }
 
 void mmCheckingPanel::displaySplitCategories(Fused_Transaction::IdB fused_id)

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -147,7 +147,7 @@ private:
     wxStaticText* m_info_panel = nullptr;
     wxStaticText* m_info_panel_mini = nullptr;
     wxVector<wxBitmapBundle> m_images;
-    TransactionListCtrl* m_listCtrlAccount = nullptr;
+    TransactionListCtrl* m_lc = nullptr;
     wxSharedPtr<mmFilterTransactionsDialog> m_trans_filter_dlg;
 
 private:
@@ -167,7 +167,7 @@ private:
     void loadFilterSettings();
     void saveFilterSettings();
     void filterList();
-    void sortTable();
+    void sortList();
     void updateExtraTransactionData(bool single, int repeat_num, bool foreign);
     void enableButtons(bool edit, bool dup, bool del, bool enter, bool skip, bool attach);
     void showTips();

--- a/src/mmhelppanel.cpp
+++ b/src/mmhelppanel.cpp
@@ -93,7 +93,7 @@ void mmHelpPanel::CreateControls()
     itemBoxSizer2->Add(browser_, 1, wxGROW | wxALL, 1);
 }
 
-void mmHelpPanel::sortTable()
+void mmHelpPanel::sortList()
 {
 }
 

--- a/src/mmhelppanel.h
+++ b/src/mmhelppanel.h
@@ -53,7 +53,7 @@ private:
         , const wxString& name = "mmHelpPanel");
 
     void CreateControls();
-    virtual void sortTable();
+    virtual void sortList();
 
     void OnHelpPageBack(wxCommandEvent& event);
     void OnHelpPageForward(wxCommandEvent& event);

--- a/src/mmhomepagepanel.h
+++ b/src/mmhomepagepanel.h
@@ -57,7 +57,7 @@ private:
     wxString GetHomePageText() const;
     wxWebView* browser_ = nullptr;
     void createControls();
-    void sortTable() {}
+    void sortList() {}
     void OnNewWindow(wxWebViewEvent& evt);
 
     wxString m_templateText;

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -1,22 +1,23 @@
 /*******************************************************
-Copyright (C) 2006 Madhan Kanagavel
-Copyright (C) 2015 James Higley
-Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
+ Copyright (C) 2006 Madhan Kanagavel
+ Copyright (C) 2015 James Higley
+ Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
+ Copyright (C) 2025 George Ef (george.a.ef@gmail.com)
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-********************************************************/
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ ********************************************************/
 
 #include "images_list.h"
 #include "mmpanelbase.h"
@@ -29,6 +30,16 @@ wxBEGIN_EVENT_TABLE(mmListCtrl, wxListCtrl)
     EVT_LIST_COL_RIGHT_CLICK(wxID_ANY, mmListCtrl::onColRightClick)
     EVT_MENU(wxID_ANY,                 mmListCtrl::onHeaderPopup)
 wxEND_EVENT_TABLE()
+
+const std::vector<int> ListColumnInfo::getId(const std::vector<ListColumnInfo>& a_info)
+{
+    std::vector<int> a_id;
+    for (int i = 0; i < static_cast<int>(a_info.size()); ++i)
+        a_id.push_back(a_info[i].id);
+    return a_id;
+}
+
+//----------------------------------------------------------------------------
 
 mmListCtrl::mmListCtrl(wxWindow *parent, wxWindowID winid) :
     wxListCtrl(
@@ -50,83 +61,20 @@ mmListCtrl::mmListCtrl(wxWindow *parent, wxWindowID winid) :
 
 mmListCtrl::~mmListCtrl()
 {
-    // Save the column widths of the list control. This will ensure that the
-    // column widths get set incase the onItemResize does not work on some systems.
-    std::vector<int> columnOrder;
-    for (int column_number = 0; column_number < GetColumnCount(); ++column_number) {
-        int column_width = GetColumnWidth(column_number);
-        if (loadColumnWidth(column_number) != column_width)
-            saveColumnWidth(column_number, column_width);
-
-        #ifdef wxHAS_LISTCTRL_COLUMN_ORDER
-        if (m_column_order.size() > 0)
-            columnOrder.push_back(m_column_order[GetColumnIndexFromOrder(column_number)]);
-        #endif
-    }
-
-    if (!columnOrder.empty())
-        saveColumnOrder(columnOrder);
+    savePreferences();
 }
 
 //----------------------------------------------------------------------------
 
-wxListItemAttr* mmListCtrl::OnGetItemAttr(long row) const
+void mmListCtrl::createColumns()
 {
-    return (row % 2) ? attr2_.get() : attr1_.get();
-}
-
-// Set new column order. Called when closing the dialog using the "OK" button
-void mmListCtrl::saveColumnOrder(std::vector<int> columnList)
-{
-    if (columnList.empty())
-        columnList = m_column_order;
-
-    wxString columnOrder;
-    for (int col_enum : columnList) {
-        columnOrder.Append((columnOrder.IsEmpty() ? "" : "|") + wxString::Format("%i", col_enum));
+    loadPreferences();
+    for (int col_nr = 0; col_nr < getColNrSize(); ++col_nr) {
+        int col_id = getColId(col_nr);
+        ListColumnInfo col_info = m_col_id_info[col_id];
+        int col_width = isHiddenColId(col_id) ? 0 : m_col_id_width[col_id];
+        InsertColumn(col_nr, getColHeader(col_id), col_info.format, col_width);
     }
-    Model_Setting::instance().setString(m_col_type_str + "_COLUMNORDER", columnOrder);
-}
-
-// Get the current column order from the settings, or initialize a default order
-std::vector<int> mmListCtrl::loadColumnOrder()
-{
-    wxString order_str = Model_Setting::instance().getString(m_col_type_str + "_COLUMNORDER", "");
-    wxArrayString order_a = wxSplit(order_str, '|');
-    if (order_a.IsEmpty())
-        return m_column_order;
-
-    std::vector<int> order;
-    for (const auto& col_str : order_a) {
-        int col_id = wxAtoi(col_str);
-        if (std::find(m_column_order.begin(), m_column_order.end(), col_id) !=
-            m_column_order.end()
-        )
-            order.push_back(col_id);
-    }
-
-    // add missing columns
-    for (int col_id : m_column_order) {
-        if (std::find(order.begin(), order.end(), col_id) == order.end())
-            order.push_back(col_id);
-    }
-
-    return order;
-}
-
-void mmListCtrl::saveColumnWidth(int column_number, int column_width)
-{
-    if (m_col_width_fmt.IsEmpty())
-        return;
-
-    wxString key = wxString::Format(m_col_width_fmt, getColumnId(column_number));
-    Model_Setting::instance().setInt(key, column_width);
-}
-
-int mmListCtrl::loadColumnWidth(int column_number, int default_size)
-{
-    wxString key = wxString::Format(m_col_width_fmt, getColumnId(column_number));
-    return Model_Setting::instance().getInt(key, default_size);
 }
 
 wxString mmListCtrl::BuildPage(const wxString &title) const
@@ -142,18 +90,18 @@ wxString mmListCtrl::BuildPage(const wxString &title) const
     ) + eol;
 
     text << "<tr>" << eol;
-    for (int c = 0; c < GetColumnCount(); c++) {
-        wxListItem col;
-        col.SetMask(wxLIST_MASK_TEXT);
-        GetColumn(c, col);
-        text << "<th><i>" << col.GetText() << "</i></th>" << eol;
+    for (int col_nr = 0; col_nr < GetColumnCount(); ++col_nr) {
+        wxListItem col_item;
+        col_item.SetMask(wxLIST_MASK_TEXT);
+        GetColumn(col_nr, col_item);
+        text << "<th><i>" << col_item.GetText() << "</i></th>" << eol;
     }
     text << "</tr>" << eol;
 
-    for (int i = 0; i < GetItemCount(); i++) {
+    for (int row_nr = 0; row_nr < GetItemCount(); ++row_nr) {
         text << "<tr>" << eol;
-        for (int col = 0; col < GetColumnCount(); col++) {
-            text << "<td>" << wxListCtrl::GetItemText(i, col) << "</td>" << eol;
+        for (int col_nr = 0; col_nr < GetColumnCount(); ++col_nr) {
+            text << "<td>" << wxListCtrl::GetItemText(row_nr, col_nr) << "</td>" << eol;
         }
         text << eol << "</tr>" << eol;
     }
@@ -166,137 +114,230 @@ wxString mmListCtrl::BuildPage(const wxString &title) const
 
 //----------------------------------------------------------------------------
 
-void mmListCtrl::createColumns()
+const wxString mmListCtrl::getColHeader(int col_id, bool show_icon) const
 {
-    std::vector<int> columnOrder = loadColumnOrder();
-    std::vector<ListColumnInfo> columns = {};
-    for (unsigned int i = 0; i < columnOrder.size(); i++) {
-        unsigned int index = std::find(m_column_order.begin(), m_column_order.end(), columnOrder[i]) - m_column_order.begin();
-        if (index < m_columns.size())
-            columns.push_back(m_columns[index]);
-    }
-
-    m_column_order = columnOrder;
-    m_columns = columns;
-
-    for (const auto& entry : m_columns) {
-        int count = GetColumnCount();
-        wxString key = wxString::Format(m_col_width_fmt, getColumnId(count));
-        int width = Model_Setting::instance().getInt(key, entry.width);
-        InsertColumn(count, entry.header, entry.format, width);
-    }
-}
-
-int mmListCtrl::getColumnId(int col_nr) const
-{
-    return m_column_order.empty() ? col_nr : m_column_order[col_nr];
-}
-
-int mmListCtrl::getColumnNr(int col_id) const
-{
-    return m_column_order.empty() ? col_id :
-        std::find(m_column_order.begin(), m_column_order.end(), col_id) - m_column_order.begin();
+    ListColumnInfo col_info = m_col_id_info[col_id];
+    if (!show_icon && col_id == 0 && col_info.header == "Icon")
+        return " ";
+    return col_info.translate ? wxGetTranslation(col_info.header) : col_info.header;
 }
 
 //----------------------------------------------------------------------------
 
+wxListItemAttr* mmListCtrl::OnGetItemAttr(long row) const
+{
+    return (row % 2) ? attr2_.get() : attr1_.get();
+}
+
 void mmListCtrl::OnColClick(wxListEvent& WXUNUSED(event))
 {
-    // Default to do nothing and implement in derived class
+    // To be implemented in derived class
+}
+
+//----------------------------------------------------------------------------
+
+void mmListCtrl::savePreferences()
+{
+    savePreferences_v190();
+}
+
+void mmListCtrl::loadPreferences()
+{
+    loadPreferences_v190();
+}
+
+void mmListCtrl::savePreferences_v190()
+{
+    // save m_col_nr_id
+    if (!m_col_nr_id.empty() && !o_col_order_prefix.empty()) {
+        wxString order_str;
+        for (int col_id : m_col_nr_id)
+            order_str.Append((order_str.IsEmpty() ? "" : "|") + wxString::Format("%i", col_id));
+        Model_Setting::instance().setString(getColOrderKey_v190(), order_str);
+    }
+
+    // save m_col_id_width, m_col_id_hidden
+    if (!o_col_width_prefix.IsEmpty()) {
+        for (int col_nr = 0; col_nr < GetColumnCount(); ++col_nr) {
+            int col_id = getColId(col_nr);
+            Model_Setting::instance().setInt(
+                getColWidthKey_v190(col_id), GetColumnWidth(col_nr)
+            );
+        }
+    }
+
+    // save m_sort_col_id, m_sort_asc
+    bool asc_isInt = (m_sort_col_id.size() == 2);
+    for (int i = 0; i < static_cast<int>(m_sort_col_id.size()); ++i) {
+        Model_Setting::instance().setInt(getSortColKey_v190(i), getSortColNr(i));
+        saveBoolInt(getSortAscKey_v190(i), getSortAsc(i), asc_isInt);
+    }
+}
+
+void mmListCtrl::loadPreferences_v190()
+{
+    // load m_col_nr_id if columns can be ordered
+    if (!m_col_nr_id.empty() && !o_col_order_prefix.empty()) {
+        wxString order_str = Model_Setting::instance().getString(getColOrderKey_v190(), "");
+        wxArrayString col_nr_idstr = wxSplit(order_str, '|');
+        std::vector<int> col_nr_id;
+        for (const auto& col_idstr : col_nr_idstr) {
+            int col_id = wxAtoi(col_idstr);
+            if (isValidColId(col_id) &&
+                std::find(col_nr_id.begin(), col_nr_id.end(), col_id) == col_nr_id.end()
+            )
+                col_nr_id.push_back(col_id);
+        }
+        for (int col_id : m_col_nr_id) {
+            if (std::find(col_nr_id.begin(), col_nr_id.end(), col_id) == col_nr_id.end())
+                col_nr_id.push_back(col_id);
+        }
+        m_col_nr_id = col_nr_id;
+    }
+
+    // load m_col_id_width, m_col_id_hidden
+    m_col_id_width.clear();
+    m_col_id_hidden.clear();
+    for (int col_id = 0; col_id < getColIdSize(); ++col_id) {
+        ListColumnInfo col_info = m_col_id_info[col_id];
+        int col_width = col_info.default_width;
+        if (!o_col_width_prefix.empty()) {
+            col_width = Model_Setting::instance().getInt(
+                getColWidthKey_v190(col_id), col_info.default_width
+            );
+        }
+        if (col_width == 0) {
+            m_col_id_hidden.insert(col_id);
+            col_width = col_info.default_width;
+        }
+        m_col_id_width.push_back(col_width);
+    }
+
+    // load m_sort_col_id, m_sort_asc
+    // NOTE:
+    //   *_SORT_COL* represents a col_nr in TransactionListCtrl (others have a bug).
+    //   *_ASC* is stored as Int in TransactionListCtrl, or as Bool otherwise.
+    //   Only TransactionListCtrl has two sorting columns.
+    bool asc_isInt = (m_sort_col_id.size() == 2);
+    if (c_sort_col_nr.size() != m_sort_col_id.size())
+        c_sort_col_nr = std::vector<int>(m_sort_col_id.size(), -1);
+    if (m_sort_asc.size() != m_sort_col_id.size())
+        m_sort_asc = std::vector<bool>(m_sort_col_id.size(), true);
+    for (int i = 0; i < static_cast<int>(m_sort_col_id.size()); ++i) {
+        int col_nr = Model_Setting::instance().getInt(getSortColKey_v190(i), -1);
+        int col_id = isValidColNr(col_nr) ? getColId(col_nr) : m_sort_col_id[i];
+        bool asc = loadBoolInt(getSortAscKey_v190(i), m_sort_asc[i], asc_isInt);
+        if (isValidColId(col_id)) {
+            m_sort_col_id[i] = col_id;
+            m_sort_asc[i] = asc;
+        }
+    }
+}
+
+void mmListCtrl::saveBoolInt(const wxString& key, bool value, bool isInt)
+{
+    if (isInt)
+        Model_Setting::instance().setInt(key, (value ? 1 : 0));
+    else
+        Model_Setting::instance().setBool(key, value);
+}
+
+bool mmListCtrl::loadBoolInt(const wxString& key, bool default_value, bool isInt) const
+{
+    return isInt ?
+        Model_Setting::instance().getInt(key, (default_value ? 1 : 0)) != 0 :
+        Model_Setting::instance().getBool(key, default_value);
+}
+
+//----------------------------------------------------------------------------
+
+int mmListCtrl::cacheSortColNr(int i)
+{
+    int col_id = m_sort_col_id[i];
+    int col_nr = isValidColId(col_id) ? getColNr(col_id) : -1;
+    c_sort_col_nr[i] = col_nr;
+    return col_nr;
 }
 
 //----------------------------------------------------------------------------
 
 void mmListCtrl::onItemResize(wxListEvent& event)
 {
-    int i = event.GetColumn();
-    int width = GetColumnWidth(i);
-    if (!m_col_width_fmt.IsEmpty()) {
-        wxString key = wxString::Format(m_col_width_fmt, getColumnId(i));
-        Model_Setting::instance().setInt(key, width);
-    }
+    // update m_col_id_width but do not save in Setting
+    int col_nr = event.GetColumn();
+    int col_id = getColId(col_nr);
+    int col_width = GetColumnWidth(col_nr);
+    m_col_id_width[col_id] = col_width;
 }
 
 void mmListCtrl::onColRightClick(wxListEvent& event)
 {
-    if (m_columns.size() == 0 || m_col_width_fmt.IsEmpty())
-        return;
-
-    m_ColumnHeaderNbr = event.GetColumn();
-    if (m_ColumnHeaderNbr < 0 || m_ColumnHeaderNbr >= static_cast<int>(m_columns.size()))
+    m_col_nr = event.GetColumn();
+    if (!isValidColNr(m_col_nr))
         return;
 
     wxMenu menu;
-    wxMenu *submenu = new wxMenu;
-    for (int i = 0; i < static_cast<int>(m_columns.size()); i++) {
-        int id = MENU_HEADER_COLUMN + i;
-        submenu->AppendCheckItem(id, m_columns[i].header);
-        wxString key = wxString::Format(m_col_width_fmt, getColumnId(i));
-        int width = Model_Setting::instance().getInt(key, m_columns[i].width);
-        submenu->Check(id, width != 0);
+    // hide and show columns
+    wxMenu *menu_toggle = new wxMenu;
+    for (int col_nr = 0; col_nr < getColNrSize(); col_nr++) {
+        int event_id = MENU_HEADER_TOGGLE_MIN + col_nr;
+        if (event_id > MENU_HEADER_TOGGLE_MAX)
+            break;
+        int col_id = getColId(col_nr);
+        menu_toggle->AppendCheckItem(event_id, getColHeader(col_id, true));
+        menu_toggle->Check(event_id, !isHiddenColId(col_id));
     }
-    menu.AppendSubMenu(submenu, _t("Hide/Show Columns"));
+    menu.AppendSubMenu(menu_toggle, _t("Hide/Show column"));
     menu.Append(MENU_HEADER_HIDE, _t("Hide this column"));
-    if (m_default_sort_column >= 0 && m_columns[m_ColumnHeaderNbr].sortable)
-        menu.Append(MENU_HEADER_SORT, _t("Order by this column"));
-    // Do not show e.g. for Assets root list. Only for sublists.
-    if (m_column_order.size() > 0) {
-        menu.Append(MENU_HEADER_MOVE_LEFT, _t("Move column left"));
-        menu.Append(MENU_HEADER_MOVE_RIGHT, _t("Move column right"));
+
+    // move columns
+    if (m_col_nr_id.size() > 0) {
+        wxMenu *menu_show = new wxMenu;
+        bool found = false;
+        for (int col_nr = 0; col_nr < getColNrSize(); col_nr++) {
+            int event_id = MENU_HEADER_SHOW_MIN + col_nr;
+            if (event_id > MENU_HEADER_SHOW_MAX)
+                break;
+            int col_id = getColId(col_nr);
+            if (isHiddenColId(col_id)) {
+                menu_show->Append(event_id, getColHeader(col_id, true));
+                found = true;
+            }
+        }
+        if (found)
+            menu.AppendSubMenu(menu_show, _t("Move hidden column"));
+        if (m_col_nr > 0)
+            menu.Append(MENU_HEADER_MOVE_LEFT, _t("Move column left"));
+        if (m_col_nr < getColNrSize() - 1)
+            menu.Append(MENU_HEADER_MOVE_RIGHT, _t("Move column right"));
     }
-    menu.Append(MENU_HEADER_RESET, _t("Reset columns"));
+
+    if (m_col_id_info[getColId(m_col_nr)].sortable)
+        menu.Append(MENU_HEADER_SORT, _t("Sort by this column"));
+
+    menu.Append(MENU_HEADER_RESET, _t("Reset column widths"));
+
     PopupMenu(&menu);
-    this->SetFocus();
+    SetFocus();
 }
 
 void mmListCtrl::onHeaderPopup(wxCommandEvent& event)
 {
-    switch (event.GetId()) {
-    case MENU_HEADER_HIDE:
-        onHeaderHide(event);
-        break;
-    case MENU_HEADER_SORT:
+    int event_id = event.GetId();
+    if (event_id == MENU_HEADER_SORT)
         onHeaderSort(event);
-        break;
-    case MENU_HEADER_MOVE_LEFT:
+    else if (event_id >= MENU_HEADER_TOGGLE_MIN && event_id <= MENU_HEADER_TOGGLE_MAX)
+        onHeaderToggle(event);
+    else if (event_id == MENU_HEADER_HIDE)
+        onHeaderHide(event);
+    else if (event_id >= MENU_HEADER_SHOW_MIN && event_id <= MENU_HEADER_SHOW_MAX)
+        onHeaderShow(event);
+    else if (event_id == MENU_HEADER_MOVE_LEFT)
         onHeaderMove(event, -1);
-        break;
-    case MENU_HEADER_MOVE_RIGHT:
+    else if (event_id == MENU_HEADER_MOVE_RIGHT)
         onHeaderMove(event, 1);
-        break;
-    case MENU_HEADER_RESET:
+    else if (event_id == MENU_HEADER_RESET)
         onHeaderReset(event);
-        break;
-    default:
-        onHeaderColumn(event);
-    }
-}
-
-void mmListCtrl::onHeaderColumn(wxCommandEvent& event)
-{
-    int id = event.GetId();
-    int columnNbr = id - MENU_HEADER_COLUMN;
-    if (columnNbr < 0 || columnNbr >= static_cast<int>(m_columns.size()) || m_col_width_fmt.IsEmpty())
-        return;
-
-    int default_width = m_columns[columnNbr].width;
-    if (default_width == 0)
-        default_width = wxLIST_AUTOSIZE_USEHEADER;
-    const wxString parameter_name = wxString::Format(m_col_width_fmt, getColumnId(columnNbr));
-    int cur_width = Model_Setting::instance().getInt(parameter_name, default_width);
-    int new_width = (cur_width != 0 ? 0 : default_width);
-    SetColumnWidth(columnNbr, new_width);
-    Model_Setting::instance().setInt(parameter_name, GetColumnWidth(columnNbr));
-}
-
-void mmListCtrl::onHeaderHide(wxCommandEvent& WXUNUSED(event))
-{
-    if (m_ColumnHeaderNbr < 0 || m_col_width_fmt.IsEmpty())
-        return;
-
-    SetColumnWidth(m_ColumnHeaderNbr, 0);
-    const wxString key = wxString::Format(m_col_width_fmt, getColumnId(m_ColumnHeaderNbr));
-    Model_Setting::instance().setInt(key, 0);
 }
 
 void mmListCtrl::onHeaderSort(wxCommandEvent& WXUNUSED(event))
@@ -306,97 +347,163 @@ void mmListCtrl::onHeaderSort(wxCommandEvent& WXUNUSED(event))
     OnColClick(e);
 }
 
-void mmListCtrl::onHeaderReset(wxCommandEvent& WXUNUSED(event))
+void mmListCtrl::onHeaderToggle(wxCommandEvent& event)
 {
-    wxString parameter_name;
+    int col_nr = event.GetId() - MENU_HEADER_TOGGLE_MIN;
+    if (!isValidColNr(col_nr))
+        return;
     Freeze();
-    for (int i = 0; i < static_cast<int>(m_columns.size()); i++) {
-        SetColumnWidth(i, m_columns[i].width);
-        if (!m_col_width_fmt.IsEmpty()) {
-            parameter_name = wxString::Format(m_col_width_fmt, getColumnId(i));
-            Model_Setting::instance().setInt(parameter_name, GetColumnWidth(i));
-        }
+    int col_id = getColId(col_nr);
+    bool cur_hidden = (m_col_id_hidden.find(col_id) != m_col_id_hidden.end());
+    int new_width;
+    if (cur_hidden) {
+        m_col_id_hidden.erase(col_id);
+        new_width = m_col_id_width[col_id];
+        if (new_width == 0) new_width = m_col_id_info[col_id].default_width;
     }
-    wxListEvent e;
-    e.SetId(MENU_HEADER_RESET);
-    m_ColumnHeaderNbr = m_default_sort_column;
-    m_asc = true;
-    OnColClick(e);
+    else {
+        m_col_id_width[col_id] = GetColumnWidth(col_nr);
+        m_col_id_hidden.insert(col_id);
+        new_width = 0;
+    }
+    SetColumnWidth(col_nr, new_width);
+    savePreferences();
+    Thaw();
+}
+
+void mmListCtrl::onHeaderHide(wxCommandEvent& WXUNUSED(event))
+{
+    if (!isValidColNr(m_col_nr))
+        return;
+    Freeze();
+    int col_id = getColId(m_col_nr);
+    m_col_id_width[col_id] = GetColumnWidth(m_col_nr);
+    m_col_id_hidden.insert(col_id);
+    SetColumnWidth(m_col_nr, 0);
+    savePreferences();
+    Thaw();
+}
+
+void mmListCtrl::onHeaderShow(wxCommandEvent& event)
+{
+    if (m_col_nr_id.empty())
+        return;
+    if (!isValidColNr(m_col_nr))
+        return;
+    int cur_nr = event.GetId() - MENU_HEADER_SHOW_MIN;
+    if (!isValidColNr(cur_nr))
+        return;
+    Freeze();
+
+    // show hidden column cur_nr
+    int cur_id = getColId(cur_nr);
+    m_col_id_hidden.erase(cur_id);
+    int cur_width = m_col_id_width[cur_id];
+    if (cur_width == 0) cur_width = m_col_id_info[cur_id].default_width;
+    SetColumnWidth(cur_nr, cur_width);
+
+    // move cur_nr to the right of m_col_nr
+    while (cur_nr != m_col_nr && cur_nr != m_col_nr + 1) {
+        int new_nr = cur_nr + (cur_nr < m_col_nr ? 1 : -1);
+        int cur_id = getColId(cur_nr);
+        int new_id = getColId(new_nr);
+        wxLogDebug("mmListCtrl::onHeaderShow(): swap columns %d (%s) <-> %d (%s)",
+            cur_nr, m_col_id_info[cur_id].header,
+            new_nr, m_col_id_info[new_id].header
+        );
+        std::swap(m_col_nr_id[new_nr], m_col_nr_id[cur_nr]);
+        wxListItem cur_item, new_item;
+        cur_item.SetText(getColHeader(cur_id));
+        cur_item.SetAlign(static_cast<wxListColumnFormat>(m_col_id_info[cur_id].format));
+        new_item.SetText(getColHeader(new_id));
+        new_item.SetAlign(static_cast<wxListColumnFormat>(m_col_id_info[new_id].format));
+        int cur_width = GetColumnWidth(cur_nr);
+        int new_width = GetColumnWidth(new_nr);
+        SetColumn(cur_nr, new_item); SetColumnWidth(cur_nr, new_width);
+        SetColumn(new_nr, cur_item); SetColumnWidth(new_nr, cur_width);
+        std::swap(new_nr, cur_nr);
+    }
+    savePreferences();
+
     Thaw();
 }
 
 void mmListCtrl::onHeaderMove(wxCommandEvent& WXUNUSED(event), int direction)
 {
+    if (m_col_nr_id.empty())
+        return;
     Freeze();
 
     #ifdef wxHAS_LISTCTRL_COLUMN_ORDER
     // on Windows the visual order can differ from the array order due to drag/drop
     // so we need to realign them before adjusting the column orders programatically
-    std::vector<int> realColumns, widths;
-
-    wxArrayInt columnorder;
-
-    std::vector<ListColumnInfo> columns;
-    bool reindexSelection = false;
-    for (int i = 0; i < m_columns.size(); i++) {
+    std::vector<int> new_nr_order;
+    std::vector<int> new_nr_id;
+    bool col_found = false;
+    for (int new_nr = 0; new_nr < getColNrSize(); ++new_nr) {
         // we will reset the visual indices in sequential order
-        columnorder.push_back(i);
-
+        new_nr_order.push_back(new_nr);
         // get the true index from the visual column position
-        int index = GetColumnIndexFromOrder(i);
-
-        // update the selected column index
-        if (index == m_ColumnHeaderNbr && !reindexSelection) {
-            m_ColumnHeaderNbr = i;
-            reindexSelection = true;
+        int cur_nr = GetColumnIndexFromOrder(new_nr);
+        // update m_col_nr
+        if (!col_found && m_col_nr == cur_nr) {
+            col_found = true;
+            m_col_nr = new_nr;
         }
-
-        realColumns.push_back(m_column_order[index]);
-        columns.push_back(m_columns[index]);
-        int width = GetColumnWidth(i);
-        wxListItem column;
-        column.SetText(m_columns[index].header);
-        column.SetAlign(static_cast<wxListColumnFormat>(m_columns[index].format));
-        SetColumn(i, column);
-        SetColumnWidth(i, width);
+        int new_id = m_col_nr_id[cur_nr];
+        ListColumnInfo new_info = m_col_id_info[new_id];
+        new_nr_id.push_back(new_id);
+        wxListItem new_item;
+        new_item.SetText(getColHeader(new_id));
+        new_item.SetAlign(static_cast<wxListColumnFormat>(new_info.format));
+        int new_width = GetColumnWidth(new_nr);
+        SetColumn(new_nr, new_item);
+        SetColumnWidth(new_nr, new_width);
     }
-
-    SetColumnsOrder(columnorder);
-    m_column_order = realColumns;
-    m_columns = columns;
+    SetColumnsOrder(new_nr_order);
+    m_col_nr_id = new_nr_id;
     #endif
 
     // find the next visible column
-    int distance = direction;
-    while (m_ColumnHeaderNbr + distance > 0 &&
-        m_ColumnHeaderNbr + distance < static_cast<int>(m_columns.size()) - 1 &&
-        GetColumnWidth(m_ColumnHeaderNbr + distance) == 0
-    ) {
-        distance += direction;
+    int cur_nr = m_col_nr;
+    int new_nr = cur_nr + direction;
+    while (isValidColNr(new_nr) && isHiddenColNr(new_nr))
+        new_nr += direction;
+    if (isValidColNr(new_nr)) {
+        int cur_id = getColId(cur_nr);
+        int new_id = getColId(new_nr);
+        wxLogDebug("mmListCtrl::onHeaderMove(): swap columns %d (%s) <-> %d (%s)",
+            cur_nr, m_col_id_info[cur_id].header,
+            new_nr, m_col_id_info[new_id].header
+        );
+        std::swap(m_col_nr_id[new_nr], m_col_nr_id[cur_nr]);
+        wxListItem cur_item, new_item;
+        cur_item.SetText(getColHeader(cur_id));
+        cur_item.SetAlign(static_cast<wxListColumnFormat>(m_col_id_info[cur_id].format));
+        new_item.SetText(getColHeader(new_id));
+        new_item.SetAlign(static_cast<wxListColumnFormat>(m_col_id_info[new_id].format));
+        int cur_width = GetColumnWidth(cur_nr);
+        int new_width = GetColumnWidth(new_nr);
+        SetColumn(cur_nr, new_item); SetColumnWidth(cur_nr, new_width);
+        SetColumn(new_nr, cur_item); SetColumnWidth(new_nr, cur_width);
+        savePreferences();
     }
-    wxLogDebug("Moving column %d (%s) %d", m_ColumnHeaderNbr, m_columns[m_ColumnHeaderNbr].header.c_str(), distance);
-    if (m_ColumnHeaderNbr + distance >= 0 &&
-        static_cast<int>(m_columns.size()) > m_ColumnHeaderNbr + distance &&
-        static_cast<int>(m_column_order.size()) > m_ColumnHeaderNbr + distance
-    ) {
-        // swap order of column data
-        std::swap(m_column_order[m_ColumnHeaderNbr + distance], m_column_order[m_ColumnHeaderNbr]);
-        std::swap(m_columns[m_ColumnHeaderNbr + distance], m_columns[m_ColumnHeaderNbr]);
-        saveColumnOrder(m_column_order);
-    
-        // swap column headers & widths
-        wxListItem col1, col2;
-        col1.SetText(m_columns[m_ColumnHeaderNbr].header);
-        col1.SetAlign(static_cast<wxListColumnFormat>(m_columns[m_ColumnHeaderNbr].format));
-        col2.SetText(m_columns[m_ColumnHeaderNbr + distance].header);
-        col2.SetAlign(static_cast<wxListColumnFormat>(m_columns[m_ColumnHeaderNbr + distance].format));
-        int width = GetColumnWidth(m_ColumnHeaderNbr);
-        SetColumn(m_ColumnHeaderNbr, col1);
-        SetColumnWidth(m_ColumnHeaderNbr, GetColumnWidth(m_ColumnHeaderNbr + distance));
-        SetColumn(m_ColumnHeaderNbr + distance, col2);
-        SetColumnWidth(m_ColumnHeaderNbr + distance, width);
-        Thaw();
+
+    Thaw();
+}
+
+void mmListCtrl::onHeaderReset(wxCommandEvent& WXUNUSED(event))
+{
+    Freeze();
+    m_col_id_hidden.clear();
+    for (int col_nr = 0; col_nr < getColNrSize(); ++col_nr) {
+        int col_id = getColId(col_nr);
+        int col_width = m_col_id_info[col_id].default_width;
+        m_col_id_width[col_id] = col_width;
+        SetColumnWidth(col_nr, col_width);
     }
+    savePreferences();
+    Thaw();
 }
 
 //----------------------------------------------------------------------------

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -2,6 +2,7 @@
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2015 James Higley
  Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
+ Copyright (C) 2025 George Ef (george.a.ef@gmail.com)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -20,74 +21,203 @@
 
 #pragma once
 
+#include <unordered_set>
 #include "util.h"
-#include "wx/event.h"
+#include <wx/event.h>
 #include <wx/webview.h>
 #include <wx/webviewfshandler.h>
 
-typedef struct {
+// short names for wx macros
+#define _WA wxLIST_AUTOSIZE
+#define _WH wxLIST_AUTOSIZE_USEHEADER
+#define _FL wxLIST_FORMAT_LEFT
+#define _FR wxLIST_FORMAT_RIGHT
+#define _FC wxLIST_FORMAT_CENTER
+
+struct ListColumnInfo
+{
+    int id;
+    bool translate;
     wxString header;
-    int width;
+    int default_width;
     int format;
     bool sortable;
-} ListColumnInfo;
+
+    static const std::vector<int> getId(const std::vector<ListColumnInfo>& a_info);
+};
+
+//----------------------------------------------------------------------------
 
 class mmListCtrl : public wxListCtrl
 {
+protected:
+    wxDECLARE_EVENT_TABLE();
+    enum {
+        MENU_HEADER_SORT = wxID_HIGHEST + 2000,
+        MENU_HEADER_TOGGLE_MIN,
+        MENU_HEADER_TOGGLE_MAX = MENU_HEADER_TOGGLE_MIN + 99,
+        MENU_HEADER_HIDE,
+        MENU_HEADER_SHOW_MIN,
+        MENU_HEADER_SHOW_MAX = MENU_HEADER_SHOW_MIN + 99,
+        MENU_HEADER_MOVE_LEFT,
+        MENU_HEADER_MOVE_RIGHT,
+        MENU_HEADER_RESET,
+    };
+
 public:
-    std::vector<int> m_column_order;       // map: col_nr -> col_id
-    std::vector<ListColumnInfo> m_columns; // map: col_nr -> ListColumnInfo
-    int m_default_sort_column = -1;
-    bool m_asc = true;
-    long m_selected_row = -1;
-    int m_selected_col = 0;
-    wxString m_col_width_fmt;
-    wxString m_col_type_str;
-    wxSharedPtr<wxListItemAttr> attr1_, attr2_; // style1, style2
+    // configured by constructor (cannot be updated)
+    const wxSharedPtr<wxListItemAttr> attr1_, attr2_; // style1, style2
+
+    // configured by constructor (but may be updated)
+    wxString o_col_order_prefix;               // v1.9.0 prefix for column order
+    wxString o_col_width_prefix;               // v1.9.0 prefix for column width
+    wxString o_sort_prefix;                    // v1.9.0 prefix for sort
+    std::vector<ListColumnInfo> m_col_id_info; // map: col_id -> col_info
+
+    // dynamic
+    std::vector<int> m_col_nr_id;              // map: col_nr -> col_id; or empty
+    std::vector<int> m_col_id_width;           // map: col_id -> col_width (lazy)
+    std::unordered_set<int> m_col_id_hidden;   // set: col_id -> hidden
+    std::vector<int> m_sort_col_id;            // sorting col_id; can be empty
+    std::vector<bool> m_sort_asc;              // sorting direction
+    int m_col_nr = -1;                         // updated by onColRightClick()
+
+private:
+    std::vector<int> c_sort_col_nr;            // sorting col_nr (cache)
 
 public:
     mmListCtrl(wxWindow *parent, wxWindowID winid);
     virtual ~mmListCtrl();
 
-    virtual wxListItemAttr* OnGetItemAttr(long row) const;
-
-    void saveColumnOrder(std::vector<int> columnList);
-    std::vector<int> loadColumnOrder();
-    void saveColumnWidth(int column_number, int column_width);
-    int loadColumnWidth(int column_number, int default_size = wxLIST_AUTOSIZE);
+    void createColumns();
     wxString BuildPage(const wxString &title) const;
 
-protected:
-    wxDECLARE_EVENT_TABLE();
-    enum {
-        MENU_HEADER_HIDE = wxID_HIGHEST + 2000,
-        MENU_HEADER_SORT,
-        MENU_HEADER_RESET,
-        MENU_HEADER_MOVE_LEFT,
-        MENU_HEADER_MOVE_RIGHT,
-        MENU_HEADER_COLUMN, // Must be last in list
-    };
+public:
+    int getColIdSize() const;
+    int getColNrSize() const;
+    bool isValidColId(int col_id) const;
+    bool isValidColNr(int col_nr) const;
+    int getColId(int col_nr) const;
+    int getColNr(int col_id) const;
+    const wxString getColHeader(int col_id, bool show_icon = false) const;
+    bool isHiddenColId(int col_id) const;
+    bool isHiddenColNr(int col_id) const;
+    int getSortColId(int i = 0) const;
+    int getSortColNr(int i = 0);
+    bool getSortAsc(int i = 0) const;
+    void savePreferences();
+    void loadPreferences();
+
+private:
+    int cacheSortColNr(int i);
+
+    // backwards compatibility
+    const wxString getColOrderKey_v190() const;
+    const wxString getColWidthKey_v190(int col_id) const;
+    const wxString getSortColKey_v190(int i = 0) const;
+    const wxString getSortAscKey_v190(int i = 0) const;
+    void savePreferences_v190();
+    void loadPreferences_v190();
+    void saveBoolInt(const wxString& key, bool value, bool isInt);
+    bool loadBoolInt(const wxString& key, bool default_value, bool isInt) const;
 
 protected:
-    int m_ColumnHeaderNbr = -1;
-
-protected:
-    void createColumns();
-    int getColumnId(int col_nr) const;
-    int getColumnNr(int col_id) const;
-
+    virtual wxListItemAttr* OnGetItemAttr(long row) const;
     virtual void OnColClick(wxListEvent& event);
 
+private:
     void onItemResize(wxListEvent& event);
     void onColRightClick(wxListEvent& event);
     // Headers Right Click
     void onHeaderPopup(wxCommandEvent& event);
-    void onHeaderColumn(wxCommandEvent& event);
-    void onHeaderHide(wxCommandEvent& WXUNUSED(event));
     void onHeaderSort(wxCommandEvent& event);
-    void onHeaderReset(wxCommandEvent& WXUNUSED(event));
+    void onHeaderToggle(wxCommandEvent& event);
+    void onHeaderHide(wxCommandEvent& WXUNUSED(event));
+    void onHeaderShow(wxCommandEvent& WXUNUSED(event));
     void onHeaderMove(wxCommandEvent& WXUNUSED(event), int direction);
+    void onHeaderReset(wxCommandEvent& WXUNUSED(event));
 };
+
+inline int mmListCtrl::getColIdSize() const
+{
+    return static_cast<int>(m_col_id_info.size());
+}
+
+inline int mmListCtrl::getColNrSize() const
+{
+    return !m_col_nr_id.empty() ?
+        static_cast<int>(m_col_nr_id.size()) :
+        static_cast<int>(m_col_id_info.size());
+}
+
+inline bool mmListCtrl::isValidColId(int col_id) const
+{
+    return (col_id >= 0 && col_id < static_cast<int>(m_col_id_info.size()));
+}
+
+inline bool mmListCtrl::isValidColNr(int col_nr) const
+{
+    return (col_nr >= 0 && col_nr < getColNrSize());
+}
+
+inline int mmListCtrl::getColId(int col_nr) const
+{
+    return m_col_nr_id.empty() ? col_nr : m_col_nr_id[col_nr];
+}
+
+inline int mmListCtrl::getColNr(int col_id) const
+{
+    return m_col_nr_id.empty() ? col_id :
+        std::find(m_col_nr_id.begin(), m_col_nr_id.end(), col_id) - m_col_nr_id.begin();
+}
+
+inline bool mmListCtrl::isHiddenColId(int col_id) const
+{
+    return m_col_id_hidden.find(col_id) != m_col_id_hidden.end();
+}
+
+inline bool mmListCtrl::isHiddenColNr(int col_nr) const
+{
+    return isHiddenColId(getColId(col_nr));
+}
+
+inline int mmListCtrl::getSortColId(int i) const
+{
+    return m_sort_col_id[i];
+}
+
+inline int mmListCtrl::getSortColNr(int i)
+{
+    int col_id = m_sort_col_id[i];
+    int col_nr = c_sort_col_nr[i];
+    return (isValidColNr(col_nr) && getColId(col_nr) == col_id) ? col_nr :
+        cacheSortColNr(i);
+}
+
+inline bool mmListCtrl::getSortAsc(int i) const
+{
+    return m_sort_asc[i];
+}
+
+inline const wxString mmListCtrl::getColOrderKey_v190() const
+{
+    return o_col_order_prefix + "_COLUMNORDER";
+}
+
+inline const wxString mmListCtrl::getColWidthKey_v190(int col_id) const
+{
+    return wxString::Format(o_col_width_prefix + "%d_WIDTH", col_id);
+}
+
+inline const wxString mmListCtrl::getSortColKey_v190(int i) const
+{
+    return wxString::Format("%s_SORT_COL%s", o_sort_prefix, (i == 1 ? "2" : ""));
+}
+
+inline const wxString mmListCtrl::getSortAscKey_v190(int i) const
+{
+    return wxString::Format("%s_ASC%s", o_sort_prefix, (i == 1 ? "2" : ""));
+}
 
 //----------------------------------------------------------------------------
 
@@ -99,7 +229,7 @@ public:
 
     virtual wxString BuildPage() const;
     virtual void PrintPage();
-    virtual void sortTable() = 0;
+    virtual void sortList() = 0;
 
     void windowsFreezeThaw();
 };

--- a/src/mmreportspanel.h
+++ b/src/mmreportspanel.h
@@ -51,7 +51,7 @@ public:
         const wxString& name = "mmReportsPanel");
 
     void CreateControls();
-    void sortTable() {}
+    void sortList() {}
 
     bool saveReportText(bool initial = true);
     mmPrintableBase* getPrintableBase();

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -45,48 +45,45 @@ enum class ico { GAIN, LOSS, ARROW_UP, ARROW_DOWN };
 /*******************************************************/
 
 wxBEGIN_EVENT_TABLE(StocksListCtrl, mmListCtrl)
-    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, StocksListCtrl::OnListItemActivated)
-    EVT_LIST_ITEM_SELECTED(wxID_ANY, StocksListCtrl::OnListItemSelected)
-    EVT_LIST_KEY_DOWN(wxID_ANY, StocksListCtrl::OnListKeyDown)
-    EVT_MENU(MENU_TREEPOPUP_NEW, StocksListCtrl::OnNewStocks)
-    EVT_MENU(MENU_TREEPOPUP_EDIT, StocksListCtrl::OnEditStocks)
-    EVT_MENU(MENU_TREEPOPUP_ADDTRANS, StocksListCtrl::OnEditStocks)
-    EVT_MENU(MENU_TREEPOPUP_VIEWTRANS, StocksListCtrl::OnEditStocks)
-    EVT_MENU(MENU_TREEPOPUP_DELETE, StocksListCtrl::OnDeleteStocks)
-    EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, StocksListCtrl::OnOrganizeAttachments)
-    EVT_MENU(wxID_INDEX, StocksListCtrl::OnStockWebPage)
-    EVT_RIGHT_DOWN(StocksListCtrl::OnMouseRightClick)
     EVT_LEFT_DOWN(StocksListCtrl::OnListLeftClick)
+    EVT_RIGHT_DOWN(StocksListCtrl::OnMouseRightClick)
+
+    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, StocksListCtrl::OnListItemActivated)
+    EVT_LIST_ITEM_SELECTED(wxID_ANY,  StocksListCtrl::OnListItemSelected)
+    EVT_LIST_KEY_DOWN(wxID_ANY,       StocksListCtrl::OnListKeyDown)
+
+    EVT_MENU(MENU_TREEPOPUP_NEW,                  StocksListCtrl::OnNewStocks)
+    EVT_MENU(MENU_TREEPOPUP_EDIT,                 StocksListCtrl::OnEditStocks)
+    EVT_MENU(MENU_TREEPOPUP_ADDTRANS,             StocksListCtrl::OnEditStocks)
+    EVT_MENU(MENU_TREEPOPUP_VIEWTRANS,            StocksListCtrl::OnEditStocks)
+    EVT_MENU(MENU_TREEPOPUP_DELETE,               StocksListCtrl::OnDeleteStocks)
+    EVT_MENU(MENU_TREEPOPUP_ORGANIZE_ATTACHMENTS, StocksListCtrl::OnOrganizeAttachments)
+    EVT_MENU(wxID_INDEX,                          StocksListCtrl::OnStockWebPage)
 wxEND_EVENT_TABLE()
 
-const std::vector<ListColumnInfo> StocksListCtrl::col_info_all()
-{
-    return {
-        { " ",                       25,                        wxLIST_FORMAT_LEFT,  false },
-        { _t("ID"),                   wxLIST_AUTOSIZE,           wxLIST_FORMAT_RIGHT, true },
-        { _t("*Date"),                wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Company Name"),         wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Symbol"),               wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Share Total"),          wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Avg Share Price"),      wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Total Cost"),           wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Realized Gain/Loss"),   wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Unrealized Gain/Loss"), wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Curr. Share Price"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Curr. Total Value"),    wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Price Date"),           wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-        { _t("Commission"),           wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_RIGHT, true },
-        { _t("Notes"),                wxLIST_AUTOSIZE_USEHEADER, wxLIST_FORMAT_LEFT,  true },
-    };
-}
+const std::vector<ListColumnInfo> StocksListCtrl::LISTCOL_INFO = {
+    { LISTCOL_ID_ICON,           true, _n("Icon"),                 25,  _FL, false },
+    { LISTCOL_ID_ID,             true, _n("ID"),                   _WA, _FR, true },
+    { LISTCOL_ID_DATE,           true, _n("*Date"),                _WH, _FL, true },
+    { LISTCOL_ID_NAME,           true, _n("Company Name"),         _WH, _FL, true },
+    { LISTCOL_ID_SYMBOL,         true, _n("Symbol"),               _WH, _FL, true },
+    { LISTCOL_ID_NUMBER,         true, _n("Share Total"),          _WH, _FR, true },
+    { LISTCOL_ID_PRICE,          true, _n("Avg Share Price"),      _WH, _FR, true },
+    { LISTCOL_ID_VALUE,          true, _n("Total Cost"),           _WH, _FR, true },
+    { LISTCOL_ID_REAL_GAIN_LOSS, true, _n("Realized Gain/Loss"),   _WH, _FR, true },
+    { LISTCOL_ID_GAIN_LOSS,      true, _n("Unrealized Gain/Loss"), _WH, _FR, true },
+    { LISTCOL_ID_CURRENT,        true, _n("Curr. Share Price"),    _WH, _FR, true },
+    { LISTCOL_ID_CURRVALUE,      true, _n("Curr. Total Value"),    _WH, _FR, true },
+    { LISTCOL_ID_PRICEDATE,      true, _n("Price Date"),           _WH, _FL, true },
+    { LISTCOL_ID_COMMISSION,     true, _n("Commission"),           _WH, _FR, true },
+    { LISTCOL_ID_NOTES,          true, _n("Notes"),                _WH, _FL, true },
+};
 
-StocksListCtrl::~StocksListCtrl()
-{
-}
-
-StocksListCtrl::StocksListCtrl(mmStocksPanel* cp, wxWindow *parent, wxWindowID winid)
-    : mmListCtrl(parent, winid)
-    , m_stock_panel(cp)
+StocksListCtrl::StocksListCtrl(
+    mmStocksPanel* cp, wxWindow *parent, wxWindowID winid
+) :
+    mmListCtrl(parent, winid),
+    m_stock_panel(cp)
 {
     wxVector<wxBitmapBundle> images;
     images.push_back(mmBitmapBundle(png::PROFIT));
@@ -97,23 +94,21 @@ StocksListCtrl::StocksListCtrl(mmStocksPanel* cp, wxWindow *parent, wxWindowID w
     SetSmallImages(images);
     mmThemeMetaColour(this, meta::COLOR_LISTPANEL);
 
-    // load the global variables
-    m_selected_col = Model_Setting::instance().getInt("STOCKS_SORT_COL", col_sort());
-    m_asc = Model_Setting::instance().getBool("STOCKS_ASC", true);
-
-    m_columns = col_info_all();
-    for (int i = 0; i < LIST_COL_size; ++i)
-        m_column_order.push_back(i);
-    m_col_width_fmt = "STOCKS_COL%d_WIDTH";
-    m_col_type_str = "STOCKS";
-    m_default_sort_column = col_sort();
-
+    o_col_order_prefix = "STOCKS";
+    o_col_width_prefix = "STOCKS_COL";
+    o_sort_prefix = "STOCKS";
+    m_col_id_info = LISTCOL_INFO;
+    m_col_nr_id = ListColumnInfo::getId(LISTCOL_INFO);
+    m_sort_col_id = { col_sort() };
     createColumns();
 
-    initVirtualListControl(-1, m_selected_col, m_asc);
+    initVirtualListControl(-1, getSortColNr(), getSortAsc());
     if (!m_stocks.empty())
         EnsureVisible(m_stocks.size() - 1);
+}
 
+StocksListCtrl::~StocksListCtrl()
+{
 }
 
 void StocksListCtrl::OnMouseRightClick(wxMouseEvent& event)
@@ -157,38 +152,39 @@ void StocksListCtrl::OnMouseRightClick(wxMouseEvent& event)
     this->SetFocus();
 }
 
-wxString StocksListCtrl::OnGetItemText(long item, long column) const
+wxString StocksListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    switch (m_column_order[column]) {
-    case LIST_COL_ID:
+    int col_id = getColId(static_cast<int>(col_nr));
+    switch (col_id) {
+    case LISTCOL_ID_ID:
         return wxString::Format("%lld", m_stocks[item].STOCKID).Trim();
-    case LIST_COL_DATE:
+    case LISTCOL_ID_DATE:
         return mmGetDateTimeForDisplay(m_stocks[item].PURCHASEDATE);
-    case LIST_COL_NAME:
+    case LISTCOL_ID_NAME:
         return m_stocks[item].STOCKNAME;
-    case LIST_COL_SYMBOL:
+    case LISTCOL_ID_SYMBOL:
         return m_stocks[item].SYMBOL;
-    case LIST_COL_NUMBER: {
+    case LISTCOL_ID_NUMBER: {
         int precision = m_stocks[item].NUMSHARES == floor(m_stocks[item].NUMSHARES) ? 0 : 4;
         return Model_Currency::toString(m_stocks[item].NUMSHARES, m_stock_panel->m_currency, precision);
     }
-    case LIST_COL_PRICE:
+    case LISTCOL_ID_PRICE:
         return Model_Currency::toString(m_stocks[item].PURCHASEPRICE, m_stock_panel->m_currency, 4);
-    case LIST_COL_VALUE:
+    case LISTCOL_ID_VALUE:
         return Model_Currency::toString(m_stocks[item].VALUE, m_stock_panel->m_currency);
-    case LIST_COL_REAL_GAIN_LOSS:
+    case LISTCOL_ID_REAL_GAIN_LOSS:
         return Model_Currency::toString(GetRealGainLoss(item), m_stock_panel->m_currency);
-    case LIST_COL_GAIN_LOSS:
+    case LISTCOL_ID_GAIN_LOSS:
         return Model_Currency::toString(GetGainLoss(item), m_stock_panel->m_currency);
-    case LIST_COL_CURRENT:
+    case LISTCOL_ID_CURRENT:
         return Model_Currency::toString(m_stocks[item].CURRENTPRICE, m_stock_panel->m_currency, 4);
-    case LIST_COL_CURRVALUE:
+    case LISTCOL_ID_CURRVALUE:
         return Model_Currency::toString(Model_Stock::CurrentValue(m_stocks[item]), m_stock_panel->m_currency);
-    case LIST_COL_PRICEDATE:
+    case LISTCOL_ID_PRICEDATE:
         return mmGetDateTimeForDisplay(Model_Stock::instance().lastPriceDate(&m_stocks[item]));
-    case LIST_COL_COMMISSION:
+    case LISTCOL_ID_COMMISSION:
         return Model_Currency::toString(m_stocks[item].COMMISSION, m_stock_panel->m_currency);
-    case LIST_COL_NOTES: {
+    case LISTCOL_ID_NOTES: {
         wxString full_notes = m_stocks[item].NOTES;
         full_notes.Replace("\n", " ");
         if (Model_Attachment::NrAttachments(Model_Attachment::REFTYPE_NAME_STOCK, m_stocks[item].STOCKID))
@@ -398,27 +394,27 @@ void StocksListCtrl::OnListItemActivated(wxListEvent& event)
 
 void StocksListCtrl::OnColClick(wxListEvent& event)
 {
-    int ColumnNr;
+    int col_nr;
     if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
-        ColumnNr = event.GetColumn();
+        col_nr = event.GetColumn();
     else
-        ColumnNr = m_ColumnHeaderNbr;
-    if (0 >= ColumnNr || ColumnNr >= getColumnsNumber()) return;
+        col_nr = m_col_nr;
+    if (!isValidColNr(col_nr))
+        return;
 
-    if (m_selected_col == ColumnNr &&
+    if (getSortColNr() == col_nr &&
         event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
     )
-        m_asc = !m_asc;
+        m_sort_asc[0] = !m_sort_asc[0];
 
     wxListItem item;
     item.SetMask(wxLIST_MASK_IMAGE);
     item.SetImage(-1);
-    SetColumn(m_selected_col, item);
+    SetColumn(getSortColNr(), item);
 
-    m_selected_col = ColumnNr;
+    m_sort_col_id[0] = getColId(col_nr);
 
-    Model_Setting::instance().setBool("STOCKS_ASC", m_asc);
-    Model_Setting::instance().setInt("STOCKS_SORT_COL", m_selected_col);
+    savePreferences();
 
     int64 trx_id = -1;
     if (m_selected_row>=0) trx_id = m_stocks[m_selected_row].STOCKID;
@@ -428,11 +424,11 @@ void StocksListCtrl::OnColClick(wxListEvent& event)
 
 void StocksListCtrl::doRefreshItems(int64 trx_id)
 {
-    int selectedIndex = initVirtualListControl(trx_id, m_selected_col, m_asc);
+    int selectedIndex = initVirtualListControl(trx_id, getSortColNr(), getSortAsc());
     long cnt = static_cast<long>(m_stocks.size());
 
     if (selectedIndex >= cnt || selectedIndex < 0)
-        selectedIndex = m_asc ? cnt - 1 : 0;
+        selectedIndex = getSortAsc() ? cnt - 1 : 0;
 
     if (cnt>0)
     {
@@ -464,7 +460,7 @@ int StocksListCtrl::initVirtualListControl(int64 trx_id, int col, bool asc)
     }
 
     m_stocks = Model_Stock::instance().find(Model_Stock::HELDAT(m_stock_panel->m_account_id));
-    sortTable();
+    sortList();
 
     int cnt = 0, selected_item = -1;
     for (auto& stock : m_stocks)
@@ -484,54 +480,54 @@ int StocksListCtrl::initVirtualListControl(int64 trx_id, int col, bool asc)
     return selected_item;
 }
 
-void StocksListCtrl::sortTable()
+void StocksListCtrl::sortList()
 {
     std::sort(m_stocks.begin(), m_stocks.end());
-    switch (m_selected_col)
+    switch (getSortColId())
     {
-    case StocksListCtrl::LIST_COL_ID:
+    case StocksListCtrl::LISTCOL_ID_ID:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterBySTOCKID());
         break;
-    case StocksListCtrl::LIST_COL_DATE:
+    case StocksListCtrl::LISTCOL_ID_DATE:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByPURCHASEDATE());
         break;
-    case StocksListCtrl::LIST_COL_NAME:
+    case StocksListCtrl::LISTCOL_ID_NAME:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterBySTOCKNAME());
         break;
-    case StocksListCtrl::LIST_COL_SYMBOL:
+    case StocksListCtrl::LISTCOL_ID_SYMBOL:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterBySYMBOL());
         break;
-    case StocksListCtrl::LIST_COL_NUMBER:
+    case StocksListCtrl::LISTCOL_ID_NUMBER:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByNUMSHARES());
         break;
-    case StocksListCtrl::LIST_COL_PRICE:
+    case StocksListCtrl::LISTCOL_ID_PRICE:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByPURCHASEPRICE());
         break;
-    case StocksListCtrl::LIST_COL_VALUE:
+    case StocksListCtrl::LISTCOL_ID_VALUE:
         std::stable_sort(m_stocks.begin(), m_stocks.end()
             , [](const Model_Stock::Data& x, const Model_Stock::Data& y)
             {
                 return x.VALUE < y.VALUE;
             });
         break;
-    case StocksListCtrl::LIST_COL_REAL_GAIN_LOSS:
+    case StocksListCtrl::LISTCOL_ID_REAL_GAIN_LOSS:
         std::stable_sort(m_stocks.begin(), m_stocks.end()
             , [](const Model_Stock::Data& x, const Model_Stock::Data& y)
         {
             return getRealGainLoss(x) < getRealGainLoss(y);
         });
         break;
-    case StocksListCtrl::LIST_COL_GAIN_LOSS:
+    case StocksListCtrl::LISTCOL_ID_GAIN_LOSS:
         std::stable_sort(m_stocks.begin(), m_stocks.end()
             , [](const Model_Stock::Data& x, const Model_Stock::Data& y)
             {
                 return getGainLoss(x) < getGainLoss(y);
             });
         break;
-    case StocksListCtrl::LIST_COL_CURRENT:
+    case StocksListCtrl::LISTCOL_ID_CURRENT:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByCURRENTPRICE());
         break;
-    case StocksListCtrl::LIST_COL_CURRVALUE:
+    case StocksListCtrl::LISTCOL_ID_CURRVALUE:
         std::stable_sort(m_stocks.begin(), m_stocks.end()
             , [](const Model_Stock::Data& x, const Model_Stock::Data& y)
             {
@@ -540,17 +536,17 @@ void StocksListCtrl::sortTable()
                 return valueX < valueY;
             });
         break;
-    case StocksListCtrl::LIST_COL_PRICEDATE:
+    case StocksListCtrl::LISTCOL_ID_PRICEDATE:
         //TODO
         break;
-    case StocksListCtrl::LIST_COL_COMMISSION:
+    case StocksListCtrl::LISTCOL_ID_COMMISSION:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByCOMMISSION());
         break;
-    case StocksListCtrl::LIST_COL_NOTES:
+    case StocksListCtrl::LISTCOL_ID_NOTES:
         std::stable_sort(m_stocks.begin(), m_stocks.end(), SorterByNOTES());
         break;
     default:
         break;
     }
-    if (!m_asc) std::reverse(m_stocks.begin(), m_stocks.end());
+    if (!getSortAsc()) std::reverse(m_stocks.begin(), m_stocks.end());
 }

--- a/src/stocks_list.h
+++ b/src/stocks_list.h
@@ -34,35 +34,43 @@ class StocksListCtrl: public mmListCtrl
     wxDECLARE_EVENT_TABLE();
 
 public:
-    enum LIST_COL
+    enum LISTCOL_ID
     {
-        LIST_COL_ICON = 0,
-        LIST_COL_ID,
-        LIST_COL_DATE,
-        LIST_COL_NAME,
-        LIST_COL_SYMBOL,
-        LIST_COL_NUMBER,
-        LIST_COL_PRICE,
-        LIST_COL_VALUE,
-        LIST_COL_REAL_GAIN_LOSS,
-        LIST_COL_GAIN_LOSS,
-        LIST_COL_CURRENT,
-        LIST_COL_CURRVALUE,
-        LIST_COL_PRICEDATE,
-        LIST_COL_COMMISSION,
-        LIST_COL_NOTES,
-        LIST_COL_size, // number of columns
+        LISTCOL_ID_ICON = 0,
+        LISTCOL_ID_ID,
+        LISTCOL_ID_DATE,
+        LISTCOL_ID_NAME,
+        LISTCOL_ID_SYMBOL,
+        LISTCOL_ID_NUMBER,
+        LISTCOL_ID_PRICE,
+        LISTCOL_ID_VALUE,
+        LISTCOL_ID_REAL_GAIN_LOSS,
+        LISTCOL_ID_GAIN_LOSS,
+        LISTCOL_ID_CURRENT,
+        LISTCOL_ID_CURRVALUE,
+        LISTCOL_ID_PRICEDATE,
+        LISTCOL_ID_COMMISSION,
+        LISTCOL_ID_NOTES,
+        LISTCOL_ID_size, // number of columns
     };
 
+public:
+    Model_Stock::Data_Set m_stocks;
+
 private:
-    static const std::vector<ListColumnInfo> col_info_all();
-    int col_sort();
+    static const std::vector<ListColumnInfo> LISTCOL_INFO;
+    mmStocksPanel* m_stock_panel;
+    long m_selected_row = -1;
 
 public:
     StocksListCtrl(mmStocksPanel* cp, wxWindow *parent, wxWindowID winid = wxID_ANY);
     ~StocksListCtrl();
 
     void doRefreshItems(int64 trx_id = -1);
+    long get_selectedIndex();
+    wxString getStockInfo(int selectedIndex) const;
+    int initVirtualListControl(int64 trx_id = -1, int col = 0, bool asc = true);
+
     void OnNewStocks(wxCommandEvent& event);
     void OnDeleteStocks(wxCommandEvent& event);
     void OnMoveStocks(wxCommandEvent& event);
@@ -70,17 +78,17 @@ public:
     void OnOrganizeAttachments(wxCommandEvent& event);
     void OnStockWebPage(wxCommandEvent& event);
     void OnOpenAttachment(wxCommandEvent& event);
-    long get_selectedIndex();
-    int getColumnsNumber();
-    wxString getStockInfo(int selectedIndex) const;
-    /* Helper Functions/data */
-    Model_Stock::Data_Set m_stocks;
-    /* updates thstockide checking panel data */
-    int initVirtualListControl(int64 trx_id = -1, int col = 0, bool asc = true);
 
 private:
-    /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long column) const;
+    static int col_sort();
+    double GetGainLoss(long item) const;
+    static double getGainLoss(const Model_Stock::Data& stock);
+    double GetRealGainLoss(long item) const;
+    static double getRealGainLoss(const Model_Stock::Data& stock);
+    void sortList();
+
+    // required overrides for virtual style list control
+    virtual wxString OnGetItemText(long item, long col_nr) const;
     virtual int OnGetItemImage(long item) const;
 
     void OnMouseRightClick(wxMouseEvent& event);
@@ -91,18 +99,9 @@ private:
     void OnMarkAllTransactions(wxCommandEvent& event);
     void OnListKeyDown(wxListEvent& event);
     void OnListItemSelected(wxListEvent& event);
-
-    mmStocksPanel* m_stock_panel;
-
-    double GetGainLoss(long item) const;
-    static double getGainLoss(const Model_Stock::Data& stock);
-    double GetRealGainLoss(long item) const;
-    static double getRealGainLoss(const Model_Stock::Data& stock);
-    void sortTable();
 };
 
+inline int StocksListCtrl::col_sort() { return LISTCOL_ID_DATE; }
 inline long StocksListCtrl::get_selectedIndex() { return m_selected_row; }
-inline int StocksListCtrl::getColumnsNumber() { return LIST_COL_size; }
-inline int StocksListCtrl::col_sort() { return LIST_COL_DATE; }
 
 #endif

--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -112,13 +112,13 @@ void mmStocksPanel::CreateControls()
         , wxID_ANY, wxDefaultPosition, wxSize(200, 200)
         , wxSP_3DBORDER | wxSP_3DSASH | wxNO_BORDER);
 
-    listCtrlAccount_ = new StocksListCtrl(this, itemSplitterWindow10, wxID_ANY);
+    m_lc = new StocksListCtrl(this, itemSplitterWindow10, wxID_ANY);
 
     wxPanel* BottomPanel = new wxPanel(itemSplitterWindow10, wxID_ANY
         , wxDefaultPosition, wxDefaultSize, wxNO_BORDER | wxTAB_TRAVERSAL);
     mmThemeMetaColour(BottomPanel, meta::COLOR_LISTPANEL);
 
-    itemSplitterWindow10->SplitHorizontally(listCtrlAccount_, BottomPanel);
+    itemSplitterWindow10->SplitHorizontally(m_lc, BottomPanel);
     itemSplitterWindow10->SetMinimumPaneSize(100);
     itemSplitterWindow10->SetSashGravity(1.0);
     itemBoxSizer9->Add(itemSplitterWindow10, g_flagsExpandBorder1);
@@ -184,11 +184,11 @@ void mmStocksPanel::CreateControls()
 
 void mmStocksPanel::AddStockTransaction(int selectedIndex)
 {
-    Model_Stock::Data* stock = &listCtrlAccount_->m_stocks[selectedIndex];
+    Model_Stock::Data* stock = &m_lc->m_stocks[selectedIndex];
     ShareTransactionDialog dlg(this, stock);
     if (dlg.ShowModal() == wxID_OK)
     {
-        listCtrlAccount_->doRefreshItems(dlg.m_stock_id);
+        m_lc->doRefreshItems(dlg.m_stock_id);
         updateExtraStocksData(selectedIndex);
     }
 }
@@ -202,7 +202,7 @@ void mmStocksPanel::OnListItemActivated(int selectedIndex)
 //TODO: improve View Stock Transactions
 void mmStocksPanel::ViewStockTransactions(int selectedIndex)
 {
-    Model_Stock::Data* stock = &listCtrlAccount_->m_stocks[selectedIndex];
+    Model_Stock::Data* stock = &m_lc->m_stocks[selectedIndex];
     
     wxDialog dlg(this, wxID_ANY, _t("View Stock Transactions") + wxString::Format(": %s - %s", Model_Account::get_account_name(stock->HELDAT), stock->SYMBOL), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
     dlg.SetIcon(mmex::getProgramIcon());
@@ -328,7 +328,7 @@ wxString mmStocksPanel::GetPanelTitle(const Model_Account::Data& account) const
 wxString mmStocksPanel::BuildPage() const
 { 
     const Model_Account::Data* account = Model_Account::instance().get(m_account_id);
-    return listCtrlAccount_->BuildPage((account ? GetPanelTitle(*account) : ""));
+    return m_lc->BuildPage((account ? GetPanelTitle(*account) : ""));
 }
 
 const wxString mmStocksPanel::Total_Shares()
@@ -378,27 +378,27 @@ void mmStocksPanel::updateHeader()
 
 void mmStocksPanel::OnDeleteStocks(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnDeleteStocks(event);
+    m_lc->OnDeleteStocks(event);
 }
 
 void mmStocksPanel::OnMoveStocks(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnMoveStocks(event);
+    m_lc->OnMoveStocks(event);
 }
 
 void mmStocksPanel::OnNewStocks(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnNewStocks(event);
+    m_lc->OnNewStocks(event);
 }
 
 void mmStocksPanel::OnEditStocks(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnEditStocks(event);
+    m_lc->OnEditStocks(event);
 }
 
 void mmStocksPanel::OnOpenAttachment(wxCommandEvent& event)
 {
-    listCtrlAccount_->OnOpenAttachment(event);
+    m_lc->OnOpenAttachment(event);
 }
 
 void mmStocksPanel::OnRefreshQuotes(wxCommandEvent& WXUNUSED(event))
@@ -433,7 +433,7 @@ bool mmStocksPanel::onlineQuoteRefresh(wxString& msg)
         return false;
     }
 
-    if (listCtrlAccount_->m_stocks.empty())
+    if (m_lc->m_stocks.empty())
     {
         msg = _t("Nothing to update");
         return false;
@@ -505,7 +505,7 @@ void mmStocksPanel::updateExtraStocksData(int selectedIndex)
     enableEditDeleteButtons(selectedIndex >= 0);
     if (selectedIndex >= 0)
     {
-        const wxString additionInfo = listCtrlAccount_->getStockInfo(selectedIndex);
+        const wxString additionInfo = m_lc->getStockInfo(selectedIndex);
         stock_details_->SetLabelText(additionInfo);
     }
 }
@@ -572,7 +572,7 @@ wxString StocksListCtrl::getStockInfo(int selectedIndex) const
             , sTotalDifference, sTotalNumShares
             , Model_Currency::toCurrency(stocktotalgainloss)
             , Model_Currency::toStringNoFormatting(stocktotalPercentage, nullptr, 2)
-            , OnGetItemText(selectedIndex, static_cast<long>(LIST_COL_NOTES)));
+            , OnGetItemText(selectedIndex, static_cast<long>(LISTCOL_ID_NOTES)));
     }
     return additionInfo;
 }
@@ -601,10 +601,10 @@ void mmStocksPanel::enableEditDeleteButtons(bool en)
 
 void mmStocksPanel::call_dialog(int selectedIndex)
 {
-    Model_Stock::Data* stock = &listCtrlAccount_->m_stocks[selectedIndex];
+    Model_Stock::Data* stock = &m_lc->m_stocks[selectedIndex];
     mmStockDialog dlg(this, m_frame, stock, m_account_id);
     dlg.ShowModal();
-    listCtrlAccount_->doRefreshItems(dlg.m_stock_id);
+    m_lc->doRefreshItems(dlg.m_stock_id);
 }
 
 void mmStocksPanel::DisplayAccountDetails(int64 accountID)
@@ -617,15 +617,15 @@ void mmStocksPanel::DisplayAccountDetails(int64 accountID)
 
     updateHeader();
     enableEditDeleteButtons(false);
-    listCtrlAccount_->initVirtualListControl();
+    m_lc->initVirtualListControl();
 
 }
 
 void mmStocksPanel::RefreshList()
 {
     int64 selected_id = -1;
-    if (listCtrlAccount_->get_selectedIndex() > -1)
-        selected_id = listCtrlAccount_->m_stocks[listCtrlAccount_->get_selectedIndex()].STOCKID;
-    listCtrlAccount_->doRefreshItems(selected_id);
+    if (m_lc->get_selectedIndex() > -1)
+        selected_id = m_lc->m_stocks[m_lc->get_selectedIndex()].STOCKID;
+    m_lc->doRefreshItems(selected_id);
 }
 

--- a/src/stockspanel.h
+++ b/src/stockspanel.h
@@ -77,10 +77,10 @@ public:
     mmGUIFrame* m_frame;
 
 private:
-    StocksListCtrl* listCtrlAccount_ = nullptr;
+    StocksListCtrl* m_lc = nullptr;
     wxStaticText* stock_details_ = nullptr;
     void call_dialog(int selectedIndex);
-    void sortTable() {}
+    void sortList() {}
     const wxString Total_Shares();
 
     wxStaticText* header_text_ = nullptr;


### PR DESCRIPTION
## GUI changes

At right-click on a column header:

- "Hide/Show column" shows the first (previously empty) column as "Icon".

- "Move column left/right" appears only if applicable.

- Added "Move hidden column", which opens a menu of hidden columns. The selected column is added after the current column. This item is shown only if there are hidden columns.

Use case: users can move a column over multiple positions as follows

- At the original column: right-click -> "Hide this column"

- At (before) the final position: right-click -> "Move hidden column" -> select column.

Other changes

- The width of a column is saved when the column is hidden, and it is restored when the column is shown again (it was reset to default before). However, the current settings format encodes the hidden state as zero width, therefore the width preferences of hidden columns is not stored in settings (to be fixed in another PR.)

## Architectural changes

Column variables indicate either a column number (0-based physical position, like 1 for the second physical column), or a column id (the code of a logical column, like LISTCOL_ID_DATE). To avoid inconsistencies, all column variables/functions have a suffix (nr, id) in their name.

Derived classes may have 0 (budgetingListCtrl), 1 (all other), or 2 (TransactionListCtrl) sorting columns. The state variables `m_col_nr_id`, `m_sort_asc` are defined as vectors in order to cover all cases.

Sorting functions need both the column number and the column id. However, maintainance of column number is tedious due to column moves. The state variable `m_col_nr_id` stores the column ids, while the corresponding column numbers are cached into `c_sort_col_nr`.

## Changes in mmListCtrl

- Rename and refactor `m_columns` -> `m_col_id_info`. Change the index from column number to column id. `m_col_id_info` is configured by the constructor and it is not updated at every column move. This simplifies the code in several functions.

- Rename `m_column_order` -> `m_col_nr_id`. The new name indicates that this is a map from column number to column id.

- Add `m_col_id_width` (lazy variable), `m_col_id_hidden`. This demultiplexes the hidden state from the width preference, when a column is hidden.

- Rename and refactor `m_selected_col` (single column number) -> `m_sort_col_id` (vector of column ids). This simplifies the maintainance of the sorting variables when columns are moved.

- Rename and refactor `m_asc` -> `m_sort_asc` (vector).

- Rename `m_ColumnHeaderNbr` -> `m_col_nr`.

- Remove `m_selected_row` (moved to derived classes), `m_default_sort_column` (not needed).

- Move all access to user settings into `savePreferences()` and `loadPreferences()`. This is also a preparation to refine the settings format.

- Add several helper functions.
