### PR TITLE
Investment: use DB_Table_ASSETS_V1::ASSETTYPE instead of Model_Asset one

### DIFF
--- a/src/model/Model_Account.cpp
+++ b/src/model/Model_Account.cpp
@@ -243,7 +243,7 @@ std::pair<double, double> Model_Account::investment_balance(const Data* r)
         sum.second += Model_Stock::InvestmentValue(stock);
     }
 
-    for (const auto& asset: Model_Asset::instance().find_or(Model_Asset::ASSETNAME(r->ACCOUNTNAME), Model_Asset::ASSETTYPE(static_cast<Model_Asset::TYPE_ID>(Model_Asset::type_id(r->ACCOUNTNAME)))))
+    for (const auto& asset: Model_Asset::instance().find_or(Model_Asset::ASSETNAME(r->ACCOUNTNAME), DB_Table_ASSETS_V1::ASSETTYPE(r->ACCOUNTNAME)))
     {
         auto asset_bal = Model_Asset::value(asset);
         sum.first += asset_bal.second;


### PR DESCRIPTION
to fix #7406 
- #7406

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7407)
<!-- Reviewable:end -->
