### PR TITLE
ref(#7200), part 3: fix sort icon in column headers

### DIFF
--- a/src/assetspanel.h
+++ b/src/assetspanel.h
@@ -76,12 +76,13 @@ public:
     void doRefreshItems(int64 trx_id = -1);
 
 protected:
-    virtual void OnColClick(wxListEvent& event);
+    virtual int getSortIcon(bool asc) const override;
+    virtual void OnColClick(wxListEvent& event) override;
 
 private:
     /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long col_nr) const;
-    virtual int OnGetItemImage(long item) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const override;
+    virtual int OnGetItemImage(long item) const override;
 
     void OnMouseRightClick(wxMouseEvent& event);
     void OnListLeftClick(wxMouseEvent& event);
@@ -114,7 +115,7 @@ public:
     mmGUIFrame* m_frame = nullptr;
 
     void updateExtraAssetData(int selIndex);
-    int initVirtualListControl(int64 trx_id = -1, int col = 0, bool asc = true);
+    int initVirtualListControl(int64 trx_id = -1);
     wxString getItem(long item, int col_id);
 
     Model_Asset::Data_Set m_assets;

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -158,28 +158,28 @@ billsDepositsListCtrl::~billsDepositsListCtrl()
     wxLogDebug("Exit billsDepositsListCtrl");
 }
 
