### PR TITLE
Update Income/Expense chart on homepage to include currency formatting

### DIFF
--- a/resources/home_page.htt
+++ b/resources/home_page.htt
@@ -138,7 +138,25 @@
                         chart: { type : 'bar', foreColor: '<TMPL_VAR INCOME_VS_EXPENSES_FORECOLOR>', toolbar : { show : false } },
                         dataLabels : { enabled : false },
                         colors: [ <TMPL_VAR INCOME_VS_EXPENSES_COLORS> ],
-                        tooltip : { theme : "dark" },
+                        tooltip: { 
+                            theme: "dark",
+                            y: {
+                                formatter: function(value) {
+                                var options = {
+                                    useGrouping: true,
+                                    minimumFractionDigits: <TMPL_VAR INCOME_VS_EXPENSES_CURR_SCALE>,
+                                    maximumFractionDigits: <TMPL_VAR INCOME_VS_EXPENSES_CURR_SCALE>,
+                                    groupingSeparator: '<TMPL_VAR INCOME_VS_EXPENSES_CURR_GROUP_SEPARATOR>',
+                                    decimalSeparator: '<TMPL_VAR INCOME_VS_EXPENSES_CURR_DECIMAL_POINT>'
+                                };
+
+                                    var formatted = value.toLocaleString('<TMPL_VAR LOCALE>', options);
+                                    return '<TMPL_VAR INCOME_VS_EXPENSES_CURR_PFX_SYMBOL>' + formatted + '<TMPL_VAR INCOME_VS_EXPENSES_CURR_SFX_SYMBOL>';
+                                }
+                            }
+                        },
+
+
                         xaxis : { labels : { show : false }, categories : [ive_json[9]]},
                         series : [
                             {

--- a/src/mmhomepagepanel.cpp
+++ b/src/mmhomepagepanel.cpp
@@ -131,6 +131,20 @@ void mmHomePagePanel::insertDataIntoTemplate()
 {
     m_frames["HTMLSCALE"] = wxString::Format("%d", Option::instance().getHtmlScale());
 
+    // Get curreny details to pass to report for Apexcharts
+    int64 baseCurrencyID = Option::instance().getBaseCurrencyID();
+    Model_Currency::Data* baseCurrency = Model_Currency::instance().get(baseCurrencyID);
+
+    // Get locale to pass to reports for Apexcharts
+    wxString locale = Model_Infotable::instance().getString("LOCALE", "en-US"); // Stay blank of not set, currency override handled in Apexcharts call.
+    wxString adjustedLocale = locale;
+    if (adjustedLocale == "")
+    {
+        adjustedLocale = "en-US";
+    }
+    adjustedLocale.Replace("_", "-");
+    m_frames["LOCALE"] = adjustedLocale;
+
     double tBalance = 0.0, tReconciled = 0.0;
     double cardBalance = 0.0, cardReconciled = 0.0;
     double termBalance = 0.0, termReconciled = 0.0;
@@ -185,6 +199,12 @@ void mmHomePagePanel::insertDataIntoTemplate()
     m_frames["INCOME_VS_EXPENSES_FORECOLOR"] = mmThemeMetaString(meta::COLOR_REPORT_FORECOLOR);
     m_frames["INCOME_VS_EXPENSES_COLORS"] = wxString::Format("'%s', '%s'", mmThemeMetaString(meta::COLOR_REPORT_CREDIT)
                                                 , mmThemeMetaString(meta::COLOR_REPORT_DEBIT));
+    m_frames["INCOME_VS_EXPENSES_CURR_PFX_SYMBOL"] = baseCurrency ? baseCurrency->PFX_SYMBOL : "$";
+    m_frames["INCOME_VS_EXPENSES_CURR_SFX_SYMBOL"] = baseCurrency ? baseCurrency->SFX_SYMBOL : "";
+    m_frames["INCOME_VS_EXPENSES_CURR_GROUP_SEPARATOR"] = baseCurrency ? baseCurrency->GROUP_SEPARATOR : ",";
+    m_frames["INCOME_VS_EXPENSES_CURR_DECIMAL_POINT"] = baseCurrency ? baseCurrency->DECIMAL_POINT : ".";
+    m_frames["INCOME_VS_EXPENSES_CURR_SCALE"] = baseCurrency ? wxString::Format("%d", static_cast<int>(log10(baseCurrency->SCALE.GetValue()))) : "";
+
 
     htmlWidgetBillsAndDeposits bills_and_deposits(_t("Upcoming Transactions"));
     m_frames["BILLS_AND_DEPOSITS"] = bills_and_deposits.getHTMLText();


### PR DESCRIPTION
Add currency formatting to the 'amount' on Apexcharts label for Income vs. Expense chart on MEMX dashboard homepage.

Labels are sensitive to the base currency configured in MMEX, and adjust accordingly.

![image](https://github.com/user-attachments/assets/c2f5c463-526c-4349-a410-a3decf3d85e8)

![image](https://github.com/user-attachments/assets/ff5c6fa5-431f-4c20-87c0-855caacd2b09)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7404)
<!-- Reviewable:end -->
