### PR TITLE
chore(NEWS): remove old 1.9.1 beta reference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,10 +62,6 @@ Bugfixes:
 * #5196 Poor icon rendering for different DPIs using wxGenericTreeCtrl
 * #2891 Locked transaction
 
-Version 1.9.1 Beta 1
-~~~~~~~~~~~~~~~~~~~~
-Released: 2025-02-08
-
 Version 1.9.0
 ~~~~~~~~~~~~~~~~~~~~
 Released: 2025-02-07


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7753)
<!-- Reviewable:end -->
