### PR TITLE
Feature#7577 unified data update 2

### DIFF
--- a/contrib.txt
+++ b/contrib.txt
@@ -70,6 +70,7 @@ Schrempfi
 goe
 STiGMaTa_ch
 Kai Kajus Noack
+Klaus Wich
 
 ### Greek
 Panagiotis Pentzeridis
@@ -111,7 +112,7 @@ Torbjorn Kvande
 ### Polish
 Damian_pl
 Andrzej
-Jerzy Machnicki 
+Jerzy Machnicki
 
 ### Portuguese (Brazilian)
 Jose Carlos
@@ -187,7 +188,7 @@ Maurizio 	 [Mau13]
 ### Polish
 Damian_pl
 
-### Russian 
+### Russian
 Nikolay 	 [Nikolay]
 
 ### Spanish

--- a/docs/de_DE/index.html
+++ b/docs/de_DE/index.html
@@ -1368,35 +1368,34 @@ PBank der Hypotheken Payee
         aufgerufen werden.
     </p>
 
+
     <h3>Allgemein</h3>
+    <h4>Zeige Überschrift</h4>
     <dl>
-        <dt>Datenbasisname</dt>
+        <dt>Benutzername</dt>
         <dd>Dieses Feld wird als Titel auf der Startseite und in den Berichten verwendet.</dd>
         <dd>Ein leeres Feld entfernt den Titel.</dd>
-
-        <dt>Sprache der Benutzeroberfläche</dt>
-        <dd>Hier kann entweder die Systemsprache oder eine spezifische Sprache aus dem Auswahlmenü gewählt werden.
-            Es ist ein MMEX Neustart erforderlich, bevor alle GUI-Elemente in der neuen Sprache angezeigt werden.
-        </dt>
-
-        <dt>Datumsformat</dt>
-        <dd>Die Datumsformateinstellung steuert die Datumsdarstellung</dd>
-
-        <dt>Währung</dt>
-        <dd>Die Basiswährungseinstellung wird verwendet, um die Währung der Datenbank einzustellen.
-           Einzelne Konten beutzen diese Einstellung als Vorgabe, können aber falls erforderlich auch in den Kontoeinstellungen spezifisch
-           konfiguriert werden.</dd>
-
-        <dt>Geschäftsjahr</dt>
-        <dd>Stellt den Beginn des Geschäftsjahres ein, im Gegensatz zu dem Kalenderjahr. Dieses kann für Berichte und Budgets
-          benutzt werden.</dd>
-
-        <dt>Originaldatum… beibehalten</dt>
-        <dd>Wenn markiert wird beim Einfügen einer Buchung das Originaldatum und nicht das aktuelle verwendet.</dd>
-
-        <dt>Buchungs-Ton</dt>
-        <dd>Hier kann ein Ton gesetzt werden, der bei einer Buchungseingabe abgespielt wird.</dd>
     </dl>
+
+    <h4>Sprache der Benutzeroberfläche</h4>
+    Hier kann entweder die Systemsprache oder eine spezifische Sprache aus dem Auswahlmenü gewählt werden.
+    Es ist ein MMEX Neustart erforderlich, bevor alle GUI-Elemente in der neuen Sprache angezeigt werden.
+
+    <h4>Datumsformat</h4>
+    Die Datumsformateinstellung steuert die Datumsdarstellung
+
+    <h4>Währung</h4>
+        <dl>
+            <dt>Basiswährung</dt>
+            <dd>Die Basiswährungseinstellung wird verwendet, um die Währung der Datenbank einzustellen.
+            Einzelne Konten beutzen diese Einstellung als Vorgabe, können aber falls erforderlich auch in den Kontoeinstellungen spezifisch
+            konfiguriert werden.</dd>
+        </dl>
+
+    <h4>Geschäftsjahr</h4>
+    Stellt den Beginn des Geschäftsjahres ein, im Gegensatz zu dem Kalenderjahr. Dieses kann für Berichte und Budgets
+    benutzt werden
+
 
     <h3>Ansichtseinstellungen</h3>
     <p>
@@ -1408,15 +1407,15 @@ PBank der Hypotheken Payee
         <dt>Sichtbare Konten</dt>
         <dd>Dieses legt fest welche Konten, abhängig vom Status, im Navigator angezeigt werden.</dd>
 
-        <dt>Kategorientrenner</dt>
+        <dt>Kategorientrennzeichen</dt>
         <dd>Legt das Trennzeicghen zwischen Kategorie und Unterkategorie(n) fest.</dd>
 
-        <dt>Keine Farben für zukünftige Buchungen</dt>
+        <dt>Für zukünftige Buchungen keine Farben benutzen</dt>
         <dd>Deaktiviert die buchungsspezifischen Farben für zukünftige Buchungen. Dieses werden damit
             einheitlich angezeigt.</dd>
 
         <dt>Nicht bestätigte Buchungen herausheben</dt>
