### PR TITLE
fix(#7445): call mmGUIFrame destructor in app exit if not already done

### DIFF
--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -459,6 +459,10 @@ bool mmGUIApp::OnInit()
 int mmGUIApp::OnExit()
 {
     wxLogDebug("{{{ mmGUIApp::OnExit()");
+
+    if (!m_frame->IsBeingDeleted())
+        m_frame->Destroy();
+
     Model_Usage::Data* usage = Model_Usage::instance().create();
     usage->USAGEDATE = wxDate::Today().FormatISODate();
 

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -460,7 +460,7 @@ int mmGUIApp::OnExit()
 {
     wxLogDebug("{{{ mmGUIApp::OnExit()");
 
-    if (!m_frame->IsBeingDeleted())
+    if (m_frame && !m_frame->IsBeingDeleted())
         m_frame->Destroy();
 
     Model_Usage::Data* usage = Model_Usage::instance().create();


### PR DESCRIPTION
Fixes #7445

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7487)
<!-- Reviewable:end -->
