### PR TITLE
Pull request misc changes01

### DIFF
--- a/src/categdialog.h
+++ b/src/categdialog.h
@@ -2,6 +2,7 @@
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2015, 2016, 2020, 2022 Nikolay Akimov
  Copyright (C) 2022 Mark Whalleuy (mark@ipx.co.uk)
+ Copyright (C) 2025 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -70,7 +71,7 @@ public:
         , const wxPoint& pos = wxDefaultPosition
         , const wxSize& size = wxDefaultSize
         , long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX | wxRESIZE_BORDER);
-    
+
     int64 getCategId() const;
     bool getRefreshRequested() const;
     bool mmIsUsed() const;
@@ -95,6 +96,7 @@ private:
     void OnCategoryRelocation(wxCommandEvent& /*event*/);
     void OnExpandOrCollapseToggle(wxCommandEvent& event);
     void OnShowHiddenToggle(wxCommandEvent& /*event*/);
+    void OnClearSettings(wxCommandEvent& /*event*/);
     void OnTextChanged(wxCommandEvent& event);
     void OnMenuSelected(wxCommandEvent& event);
     void OnItemRightClick(wxTreeEvent& event);
@@ -112,8 +114,8 @@ private:
     wxButton* m_buttonSelect = nullptr;
     wxButton* m_buttonDelete = nullptr;
     wxBitmapButton* m_buttonRelocate = nullptr;
-    wxToggleButton* m_tbCollapse = nullptr;
-    wxToggleButton* m_tbExpand = nullptr;
+    wxButton* m_tbCollapse = nullptr;
+    wxButton* m_tbExpand = nullptr;
     wxToggleButton* m_tbShowAll = nullptr;
     wxTreeItemId m_selectedItemId;
     wxTreeItemId root_;
@@ -126,18 +128,21 @@ private:
     std::map<int64, std::vector<Model_Category::Data>> m_categ_children;
     bool m_processExpandCollapse = true;
     wxColour NormalColor_;
+    wxColour m_hiddenColor;
     bool m_refresh_requested = false;
     wxString m_maskStr;
 
     enum
     {
-        MENU_ITEM_HIDE = wxID_HIGHEST + 1500,
+        MENU_ITEM_EDIT = wxID_HIGHEST + 1500,
+        MENU_ITEM_HIDE,
         MENU_ITEM_UNHIDE,
-        MENU_ITEM_CLEAR,
         MENU_ITEM_DELETE,
+        MENU_ITEM_ADD,
         ID_DIALOG_CATEGORY,
         ID_EXPAND,
-        ID_COLLAPSE
+        ID_COLLAPSE,
+        ID_CLEAR
     };
 };
 