-        <dd>Alle nicht bestätigten Buchungen werden hervorgehoben für einen besseren Überblick angezeigt.</dd>
+        <dd>Alle nicht bestätigten Buchungen werden für einen besseren Überblick hervorgehoben angezeigt.</dd>
 
         <dt>Anwendungstips anzeigen</dt>
         <dd>Aktiviert Anwendungstips für alle Bedienelemente, die beim Darüberfahren mit der Maus angezeigt werden.</dd>
@@ -1425,19 +1424,12 @@ PBank der Hypotheken Payee
         <dd>Aktiviert zufällige Anlagehinweise in der Buchungsübersicht.</dd>
     </dl>
 
-    <h4>Buchung/Budget</h4>
-    tbd.
-
-    <h4>Buchungsfarben</h4>
-    Erlaubt individuelle Farben für die Markierung von Buchungen zu definieren. Mit der <samp>Standard</samp> Schaltfläche
-    werden diese wieder auf die Programmvorgabe zurückgesetzt.
-
     <h4>Benutzerschnittstelle</h4>
     <dl>
         <dt>Stilvorlage</dt>
         <dd>Ruft den Designverwaltung auf, um ein Design für MMEX auszusuchen.</dd>
 
-        <dt>Thema</dt>
+        <dt>Design</dt>
         <dd>Erlaubt es ein helles oder ein dunkles Thema auszuwählen.</dd>
 
         <dt>HTML Skalierungsfaktor</dt>
@@ -1452,67 +1444,96 @@ PBank der Hypotheken Payee
 
 
     <h3>Übersicht</h3>
-    <dl>
-        <dt>TODO</dt>
-        <dd>TODO</dd>
-    </dl>
+    TODO
+
+
+    <h3>Buchungen</h3>
+    Enthält alle Einstellungen die das Verhalten der Buchungen festlegen.
+
+    <h4>Neue Buchung</h4>
+    Ändert die Voreinstellugen für Buchungen im Buchungsdialag.
+
+    <h4>Buchung</h4>
+        <dt>Originaldatum… beibehalten</dt>
+        <dd>Wenn gesetzt wird beim Einfügen oder Verdoppeln einer Buchung das Originaldatum und nicht das aktuelle verwendet.</dd>
+
+        <dt>Originalstatus beim Duplizieren oder Kopieren und Einfügen einer Buchung verwenden</dt>
+        <dd>Standardmäßig wird bei eienr neuen Buchung der Status auf den Standardstatus getsetzt, der unter Neue Buchung - Standardstatus
+            konfiguriert wurde. Mit dieser Einstellung wird stattdessen der originale Buchungsstatus (z.B. Überprüft) beibehalten.</dd>
+
+        <dt>Buchungs-Ton</dt>
+        <dd>Hier kann ein Klang ausgewählt werden, der bei einer Buchungseingabe abgespielt wird.</dd>
+
+    <h4>Buchung/Budget</h4>
+    Diese Einstellungen beeinflussen die Budgetierung.
+
+    <h4>Buchungsfarben</h4>
+    Erlaubt es individuelle Farben für die Markierung von Buchungen zu definieren. Mit der <samp>Standard</samp> Schaltfläche
+    werden diese wieder auf die Programmvorgabe zurückgesetzt.
 
 
     <h3>Anlagen</h3>
-    <dl>
-        <dt>TODO</dt>
-        <dd>TODO</dd>
-    </dl>
+    Definiert den Ort für das Anlagenverzeichnis.
 
 
     <h3>Netzwerk</h3>
-    <dl>
-        <dt>WebApp</dt>
-        <dd>Stellen Sie URL und GUID Ihrer WebApp Installation Daten-Sync ermöglichen.
-                            Die Parameter können in WebApp 'Guide' Seite. Parameters can be found in WebApp Guide
-            page.</dd>
-    </dl>
+
+    <h4>WebApp</h4>
+    Konfiguration der URL und GUID ihrer WebApp Installation für die Daten-Synchronisation.
+    Die Parameter können in WebApp 'Guide' gefunden werden.
 
 
     <h3>Andere</h3>
-    <dl>
+    Verschiedene Einstellungen
+
+    <h4>Wertpapiere</h4>
         <dt>Webseite für Börsenkurse</dt>
-        <dd>   Diese URL wird durch die Refresh-Taste auf der Aktienanlagen Seite verwendet.
-        Diese URL wird auch durch die Neu / Bearbeiten Auf Dialog verwendet, die Web-Seite für die gelisteten Aktie anzuzeigen.
-        Der Standardwert ist Yahoo Finance.
-                            Alternativ können auch andere Websites können bei Bedarf verwendet werden..</dd>
+        <dd>Diese URL wird für die Aktualiserung der Wertpapierkurse verwendet. Eine Aktualiserung wird entweder durch die
+        Refresh-Taste auf der Wertpapierseite
+        oder im  Neu / Bearbeiten Dialog angst0ßen. Die URL wird auch als Basis URL verwendet, um die Web-Seite für die ausgewählte
+        Aktie anzuzeigen.
+        Der Standardwert ist Yahoo Finance. Alternativ können auch andere Websites verwendet werden.</dd>
 
