### PR TITLE
fix(#7736): Default Stock URL should be: https://finance.yahoo.com/quote/%s

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -166,8 +166,8 @@ const wxString mmex::weblink::WebApp         = "https://github.com/moneymanagere
 const wxString mmex::weblink::Chiark         = "https://www.chiark.greenend.org.uk/~sgtatham/bugs.html";
 const wxString mmex::weblink::Crowdin        = "https://crowdin.com/project/moneymanagerex/";
 
-// Will display the stock page when using Looks up the current value
-const wxString mmex::weblink::DefStockUrl = "http://finance.yahoo.com/echarts?s=%s";
+// Will display the stock page when looking up the current value
+const wxString mmex::weblink::DefStockUrl = "https://finance.yahoo.com/quote/%s";
 
 // Yahoo API
 const wxString mmex::weblink::YahooQuotes = "https://query1.finance.yahoo.com/v7/finance/quote?symbols=%s&fields=regularMarketPrice,currency,shortName";


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

Please advise where the files are to:
2. Upgrade script to amend for existing users

Feel free to merge this and another patch can be created for point 2.

Thank you

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7816)
<!-- Reviewable:end -->
