### PR TITLE
fix: Yahoo finance api not working anymore #7482

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1315,7 +1315,7 @@ CURLcode getYahooFinanceQuotes(const wxString& URL, wxString& output) {
 
     struct curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8");
-    headers = curl_slist_append(headers, "User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/117.0");
+    headers = curl_slist_append(headers, "user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36");
     if (!savedCookie.IsEmpty()) headers = curl_slist_append(headers, static_cast<const char*>(("Cookie: " + savedCookie).mb_str()));
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 


### PR DESCRIPTION
With old User-Agent both the generation of the crumb and refresh API fails with "Too Many Requests". Which when used as a crumb is an invalid URL, because it contains spaces and it is not a proper JSON, therefore the two error messages experienced in the bug report.
```
curl 'https://query1.finance.yahoo.com/v7/finance/quote?symbols=AAPL&fields=regularMarketPrice,currency,shortName&crumb=ptm/idCTN/J' -b 'A1S=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc; A1=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc; A3=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc' -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/117.0'
Too Many Requests
```

There is no such problem with a current Chrome User-Agent.
```
curl 'https://query1.finance.yahoo.com/v7/finance/quote?symbols=AAPL&fields=regularMarketPrice,currency,shortName&crumb=ptm/idCTN/J' -b 'A1S=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc; A1=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc; A3=d=AQABBADoKGgCEJpF1HOCWmtYWSSXt5_7j4wFEgABCAE3KmhaaN2iPTIBAiAAAAcIAOgoaJ_7j4w&S=AQAAAus3lu3i0-TjHCWbxi0Dngc' -H 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
{"quoteResponse":{"result":[{"language":"en-US","region":"US","quoteType":"EQUITY","typeDisp":"Equity","quoteSourceName":"Nasdaq Real Time Price","triggerable":true,"customPriceAlertConfidence":"HIGH","currency":"USD","marketState":"REGULAR","regularMarketPrice":207.1688,"regularMarketTime":1747761813,"exchange":"NMS","exchangeTimezoneName":"America/New_York","exchangeTimezoneShortName":"EDT","gmtOffSetMilliseconds":-14400000,"market":"us_market","esgPopulated":false,"hasPrePostMarketData":true,"firstTradeDateMilliseconds":345479400000,"priceHint":2,"tradeable":false,"cryptoTradeable":false,"shortName":"Apple Inc.","fullExchangeName":"NasdaqGS","sourceInterval":15,"exchangeDataDelayedBy":0,"symbol":"AAPL"}],"error":null}}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7497)
<!-- Reviewable:end -->
