### PR TITLE
Feature: allow skipping or flagging duplicate transactions (QIF imports)

### DIFF
--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -181,27 +181,34 @@ void mmQIFImportDialog::CreateControls()
     //Filtering Details --------------------------------------------
     wxStaticBox* static_box = new wxStaticBox(this, wxID_ANY, _t("Filtering Details:"));
     wxStaticBoxSizer* filter_sizer = new wxStaticBoxSizer(static_box, wxVERTICAL);
-    wxFlexGridSizer* flex_sizer2 = new wxFlexGridSizer(0, 2, 0, 0);
-    filter_sizer->Add(flex_sizer2, g_flagsExpand);
+
+    // Create a horizontal sizer to hold the date and duplicate columns
+    wxBoxSizer* filter_grid_sizer = new wxBoxSizer(wxHORIZONTAL);
+    filter_sizer->Add(filter_grid_sizer, g_flagsExpand);
+
+    // Left column for dates
+    wxFlexGridSizer* dates_sizer = new wxFlexGridSizer(0, 2, 0, 0);
 
     // From Date
     dateFromCheckBox_ = new wxCheckBox(static_box, wxID_FILE8, _t("From Date")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     fromDateCtrl_ = new mmDatePickerCtrl(static_box, wxID_STATIC, wxDefaultDateTime
         , wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN);
-    fromDateCtrl_->SetMinSize(wxSize(150, -1));
     fromDateCtrl_->Enable(false);
-    flex_sizer2->Add(dateFromCheckBox_, g_flagsH);
-    flex_sizer2->Add(fromDateCtrl_, g_flagsH);
+    dates_sizer->Add(dateFromCheckBox_, g_flagsH);
+    dates_sizer->Add(fromDateCtrl_, g_flagsH);
 
     // To Date
     dateToCheckBox_ = new wxCheckBox(static_box, wxID_FILE9, _t("To Date")
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     toDateCtrl_ = new mmDatePickerCtrl(static_box, wxID_STATIC, wxDefaultDateTime
-        , wxDefaultPosition, wxSize(150, -1), wxDP_DROPDOWN);
+        , wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN);
     toDateCtrl_->Enable(false);
-    flex_sizer2->Add(dateToCheckBox_, g_flagsH);
-    flex_sizer2->Add(toDateCtrl_, g_flagsH);
+    dates_sizer->Add(dateToCheckBox_, g_flagsH);
+    dates_sizer->Add(toDateCtrl_, g_flagsH);
+
+    // Right column for duplicates
+    wxFlexGridSizer* dup_sizer = new wxFlexGridSizer(0, 2, 0, 0);
 
     // Duplicate Transactions Method
     dupTransCheckBox_ = new wxCheckBox(static_box, wxID_FILE3, _t("Duplicates")
@@ -211,8 +218,8 @@ void mmQIFImportDialog::CreateControls()
     dupTransMethod_->Append(_t("By date and amount"));
     dupTransMethod_->SetSelection(0);
     dupTransMethod_->Enable(false);
-    flex_sizer2->Add(dupTransCheckBox_, g_flagsH);
-    flex_sizer2->Add(dupTransMethod_, g_flagsH);
+    dup_sizer->Add(dupTransCheckBox_, g_flagsH);
+    dup_sizer->Add(dupTransMethod_, g_flagsH);
 
     // Duplicate Transactions Action
     wxStaticText* dupTransActionLabel = new wxStaticText(static_box, wxID_STATIC, _t("Action"));
@@ -221,8 +228,17 @@ void mmQIFImportDialog::CreateControls()
     dupTransAction_->Append(_t("Flag as duplicate"));
     dupTransAction_->SetSelection(0);
     dupTransAction_->Enable(false);
-    flex_sizer2->Add(dupTransActionLabel, g_flagsH);
-    flex_sizer2->Add(dupTransAction_, g_flagsH);
+    dup_sizer->Add(dupTransActionLabel, g_flagsH);
+    dup_sizer->Add(dupTransAction_, g_flagsH);
+
+    filter_grid_sizer->Add(dates_sizer, g_flagsH);
+
+    // Add vertical line separator
+    wxStaticLine* vline = new wxStaticLine(static_box, wxID_ANY, wxDefaultPosition,
+        wxDefaultSize, wxLI_VERTICAL);
+    filter_grid_sizer->Add(vline, wxSizerFlags().Left().Border(wxLEFT | wxRIGHT, 5).Expand());
+
+    filter_grid_sizer->Add(dup_sizer, g_flagsH);
 
     //Data viewer ----------------------------------------------
     wxNotebook* qif_notebook = new wxNotebook(this

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1261,7 +1261,10 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         joinSplit(trx_data_set, m_splitDataSets);
         saveSplit();
 
-        sMsg = _t("Import finished successfully") + "\n" + wxString::Format(_t("Total Imported: %zu"), trx_data_set.size());
+        sMsg = _t("Import finished successfully") + "\n" +
+            wxString::Format(_t("Total Imported: %zu"), trx_data_set.size()) + "\n" +
+            wxString::Format(_t("Duplicates Detected: %zu"), m_duplicateTransactions.size());
+
         trx_data_set.clear();
         vQIF_trxs_.clear();
         btnOK_->Enable(false);

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -296,6 +296,9 @@ void mmQIFImportDialog::CreateControls()
         , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     payeeMatchAddNotes_->Disable();
 
+    // Check for duplicate transactions :
+    dupTransCheckBox_ = new wxCheckBox(this, wxID_ANY, _t("Flag duplicates (same transaction number)")
+        , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
 
     // Date Format Settings
     m_dateFormatStr = Option::instance().getDateFormat();
@@ -319,6 +322,9 @@ void mmQIFImportDialog::CreateControls()
     flex_sizer_b->AddSpacer(1);
     flex_sizer_b->Add(payeeIsNotesCheckBox_, g_flagsBorder1H);
     flex_sizer_b->Add(payeeMatchAddNotes_, g_flagsBorder1H);
+    flex_sizer_b->AddSpacer(1);
+    flex_sizer_b->Add(dupTransCheckBox_, g_flagsBorder1H);
+    flex_sizer_b->AddSpacer(1);
     flex_sizer_b->AddSpacer(1);
 
     wxBoxSizer* date_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1538,7 +1544,7 @@ bool mmQIFImportDialog::completeTransaction(/*in*/ const std::unordered_map <int
     }
 
     // Check for transaction number and look for duplicates
-    if (!trx->TRANSACTIONNUMBER.empty())
+    if (dupTransCheckBox_->IsChecked() && !trx->TRANSACTIONNUMBER.empty())
     {
         const auto existing_transactions = Model_Checking::instance().find(
             Model_Checking::TRANSACTIONNUMBER(trx->TRANSACTIONNUMBER),

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1536,6 +1536,18 @@ bool mmQIFImportDialog::completeTransaction(/*in*/ const std::unordered_map <int
         }
 
     }
+
+    // Check for transaction number and look for duplicates
+    if (!trx->TRANSACTIONNUMBER.empty())
+    {
+        const auto existing_transactions = Model_Checking::instance().find(
+            Model_Checking::TRANSACTIONNUMBER(trx->TRANSACTIONNUMBER),
+            Model_Checking::DELETEDTIME(wxEmptyString, EQUAL));
+
+        if (!existing_transactions.empty())
+            trx->STATUS = Model_Checking::STATUS_KEY_DUPLICATE;
+    }
+
     return true;
 }
 

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -122,7 +122,7 @@ private:
     mmChoiceAmountMask* m_choiceDecimalSeparator = nullptr;
     wxCheckBox* colorCheckBox_ = nullptr;
     mmColorButton* mmColorBtn_ = nullptr;
-    wxCheckBox* dupTransCheckBox_ = nullptr;
+    wxChoice* dupTransChoice_ = nullptr;
 
     bool payeeIsNotes_ = false; //Include payee field in notes
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -124,6 +124,7 @@ private:
     mmColorButton* mmColorBtn_ = nullptr;
     wxChoice* dupTransMethod_ = nullptr;
     wxChoice* dupTransAction_ = nullptr;
+    wxCheckBox* dupTransCheckBox_ = nullptr;
 
     bool payeeIsNotes_ = false; //Include payee field in notes
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -122,7 +122,8 @@ private:
     mmChoiceAmountMask* m_choiceDecimalSeparator = nullptr;
     wxCheckBox* colorCheckBox_ = nullptr;
     mmColorButton* mmColorBtn_ = nullptr;
-    wxChoice* dupTransChoice_ = nullptr;
+    wxChoice* dupTransMethod_ = nullptr;
+    wxChoice* dupTransAction_ = nullptr;
 
     bool payeeIsNotes_ = false; //Include payee field in notes
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -130,6 +130,8 @@ private:
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;
     bool payeeRegExInitialized_ = false;
 
+    std::set<int64> m_duplicateTransactions; // Keep track of matched transaction IDs
+
     enum LIST_ID
     {
         LIST_ID_ID = 0,

--- a/src/import_export/qif_import_gui.h
+++ b/src/import_export/qif_import_gui.h
@@ -122,6 +122,7 @@ private:
     mmChoiceAmountMask* m_choiceDecimalSeparator = nullptr;
     wxCheckBox* colorCheckBox_ = nullptr;
     mmColorButton* mmColorBtn_ = nullptr;
+    wxCheckBox* dupTransCheckBox_ = nullptr;
 
     bool payeeIsNotes_ = false; //Include payee field in notes
     std::map<std::pair <int64, wxString>, std::map<int, std::pair<wxString, wxRegEx>> > payeeMatchPatterns_;


### PR DESCRIPTION
This is my first attempt to contribute to this project. C++ is not my main language so I'm very open to feedback.

I tend to import QIF/CSV files from my bank a few times per month and I can't really use the date filtering to avoid duplicates because sometimes my bank would take a few days to include some transactions. Pretty much the same issue as described in https://github.com/moneymanagerex/moneymanagerex/issues/6771.

So I decided to try and add a few opt-in filtering features. Default behavior is exactly the same as before.

![image](https://github.com/user-attachments/assets/f38ab5de-1b95-4382-a1bf-940081dfaa2e)

The options are:
* Duplicates:
  - By transaction number
  - By amount and exact date
  - By amount and nearby date
* Action:
  - Skip
  - Flag as duplicate

The options are pretty much self-explanatory but, just in case, the "By amount and nearby date" option will try to match the incoming transaction with any still-unmatched transaction having the exact same amount but in a time window determined from 4 days before the incoming date and 2 days after. These values might need some fine-tuning but I think they're good defaults.

I'm open to implement similar features for the CSV importing, but I'd like to get feedback first and iterate over this feature in any case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7368)
<!-- Reviewable:end -->
