### PR TITLE
Enhancement (#7559): Show total in stock transaction list

### DIFF
--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -261,6 +261,7 @@ wxListCtrl* mmStocksPanel::InitStockTxnListCtrl(wxWindow* parent)
     listCtrl->AppendColumn(_t("Trade Type"), wxLIST_FORMAT_LEFT, 80);
     listCtrl->AppendColumn(_t("Price"), wxLIST_FORMAT_RIGHT, 100);
     listCtrl->AppendColumn(_t("Commission"), wxLIST_FORMAT_RIGHT, 100);
+    listCtrl->AppendColumn(_t("Total"), wxLIST_FORMAT_RIGHT, 100);
 
     return listCtrl;
 }
@@ -303,6 +304,8 @@ void mmStocksPanel::FillListRow(wxListCtrl* listCtrl, long index, const Model_Ch
     listCtrl->SetItem(index, 3, Model_Checking::trade_type_name(Model_Checking::type_id(txn.TRANSCODE)));
     listCtrl->SetItem(index, 4, wxString::FromDouble(share_entry.SHAREPRICE, Option::instance().getSharePrecision()));
     listCtrl->SetItem(index, 5, wxString::FromDouble(share_entry.SHARECOMMISSION, 2));
+    double total = share_entry.SHARENUMBER * share_entry.SHAREPRICE + share_entry.SHARECOMMISSION;
+    listCtrl->SetItem(index, 6, wxString::FromDouble(total, 2));
 }
 
 // Bind list control events


### PR DESCRIPTION
Code for Enhancement #7559: Show total in stock transaction list
See issue description for details.

**Note**: Proposed change from Copilot (see #7560) is invalid, Buys are positiv, Sells are negativ so total with commision is correct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7566)
<!-- Reviewable:end -->
