### PR TITLE
Asset: unify initial val and market val calculation

### DIFF
--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -111,8 +111,10 @@ void mmAssetDialog::dataToControls()
         m_assetName->Enable(false);
     m_dpc->SetValue(Model_Asset::STARTDATE(m_asset));
     m_assetType->SetSelection(Model_Asset::type_id(m_asset));
-    m_value->SetValue(std::abs(m_asset->VALUE));
-    m_curr_val->SetValue(Model_Asset::value(m_asset));
+
+    auto bal = Model_Asset::value(m_asset);
+    m_value->SetValue(bal.first);
+    m_curr_val->SetValue(bal.second);
 
     int valueChangeType = Model_Asset::change_id(m_asset);
     m_valueChange->SetSelection(valueChangeType);

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -566,8 +566,9 @@ int mmAssetsPanel::initVirtualListControl(int64 id)
     double initial = 0.0, balance = 0.0;
     for (const auto& asset: this->m_assets)
     {
-        initial += asset.VALUE;
-        balance += Model_Asset::value(asset);
+        auto bal = Model_Asset::value(asset);
+        initial += bal.first;
+        balance += bal.second;
     }
     header_text_->SetLabelText(wxString::Format(_t("Total: %s, Initial: %s"), Model_Currency::toCurrency(balance), Model_Currency::toCurrency(initial))); // balance
 
@@ -623,9 +624,9 @@ wxString mmAssetsPanel::getItem(long item, int col_id)
     case mmAssetsListCtrl::LIST_ID_TYPE:
         return wxGetTranslation(asset.ASSETTYPE);
     case mmAssetsListCtrl::LIST_ID_VALUE_INITIAL:
-        return Model_Currency::toCurrency(asset.VALUE);
+        return Model_Currency::toCurrency(Model_Asset::value(asset).first);
     case mmAssetsListCtrl::LIST_ID_VALUE_CURRENT:
-        return Model_Currency::toCurrency(Model_Asset::value(asset));
+        return Model_Currency::toCurrency(Model_Asset::value(asset).second);
     case mmAssetsListCtrl::LIST_ID_DATE:
         return mmGetDateTimeForDisplay(asset.STARTDATE);
     case mmAssetsListCtrl::LIST_ID_NOTES: {

--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -245,8 +245,9 @@ std::pair<double, double> Model_Account::investment_balance(const Data* r)
 
     for (const auto& asset: Model_Asset::instance().find(Model_Asset::ASSETNAME(r->ACCOUNTNAME)))
     {
-        sum.first += Model_Asset::value(asset);
-        sum.second += asset.VALUE;
+        auto asset_bal = Model_Asset::value(asset);
+        sum.first += asset_bal.second;
+        sum.second += asset_bal.first;
     }
     return sum;
 }

--- a/src/model/Model_Asset.h
+++ b/src/model/Model_Asset.h
@@ -115,11 +115,11 @@ public:
     /** Returns the base currency Data record pointer*/
     static Model_Currency::Data* currency(const Data* /* r */);
     /** Returns the calculated current value */
-    static double value(const Data* r);
+    static std::pair<double, double> value(const Data* r);
     /** Returns the calculated current value */
-    static double value(const Data& r);
+    static std::pair<double, double> value(const Data& r);
     /** Returns the calculated value at a given date */
-    double valueAtDate(const Data* r, const wxDate date);
+    std::pair<double, double> valueAtDate(const Data* r, const wxDate date);
 };
 
 //----------------------------------------------------------------------------

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -216,7 +216,7 @@ wxString mmReportSummaryByDate::getHTMLText()
         }
 
         for (const auto& asset : Model_Asset::instance().all()) {
-            assetBalance += Model_Asset::instance().valueAtDate(&asset, end_date) * getDayRate(asset.CURRENCYID, end_date);
+            assetBalance += Model_Asset::instance().valueAtDate(&asset, end_date).second * getDayRate(asset.CURRENCYID, end_date);
         }
 
         totBalanceEntry.values.push_back(balancePerDay[Model_Account::TYPE_ID_CASH]);


### PR DESCRIPTION
```
    std::pair<double /*initial*/, double /*market*/> balance;
                    if (amount < 0) // sale, try your best to keep the principal
                        balance.first += std::min(balance.second + amount, 0.0);
                    else
                        balance.first += amount;
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7362)
<!-- Reviewable:end -->
