### PR TITLE
Tidy toolbar icon arrangements and snap to width of application

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -291,7 +291,15 @@ mmGUIFrame::mmGUIFrame(
         .Name("toolbar").ToolbarPane().Top()
         .LeftDockable(false).RightDockable(false)
         .Show(Model_Setting::instance().getBool("SHOWTOOLBAR", true))
-    );
+        .DockFixed(false)                                               
+        .Top()
+        .MinSize(wxSize(-1, toolBar_->GetSize().GetHeight())) 
+        .MaxSize(wxSize(-1, toolBar_->GetSize().GetHeight())) 
+        .Position(0)
+        .Row(0)
+        .Layer(0)
+        .Resizable(true)
+        );                          
 
     // change look and feel of wxAuiManager
     m_mgr.GetArtProvider()->SetMetric(16, 0);
@@ -2157,6 +2165,7 @@ void mmGUIFrame::createToolBar()
     toolBar_ = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
     toolBar_->SetToolBorderPadding(1);
     mmThemeMetaColour(toolBar_, meta::COLOR_LISTPANEL);
+    //toolBar_->SetBackgroundColour(wxColor(*wxRED));
     //toolBar_->SetToolBitmapSize(wxSize(toolbar_icon_size, toolbar_icon_size));  // adjust tool size to match the icon size being used
 
     toolBar_->AddTool(MENU_NEW, _t("New"), mmBitmapBundle(png::NEW_DB, toolbar_icon_size), _t("New Database"));
@@ -2175,31 +2184,33 @@ void mmGUIFrame::createToolBar()
     toolBar_->AddTool(MENU_TRANSACTIONREPORT, _t("Transaction Report"), mmBitmapBundle(png::FILTER, toolbar_icon_size), _t("Transaction Report"));
     toolBar_->AddSeparator();
     toolBar_->AddTool(wxID_VIEW_LIST, _t("General Report Manager"), mmBitmapBundle(png::GRM, toolbar_icon_size), _t("General Report Manager"));
-    toolBar_->AddSeparator();
-    toolBar_->AddTool(wxID_PREFERENCES, _t("&Settings"), mmBitmapBundle(png::OPTIONS, toolbar_icon_size), _t("Settings"));
-    toolBar_->AddSeparator();
-
-    wxString news_array;
-    for (const auto& entry : websiteNewsArray_) {
-        news_array += entry.Title + "\n";
-    }
-    if (news_array.empty()) {
-        news_array = _t("News");
-    }
-    const auto news_ico = (websiteNewsArray_.size() > 0)
-        ? mmBitmapBundle(png::NEW_NEWS, toolbar_icon_size)
-        : mmBitmapBundle(png::NEWS, toolbar_icon_size);
-    toolBar_->AddTool(MENU_ANNOUNCEMENTMAILING, _t("News"), news_ico, news_array);
 
     toolBar_->AddTool(MENU_RATES, _t("Download Rates"), mmBitmapBundle(png::CURRATES, toolbar_icon_size), _t("Download currency and stock rates"));
 
-    toolBar_->AddSeparator();
-    toolBar_->AddTool(MENU_VIEW_TOGGLE_FULLSCREEN, _t("Full Screen") + "\tF11", mmBitmapBundle(png::FULLSCREEN, toolbar_icon_size), _t("Toggle full screen"));
-
+   
     toolBar_->AddSeparator();
     toolBar_->AddTool(wxID_PRINT, _t("&Print"), mmBitmapBundle(png::PRINT, toolbar_icon_size), _t("Print"));
-
     toolBar_->AddSeparator();
+
+    toolBar_->AddStretchSpacer();
+    toolBar_->AddSeparator();
+    toolBar_->AddTool(MENU_VIEW_TOGGLE_FULLSCREEN, _t("Full Screen") + "\tF11", mmBitmapBundle(png::FULLSCREEN, toolbar_icon_size), _t("Toggle full screen"));
+    toolBar_->AddTool(wxID_PREFERENCES, _t("&Settings"), mmBitmapBundle(png::OPTIONS, toolbar_icon_size), _t("Settings"));
+    toolBar_->AddSeparator();
+
+
+    wxString news_array;
+    for (const auto& entry : websiteNewsArray_)
+    {
+        news_array += entry.Title + "\n";
+    }
+    if (news_array.empty())
+    {
+        news_array = _t("News");
+    }
+    const auto news_ico = (websiteNewsArray_.size() > 0) ? mmBitmapBundle(png::NEW_NEWS, toolbar_icon_size) : mmBitmapBundle(png::NEWS, toolbar_icon_size);
+
+    toolBar_->AddTool(MENU_ANNOUNCEMENTMAILING, _t("News"), news_ico, news_array);
     toolBar_->AddTool(wxID_ABOUT, _t("&About"), mmBitmapBundle(png::ABOUT, toolbar_icon_size), _t("About"));
     toolBar_->AddTool(wxID_HELP, _t("&Help") + "\tF1", mmBitmapBundle(png::HELP, toolbar_icon_size), _t("Help"));
 

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -2165,7 +2165,6 @@ void mmGUIFrame::createToolBar()
     toolBar_ = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
     toolBar_->SetToolBorderPadding(1);
     mmThemeMetaColour(toolBar_, meta::COLOR_LISTPANEL);
-    //toolBar_->SetBackgroundColour(wxColor(*wxRED));
     //toolBar_->SetToolBitmapSize(wxSize(toolbar_icon_size, toolbar_icon_size));  // adjust tool size to match the icon size being used
 
     toolBar_->AddTool(MENU_NEW, _t("New"), mmBitmapBundle(png::NEW_DB, toolbar_icon_size), _t("New Database"));
@@ -2184,15 +2183,14 @@ void mmGUIFrame::createToolBar()
     toolBar_->AddTool(MENU_TRANSACTIONREPORT, _t("Transaction Report"), mmBitmapBundle(png::FILTER, toolbar_icon_size), _t("Transaction Report"));
     toolBar_->AddSeparator();
     toolBar_->AddTool(wxID_VIEW_LIST, _t("General Report Manager"), mmBitmapBundle(png::GRM, toolbar_icon_size), _t("General Report Manager"));
-
     toolBar_->AddTool(MENU_RATES, _t("Download Rates"), mmBitmapBundle(png::CURRATES, toolbar_icon_size), _t("Download currency and stock rates"));
 
-   
     toolBar_->AddSeparator();
     toolBar_->AddTool(wxID_PRINT, _t("&Print"), mmBitmapBundle(png::PRINT, toolbar_icon_size), _t("Print"));
     toolBar_->AddSeparator();
 
     toolBar_->AddStretchSpacer();
+
     toolBar_->AddSeparator();
     toolBar_->AddTool(MENU_VIEW_TOGGLE_FULLSCREEN, _t("Full Screen") + "\tF11", mmBitmapBundle(png::FULLSCREEN, toolbar_icon_size), _t("Toggle full screen"));
     toolBar_->AddTool(wxID_PREFERENCES, _t("&Settings"), mmBitmapBundle(png::OPTIONS, toolbar_icon_size), _t("Settings"));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5ca2ea39-04dd-47e3-9068-b94f4d6a3f72)

**Purpose:** Modernise appearance of toolbar.

When snapped to top, toolbar will automatically span width of application.
Rearranged icons, and separated utility icons (full screen, settings, help, news, about) to the right-hand side.

Toolbar can still be undocked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7382)
<!-- Reviewable:end -->