+int billsDepositsListCtrl::getSortIcon(bool asc) const
+{
+    return asc ? mmBillsDepositsPanel::ICON_UPARROW : mmBillsDepositsPanel::ICON_DOWNARROW;
+}
+
 void billsDepositsListCtrl::OnColClick(wxListEvent& event)
 {
     int col_nr;
     if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
         col_nr = event.GetColumn();
     else
-        col_nr = m_col_nr;
+        col_nr = m_sel_col_nr;
     if (!isValidColNr(col_nr) || col_nr == 0)
         return;
 
-    if (getSortColNr() == col_nr &&
-        event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET
-    )
+    int col_id = getColId(col_nr);
+    if (m_sort_col_id[0] != col_id)
+        m_sort_col_id[0] = col_id;
+    else if (event.GetId() != MENU_HEADER_SORT && event.GetId() != MENU_HEADER_RESET)
         m_sort_asc[0] = !m_sort_asc[0];
 
-    wxListItem item;
-    item.SetMask(wxLIST_MASK_IMAGE);
-    item.SetImage(-1);
-    SetColumn(getSortColNr(), item);
-
-    m_sort_col_id[0] = getColId(col_nr);
-
+    updateSortIcon();
     savePreferences();
 
     if (m_selected_row >= 0)
@@ -340,11 +340,6 @@ void mmBillsDepositsPanel::CreateControls()
 int mmBillsDepositsPanel::initVirtualListControl(int64 id)
 {
     m_lc->DeleteAllItems();
-
-    wxListItem item;
-    item.SetMask(wxLIST_MASK_IMAGE);
-    item.SetImage(m_lc->getSortAsc() ? ICON_UPARROW : ICON_DOWNARROW);
-    m_lc->SetColumn(m_lc->getSortColNr(), item);
 
     bills_.clear();
     const auto split = Model_Budgetsplittransaction::instance().get_all();

--- a/src/billsdepositspanel.h
+++ b/src/billsdepositspanel.h
@@ -77,16 +77,17 @@ public:
     void RefreshList();
 
 protected:
-    virtual void OnColClick(wxListEvent& event);
-    virtual wxListItemAttr *OnGetItemAttr(long item) const;
+    virtual int getSortIcon(bool asc) const override;
+    virtual void OnColClick(wxListEvent& event) override;
+    virtual wxListItemAttr *OnGetItemAttr(long item) const override;
 
 private:
     static int col_sort();
     void refreshVisualList(int selected_index = -1);
 
     /* required overrides for virtual style list control */
-    virtual wxString OnGetItemText(long item, long col_nr) const;
-    virtual int OnGetItemImage(long item) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const override;
+    virtual int OnGetItemImage(long item) const override;
 
     void OnItemRightClick(wxMouseEvent& event);
     void OnListLeftClick(wxMouseEvent& event);

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -158,12 +158,13 @@ private:
 
 private:
     // required overrides for virtual style list control
-    virtual wxString OnGetItemText(long item, long col_nr) const;
-    virtual int OnGetItemColumnImage(long item, long col_nr) const;
-    virtual wxListItemAttr* OnGetItemAttr(long item) const;
+    virtual wxString OnGetItemText(long item, long col_nr) const override;
+    virtual int OnGetItemColumnImage(long item, long col_nr) const override;
+    virtual wxListItemAttr* OnGetItemAttr(long item) const override;
 
 protected:
-    virtual void OnColClick(wxListEvent& event);
+    virtual int getSortIcon(bool asc) const override;
+    virtual void OnColClick(wxListEvent& event) override;
 
 private:
     void onChar(wxKeyEvent& event);
@@ -203,7 +204,6 @@ private:
 
 private:
     const wxString getItem(long item, int col_id) const;
-    void setColumnImage(int col, int image);
     void setExtraTransactionData(const bool single);
     void markItem(long selectedItem);
     void setSelectedId(Fused_Transaction::IdRepeat sel_id);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -240,7 +240,6 @@ void mmCheckingPanel::createControls()
     m_lc = new TransactionListCtrl(this, splitterListFooter);
     m_lc->SetSmallImages(m_images);
     m_lc->SetNormalImages(m_images);
-    m_lc->setColumnImage(m_lc->getSortColNr(0), (m_lc->getSortAsc(0) ? ICON_ASC : ICON_DESC));
 
     wxPanel* panelFooter = new wxPanel(
         splitterListFooter, wxID_ANY, wxDefaultPosition, wxDefaultSize,

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -79,13 +79,14 @@ public:
     // dynamic
     std::vector<int> m_col_nr_id;              // map: col_nr -> col_id; or empty
     std::vector<int> m_col_id_width;           // map: col_id -> col_width (lazy)
-    std::unordered_set<int> m_col_id_hidden;   // set: col_id -> isHidden
+    std::unordered_set<int> m_col_id_hidden;   // map (set): col_id -> isHidden
     std::vector<int> m_sort_col_id;            // sorting col_id; can be empty
     std::vector<bool> m_sort_asc;              // sorting direction
-    int m_col_nr = -1;                         // updated by onColRightClick()
+    int m_sel_col_nr = -1;                     // set by onColRightClick()
 
 private:
     std::vector<int> c_sort_col_nr;            // sorting col_nr (cache)
+    int c_icon_col_nr = -1;                    // sort icon col_nr (cache)
 
 public:
     mmListCtrl(wxWindow *parent, wxWindowID winid);
@@ -113,9 +114,6 @@ public:
     void loadPreferences();
 
 private:
-    int cacheSortColNr(int i);
-    void shiftColumn(int col_nr, int offset);
-
     // backwards compatibility
     const wxString getColOrderKey_v190() const;
     const wxString getColWidthKey_v190(int col_id) const;
@@ -126,11 +124,18 @@ private:
     void saveBoolInt(const wxString& key, bool value, bool isInt);
     bool loadBoolInt(const wxString& key, bool default_value, bool isInt) const;
 
+private:
+    int cacheSortColNr(int i);
+
 protected:
     virtual wxListItemAttr* OnGetItemAttr(long row) const;
     virtual void OnColClick(wxListEvent& event);
+    virtual int getSortIcon(bool asc) const;
+    void updateSortIcon();
 
 private:
+    void shiftColumn(int col_nr, int offset);
+
     void onItemResize(wxListEvent& event);
     void onColRightClick(wxListEvent& event);
     // Headers Right Click

--- a/src/stocks_list.h
+++ b/src/stocks_list.h
@@ -69,7 +69,7 @@ public:
     void doRefreshItems(int64 trx_id = -1);
     long get_selectedIndex();
     wxString getStockInfo(int selectedIndex) const;
-    int initVirtualListControl(int64 trx_id = -1, int col = 0, bool asc = true);
+    int initVirtualListControl(int64 trx_id = -1);
 
     void OnNewStocks(wxCommandEvent& event);
     void OnDeleteStocks(wxCommandEvent& event);
@@ -88,13 +88,14 @@ private:
     void sortList();
 
     // required overrides for virtual style list control
-    virtual wxString OnGetItemText(long item, long col_nr) const;
-    virtual int OnGetItemImage(long item) const;
+    virtual int getSortIcon(bool asc) const override;
+    virtual wxString OnGetItemText(long item, long col_nr) const override;
+    virtual int OnGetItemImage(long item) const override;
+    void OnColClick(wxListEvent& event) override;
 
     void OnMouseRightClick(wxMouseEvent& event);
     void OnListLeftClick(wxMouseEvent& event);
     void OnListItemActivated(wxListEvent& event);
-    void OnColClick(wxListEvent& event);
     void OnMarkTransaction(wxCommandEvent& event);
     void OnMarkAllTransactions(wxCommandEvent& event);
     void OnListKeyDown(wxListEvent& event);


### PR DESCRIPTION
## GUI changes

Fix the appearance of sort icon (up/down arrow) after operations on columns.

## Changes in mmListCtrl

- Add `c_icon_col_nr` (stores the column number with sort icon).

- Rename `m_col_nr` -> `m_sel_col_nr`.

- Add virtual `getSortIcon()`. Add implementation in derived classes.

- Add `updateSortIcon()`.

## Other changes

- Remove `TransactionListCtrl::setColumnImage()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7267)
<!-- Reviewable:end -->
