### PR TITLE
fix(#7271): fix TransactionListCtrl::setSelectedId()

### DIFF
--- a/src/mmchecking_list.cpp
+++ b/src/mmchecking_list.cpp
@@ -1942,7 +1942,7 @@ void TransactionListCtrl::setSelectedId(Fused_Transaction::IdRepeat sel_id)
 { 
     int i = 0;
     for (const auto& fused : m_trans) {
-        if (fused.m_repeat_num == sel_id.first && fused.TRANSID == sel_id.first) {
+        if (fused.m_repeat_num == sel_id.second && fused.TRANSID == sel_id.first) {
             SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
             SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
             m_topItemIndex = i;


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7297)
<!-- Reviewable:end -->