-        <dt>Neue Buchungen</dt>
-        <dd>Ändert die Standardeinstellungen für die Neu / Bearbeiten Buchungen Dialog</dd>
+    <h4>Assets</h4>
+    TBD.
 
-        <dt>Databank</dt>
-        <dd>Bestimmt ob und wie Sicherungen der Datenbank von MMEX durchgeführt werden:
-            <dl>
-                <dt>Datenbank beim Start sichern</dt>
-                <dd>Dies kopiert beim Start von MMEX die Datenbank in eine neue Datei mit dem heutigen Datum.</dd>
-                <dd>Die Datei wird beim nächsten Start nicht überschrieben. Wenn es mehr als die Maximalzahl an Backup
-                  dateien gibt, wird die älteste Datei gelöscht.</dd>
+    <h4>Databank</h4>
+    Bestimmt ob und wie Sicherungen der Datenbank von MMEX durchgeführt werden
+    <dl>
+        <dt>Datenbank beim Start sichern</dt>
+        <dd>Dieses kopiert beim Start von MMEX die Datenbank in eine neue Datei mit dem heutigen Datum.</dd>
+        <dd>Die Datei wird beim nächsten Start nicht überschrieben. Wenn es mehr als die Maximalzahl an Backup
+            dateien gibt, wird die älteste Datei gelöscht.</dd>
 
-                <dt>Datenbank beim Beenden sichern</dt>
-                <dd>Dies kopiert beim Beenden von MMEX die Datenbank in eine neue Datei mit dem heutigen Datum.</dd>
-                <dd>Wenn weitere Änderungen am selben Tag vorgenommen werden, wird die vorhandene Sicherung überschrieben.
-                  Wenn es mehr als die Maximalzahl an Backup Dateien gibt, wird die älteste Datei gelöscht.
-                </dd>
-            </dl>
+        <dt>Datenbank beim Beenden sichern</dt>
+        <dd>Dies kopiert beim Beenden von MMEX die Datenbank in eine neue Datei mit dem heutigen Datum.</dd>
+        <dd>Wenn weitere Änderungen am selben Tag vorgenommen werden, wird die vorhandene Sicherung überschrieben.
+            Wenn es mehr als die Maximalzahl an Backup Dateien gibt, wird die älteste Datei gelöscht.
         </dd>
 
-        <dt>CSV-Trennzeichen</dt>
+        <dt>Maximale Anzahl an Dateien</dt>
+        <dd>Konfiguriert die maximale Anzahl an Sicherungskopien.</dd>
+
+        <dt>Tage für die Aufbewahrung gelöschter Buchungen</dt>
+        <dd>Konfiguriet wieviele Tage gelöschte Buchungen aufbewahrt und wierderhergestellt werden können.
+            Anschliesend werden die Buchungen endgültig gelöscht.</dd>
+
+    </dl>
+
+    <h4>CSV</h4>
+        <dt>Trennzeichen</dt>
         <dd>Dieses wird als Trennzeichen verwendet um CSV-Dateien parsen. Dies ist nützlich,
           um die Standardeinstellung <kbd>,</kbd> zu ändern wenn Währungen benutzt werden, die <kbd>,</kbd> für den
           Dezimaltrenner verwenden.
-      .</dd>
+        </dd>
 
-      <!--<s><dt>Aktivieren Online-Währung ...</dt>
-       <dd>Aktivieren Sie Währungen zu ermöglichen, über das Internet aktualisiert werden.</dd>
-      </s>-->
-    </dl>
-
-
+    <h4>Filter</h4>
+        <dt>Individuelle Datumsfilter für jedes Konto und Bericht aktivieren</dt>
+        <dd>Wenn die Option nicht aktiviert ist (Voreinstellung) wird für all Konten und Berichte der gleiche Datumsbereich versendet.
+            Wenn der Datumsbereich für ein Konto oder Bericht geändert wird, wird diese Änderung für alle anderen mit übernommen.
+            Damit können die Buchungen in verschieden Konten einfach miteinander verglichen werden.
+        </dd>
+        <dd>Wenn die Option aktiviert ist, wird für jedes Konto und Bericht ein eigener Datumsbereich verwendet und gespeichert.</dd>
 
 
     <!--Frequently Asked Questions-->

--- a/docs/en_US/index.html
+++ b/docs/en_US/index.html
@@ -1467,6 +1467,8 @@ PBank Of Mortgage Payee
         <kbd><samp>File</samp> → <samp>Print…</samp></kbd> menu.
     </p>
 
+
+
     <h2>Settings</h2>
     <aside class="sticky notes">
         Some settings require after a change a restart of the program to be effective.
@@ -1484,35 +1486,37 @@ PBank Of Mortgage Payee
     </p>
 
     <h3>General Panel</h3>
+    <h4>Display Heading</h4>
     <dl>
         <dt>User Name</dt>
         <dd>This field is used as a title on the Dashboard, and on Reports.</dd>
+
         <dd>Leaving this field blank, will remove the Dashboard and
             Report titles.</dd>
