### PR TITLE
fix(layout): Better layout for type/status fields

### DIFF
--- a/src/billsdepositsdialog.cpp
+++ b/src/billsdepositsdialog.cpp
@@ -498,7 +498,7 @@ void mmBDDialog::CreateControls()
     mmToolTip(m_choice_status, _t("Specify the status for the transaction"));
 
     transPanelSizer->Add(new wxStaticText(this, wxID_STATIC, _t("Status")), g_flagsH);
-    transPanelSizer->Add(m_choice_status, g_flagsH);
+    transPanelSizer->Add(m_choice_status, g_flagsExpand);
     transPanelSizer->AddSpacer(1);
 
     // Type --------------------------------------------
@@ -510,11 +510,11 @@ void mmBDDialog::CreateControls()
     mmToolTip(cAdvanced_, _t("Allows the setting of different amounts in the FROM and TO accounts."));
 
     wxBoxSizer* typeSizer = new wxBoxSizer(wxHORIZONTAL);
-    typeSizer->Add(m_choice_transaction_type, g_flagsH);
+    typeSizer->Add(m_choice_transaction_type, g_flagsExpand);
     typeSizer->Add(cAdvanced_, g_flagsH);
 
     transPanelSizer->Add(new wxStaticText(this, wxID_STATIC, _t("Type")), g_flagsH);
-    transPanelSizer->Add(typeSizer);
+    transPanelSizer->Add(typeSizer, g_flagsExpand);
     transPanelSizer->AddSpacer(1);
 
     // Amount Fields --------------------------------------------

--- a/src/transactionsupdatedialog.cpp
+++ b/src/transactionsupdatedialog.cpp
@@ -161,7 +161,7 @@ void transactionsUpdateDialog::CreateControls()
     m_status_choice->Select(0);
 
     grid_sizer->Add(m_status_checkbox, g_flagsH);
-    grid_sizer->Add(m_status_choice, g_flagsH);
+    grid_sizer->Add(m_status_choice, g_flagsExpand);
 
     // Type --------------------------------------------
     m_type_checkbox = new wxCheckBox(this, wxID_ANY, _t("Type")
@@ -180,7 +180,7 @@ void transactionsUpdateDialog::CreateControls()
 
 
     grid_sizer->Add(m_type_checkbox, g_flagsH);
-    grid_sizer->Add(m_type_choice, g_flagsH);
+    grid_sizer->Add(m_type_choice, g_flagsExpand);
 
     // Amount Field --------------------------------------------
     m_amount_checkbox = new wxCheckBox(this, wxID_ANY, _t("Amount")

--- a/src/transdialog.cpp
+++ b/src/transdialog.cpp
@@ -476,8 +476,8 @@ void mmTransDialog::CreateControls()
     wxBoxSizer* typeSizer = new wxBoxSizer(wxHORIZONTAL);
 
     flex_sizer->Add(new wxStaticText(static_box, wxID_STATIC, _t("Type")), g_flagsH);
-    flex_sizer->Add(typeSizer);
-    typeSizer->Add(transaction_type_, g_flagsH);
+    flex_sizer->Add(typeSizer, g_flagsExpand);
+    typeSizer->Add(transaction_type_, g_flagsExpand);
     typeSizer->Add(cAdvanced_, g_flagsH);
     flex_sizer->AddSpacer(1);
 
@@ -566,7 +566,7 @@ void mmTransDialog::CreateControls()
     }
 
     flex_sizer->Add(new wxStaticText(static_box, wxID_STATIC, _t("Status")), g_flagsH);
-    flex_sizer->Add(choiceStatus_, g_flagsH);
+    flex_sizer->Add(choiceStatus_, g_flagsExpand);
     flex_sizer->AddSpacer(1);
 
     // Number  ---------------------------------------------


### PR DESCRIPTION
Better layout of Transaction type and status fields in transaction dialogs. Now fills the dialog to align with other fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7848)
<!-- Reviewable:end -->
