### PR TITLE
Fix built-in category reports not showing newly created categories

### DIFF
--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -561,9 +561,9 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
     {
         wxStringTokenizer tokenizer(sData, ":");
         int i =0;
-        int catID = -1;
-        int subCatID = -1;
-        int payeeID = -1;
+        int64 catID = -1;
+        int64 subCatID = -1;
+        int64 payeeID = -1;
         // categoryID, subcategoryID, payeeID
         //      subcategoryID = -2 means inlude all sub categories for the given category
         while ( tokenizer.HasMoreTokens() )


### PR DESCRIPTION
Recent change to int64 for SUID caused built-in category reports not to show any transactions for recently categories that had been created with a SUID-type identifier.
This is because the catID/subCatID/payeeID variables were initialised as int and not int64, causing an overflow.


Fixes #7392

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7401)
<!-- Reviewable:end -->
