### PR TITLE
Click transaction sum to copy to clipboard

### DIFF
--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -347,6 +347,14 @@ void mmCheckingPanel::createControls()
         wxTE_MULTILINE | wxTE_WORDWRAP
     );
     sizerVFooter->Add(m_info_panel, g_flagsExpandBorder1);
+    mmToolTip(m_info_panel, _t("Click to copy to clipboard"));
+
+    m_info_panel->Bind(wxEVT_LEFT_DOWN,
+                       [this, infoPanel = m_info_panel](wxMouseEvent& event)
+                       {
+                           onInfoPanelClick(event, infoPanel);
+                       });
+
     //Show tips when no any transaction selected
     showTips();
 }
@@ -899,6 +907,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
                 }
             }
         }
+        m_info_panel_selectedbal.clear(); // Not displaying any selected transactions in m_info_panel, clear selected transaction balance var
         m_info_panel->SetLabelText(notesStr);
     }
     else /* !single */ {
@@ -943,12 +952,13 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
             int days = max_date.Subtract(min_date).GetDays();
 
             wxString msg;
+            wxString selectedBal = Model_Currency::toCurrency(flow, currency);
+            m_info_panel_selectedbal = selectedBal;
             msg = wxString::Format(_t("Transactions selected: %zu"), selected.size());
             msg += "\n";
             if (currency) {
                 msg += wxString::Format(
-                    _t("Selected transactions balance: %s"),
-                    Model_Currency::toCurrency(flow, currency)
+                    _t("Selected transactions balance: %s"), selectedBal
                 );
                 msg += "\n";
             }
@@ -959,7 +969,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
 #ifdef __WXMAC__    // See issue #2914
             msg = "";
 #endif
-            m_info_panel->SetLabelText(msg);
+            m_info_panel->SetLabelText(msg);         
         }
         else /* selected.size() == 0 */ {
             enableButtons(false, false, false, false, false, false);
@@ -988,6 +998,8 @@ void mmCheckingPanel::enableButtons(bool edit, bool dup, bool del, bool enter, b
 
 void mmCheckingPanel::showTips()
 {
+    m_info_panel_selectedbal.clear(); // Not displaying any selected transactions in m_info_panel, clear selected transaction balance var
+
     if (m_show_tips) {
         m_show_tips = false;
         return;
@@ -1006,6 +1018,7 @@ void mmCheckingPanel::showTips()
 
 void mmCheckingPanel::showTips(const wxString& tip)
 {
+    m_info_panel_selectedbal.clear(); // Not displaying any selected transactions in m_info_panel, clear selected transaction balance var
     if (Option::instance().getShowMoneyTips())
         m_info_panel->SetLabelText(tip);
     else
@@ -1191,6 +1204,33 @@ void mmCheckingPanel::onButtonRightDown(wxMouseEvent& event)
         break;
     }
 }
+
+void mmCheckingPanel::onInfoPanelClick(wxMouseEvent& event, wxStaticText* infoPanel)
+{
+    wxString clipboardValue = "";
+    if (!m_info_panel_selectedbal.IsEmpty())
+    {
+        clipboardValue = m_info_panel_selectedbal;
+    }
+    else
+    {
+        clipboardValue = infoPanel->GetLabel();
+    }
+    if (!clipboardValue.IsEmpty())
+    {
+        // Copy to clipboard
+        if (wxTheClipboard->Open())
+        {
+            wxTheClipboard->SetData(new wxTextDataObject(clipboardValue));
+            wxTheClipboard->Close();
+            this->Layout();
+        }
+        m_info_panel_selectedbal.empty();
+    }
+
+    event.Skip();
+}
+
 
 //----------------------------------------------------------------------------
 

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -145,6 +145,7 @@ private:
     wxStaticText* m_header_balance = nullptr;
     wxStaticText* m_info_panel = nullptr;
     wxStaticText* m_info_panel_mini = nullptr;
+    wxString m_info_panel_selectedbal; 
     wxVector<wxBitmapBundle> m_images;
     TransactionListCtrl* m_lc = nullptr;
     wxSharedPtr<mmFilterTransactionsDialog> m_trans_filter_dlg;
@@ -189,6 +190,7 @@ private:
     void onOpenAttachment(wxCommandEvent& event);
     void onSearchTxtEntered(wxCommandEvent& event);
     void onButtonRightDown(wxMouseEvent& event);
+    void onInfoPanelClick(wxMouseEvent& event, wxStaticText* infoPanel);
 
     wxString getPanelTitle() const;
     static void mmPlayTransactionSound();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/527d5b3e-51f9-4710-94fc-c72af9c400a0)

As a heavy Excel user, I can see how this one could be handy.
If a single transaction is selected, the value of the label (transaction memo) is copied to clipboard.
If multiple transactions are selected, the summed value of the selected transactions is copied to clipboard.

I tried to pushback the transaction sum value via SetHelpText to m_info_panel, however this function this doesn't appear to be supported by wxStaticText.

Last PR for a short while before my wife gets too upset :)

Closes #7334

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7405)
<!-- Reviewable:end -->
