### PR TITLE
fix(#7745): "Save" and "Save and New" has the same keyboard shortcut

### DIFF
--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -616,7 +616,7 @@ void mmTransDialog::CreateControls()
 
     buttons_sizer->Add(new wxButton(buttons_panel, wxID_OK, _t("&Save")), wxSizerFlags(g_flagsH).Border(wxBOTTOM | wxRIGHT, 10));
     if (m_mode == MODE_NEW) {
-        buttons_sizer->Add(new wxButton(buttons_panel, ID_BTN_OK_NEW, _t("&Save and New")), wxSizerFlags(g_flagsH).Border(wxBOTTOM | wxRIGHT, 10));
+        buttons_sizer->Add(new wxButton(buttons_panel, ID_BTN_OK_NEW, _t("Save and &New")), wxSizerFlags(g_flagsH).Border(wxBOTTOM | wxRIGHT, 10));
     }
     m_button_cancel = new wxButton(buttons_panel, wxID_CANCEL, wxGetTranslation(g_CancelLabel));
     buttons_sizer->Add(m_button_cancel, wxSizerFlags(g_flagsH).Border(wxBOTTOM | wxRIGHT, 10));


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7814)
<!-- Reviewable:end -->
