### PR TITLE
Stock: simplify mmSplitTransactionDialog via totalAmount_ & transType_ removal

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -1413,7 +1413,7 @@ void mmBDDialog::activateSplitTransactionsDlg()
         m_bill_data.local_splits.push_back(s);
     }
 
-    mmSplitTransactionDialog dlg(this, m_bill_data.local_splits, m_bill_data.ACCOUNTID, m_choice_transaction_type->GetSelection());
+    mmSplitTransactionDialog dlg(this, m_bill_data.local_splits, m_bill_data.ACCOUNTID);
     if (dlg.ShowModal() == wxID_OK)
     {
         m_bill_data.local_splits = dlg.mmGetResult();

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -1239,8 +1239,7 @@ void mmCheckingPanel::displaySplitCategories(Fused_Transaction::IdB fused_id)
         splits.push_back(s);
     }
     if (splits.empty()) return;
-    int tranType = Model_Checking::type_id(fused.TRANSCODE);
-    mmSplitTransactionDialog splitTransDialog(this, splits, m_account_id, tranType, 0.0, true);
+    mmSplitTransactionDialog splitTransDialog(this, splits, m_account_id, true);
 
     //splitTransDialog.SetDisplaySplitCategories();
     splitTransDialog.ShowModal();

--- a/src/sharetransactiondialog.cpp
+++ b/src/sharetransactiondialog.cpp
@@ -490,9 +490,7 @@ void ShareTransactionDialog::OnDeductibleSplit(wxCommandEvent& event)
         m_local_deductible_splits.push_back({0, commission, wxArrayInt64(), ""});
     }
 
-    mmSplitTransactionDialog dlg(this, m_local_deductible_splits 
-        , m_stock->HELDAT
-        , Model_Checking::TYPE_ID_DEPOSIT);
+    mmSplitTransactionDialog dlg(this, m_local_deductible_splits, m_stock->HELDAT);
 
     if (dlg.ShowModal() == wxID_OK)
     {

--- a/src/splittransactionsdialog.cpp
+++ b/src/splittransactionsdialog.cpp
@@ -98,7 +98,7 @@ void mmEditSplitOther::CreateControls()
     fgSizer1->Add(m_Notes, g_flagsExpand);
     mmToolTip(m_Notes, _t("Enter notes to describe this split transaction"));
 
-    //Buttons
+    // Buttons
     wxBoxSizer* bSizer3 = new wxBoxSizer(wxHORIZONTAL);
     bSizer1->Add(bSizer3, wxSizerFlags(g_flagsV).Center());
     wxButton* itemButtonOK = new wxButton(this, wxID_OK, _t("&OK "));
@@ -156,13 +156,9 @@ mmSplitTransactionDialog::~mmSplitTransactionDialog()
 mmSplitTransactionDialog::mmSplitTransactionDialog(wxWindow* parent
     , std::vector<Split>& split
     , int64 accountID
-    , int transType
-    , double totalAmount
     , bool is_view_only
 )
     : m_orig_splits(split)
-    , totalAmount_(totalAmount)
-    , transType_(transType)
     , row_num_(static_cast<int>(split.size()))
     , is_view_only_(is_view_only)
 {
@@ -406,11 +402,11 @@ void mmSplitTransactionDialog::OnOk( wxCommandEvent& /*event*/ )
             return;
 
     //Check total amount - should be positive
-    totalAmount_ = 0;
+    double totalAmount = 0;
     for (const auto& entry : m_splits)
-        totalAmount_ += entry.SPLITTRANSAMOUNT;
-    totalAmount_ = std::round(totalAmount_ * m_currency->SCALE.GetValue()) / m_currency->SCALE.GetValue();
-    if (totalAmount_ < 0) {
+        totalAmount += entry.SPLITTRANSAMOUNT;
+    totalAmount = std::round(totalAmount * m_currency->SCALE.GetValue()) / m_currency->SCALE.GetValue();
+    if (totalAmount < 0) {
         return mmErrorDialogs::MessageError(this, _t("Invalid Total Amount"), _t("Error"));
     }
 

--- a/src/splittransactionsdialog.h
+++ b/src/splittransactionsdialog.h
@@ -69,8 +69,6 @@ public:
     mmSplitTransactionDialog(wxWindow* parent
         , std::vector<Split>& split
         , int64 accountID
-        , int transType
-        , double totalAmount = 0.0
         , bool is_view_only = false
         );
     std::vector<Split> mmGetResult() const;
@@ -113,8 +111,6 @@ private:
 
     std::vector<SplitWidget> m_splits_widgets;
     std::vector<Split> m_orig_splits, m_splits;
-    double totalAmount_ =0.0;
-    int transType_ = 0;
     int row_num_ = 0;
     Model_Currency::Data* m_currency = nullptr;
     bool is_view_only_;

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -1077,11 +1077,7 @@ void mmTransDialog::OnCategs(wxCommandEvent& WXUNUSED(event))
         m_local_splits.push_back(s);
     }
 
-    bool isDeposit = Model_Checking::is_deposit(m_fused_data.TRANSCODE);
-    mmSplitTransactionDialog dlg(this, m_local_splits
-        , m_fused_data.ACCOUNTID
-        , isDeposit ? Model_Checking::TYPE_ID_DEPOSIT : Model_Checking::TYPE_ID_WITHDRAWAL
-        , m_fused_data.TRANSAMOUNT);
+    mmSplitTransactionDialog dlg(this, m_local_splits, m_fused_data.ACCOUNTID);
 
     if (dlg.ShowModal() == wxID_OK)
     {


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7348)
<!-- Reviewable:end -->