-        <dt>Base Currency</dt>
-        <dd>The base currency setting is used to set the
-            currency of the database. Individual accounts will use
-            this as the default, but can be changed if different
-            currencies as required.</dd>
-        <dt>Date Format</dt>
-        <dd>The date format setting is used to control how dates
-            should be displayed <s>and also how dates should be parsed
-            when importing QIF, CSV files.</s></dd>
-        <dt>Financial Year</dt>
-        <dd>Sets the start Day and Month for a Financial Year
-            period, as opposed to a calendar year. This is used in
-            Budgets and Reports.</dd>
-        <dt>Use Original date…</dt>
-        <dd>Activate to use the date of the transaction date when
-            using paste transaction, in account view.</dd>
-        <dt>Use Transaction Sound…</dt>
-        <dd>Activate to plays a sound when a transaction is entered.</dd>
     </dl>
 
+    <h4>User Interface Language</h4>
+    Allows the selection of the user interface language, requires a restart of the program!
+
+    <h4>Date Format</h4>
+    The date format setting is used to control how dates are displayed.
+
+    <h4>Currency</h4>
+        <dl>
+            <dt>Base Currency</dt>
+            <dd>The base currency setting is used to set the
+                currency of the database. Individual accounts will use
+                this as the default, but can be changed if different
+                currencies as required.</dd>
+        </dl>
+
+    <h4>Financial Year</h4>
+    Sets the start Day and Month for a Financial Year period, as opposed to a calendar year. This is used in
+    Budgets and Reports.
+
+
     <h3>View Panel</h3>
-    <p>
-        These settings control the appearance of the MMEX. It is subdivided in several sections:
-    </p>
+    These settings control the appearance of the MMEX. It is subdivided in several sections:
 
     <h4>View</h4>
     <dl>
@@ -1535,12 +1539,6 @@ PBank Of Mortgage Payee
         <dd>Enables randomly selected money tips in the transaction view.</dd>
     </dl>
 
-    <h4>Transaction/Budget</h4>
-    tbd.
-
-    <h4>Transaction Colors</h4>
-    Allows the definition of individual colors, which can mark transactions. The <samp>Default</samp> button resets
-    the defintions to original ones.
 
     <h4>User Interface</h4>
     <dl>
@@ -1561,60 +1559,102 @@ PBank Of Mortgage Payee
     </dl>
 
     <h3>Dashboard Panel</h3>
-    <dl>
-        <dt>TODO</dt>
-        <dd>TODO</dd>
-    </dl>
+    TODO
+
+
+    <h3>Transactions Panel</h3>
+    Contains all transaction related settings.
+
+    <h4>New Transaction</h4>
+    Changes the default settings for the New/Edit Transactions Dialog.
+
+    <h4>Transaction</h4>
+        <dt>Use Original date… </dt>
+        <dd>Activate the related setting to use the original transaction date, when
+            pasting or duplicating a transaction in the account view.</dd>
+
+        <dt>Use Original state when Duplicating or Pasting Transactions</dt>
+        <dd>Per default the state of a duplicated or pasted transaction is set to the Default Status defined in the settings panel
+            for new transactions. If this option is active the original state is kept (e.g. Reconciled)</dd>
+
+        <dt>Transaction Sound…</dt>
+        <dd>Activate to play a sound when a transaction is entered.</dd>
+
+    <h4>Transaction/Budget</h4>
+    These settings control the budget handling.
+
+    <h4>Transaction Colors</h4>
+    Allows the definition of individual colors, which can mark transactions. The <samp>Default</samp> button resets
+    the colors to original ones.
+
 
     <h3>Attachments Panel</h3>
-    <dl>
-        <dt>TODO</dt>
-        <dd>TODO</dd>
-    </dl>
+    Define the location of the attachments folder.
+
 
     <h3>Network Panel</h3>
-    <dl>
-        <dt>WebApp settings</dt>
-        <dd>Set URL and GUID of your WebApp installation to allow
-            data sync. Parameters can be found in WebApp Guide
-            page.</dd>
-    </dl>
+
+    <h4>WebApp</h4>
+    <dd>Set URL and GUID of your WebApp installation to allow
+        data sync. Parameters can be found in WebApp Guide
+        page.</dd>
+
 
     <h3>Other Panel</h3>
-    <dl>
+    Miscelleanous settings
+
+    <h4>Stocks</h4>
         <dt>Stock Quote Web Page</dt>
         <dd>This URL is used by the Refresh button on the Stock
             Investments page. This URL is also used by the New/Edit
             Stock dialog, to display the web page for the listed stock.
             The default is yahoo finance. Alternatively other sites can
             be used if necessary.</dd>