--- a/src/images_list.cpp
+++ b/src/images_list.cpp
@@ -1,6 +1,7 @@
 /*******************************************************
 Copyright (C) 2014, 2015, 2021 Nikolay Akimov
 Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
+Copyright (C) 2025 Klaus Wich
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -167,16 +168,17 @@ const std::map<int, std::tuple<wxString, wxString, bool> > metaDataTrans()
     md[COLOR_LISTFUTURE]       = std::make_tuple("/colors/listFutureDate",      "#7486A8", false);
     md[COLOR_HTMLPANEL_BACK]   = std::make_tuple("/colors/htmlPanel/background", "",       false);
     md[COLOR_HTMLPANEL_FORE]   = std::make_tuple("/colors/htmlPanel/foreColor",  "",       false);
-    md[COLOR_REPORT_ALTROW]    = std::make_tuple("/colors/reports/altRow",      "#F5F5F5", false);    
+    md[COLOR_REPORT_ALTROW]    = std::make_tuple("/colors/reports/altRow",      "#F5F5F5", false);
     md[COLOR_REPORT_CREDIT]    = std::make_tuple("/colors/reports/credit",      "#50B381", false);
     md[COLOR_REPORT_DEBIT]     = std::make_tuple("/colors/reports/debit",       "#F75E51", false);
     md[COLOR_REPORT_DELTA]     = std::make_tuple("/colors/reports/delta",       "#008FFB", false);
     md[COLOR_REPORT_PERF]      = std::make_tuple("/colors/reports/perf",       "#FF6307", false);
-    md[COLOR_REPORT_FORECOLOR] = std::make_tuple("/colors/reports/foreColor",   "#373D3F", false);  
+    md[COLOR_REPORT_FORECOLOR] = std::make_tuple("/colors/reports/foreColor",   "#373D3F", false);
     md[COLOR_REPORT_PALETTE]   = std::make_tuple("/colors/reports/palette",  "#008FFB "
             "#00E396 #FEB019 #FF4560 #775DD0 #3F51B5 #03A9F4 #4cAF50 #F9CE1D #FF9800 "
             "#33B2DF #546E7A #D4526E #13D8AA #A5978B #4ECDC4 #81D4FA #546E7A #FD6A6A "
             "#2B908F #F9A3A4 #90EE7E #FA4443 #69D2E7 #449DD1 #F86624",                     false);
+    md[COLOR_HIDDEN]           = std::make_tuple("/colors/other/hidden",    "#81D4FA", false);
 
     return md;
 };
@@ -252,7 +254,7 @@ wxVector<wxBitmapBundle> navtree_images_list(const int size)
         images.push_back(img.second);
     for (const auto& img : acc_images(x))
          images.push_back(img.second);
-         
+
     return (images);
 }
 
@@ -274,7 +276,7 @@ bool processThemes(wxString themeDir, wxString myTheme, bool metaPhase)
     wxLogDebug("Scanning [%s] for Theme [%s]", themeDir, myTheme);
     if (!directory.IsOpened()) {
         wxLogDebug("}}}");
-        return false;  
+        return false;
     }
 
     bool themeMatched = false;
@@ -312,7 +314,7 @@ bool processThemes(wxString themeDir, wxString myTheme, bool metaPhase)
 
                 if (fileEntryName.IsDir())
                     continue;   // We can skip directories
-                
+
                 if (metaPhase) {
                     // For this phase we are only interested in the metadata and checking
                     // if theme has dark-mode components
@@ -344,12 +346,12 @@ bool processThemes(wxString themeDir, wxString myTheme, bool metaPhase)
                         continue;
                 }
 
-                // Remove dark mode prefix 
-                if (darkFound && darkMode) 
+                // Remove dark mode prefix
+                if (darkFound && darkMode)
                     fileName = fileName.substr(5);
 
                 // If the file does not match an icon file then just load into VFS / tmp
-                if (!iconName2enum.count(fileName)) {                                        
+                if (!iconName2enum.count(fileName)) {
 #if defined(__WXMSW__) || defined(__WXMAC__)
                     wxMemoryOutputStream memOut(nullptr);
                     themeStream.Read(memOut);
@@ -361,7 +363,7 @@ bool processThemes(wxString themeDir, wxString myTheme, bool metaPhase)
                         fileName, buffer->GetBufferStart(), buffer->GetBufferSize()
                     );
                     wxLogDebug("Theme: '%s' File: '%s' has been copied to VFS", thisTheme, fileName);
-#else                    
+#else
                     const wxString theme_file = mmex::getTempFolder() + fileName;
                     wxFileOutputStream fileOut(theme_file);
                     if (!fileOut.IsOk())
@@ -408,7 +410,7 @@ bool checkThemeContents(wxArrayString *filesinTheme)
 
     // Check for required files
     const wxString neededFiles[] = { "master.css", "" };
-    
+
     for (int i = 0; !neededFiles[i].IsEmpty(); i++)
     {
         const wxString realName = (darkFound && darkMode) ? neededFiles[i].AfterLast('-') : neededFiles[i];
@@ -470,12 +472,12 @@ void reverttoDefaultTheme()
     Model_Setting::instance().setTheme("default");
     darkFound = false;
     processThemes(mmex::getPathResource(mmex::THEMESDIR), Model_Setting::instance().getTheme(), true);
-    processThemes(mmex::getPathResource(mmex::THEMESDIR), Model_Setting::instance().getTheme(), false);  
+    processThemes(mmex::getPathResource(mmex::THEMESDIR), Model_Setting::instance().getTheme(), false);
 }
 
 void LoadTheme()
 {
-    darkMode = ( (mmex::isDarkMode() && (Option::THEME_MODE::AUTO == Option::instance().getThemeMode())) 
+    darkMode = ( (mmex::isDarkMode() && (Option::THEME_MODE::AUTO == Option::instance().getThemeMode()))
                     || (Option::THEME_MODE::DARK == Option::instance().getThemeMode()));
     filesInVFS = new wxArrayString();
 
@@ -492,7 +494,7 @@ void LoadTheme()
                 , Model_Setting::instance().getTheme()), _t("Warning"), wxOK | wxICON_WARNING);
             reverttoDefaultTheme();
         }
-    
+
     if (!checkThemeContents(filesInVFS.get()))
     {
         wxMessageBox(wxString::Format(_t("Theme %s has missing items and is incompatible. Reverting to default theme"), Model_Setting::instance().getTheme()), _t("Warning"), wxOK | wxICON_WARNING);
@@ -504,14 +506,14 @@ void LoadTheme()
                 , _t("Error"), wxOK | wxICON_ERROR);
             exit(EXIT_FAILURE);
         }
-    } 
+    }
 }
 
 void CloseTheme()
 {
     // Release icons - needed before app closure
     // https://github.com/wxWidgets/wxWidgets/issues/22862
-    for (int i = 0; i < numSizes; i++) 
+    for (int i = 0; i < numSizes; i++)
         for (int j = 0; j < MAX_PNG; j++)
             programIconBundles[i][j].reset();
 }

--- a/src/images_list.h
+++ b/src/images_list.h
@@ -1,6 +1,7 @@
 /*******************************************************
 Copyright (C) 2014, 2015 Nikolay Akimov
 Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
+Copyright (C) 2025 Klaus Wich
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -27,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 enum meta {
     THEME_NAME,
     THEME_AUTHOR,
-    THEME_DESCRIPTION,  
+    THEME_DESCRIPTION,
     THEME_URL,
     COLOR_NAVPANEL,
     COLOR_NAVPANEL_FONT,
@@ -47,6 +48,7 @@ enum meta {
     COLOR_REPORT_PERF,
     COLOR_REPORT_FORECOLOR,
     COLOR_REPORT_PALETTE,
+    COLOR_HIDDEN,
     // The end
     MAX_METADATA
 };
@@ -104,59 +106,59 @@ enum png {
     PAYEE,
     CURR,
     TAG,
-    FILTER, 
+    FILTER,
     GRM,
-    OPTIONS, 
-    NEW_TRX, 
+    OPTIONS,
+    NEW_TRX,
     NEW_NEWS,
     NEWS,
-    CURRATES, 
-    FULLSCREEN, 
+    CURRATES,
+    FULLSCREEN,
     PRINT,
-    ABOUT, 
+    ABOUT,
     HELP,
 
     // Navigation
     NAV_HOME,
-    ALLTRANSACTIONS, 
+    ALLTRANSACTIONS,
     NAV_FILTER,
     NAV_GRM,
     NAV_HELP,
     FAVOURITE,
-    SAVINGS_NORMAL, 
+    SAVINGS_NORMAL,
     CC_NORMAL,
-    CASH_NORMAL, 
+    CASH_NORMAL,
     LOAN_ACC_NORMAL,
     TERM_NORMAL,
-    STOCKS_NORMAL, 
+    STOCKS_NORMAL,
     ASSET_NORMAL,
     ACCOUNT_CLOSED,
     RECURRING,
     TRASH,
     BUDGET,
     PIE_CHART,
-    
+
     // Status
     UNRECONCILED,
     RECONCILED,
     DUPLICATE_STAT,
     FOLLOW_UP,
-    VOID_STAT, 
+    VOID_STAT,
     PROFIT,
     LOSS,
     LED_OFF,
-    LED_GREEN, 
-    LED_YELLOW, 
+    LED_GREEN,
+    LED_YELLOW,
     LED_RED,
     RUN,
-    RUN_AUTO, 
+    RUN_AUTO,
 
     // Assets
     PROPERTY,
     CAR,
-    HOUSEHOLD_OBJ, 
+    HOUSEHOLD_OBJ,
     ART,
-    JEWELLERY, 
+    JEWELLERY,
     CASH,
     OTHER,
 

--- a/src/import_export/ofx_import_gui.cpp
+++ b/src/import_export/ofx_import_gui.cpp
@@ -80,7 +80,7 @@ wxString DecodeHTMLEntities(const wxString& input)
 
 
 
-void mmPayeeSelectionDialog::OnCategorySelection(wxCommandEvent& event)
+void mmPayeeSelectionDialog::OnCategorySelection(wxCommandEvent& WXUNUSED(event))
 {
     int sel = categoryChoice_->GetSelection();
     long long selectedCategoryId = GetSelectedCategoryID();
@@ -325,7 +325,7 @@ void mmPayeeSelectionDialog::OnTitleCase(wxCommandEvent& /*event*/)
     newPayeeTextCtrl_->SetValue(result);
 }
 
