### PR TITLE
tidy: fix enum operation deprecation warnings in C++20

### DIFF
--- a/src/accountdialog.cpp
+++ b/src/accountdialog.cpp
@@ -58,7 +58,7 @@ EVT_BUTTON(wxID_OK, mmNewAcctDialog::OnOk)
 EVT_BUTTON(wxID_CANCEL, mmNewAcctDialog::OnCancel)
 EVT_BUTTON(ID_DIALOG_NEWACCT_BUTTON_CURRENCY, mmNewAcctDialog::OnCurrency)
 EVT_BUTTON(wxID_FILE, mmNewAcctDialog::OnAttachments)
-EVT_MENU_RANGE(wxID_HIGHEST, wxID_HIGHEST + acc_img::MAX_ACC_ICON, mmNewAcctDialog::OnCustonImage)
+EVT_MENU_RANGE(wxID_HIGHEST, wxID_HIGHEST + static_cast<int>(acc_img::MAX_ACC_ICON), mmNewAcctDialog::OnCustonImage)
 EVT_CHOICE(ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS, mmNewAcctDialog::OnAccountStatus)
 wxEND_EVENT_TABLE()
 
@@ -431,7 +431,7 @@ void mmNewAcctDialog::OnAttachments(wxCommandEvent& /*event*/)
 void mmNewAcctDialog::OnImageButton(wxCommandEvent& /*event*/)
 {
     wxMenu mainMenu;
-    wxMenuItem* menuItem = new wxMenuItem(&mainMenu, wxID_HIGHEST + acc_img::ACC_ICON_MONEY - 1, _t("Default Image"));
+    wxMenuItem* menuItem = new wxMenuItem(&mainMenu, wxID_HIGHEST + static_cast<int>(acc_img::ACC_ICON_MONEY) - 1, _t("Default Image"));
 
     menuItem->SetBitmap(m_images.at(Option::instance().AccountImageId(this->m_account->ACCOUNTID, true)));
     mainMenu.Append(menuItem);

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1006,7 +1006,7 @@ void mmGUIFrame::DoRecreateNavTreeControl(bool home_page)
                     Model_Account::Data* share_account = Model_Account::instance().get(stock.STOCKNAME);
                     if (!share_account)
                         continue;
-                    wxTreeItemId stockItem = m_nav_tree_ctrl->AppendItem(accountItem, stock.STOCKNAME, accountImg, accountImg);
+                    stockItem = m_nav_tree_ctrl->AppendItem(accountItem, stock.STOCKNAME, accountImg, accountImg);
                     m_nav_tree_ctrl->SetItemData(stockItem, new mmTreeItemData(mmTreeItemData::CHECKING, share_account->ACCOUNTID));
                 }
                 break;

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -351,7 +351,7 @@ private:
         MENU_CURRENCY,
         MENU_RATES,
         MENU_LANG,
-        MENU_LANG_MAX = MENU_LANG + wxLANGUAGE_USER_DEFINED,
+        MENU_LANG_MAX = MENU_LANG + static_cast<int>(wxLANGUAGE_USER_DEFINED),
 
         MENU_IMPORT_MMNETCSV,
         MENU_IMPORT_QIF,

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -665,7 +665,7 @@ int Option::AccountImageId(const int64 account_id, const bool def, const bool ig
     if (!def && !ignoreClosure && (acctStatus == "Closed"))
         return img::ACCOUNT_CLOSED_PNG;
 
-    int max = acc_img::MAX_ACC_ICON - img::LAST_NAVTREE_PNG;
+    int max = acc_img::MAX_ACC_ICON - static_cast<int>(img::LAST_NAVTREE_PNG);
     int min = 1;
     int custom_img_id = Model_Infotable::instance().getInt(wxString::Format("ACC_IMAGE_ID_%lld", account_id), 0);
     if (custom_img_id > max) custom_img_id = custom_img_id - 20; //Bug #963 fix 


### PR DESCRIPTION
Explicitly type casting a few enums to int to clear compiler warnings. Direct arithmetic operations between different enums is deprecated in C++20.