-        <dt>New Transaction</dt>
-        <dd>Changes the default settings for the New/Edit
-            Transactions Dialog</dd>
-        <dt>Database</dt>
-        <dd>Sets the way the backups are performed when MMEX starts.
-            <dl>
-                <dt>Create a new backup when MMEX Start</dt>
-                <dd>This copies the database to a new file with today’s
-                    date, when MMEX Starts.</dd>
-                <dd>The file will not be over written when MMEX starts
-                    up again. When there are more that 4 backup files,
-                    the oldest file is deleted.</dd>
-                <dt>Backup database on exit</dt>
-                <dd>When MMEX shuts down, the existing database will be
-                    copied to a backup database file for that day when
-                    changes to the database have been detected. When
-                    changes are made on the same day, the existing
-                    backup is over written. When there are more that 4
-                    backup files, the oldest file is deleted.</dd>
-            </dl>
-        </dd>
-        <dt>CSV Delimiter</dt>
+
+    <h4>Assets</h4>
+    TBD.
+
+    <h4>Database</h4>
+    Sets the way backups of the MMEX database are performed
+    <dl>
+        <dt>Backup database on start up</dt>
+        <dd>This copies the database to a new file with today’s
+            date, when MMEX Starts.</dd>
+        <dd>The file will not be over written when MMEX starts
+            up again. When there are more than "Max Files" backup files,
+            the oldest file is deleted.</dd>
+
+        <dt>Backup database on exit</dt>
+        <dd>When MMEX shuts down, the existing database will be
+            copied to a backup database file for that day when
+            changes to the database have been detected. When
+            changes are made on the same day, the existing
+            backup is over written. When there are more than "Max Files"
+            backup files, the oldest file is deleted.</dd>
+
+        <dt>Max Files</dt>
+        <dd>Maximum number of backup files to retain.</dd>
+
+        <dt>Days to retain deleted transactions</dt>
+        <dd>The number of days deleted transactions are retained and can be restored before they are finally deleted.</dd>
+    </dl>
+
+    <h4>CSV</h4>
+        <dt>Delimiter</dt>
         <dd>This is used as the delimiting character when parsing
             CSV files. This is useful to modify from the default
             <kbd>,</kbd> when dealing with currencies that use
             <kbd>,</kbd> to denote decimal points in amounts.</dd>
-    </dl>
+
+    <h4>Filter</h4>
+        <dt>Enable date range filter per account or report</dt>
+        <dd>If deactivated (default), all accounts and reports use the same date range. If the date range is changed in one
+            account or report the new range is also applied to all other accounts or reports. This allows a quick comparision of time periods between
+            accounts and reports.
+        </dd>
+        <dd>If activated, the selected date range for each account or report will be stored seperately
+            for an individual view of the accounts or reports</dd>
+
 
     <!--Frequently Asked Questions-->
     <h2>Frequently Asked Questions</h2>

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -4741,8 +4741,8 @@ msgid "Scheduled transactions are not available, because the current filter ends
 msgstr "Geplante Buchungen können nicht angezeigt werden, da der aktuelle Filter in der Vergangenheit endet"
 
 #: mmcheckingpanel.cpp:1154
-msgid "Unable to show scheduled transactions because the current filter choice extends into the future without limit."
-msgstr "Geplante Buchungen können nicht angezeigt werden, da sich die aktuelle Filterauswahl uneingeschränkt auf die Zukunft erstreckt."
+#msgid "Unable to show scheduled transactions because the current filter choice extends into the future without limit."
+#msgstr "Geplante Buchungen können nicht angezeigt werden, da sich die aktuelle Filterauswahl uneingeschränkt auf die Zukunft erstreckt."
 
 #: mmcheckingpanel.cpp:1155
 msgid "Click to show scheduled transactions. This feature works best with filter choices that extend into the future (e.g., Current Month)."
@@ -6720,12 +6720,12 @@ msgid "Filter"
 msgstr "Filter"
 
 #: optionsettingsmisc.cpp:187
-msgid "Enable combined transaction filter"
-msgstr "Kombinierten Buchungsfilter aktivieren"
+msgid "Enable date range filter per account or report"
+msgstr "Individuelle Datumsfilter für jedes Konto und Bericht aktivieren"
 
 #: optionsettingsmisc.cpp:189
-msgid "Switch to one filter control for date and attributes"
-msgstr "Eine kombinierte Schaltfläche für Datumsbereiche und Filter verwenden"
+msgid "Store filter values per account or report and not globally"
+msgstr "Filtereinstellungen individuell per Konto und Bericht abspeichern und nicht global"
 
 #: optionsettingsnet.cpp:65
 msgid "WebApp"
@@ -8882,4 +8882,3 @@ msgstr "Fehler "
 #: wizard_update.cpp:326 wizard_update.cpp:341
 msgid "MMEX Update Check"
 msgstr "MMEX Update Überprüfung"
-

--- a/po/mmex.pot
+++ b/po/mmex.pot
@@ -4738,10 +4738,6 @@ msgstr ""
 msgid "Scheduled transactions are not available, because the current filter ends in the past"
 msgstr ""
 
-#: mmcheckingpanel.cpp:1154
-msgid "Unable to show scheduled transactions because the current filter choice extends into the future without limit."
-msgstr ""
-
 #: mmcheckingpanel.cpp:1155
 msgid "Click to show scheduled transactions. This feature works best with filter choices that extend into the future (e.g., Current Month)."
 msgstr ""