-void mmPayeeSelectionDialog::OnOK(wxCommandEvent& event)
+void mmPayeeSelectionDialog::OnOK(wxCommandEvent& WXUNUSED(event))
 {
     if (useExistingRadio_->GetValue())
     {
@@ -599,7 +599,7 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
                                                int newTransactions, wxLongLong importStartTime, double matchConfidence, const wxString& matchMethod,
                                                int totalTransactions)
     : wxDialog(parent, wxID_ANY, _("Payee Confirmation Required"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
-      suggestedPayeeName_(suggestedPayeeName), matchConfidence_(matchConfidence), matchMethod_(matchMethod), confidenceLabel_(nullptr),
+      matchConfidence_(matchConfidence), matchMethod_(matchMethod), confidenceLabel_(nullptr), suggestedPayeeName_(suggestedPayeeName),
       useExistingRadio_(nullptr), createNewRadio_(nullptr), payeeChoice_(nullptr), newPayeeTextCtrl_(nullptr), titleCaseButton_(nullptr),
       categoryChoice_(nullptr), updateRegexCheckBox_(nullptr), regexGrid_(nullptr), okButton_(nullptr), updateCategoryButton_(nullptr),
       insertRowButton_(nullptr), deleteRowButton_(nullptr), existingPayeeLabel_(nullptr), newPayeeLabel_(nullptr), payeeSizer_(nullptr),
@@ -1692,7 +1692,7 @@ bool mmOFXImportDialog::ImportTransactions(wxXmlNode* banktranlist, wxLongLong a
             result.matchMode = matchMethod;
             result.matchConfidence = matchConfidence;
 
-            if (usedRegex && matchRegexPattern)
+            if (usedRegex && !matchRegexPattern.IsEmpty())
             {
                 result.matchRegexPattern = matchRegexPattern;
             }
@@ -1991,5 +1991,3 @@ wxString mmOFXImportSummaryDialog::FormatTimeTaken(double seconds) const
     }
     return result;
 }
-
-

--- a/src/import_export/ofx_import_gui.h
+++ b/src/import_export/ofx_import_gui.h
@@ -144,7 +144,6 @@ private:
     void AddCategoryToChoice(wxChoice* choice, long long categId, const std::map<long long, Model_Category::Data>& categoryMap, int level);
 
     double matchConfidence_;
-    int totalTransactions_;
     wxString matchMethod_;
     wxStaticText* confidenceLabel_;
     wxString suggestedPayeeName_;
@@ -174,6 +173,7 @@ private:
     int newTransactions_;
     wxLongLong importStartTime_;
     bool categoryManuallyChanged_;
+    int totalTransactions_;
     wxString memo_;
 };
 

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -627,7 +627,7 @@ void mmCheckingPanel::filterList()
                 break;
             }
         }
