### PR TITLE
Binds Navigator hotkey to F6

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -332,6 +332,7 @@ mmGUIFrame::mmGUIFrame(
     const wxAcceleratorEntry entries[] = {
         wxAcceleratorEntry(wxACCEL_NORMAL, WXK_F9, wxID_NEW),
         wxAcceleratorEntry(wxACCEL_NORMAL, WXK_F5, wxID_REFRESH),
+        wxAcceleratorEntry(wxACCEL_NORMAL, WXK_F6, MENU_VIEW_LINKS),
     };
 
     wxAcceleratorTable tab(sizeof(entries) / sizeof(*entries), entries);
@@ -1756,7 +1757,7 @@ void mmGUIFrame::createMenu()
     wxMenuItem* menuItemLinks = new wxMenuItem(
         menuView,
         MENU_VIEW_LINKS,
-        _t("&Navigator") + "\tF5",
+        _t("&Navigator") + "\tF6",
         _t("Show/Hide Navigator"),
         wxITEM_CHECK
     );


### PR DESCRIPTION
F5 hotkey is already bound in code to refresh functionality.
This PR binds hotkey to F6 (unused elsewhere in application), and updates menu label.

Fixes #7389 