@@ -6716,11 +6712,11 @@ msgid "Filter"
 msgstr ""
 
 #: optionsettingsmisc.cpp:187
-msgid "Enable combined transaction filter"
+msgid "Enable date range filter per account or report"
 msgstr ""
 
 #: optionsettingsmisc.cpp:189
-msgid "Switch to one filter control for date and attributes"
+msgid "Store filter values per account or report and not globally"
 msgstr ""
 
 #: optionsettingsnet.cpp:65

--- a/src/filtertransdialog.cpp
+++ b/src/filtertransdialog.cpp
@@ -119,7 +119,7 @@ mmFilterTransactionsDialog::mmFilterTransactionsDialog(wxWindow* parent, const w
 
 void mmFilterTransactionsDialog::mmDoInitVariables()
 {
-    m_use_date_filter = isReportMode_ || Option::instance().getUseCombinedTransactionFilter();
+    m_use_date_filter = isReportMode_; //|| Option::instance().getUsePerAccountFilter();
 
     m_custom_fields = new mmCustomDataTransaction(this, 0, ID_CUSTOMFIELDS + (isReportMode_ ? 100 : 0));
 

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -141,7 +141,7 @@ private:
     // set by showTips()
     bool m_show_tips = false;
 
-    bool m_use_dedicated_filter;
+    bool m_use_account_specific_filter;
 
     mmGUIFrame* m_frame = nullptr;
     wxButton* m_bitmapTransFilter = nullptr;

--- a/src/mmreportspanel.h
+++ b/src/mmreportspanel.h
@@ -118,7 +118,7 @@ private:
     int m_shift = 0;
 
     // New filtering
-    bool m_use_dedicated_filter;
+    bool m_use_account_specific_filter;
     int m_date_range_m = -1;
     wxString htmlreport_;
 

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -130,7 +130,7 @@ void Option::load(bool include_infotable)
     loadUseTransDateTime();
     loadDoNotColorFuture();
     loadDoSpecialColorReconciled();
-    loadUseCombinedTransactionFilter();
+    loadUsePerAccountFilter();
     loadShowToolTips();
     loadShowMoneyTips();
     loadTransPayeeNone();
@@ -447,14 +447,14 @@ void Option::setDoSpecialColorReconciled(const bool value)
     m_do_special_color_reconciled = value;
 }
 
-void Option::loadUseCombinedTransactionFilter()
+void Option::loadUsePerAccountFilter()
 {
-    m_use_combined_transaction_filter = Model_Setting::instance().getBool("USE_COMBINED_TRANSACTION_FILTER", true);
+    m_store_account_specific_filter = Model_Setting::instance().getBool("USE_PER_ACCOUNT_FILTER", true);
 }
-void Option::setUseCombinedTransactionFilter(const bool value)
+void Option::setUsePerAccountFilter(const bool value)
 {
-    Model_Setting::instance().setBool("USE_COMBINED_TRANSACTION_FILTER", value);
-    m_use_combined_transaction_filter = value;
+    Model_Setting::instance().setBool("USE_PER_ACCOUNT_FILTER", value);
+    m_store_account_specific_filter = value;
 }
 
 

--- a/src/option.h
+++ b/src/option.h
@@ -247,11 +247,10 @@ public:
     void setDoSpecialColorReconciled(const bool value);
     bool getDoSpecialColorReconciled() const noexcept;
 
-    // m_use_combined_transaction_filter
-    void loadUseCombinedTransactionFilter();
-    void setUseCombinedTransactionFilter(const bool value);
-    bool getUseCombinedTransactionFilter() const noexcept;
-
+    // m_store_account_specific_filter
+    void loadUsePerAccountFilter();
+    void setUsePerAccountFilter(const bool value);
+    bool getUsePerAccountFilter() const noexcept;
 
     // m_show_tooltips
     void loadShowToolTips();
@@ -302,7 +301,7 @@ private:
     bool m_ignore_future_transactions = false;          // IGNORE_FUTURE_TRANSACTIONS
     bool m_do_not_color_future = true;                  // DO_NOT_COLOR_FUTURE_TRANSACTIONS
     bool m_do_special_color_reconciled = true;          // SPECIAL_COLOR_RECONCILED_TRANSACTIONS
-    bool m_use_combined_transaction_filter = false;     // USE_COMBINED_TRANSACTION_FILTER
+    bool m_store_account_specific_filter = false;       // USE_PER_ACCOUNT_FILTER
     bool m_show_tooltips = true;                        // IGNORE_SHOW_TOOLTIPS
     bool m_show_moneytips = true;                       // IGNORE_SHOW_MONEYTIPS
     bool m_use_trans_datetime = false;                  // TRANSACTION_USE_DATE_TIME
@@ -523,9 +522,9 @@ inline bool Option::getDoSpecialColorReconciled() const noexcept
     return m_do_special_color_reconciled;
 }
 