-        date_end_str = m_current_date_range.checking_end().IsValid() ? m_current_date_range.checking_end_str() : 
+        date_end_str = m_current_date_range.checking_end().IsValid() ? m_current_date_range.checking_end_str() :
             date_end.FormatISODate() + "~";
     }
     std::map<int64, Model_Budgetsplittransaction::Data_Set> bills_splits;
@@ -794,7 +794,7 @@ void mmCheckingPanel::filterList()
                 m_flow += account_flow;
             continue;
         }
-  
+
         int splitIndex = 1;
         wxString tranTagnames = full_tran.TAGNAMES;
         wxString tranDisplaySN = full_tran.displaySN;
@@ -944,8 +944,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
                 if (item == -1) break;
                 Model_Currency::Data* curr = Model_Account::currency(Model_Account::instance().get(m_lc->m_trans[item].ACCOUNTID));
                 if ((m_account_id < 0) && Model_Checking::is_transfer(m_lc->m_trans[item].TRANSCODE)) continue;
-                double convrate = (curr != m_currency) ? convrate = Model_CurrencyHistory::getDayRate(curr->CURRENCYID, m_lc->m_trans[item].TRANSDATE) : 
-                                                         convrate = 1.0; 
+                double convrate = (curr != m_currency) ? Model_CurrencyHistory::getDayRate(curr->CURRENCYID, m_lc->m_trans[item].TRANSDATE) : 1.0;
                 flow += convrate * Model_Checking::account_flow(m_lc->m_trans[item], (m_account_id < 0) ? m_lc->m_trans[item].ACCOUNTID : m_account_id);
                 wxString transdate = m_lc->m_trans[item].TRANSDATE;
                 if (minDate > transdate || minDate.empty()) minDate = transdate;
