### PR TITLE
ref(#7200), part 6: refine user preferences

### DIFF
--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -314,7 +314,7 @@ void mmAssetsListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId(col_nr);
-    if (col_id == LIST_ID_ICON)
+    if (!m_col_id_info[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -136,7 +136,7 @@ void mmAssetsListCtrl::OnListLeftClick(wxMouseEvent& event)
 
 wxString mmAssetsListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return m_panel->getItem(item, getColId(col_nr));
+    return m_panel->getItem(item, getColId_Nr(col_nr));
 }
 
 void mmAssetsListCtrl::OnListItemSelected(wxListEvent& event)
@@ -313,7 +313,7 @@ void mmAssetsListCtrl::OnColClick(wxListEvent& event)
     int col_nr = (event.GetId() == MENU_HEADER_SORT) ? m_sel_col_nr : event.GetColumn();
     if (!isValidColNr(col_nr))
         return;
-    int col_id = getColId(col_nr);
+    int col_id = getColId_Nr(col_nr);
     if (!m_col_id_info[col_id].sortable)
         return;
 

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -67,8 +67,8 @@ mmAssetsListCtrl::mmAssetsListCtrl(mmAssetsPanel* cp, wxWindow *parent, wxWindow
     o_col_order_prefix = "ASSETS";
     o_col_width_prefix = "ASSETS_COL";
     o_sort_prefix = "ASSETS";
-    m_col_id_info = LIST_INFO;
-    m_col_nr_id = ListColumnInfo::getListId(LIST_INFO);
+    m_col_info_id = LIST_INFO;
+    m_col_id_nr = ListColumnInfo::getListId(LIST_INFO);
     m_sort_col_id = { LIST_ID_DATE };
     createColumns();
 }
@@ -314,7 +314,7 @@ void mmAssetsListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId_Nr(col_nr);
-    if (!m_col_id_info[col_id].sortable)
+    if (!m_col_info_id[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -169,7 +169,7 @@ void billsDepositsListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId(col_nr);
-    if (col_id == LIST_ID_ICON)
+    if (!m_col_id_info[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -147,8 +147,8 @@ billsDepositsListCtrl::billsDepositsListCtrl(
     o_col_order_prefix = "BD";
     o_col_width_prefix = "BD_COL";
     o_sort_prefix = "BD";
-    m_col_id_info = LIST_INFO;
-    m_col_nr_id = ListColumnInfo::getListId(LIST_INFO);
+    m_col_info_id = LIST_INFO;
+    m_col_id_nr = ListColumnInfo::getListId(LIST_INFO);
     m_sort_col_id = { col_sort() };
     createColumns();
 }
@@ -169,7 +169,7 @@ void billsDepositsListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId_Nr(col_nr);
-    if (!m_col_id_info[col_id].sortable)
+    if (!m_col_info_id[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -168,7 +168,7 @@ void billsDepositsListCtrl::OnColClick(wxListEvent& event)
     int col_nr = (event.GetId() == MENU_HEADER_SORT) ? m_sel_col_nr : event.GetColumn();
     if (!isValidColNr(col_nr))
         return;
-    int col_id = getColId(col_nr);
+    int col_id = getColId_Nr(col_nr);
     if (!m_col_id_info[col_id].sortable)
         return;
 
@@ -555,7 +555,7 @@ const wxString mmBillsDepositsPanel::GetRemainingDays(const Model_Billsdeposits:
 
 wxString billsDepositsListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return m_bdp->getItem(item, getColId(static_cast<int>(col_nr)));
+    return m_bdp->getItem(item, getColId_Nr(static_cast<int>(col_nr)));
 }
 
 void billsDepositsListCtrl::OnListItemSelected(wxListEvent& event)

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -659,7 +659,7 @@ int mmBudgetingPanel::GetItemImage(long item) const
 
 wxString budgetingListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return cp_->getItem(item, getColId(static_cast<int>(col_nr)));
+    return cp_->getItem(item, getColId_Nr(static_cast<int>(col_nr)));
 }
 
 wxListItemAttr* budgetingListCtrl::OnGetItemAttr(long item) const

--- a/src/budgetingpanel.cpp
+++ b/src/budgetingpanel.cpp
@@ -284,7 +284,7 @@ budgetingListCtrl::budgetingListCtrl(
     mmThemeMetaColour(this, meta::COLOR_LISTPANEL);
 
     m_setting_name = "BUDGET";
-    m_col_id_info = LIST_INFO;
+    m_col_info_id = LIST_INFO;
     o_col_width_prefix = "BUDGET_COL";
 }
 

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -235,8 +235,8 @@ void TransactionListCtrl::setColumnsInfo()
     }
     else if (m_cp->isAccount()) {
         m_setting_name = "TRANS1";
-        o_col_order_prefix = m_cp->m_account->ACCOUNTTYPE.Upper();
-        o_col_order_prefix.Replace(" ", "_");
+        // note: migrate from CHECKING_COLUMNORDER for all account types
+        o_col_order_prefix = "CHECKING";
         o_col_width_prefix = "CHECK2_COLV2";
         o_sort_prefix = "CHECK";
     }
@@ -244,7 +244,8 @@ void TransactionListCtrl::setColumnsInfo()
         m_setting_name = "TRANS2";
         o_col_order_prefix = "ALLTRANS";
         o_col_width_prefix = "ALLTRANS_COLV2";
-        o_sort_prefix = m_cp->isGroup() ? "MULTI" : "ALLTRANS";
+        // note: MULTI_{SORT_COL,ASC}*` are ignored (not migrated)
+        o_sort_prefix = "ALLTRANS";
     }
 
     m_col_info_id = LIST_INFO;

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -247,36 +247,36 @@ void TransactionListCtrl::setColumnsInfo()
         o_sort_prefix = m_cp->isGroup() ? "MULTI" : "ALLTRANS";
     }
 
-    m_col_id_info = LIST_INFO;
-    m_col_id_disabled.clear();
-    m_col_nr_id.clear();
+    m_col_info_id = LIST_INFO;
+    m_col_disabled_id.clear();
+    m_col_id_nr.clear();
 
     if (!Option::instance().UseTransDateTime())
-        m_col_id_disabled.insert(LIST_ID_TIME);
+        m_col_disabled_id.insert(LIST_ID_TIME);
     if (m_cp->isAccount() && m_cp->m_account->CREDITLIMIT == 0)
-        m_col_id_disabled.insert(LIST_ID_CREDIT);
+        m_col_disabled_id.insert(LIST_ID_CREDIT);
 
-    m_col_nr_id.push_back(LIST_ID_ICON);
-    m_col_nr_id.push_back(LIST_ID_SN);
-    m_col_nr_id.push_back(LIST_ID_ID);
-    m_col_nr_id.push_back(LIST_ID_DATE);
-    m_col_nr_id.push_back(LIST_ID_TIME);
-    m_col_nr_id.push_back(LIST_ID_NUMBER);
+    m_col_id_nr.push_back(LIST_ID_ICON);
+    m_col_id_nr.push_back(LIST_ID_SN);
+    m_col_id_nr.push_back(LIST_ID_ID);
+    m_col_id_nr.push_back(LIST_ID_DATE);
+    m_col_id_nr.push_back(LIST_ID_TIME);
+    m_col_id_nr.push_back(LIST_ID_NUMBER);
     if (!m_cp->isAccount())
-        m_col_nr_id.push_back(LIST_ID_ACCOUNT);
-    m_col_nr_id.push_back(LIST_ID_PAYEE_STR);
-    m_col_nr_id.push_back(LIST_ID_STATUS);
-    m_col_nr_id.push_back(LIST_ID_CATEGORY);
-    m_col_nr_id.push_back(LIST_ID_TAGS);
-    m_col_nr_id.push_back(LIST_ID_WITHDRAWAL);
-    m_col_nr_id.push_back(LIST_ID_DEPOSIT);
+        m_col_id_nr.push_back(LIST_ID_ACCOUNT);
+    m_col_id_nr.push_back(LIST_ID_PAYEE_STR);
+    m_col_id_nr.push_back(LIST_ID_STATUS);
+    m_col_id_nr.push_back(LIST_ID_CATEGORY);
+    m_col_id_nr.push_back(LIST_ID_TAGS);
+    m_col_id_nr.push_back(LIST_ID_WITHDRAWAL);
+    m_col_id_nr.push_back(LIST_ID_DEPOSIT);
     if (m_cp->isAccount()) {
-        m_col_nr_id.push_back(LIST_ID_BALANCE);
-        m_col_nr_id.push_back(LIST_ID_CREDIT);
+        m_col_id_nr.push_back(LIST_ID_BALANCE);
+        m_col_id_nr.push_back(LIST_ID_CREDIT);
     }
-    m_col_nr_id.push_back(LIST_ID_NOTES);
+    m_col_id_nr.push_back(LIST_ID_NOTES);
     if (m_cp->isDeletedTrans())
-        m_col_nr_id.push_back(LIST_ID_DELETEDTIME);
+        m_col_id_nr.push_back(LIST_ID_DELETEDTIME);
 
     const auto& ref_type = Model_Attachment::REFTYPE_NAME_TRANSACTION;
     int col_id = LIST_ID_UDFC01;
@@ -286,18 +286,18 @@ void TransactionListCtrl::setColumnsInfo()
 
         const auto& name = Model_CustomField::getUDFCName(ref_type, udfc_entry);
         if (!name.IsEmpty() && name != udfc_entry) {
-            m_col_id_info[col_id].header = name;
+            m_col_info_id[col_id].header = name;
             const auto& type = Model_CustomField::getUDFCType(ref_type, udfc_entry);
             if (type == Model_CustomField::TYPE_ID_DECIMAL || type == Model_CustomField::TYPE_ID_INTEGER)
-                m_col_id_info[col_id].format = _FR;
+                m_col_info_id[col_id].format = _FR;
             else if (type == Model_CustomField::TYPE_ID_BOOLEAN)
-                m_col_id_info[col_id].format = _FC;
-            m_col_nr_id.push_back(col_id);
+                m_col_info_id[col_id].format = _FC;
+            m_col_id_nr.push_back(col_id);
         }
         col_id++;
     }
 
-    m_col_nr_id.push_back(LIST_ID_UPDATEDTIME);
+    m_col_id_nr.push_back(LIST_ID_UPDATEDTIME);
 
     m_sort_col_id = { LIST_ID_DATE, LIST_ID_ID };
 }
@@ -565,7 +565,7 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId_Nr(col_nr);
-    if (!m_col_id_info[col_id].sortable)
+    if (!m_col_info_id[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id) {
@@ -735,7 +735,7 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
         );
     }
     bool columnIsAmount = false;
-    int col_nr = getColumnFromPosition(event.GetX());
+    int col_nr = getColNr_X(event.GetX());
     int flags;
     unsigned long row = HitTest(event.GetPosition(), flags);
     if (row < m_trans.size() && (flags & wxLIST_HITTEST_ONITEM) && col_nr < getColNrSize()) {
@@ -1968,16 +1968,17 @@ void TransactionListCtrl::findSelectedTransactions()
     }
 }
 
-int TransactionListCtrl::getColumnFromPosition(int xPos)
+int TransactionListCtrl::getColNr_X(int xPos)
 {
-    int column = 0;
+    int col_vo = 0;
     int x = -GetScrollPos(wxHORIZONTAL);
-    for (column = 0; column < GetColumnCount(); column++) {
-        x += GetColumnWidth(column);
+    for (col_vo = 0; col_vo < GetColumnCount(); col_vo++) {
+        x += GetColumnWidth(getColNr_Vo(col_vo));
         if (x >= xPos) break;
     }
-    if (!(column < GetColumnCount())) return -1;
-    return column;
+    if (col_vo >= GetColumnCount())
+        return -1;
+    return getColNr_Vo(col_vo);
 }
 
 void TransactionListCtrl::doSearchText(const wxString& value)

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -497,7 +497,7 @@ void TransactionListCtrl::sortTransactions(int col_id, bool ascend)
 
 wxString TransactionListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    return getItem(item, getColId(static_cast<int>(col_nr)));
+    return getItem(item, getColId_Nr(static_cast<int>(col_nr)));
 }
 
 // Returns the icon to be shown for each transaction for the required column
@@ -506,7 +506,7 @@ int TransactionListCtrl::OnGetItemColumnImage(long item, long col_nr) const
     if (m_trans.empty())
         return -1;
 
-    int col_id = getColId(static_cast<int>(col_nr));
+    int col_id = getColId_Nr(static_cast<int>(col_nr));
     if (col_id != LIST_ID_ICON)
         return -1;
 
@@ -564,7 +564,7 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     int col_nr = (event.GetId() == MENU_HEADER_SORT) ?  m_sel_col_nr : event.GetColumn();
     if (!isValidColNr(col_nr))
         return;
-    int col_id = getColId(col_nr);
+    int col_id = getColId_Nr(col_nr);
     if (!m_col_id_info[col_id].sortable)
         return;
 
@@ -739,7 +739,7 @@ void TransactionListCtrl::onMouseRightClick(wxMouseEvent& event)
     int flags;
     unsigned long row = HitTest(event.GetPosition(), flags);
     if (row < m_trans.size() && (flags & wxLIST_HITTEST_ONITEM) && col_nr < getColNrSize()) {
-        int col_id = getColId(col_nr);
+        int col_id = getColId_Nr(col_nr);
         wxString menuItemText;
         wxString refType = Model_Attachment::REFTYPE_NAME_TRANSACTION;
         wxDateTime datetime;
@@ -1568,8 +1568,9 @@ void TransactionListCtrl::onCopy(wxCommandEvent& WXUNUSED(event))
         wxString data = "";
         for (int row = 0; row < GetItemCount(); row++) {
             if (GetItemState(row, wxLIST_STATE_SELECTED) == wxLIST_STATE_SELECTED) {
-                for (int col_nr = 0; col_nr < getColNrSize(); ++col_nr) {
-                    if (GetColumnWidth(col_nr) > 0) {
+                for (int col_vo = 0; col_vo < getColNrSize(); ++col_vo) {
+                    int col_nr = getColNr_Vo(col_vo);
+                    if (!isHiddenColNr(col_nr)) {
                         data += inQuotes(OnGetItemText(row, col_nr), seperator);
                         data += seperator;
                     }

--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -565,7 +565,7 @@ void TransactionListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId(col_nr);
-    if (col_id == LIST_ID_ICON)
+    if (!m_col_id_info[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id) {

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -210,7 +210,7 @@ private:
     std::vector<Fused_Transaction::IdRepeat> getSelectedId() const;
     std::vector<Fused_Transaction::IdRepeat> getSelectedForCopy() const;
     void findSelectedTransactions();
-    int getColumnFromPosition(int xPos);
+    int getColNr_X(int xPos);
     void doSearchText(const wxString& value);
     void setVisibleItemIndex(long v);
     void markSelectedTransaction();

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -100,13 +100,18 @@ public:
     int getColNrSize() const;
     bool isValidColId(int col_id) const;
     bool isValidColNr(int col_nr) const;
-    int getColId(int col_nr) const;
-    int getColNr(int col_id) const;
+    int getColId_Nr(int col_nr) const;
+    int getColNr_Id(int col_id) const;
+    int getColNr_Vo(int col_vo) const;
+    int getColVo_Nr(int col_nr) const;
+    int getColId_Vo(int col_vo) const;
+    int getColVo_Id(int col_id) const;
     const wxString getColHeader(int col_id, bool show_icon = false) const;
     bool isDisabledColId(int col_id) const;
     bool isDisabledColNr(int col_nr) const;
     bool isHiddenColId(int col_id) const;
     bool isHiddenColNr(int col_nr) const;
+    bool isHiddenColVo(int col_vo) const;
     int getSortColId(int i = 0) const;
     int getSortColNr(int i = 0);
     bool getSortAsc(int i = 0) const;
@@ -134,7 +139,7 @@ protected:
     void updateSortIcon();
 
 private:
-    void shiftColumn(int col_nr, int offset);
+    void shiftColumn(int col_vo, int offset);
 
     void onItemResize(wxListEvent& event);
     void onColRightClick(wxListEvent& event);
@@ -170,15 +175,47 @@ inline bool mmListCtrl::isValidColNr(int col_nr) const
     return (col_nr >= 0 && col_nr < getColNrSize());
 }
 
-inline int mmListCtrl::getColId(int col_nr) const
+inline int mmListCtrl::getColId_Nr(int col_nr) const
 {
     return m_col_nr_id.empty() ? col_nr : m_col_nr_id[col_nr];
 }
 
-inline int mmListCtrl::getColNr(int col_id) const
+inline int mmListCtrl::getColNr_Id(int col_id) const
 {
     return m_col_nr_id.empty() ? col_id :
         std::find(m_col_nr_id.begin(), m_col_nr_id.end(), col_id) - m_col_nr_id.begin();
+}
+
+inline int mmListCtrl::getColNr_Vo(int col_vo) const
+{
+    // Return the column number (inedx) from the visual order.
+    // The column number and the visual order are always equal on Linux/macOS,
+    // but on Windows they may differ due to drag/drop actions.
+    #ifdef wxHAS_LISTCTRL_COLUMN_ORDER
+        return GetColumnIndexFromOrder(col_vo);
+    #else
+        return col_vo;
+    #endif
+}
+
+inline int mmListCtrl::getColVo_Nr(int col_nr) const
+{
+    // Return the visual order from the column number (inedx).
+    #ifdef wxHAS_LISTCTRL_COLUMN_ORDER
+        return GetColumnOrder(col_nr);
+    #else
+        return col_nr;
+    #endif
+}
+
+inline int mmListCtrl::getColId_Vo(int col_vo) const
+{
+    return getColId_Nr(getColNr_Vo(col_vo));
+}
+
+inline int mmListCtrl::getColVo_Id(int col_id) const
+{
+    return getColVo_Nr(getColNr_Id(col_id));
 }
 
 inline bool mmListCtrl::isDisabledColId(int col_id) const
@@ -188,7 +225,7 @@ inline bool mmListCtrl::isDisabledColId(int col_id) const
 
 inline bool mmListCtrl::isDisabledColNr(int col_nr) const
 {
-    return isDisabledColId(getColId(col_nr));
+    return isDisabledColId(getColId_Nr(col_nr));
 }
 
 inline bool mmListCtrl::isHiddenColId(int col_id) const
@@ -198,7 +235,12 @@ inline bool mmListCtrl::isHiddenColId(int col_id) const
 
 inline bool mmListCtrl::isHiddenColNr(int col_nr) const
 {
-    return isHiddenColId(getColId(col_nr));
+    return isHiddenColId(getColId_Nr(col_nr));
+}
+
+inline bool mmListCtrl::isHiddenColVo(int col_vo) const
+{
+    return isHiddenColId(getColId_Vo(col_vo));
 }
 
 inline int mmListCtrl::getSortColId(int i) const
@@ -210,7 +252,7 @@ inline int mmListCtrl::getSortColNr(int i)
 {
     int col_id = m_sort_col_id[i];
     int col_nr = c_sort_col_nr[i];
-    return (isValidColNr(col_nr) && getColId(col_nr) == col_id) ? col_nr :
+    return (isValidColNr(col_nr) && getColId_Nr(col_nr) == col_id) ? col_nr :
         cacheSortColNr(i);
 }
 

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -65,6 +65,9 @@ protected:
     };
 
 public:
+    // const
+    const int m_setting_version = 1;
+
     // configured by constructor (cannot be updated)
     const wxSharedPtr<wxListItemAttr> attr1_, attr2_; // style1, style2
 

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -73,13 +73,13 @@ public:
     wxString o_col_order_prefix;               // v1.9.0 prefix for column order
     wxString o_col_width_prefix;               // v1.9.0 prefix for column width
     wxString o_sort_prefix;                    // v1.9.0 prefix for sort
-    std::vector<ListColumnInfo> m_col_id_info; // map: col_id -> col_info
-    std::unordered_set<int> m_col_id_disabled; // set: col_id -> isDisabled
+    std::vector<ListColumnInfo> m_col_info_id; // map: col_id -> col_info
+    std::unordered_set<int> m_col_disabled_id; // set: col_id -> isDisabled
 
     // dynamic
-    std::vector<int> m_col_nr_id;              // map: col_nr -> col_id; or empty
-    std::vector<int> m_col_id_width;           // map: col_id -> col_width (lazy)
-    std::unordered_set<int> m_col_id_hidden;   // map (set): col_id -> isHidden
+    std::vector<int> m_col_id_nr;              // map: col_nr -> col_id; or empty
+    std::vector<int> m_col_width_id;           // map: col_id -> col_width (lazy)
+    std::unordered_set<int> m_col_hidden_id;   // map (set): col_id -> isHidden
     std::vector<int> m_sort_col_id;            // sorting col_id; can be empty
     std::vector<bool> m_sort_asc;              // sorting direction
     int m_sel_col_nr = -1;                     // set by onColRightClick()
@@ -155,14 +155,14 @@ private:
 
 inline int mmListCtrl::getColIdSize() const
 {
-    return static_cast<int>(m_col_id_info.size());
+    return static_cast<int>(m_col_info_id.size());
 }
 
 inline int mmListCtrl::getColNrSize() const
 {
-    return !m_col_nr_id.empty() ?
-        static_cast<int>(m_col_nr_id.size()) :
-        static_cast<int>(m_col_id_info.size());
+    return !m_col_id_nr.empty() ?
+        static_cast<int>(m_col_id_nr.size()) :
+        static_cast<int>(m_col_info_id.size());
 }
 
 inline bool mmListCtrl::isValidColId(int col_id) const
@@ -177,13 +177,13 @@ inline bool mmListCtrl::isValidColNr(int col_nr) const
 
 inline int mmListCtrl::getColId_Nr(int col_nr) const
 {
-    return m_col_nr_id.empty() ? col_nr : m_col_nr_id[col_nr];
+    return m_col_id_nr.empty() ? col_nr : m_col_id_nr[col_nr];
 }
 
 inline int mmListCtrl::getColNr_Id(int col_id) const
 {
-    return m_col_nr_id.empty() ? col_id :
-        std::find(m_col_nr_id.begin(), m_col_nr_id.end(), col_id) - m_col_nr_id.begin();
+    return m_col_id_nr.empty() ? col_id :
+        std::find(m_col_id_nr.begin(), m_col_id_nr.end(), col_id) - m_col_id_nr.begin();
 }
 
 inline int mmListCtrl::getColNr_Vo(int col_vo) const
@@ -220,7 +220,7 @@ inline int mmListCtrl::getColVo_Id(int col_id) const
 
 inline bool mmListCtrl::isDisabledColId(int col_id) const
 {
-    return m_col_id_disabled.find(col_id) != m_col_id_disabled.end();
+    return m_col_disabled_id.find(col_id) != m_col_disabled_id.end();
 }
 
 inline bool mmListCtrl::isDisabledColNr(int col_nr) const
@@ -230,7 +230,7 @@ inline bool mmListCtrl::isDisabledColNr(int col_nr) const
 
 inline bool mmListCtrl::isHiddenColId(int col_id) const
 {
-    return m_col_id_hidden.find(col_id) != m_col_id_hidden.end();
+    return m_col_hidden_id.find(col_id) != m_col_hidden_id.end();
 }
 
 inline bool mmListCtrl::isHiddenColNr(int col_nr) const

--- a/src/model/Model_Setting.cpp
+++ b/src/model/Model_Setting.cpp
@@ -152,6 +152,25 @@ const wxColour Model_Setting::getColour(const wxString& key, const wxColour& def
 }
 
 //-------------------------------------------------------------------
+// Jdoc
+void Model_Setting::setJdoc(const wxString& key, Document& newValue)
+{
+    wxString j_str = JSON_PrettyFormated(newValue);
+    setRaw(key, j_str);
+}
+void Model_Setting::setJdoc(const wxString& key, StringBuffer& newValue)
+{
+    wxString j_str = wxString::FromUTF8(newValue.GetString());
+    setRaw(key, j_str);
+}
+Document Model_Setting::getJdoc(const wxString& key, const wxString& defaultValue)
+{
+    Document j_doc;
+    wxString j_str = getRaw(key, defaultValue);
+    j_doc.Parse(j_str.utf8_str());
+    return j_doc;
+}
+
 // ArrayString
 void Model_Setting::setArrayString(const wxString& key, const wxArrayString& a)
 {

--- a/src/model/Model_Setting.h
+++ b/src/model/Model_Setting.h
@@ -72,6 +72,10 @@ public:
     void setColour(const wxString& key, const wxColour& newValue);
     const wxColour getColour(const wxString& key, const wxColour& defaultValue);
 
+    void setJdoc(const wxString& key, Document& newValue);
+    void setJdoc(const wxString& key, StringBuffer& newValue);
+    Document getJdoc(const wxString& key, const wxString& defaultValue);
+
     void setArrayString(const wxString& key, const wxArrayString& a);
     const wxArrayString getArrayString(const wxString& key);
 

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -404,7 +404,7 @@ void StocksListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId(col_nr);
-    if (col_id == LIST_ID_ICON)
+    if (!m_col_id_info[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -98,8 +98,8 @@ StocksListCtrl::StocksListCtrl(
     o_col_order_prefix = "STOCKS";
     o_col_width_prefix = "STOCKS_COL";
     o_sort_prefix = "STOCKS";
-    m_col_id_info = LIST_INFO;
-    m_col_nr_id = ListColumnInfo::getListId(LIST_INFO);
+    m_col_info_id = LIST_INFO;
+    m_col_id_nr = ListColumnInfo::getListId(LIST_INFO);
     m_sort_col_id = { col_sort() };
     createColumns();
 
@@ -404,7 +404,7 @@ void StocksListCtrl::OnColClick(wxListEvent& event)
     if (!isValidColNr(col_nr))
         return;
     int col_id = getColId_Nr(col_nr);
-    if (!m_col_id_info[col_id].sortable)
+    if (!m_col_info_id[col_id].sortable)
         return;
 
     if (m_sort_col_id[0] != col_id)

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -160,7 +160,7 @@ void StocksListCtrl::OnMouseRightClick(wxMouseEvent& event)
 
 wxString StocksListCtrl::OnGetItemText(long item, long col_nr) const
 {
-    int col_id = getColId(static_cast<int>(col_nr));
+    int col_id = getColId_Nr(static_cast<int>(col_nr));
     switch (col_id) {
     case LIST_ID_ID:
         return wxString::Format("%lld", m_stocks[item].STOCKID).Trim();
@@ -403,7 +403,7 @@ void StocksListCtrl::OnColClick(wxListEvent& event)
     int col_nr = (event.GetId() == MENU_HEADER_SORT) ? m_sel_col_nr : event.GetColumn();
     if (!isValidColNr(col_nr))
         return;
-    int col_id = getColId(col_nr);
+    int col_id = getColId_Nr(col_nr);
     if (!m_col_id_info[col_id].sortable)
         return;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -66,16 +66,12 @@ wxString JSON_Formated(rapidjson::Document& j_doc)
     return wxString::FromUTF8(j_buffer.GetString());
 }
 
-// Get a string value from RapidJson DOM
-bool JSON_GetStringValue(Document& j_doc, const MemoryStream::Ch* name, wxString& value)
+// Get a value from RapidJson DOM
+Value* JSON_GetValue(Document& j_doc, const MemoryStream::Ch* name)
 {
     if (!j_doc.HasMember(name))
-        return false;
-    Value& j_value = j_doc[name];
-    if (!j_value.IsString())
-        return false;
-    value = wxString::FromUTF8(j_value.GetString());
-    return true;
+        return nullptr;
+    return &j_doc[name];
 }
 
 // Get a bool value from RapidJson DOM
@@ -87,6 +83,30 @@ bool JSON_GetBoolValue(Document& j_doc, const MemoryStream::Ch* name, bool& valu
     if (!j_value.IsBool())
         return false;
     value = j_value.GetBool();
+    return true;
+}
+
+// Get an int value from RapidJson DOM
+bool JSON_GetIntValue(Document& j_doc, const MemoryStream::Ch* name, int& value)
+{
+    if (!j_doc.HasMember(name))
+        return false;
+    Value& j_value = j_doc[name];
+    if (!j_value.IsInt())
+        return false;
+    value = j_value.GetInt();
+    return true;
+}
+
+// Get a string value from RapidJson DOM
+bool JSON_GetStringValue(Document& j_doc, const MemoryStream::Ch* name, wxString& value)
+{
+    if (!j_doc.HasMember(name))
+        return false;
+    Value& j_value = j_doc[name];
+    if (!j_value.IsString())
+        return false;
+    value = wxString::FromUTF8(j_value.GetString());
     return true;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -35,8 +35,10 @@ class mmGUIApp;
 
 wxString JSON_PrettyFormated(rapidjson::Document& j_doc);
 wxString JSON_Formated(rapidjson::Document& j_doc);
-bool JSON_GetStringValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, wxString& value);
+rapidjson::Value* JSON_GetValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name);
 bool JSON_GetBoolValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, bool& value);
+bool JSON_GetIntValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, int& value);
+bool JSON_GetStringValue(rapidjson::Document& j_doc, const rapidjson::MemoryStream::Ch* name, wxString& value);
 
 struct ValuePair
 {


### PR DESCRIPTION
This PR depends on #7287.

## Database changes

Deprecated in Setting: `*_COLUMNORDER`, `*_WIDTH`, `*_SORT_COL*`, `*_ASC*`.

Added Setting `LIST_<name>` (JSON string), with fields:
- `version` (int): equal to 2 (version 1 has been used for testing)
- `col_id_nr` (array of int `col_id`): map column number -> column id
- `col_width_id` (array of int `width`): map column id -> column width
- `col_hidden_id` (array of int `col_id`): set of hidden column ids
- `sort_col_id` (array of int `col_id`): primary/secondary sorting column id
- `sort_asc` (array of bool `asc`): primary/secondary sorting direction

Notes:
- `col_id_nr` is omitted if columns cannot be moved.
- `sort_col_id` may have one or two elements (primary, secondary); it is omitted if the list cannot be sorted.
- `sort_asc` has the same size as `sort_col_id`.

There are 7 independent settings, identified by `<name>`:
- `TRANS1` (transactions of single account)
- `TRANS2` (All Transactions, transactions of account group)
- `DELETED` (Deleted Transactions)
- `SCHEDULED` (Scheduled Transactions)
- `ASSETS`
- `STOCKS`
- `BUDGET`

Migration from current settings to new settings:
- `*_COLUMNORDER` -> `col_id_nr`
- `*_WIDTH` (non-zero value) -> `col_width_id` (hidden columns have default width)
- `*_WIDTH` (zero value) -> `col_hidden_id` (set of column ids)
- `*_SORT_COL*` (column number) -> `sort_col_id` (array of column ids)
- `*_ASC*` (bool or int) -> `sort_asc` (array of bool)

Migration notes:
- `LIST_TRANS1.col_id_nr` is copied from `CHECKING_COLUMNORDER`; `*_COLUMNORDER` for all account types except `CHECKING` are ignored (not migrated).
- `LIST_TRANS2.sort_col_id` is copied from `ALLTRANS_SORT_COL*`; `MULTI_{SORT_COL,ASC}*` are ignored (not migrated).

## Changes in mmListCtrl

- Refine `savePreferences()`, `loadPreferences()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7288)
<!-- Reviewable:end -->