-inline bool Option::getUseCombinedTransactionFilter() const noexcept
+inline bool Option::getUsePerAccountFilter() const noexcept
 {
-    return m_use_combined_transaction_filter;
+    return m_store_account_specific_filter;
 }
 
 inline bool Option::getShowToolTips() const noexcept

--- a/src/optionsettingsmisc.cpp
+++ b/src/optionsettingsmisc.cpp
@@ -62,10 +62,15 @@ void OptionSettingsMisc::Create()
     misc_panel->SetSizer(othersPanelSizer);
     othersPanelSizer0->Add(misc_panel, wxSizerFlags(g_flagsExpand).Proportion(0));
 
-    wxStaticText* itemStaticTextURL = new wxStaticText(misc_panel, wxID_STATIC, _t("Stock Quote Web Page"));
-    SetBoldFont(itemStaticTextURL);
+    wxStaticBox* stockStaticBox = new wxStaticBox(misc_panel, wxID_STATIC, _t("Stocks"));
+    SetBoldFont(stockStaticBox);
+    wxStaticBoxSizer* stockStaticBoxSizer = new wxStaticBoxSizer(stockStaticBox, wxVERTICAL);
+    othersPanelSizer->Add(stockStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
 
-    othersPanelSizer->Add(itemStaticTextURL, g_flagsV);
+    wxStaticText* itemStaticTextURL = new wxStaticText(misc_panel, wxID_STATIC, _t("Stock Quote Web Page"));
+    //SetBoldFont(itemStaticTextURL);
+
+    stockStaticBoxSizer->Add(itemStaticTextURL, g_flagsV);
 
     wxArrayString list;
     list.Add(mmex::weblink::DefStockUrl);
@@ -78,7 +83,7 @@ void OptionSettingsMisc::Create()
         , wxDefaultPosition, wxDefaultSize, list);
     itemListOfURL->SetValue(stockURL);
 
-    othersPanelSizer->Add(itemListOfURL, wxSizerFlags(g_flagsExpand).Proportion(0));
+    stockStaticBoxSizer->Add(itemListOfURL, wxSizerFlags(g_flagsExpand).Proportion(0));
     mmToolTip(itemListOfURL, _t("Clear the field to Reset the value to system default."));
 
     // Share Precision