@@ -963,7 +962,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
             msg = wxString::Format(_t("Transactions selected: %zu"), selected.size());
             msg += "\n";
             msg += wxString::Format(
-                    _t("Selected transactions total: %s"), 
+                    _t("Selected transactions total: %s"),
                     selectedBal
                 );
             msg += "\n";

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -3845,9 +3845,14 @@ void mmGUIFrame::OnViewToolbar(wxCommandEvent &event)
     Model_Setting::instance().setBool("SHOWTOOLBAR", event.IsChecked());
 }
 
-void mmGUIFrame::OnViewLinks(wxCommandEvent &event)
+void mmGUIFrame::OnViewLinks(wxCommandEvent& WXUNUSED(event))
 {
-    m_mgr.GetPane("Navigation").Show(event.IsChecked());
+    if (m_mgr.GetPane("Navigation").IsShown()) {
+        m_mgr.GetPane("Navigation").Hide();
+    }
+    else {
+        m_mgr.GetPane("Navigation").Show();
+    }
     m_mgr.Update();
 }
 

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -514,7 +514,7 @@ void mmReportsPanel::OnAccountChanged(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void mmReportsPanel::OnSingleDateChanged(wxDateEvent& event)
+void mmReportsPanel::OnSingleDateChanged(wxDateEvent& WXUNUSED(event))
 {
     if (rb_) {
         saveReportText(false);

--- a/src/stocks_list.cpp
+++ b/src/stocks_list.cpp
@@ -63,8 +63,8 @@ wxBEGIN_EVENT_TABLE(StocksListCtrl, mmListCtrl)
 wxEND_EVENT_TABLE()
 
 const std::vector<ListColumnInfo> StocksListCtrl::LIST_INFO = {
-    { LIST_ID_ICON,           true, _n("Icon"),                 25,  _FL, false },
-    { LIST_ID_ID,             true, _n("ID"),                   _WA, _FR, true },
+    { LIST_ID_ICON,           true, _n("Icon"),                 25,  _FC, false },
+    { LIST_ID_ID,             true, _n("ID"),                   _WA, _FL, true },
     { LIST_ID_DATE,           true, _n("*Date"),                _WH, _FL, true },
     { LIST_ID_NAME,           true, _n("Company Name"),         _WH, _FL, true },
     { LIST_ID_SYMBOL,         true, _n("Symbol"),               _WH, _FL, true },
@@ -84,7 +84,17 @@ StocksListCtrl::StocksListCtrl(
     mmStocksPanel* cp, wxWindow *parent, wxWindowID winid
 ) :
     mmListCtrl(parent, winid),
-    m_stock_panel(cp)
+    m_stock_panel(cp),
+    m_attr1(new wxListItemAttr(
+            mmThemeMetaColour(meta::COLOR_REPORT_DEBIT),
+            mmThemeMetaColour(meta::COLOR_LISTALT0),
+            GetFont()
+        )),
+    m_attr2(new wxListItemAttr(
+            mmThemeMetaColour(meta::COLOR_REPORT_DEBIT),
+            mmThemeMetaColour(meta::COLOR_LIST),
+            GetFont()
+        ))
 {
     wxVector<wxBitmapBundle> images;
     images.push_back(mmBitmapBundle(png::PROFIT));
@@ -105,8 +115,9 @@ StocksListCtrl::StocksListCtrl(
     createColumns();
 
     initVirtualListControl();
-    if (!m_stocks.empty())
+    if (!m_stocks.empty()) {
         EnsureVisible(m_stocks.size() - 1);
+    }
 }
 
 StocksListCtrl::~StocksListCtrl()
@@ -463,7 +474,7 @@ int StocksListCtrl::initVirtualListControl(int64 trx_id)
         m_stocks = Model_Stock::instance().find(
                         Model_Stock::NUMSHARES(0.0, m_stock_panel->getFilter() ? GREATER : GREATER_OR_EQUAL)
                 );
-        if (!m_stocks.empty()) 
+        if (!m_stocks.empty())
             createSummary();
     }
 
@@ -598,4 +609,9 @@ void StocksListCtrl::getInvestmentBalance(double& invested, double& current)
 {
     invested = m_investedVal;
     current = m_marketVal;
+}
+
+wxListItemAttr* StocksListCtrl::OnGetItemAttr(long item) const
+{
+    return (item % 2) ? (GetGainLoss(item) < 0 ? m_attr2.get() : attr2_.get()) : GetGainLoss(item) < 0 ? m_attr1.get() : attr1_.get();
 }

--- a/src/stocks_list.h
+++ b/src/stocks_list.h
@@ -91,11 +91,14 @@ private:
     static double getRealGainLoss(const Model_Stock::Data& stock);
     void sortList();
     void createSummary();
+    wxSharedPtr<wxListItemAttr> m_attr1;  // Style for loss
+    wxSharedPtr<wxListItemAttr> m_attr2;  // style for loss alternate
 
     // required overrides for virtual style list control
     virtual int getSortIcon(bool asc) const override;
     virtual wxString OnGetItemText(long item, long col_nr) const override;
     virtual int OnGetItemImage(long item) const override;
+    virtual wxListItemAttr* OnGetItemAttr(long item) const override;
     void OnColClick(wxListEvent& event) override;
 
     void OnMouseRightClick(wxMouseEvent& event);


### PR DESCRIPTION
This pull request contains the following changes:

1. Fixed a compile error and removed several warnings, which occurred during compilation under Linux .

2. Make stock in stock overview losses more visible:
 Old: Losses are only indicated with a symbol:
<img width="1392" height="231" alt="Stock overview old" src="https://github.com/user-attachments/assets/b0349a30-a6ea-4f61-a270-c54614479067" />
New: Row in stock is colored:
<img width="1390" height="268" alt="Stock overview new" src="https://github.com/user-attachments/assets/43c305d8-84f6-4144-8edd-79852378e69f" />

3. Toggle Navigator with F6:
   F6 did not work the show the navigator, if there was a previous click in account view window . Replaced with a more robust implementation.

4. Refactoring of the category dialog:
   The current category dialog is not very intuitive, several changes were made to improve the user experience:
- Enhancement: Adapt and refactor category dialog
- Replace expand and hide toggle buttons with buttons
- New context menu options add and edit
- Move context menu option "clear settings" in own button
- Protect against segfault in drag
- Own color for hidden entries, configurable in the theme

Old:     
<img width="530" height="711" alt="category dialog old" src="https://github.com/user-attachments/assets/5e8c991e-4c5e-4c4a-8fc7-3bc5563009d3" />

New:
<img width="547" height="707" alt="category dialog new" src="https://github.com/user-attachments/assets/478beca2-39ca-4895-a598-219d49dc70c6" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7747)
<!-- Reviewable:end -->
