### PR TITLE
Fixed sorting of investment accounts in stocks widget

### DIFF
--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -77,9 +77,11 @@ const wxString htmlWidgetStocks::getHTMLText()
     const wxDate today = wxDate::Today();
 
     wxString output = "";
-    const auto &accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::TYPE_NAME_INVESTMENT, EQUAL));
+    Model_Account::Data_Set accounts = Model_Account::instance().find(Model_Account::ACCOUNTTYPE(Model_Account::TYPE_NAME_INVESTMENT, EQUAL));
     if (!accounts.empty())
     {
+        std::stable_sort(accounts.begin(), accounts.end(), SorterByACCOUNTNAME());
+
         output = R"(<div class="shadow">)";
         output += "<table class ='sortable table'><col style='width: 50%'><col style='width: 12.5%'><col style='width: 12.5%'><col style='width: 12.5%'><col style='width: 12.5%'><thead><tr class='active'><th>\n";
         output += _t("Stocks") + "</th><th class = 'text-right'>" + _t("Gain/Loss") + "</th>\n";


### PR DESCRIPTION
The investment accounts are not sorted alphabetically by account name in the Stocks widget. They are shown in the order they were created, because the sorting function is not called.
<img width="1066" height="303" alt="stocks" src="https://github.com/user-attachments/assets/b6f0b06e-df34-4e77-a0ad-379501553b6c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7793)
<!-- Reviewable:end -->