@@ -94,9 +99,14 @@ void OptionSettingsMisc::Create()
     m_refresh_quotes_on_open = new wxCheckBox(misc_panel, wxID_REFRESH, _t("Refresh at Startup"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     m_refresh_quotes_on_open->SetValue(Model_Setting::instance().getBool("REFRESH_STOCK_QUOTES_ON_OPEN", false));
     share_precision_sizer->Add(m_refresh_quotes_on_open, wxSizerFlags(g_flagsH).Border(wxLEFT, 20));
-    othersPanelSizer->Add(share_precision_sizer, g_flagsBorder1V);
+    stockStaticBoxSizer->Add(share_precision_sizer, g_flagsBorder1V);
 
     // Asset Compounding
+    wxStaticBox* assetStaticBox = new wxStaticBox(misc_panel, wxID_STATIC, _t("Assets"));
+    SetBoldFont(assetStaticBox);
+    wxStaticBoxSizer* assetStaticBoxSizer = new wxStaticBoxSizer(assetStaticBox, wxVERTICAL);
+    othersPanelSizer->Add(assetStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
+
     wxFlexGridSizer* asset_compounding_sizer = new wxFlexGridSizer(0, 3, 0, 0);
     asset_compounding_sizer->Add(new wxStaticText(misc_panel, wxID_STATIC, _t("Asset Compounding Period")), g_flagsH);
     m_asset_compounding = new wxChoice(misc_panel, ID_DIALOG_OPTIONS_ASSET_COMPOUNDING);
@@ -107,11 +117,12 @@ void OptionSettingsMisc::Create()
         _t("Select the compounding period for the appreciation/depreciation rate of assets")
     );
     asset_compounding_sizer->Add(m_asset_compounding, wxSizerFlags(g_flagsExpand).Proportion(0));
-    othersPanelSizer->Add(asset_compounding_sizer, g_flagsBorder1V);
+    //othersPanelSizer->Add(asset_compounding_sizer, g_flagsBorder1V);
+    assetStaticBoxSizer->Add(asset_compounding_sizer, g_flagsV);
 
     //----------------------------------------------
     //a bit more space visual appearance
-    othersPanelSizer->AddSpacer(10);
+    //othersPanelSizer->AddSpacer(10);
 
     wxBoxSizer* itemBoxSizerStockURL = new wxBoxSizer(wxVERTICAL);
     othersPanelSizer->Add(itemBoxSizerStockURL);
@@ -183,11 +194,11 @@ void OptionSettingsMisc::Create()
 
     othersPanelSizer->Add(filterStaticBoxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
 
-    m_use_combined_transaction_filter = new wxCheckBox(misc_panel, ID_DIALOG_OPTIONS_CHK_FILTER
-        , _t("Enable combined transaction filter"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    m_use_combined_transaction_filter->SetValue(Option::instance().getUseCombinedTransactionFilter());
-    m_use_combined_transaction_filter->SetToolTip(_t("Switch to one filter control for date and attributes"));
-    filterStaticBoxSizer->Add(m_use_combined_transaction_filter, g_flagsV);
+    m_store_account_specific_filter = new wxCheckBox(misc_panel, ID_DIALOG_OPTIONS_CHK_FILTER
+        , _t("Enable date range filter per account or report"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    m_store_account_specific_filter->SetValue(Option::instance().getUsePerAccountFilter());
+    m_store_account_specific_filter->SetToolTip(_t("Store filter values per account or report and not globally"));
+    filterStaticBoxSizer->Add(m_store_account_specific_filter, g_flagsV);
 
     wxCommandEvent evt;
     OptionSettingsMisc::OnBackupChanged(evt);
@@ -236,7 +247,7 @@ bool OptionSettingsMisc::SaveSettings()
     Model_Setting::instance().setInt("DELETED_TRANS_RETAIN_DAYS", m_deleted_trans_retain_days->GetValue());
     Model_Setting::instance().setBool("REFRESH_STOCK_QUOTES_ON_OPEN", m_refresh_quotes_on_open->IsChecked());
 
-    Option::instance().setUseCombinedTransactionFilter(m_use_combined_transaction_filter->IsChecked());
+    Option::instance().setUsePerAccountFilter(m_store_account_specific_filter->IsChecked());
 
     wxTextCtrl* st = static_cast<wxTextCtrl*>(FindWindow(ID_DIALOG_OPTIONS_TEXTCTRL_DELIMITER4));
     const wxString& delim = st->GetValue();

--- a/src/optionsettingsmisc.h
+++ b/src/optionsettingsmisc.h
@@ -53,7 +53,7 @@ private:
     wxSpinCtrl* m_share_precision = nullptr;
     wxCheckBox* m_refresh_quotes_on_open = nullptr;
     wxChoice* m_asset_compounding = nullptr;
-    wxCheckBox* m_use_combined_transaction_filter = nullptr;
+    wxCheckBox* m_store_account_specific_filter = nullptr;
 
     enum
     {

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -2,6 +2,7 @@
  Copyright (C) 2013 James Higley
  Copyright (C) 2020 Nikolay Akimov
  Copyright (C) 2022 Mark Whalley (mark@ipx.co.uk)
+ Copyright (C) 2025 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -27,7 +28,7 @@
 #include "util.h"
 
 mmPrintableBase::mmPrintableBase(const wxString& title)
-    : m_title(title)    
+    : m_title(title)
 {
 }
 
@@ -177,8 +178,8 @@ void mmPrintableBase::restoreReportSettings()
 }
 
 void mmPrintableBase::date_range(const mmDateRange* date_range, int selection)
-{ 
-    this->m_date_range = date_range; 
+{
+    this->m_date_range = date_range;
     this->m_date_selection = selection;
 }
 
@@ -282,6 +283,9 @@ mmGeneralReport::mmGeneralReport(const Model_Report::Data* report)
 : mmPrintableBase(report->REPORTNAME)
 , m_report(report)
 {
+    if (m_id == -1) {
+        m_id = report->REPORTID.ToLong(); // Store reportid if no id is provided
+    }
 }
 
 wxString mmGeneralReport::getHTMLText()
@@ -324,7 +328,7 @@ wxString mmGeneralReport::getHTMLText()
 
     return out;
 }
- 
+
 int mmGeneralReport::report_parameters()
 {
     int params = 0;
@@ -358,4 +362,3 @@ void mm_html_template::load_context()
     const Model_Currency::Data* currency = Model_Currency::GetBaseCurrency();
     if (currency) currency->to_template(*this);
 }
-

--- a/src/reports/reportbase.h
+++ b/src/reports/reportbase.h
@@ -1,6 +1,7 @@
 /*******************************************************
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2021-2022 Mark Whalley (mark@ipx.co.uk)
+ Copyright (C) 2025 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -45,7 +46,7 @@ public:
     int64 getDateSelection() const;
     int getAccountSelection() const;
     int getChartSelection() const;
-    int getForwardMonths() const;   
+    int getForwardMonths() const;
     const wxString getAccountNames() const;
     void chart(int selection);
     void setAccounts(int selection, const wxString& name);
@@ -107,11 +108,11 @@ protected:
     wxSharedPtr<wxArrayString> accountArray_;
     wxSharedPtr<wxArrayString> selectedAccountArray_;
     bool m_only_active = false;
+    int m_id = -1;
 
 private:
     bool m_initial = true;
     int m_account_selection = 0;
-    int m_id = -1;
     int m_parameters = 0;
     wxString m_settings = "";
 };


### PR DESCRIPTION
Like discussed the change for #7577:
- remove the old date range handling
- add a switch to store the the date range either individually per account/report or globally

In addition three more related changes:
- I noticed that the report id is always set to -1 during filter storage, so there was no individual filter storage. 
- User manual update for the settings description. Is not complete but reflects the current structure
- German translation of the user manual update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7655)
<!-- Reviewable:end -->
