### PR TITLE
Feature: Dedicated Flag to show/hide future transactions on dashboard

### DIFF
--- a/docs/en_US/index.html
+++ b/docs/en_US/index.html
@@ -2208,7 +2208,23 @@ PBank Of Mortgage Payee
     </dl>
 
     <h3>Dashboard Panel</h3>
-    TODO
+    <p>These settings control the dashboard display.</p>
+    <h4>Income vs. Expenses</h4>
+    <dl>
+        <dt>Date range</dt>
+        <dd>Sets the date range used for the income vs. expense overview.</dd>
+    </dl>
+
+    <h4>Miscellaneous</h4>
+    <dl>
+        <dt>Ignore Future Transactions</dt>
+        <dd>If this checkbox is enabled, the account value corresponds with the value of the current day, future transactions are not included.</dd>
+        <dd>If this checkbox is disabled all transactions are included in the calculation of the account value.</dd>
+        <dd><b>Important:</b></dd>
+        <dd>This checkbox only controls the handling of future transactions on the dashboard, the display of future transactions in the account overviews is controlled by the corresponding
+            checkbox in the transaction panel under Transaction/Budget
+        </dd>
+    </dl>
 
 
     <h3>Transactions Panel</h3>
@@ -2230,7 +2246,7 @@ PBank Of Mortgage Payee
         <dd>Activate to play a sound when a transaction is entered.</dd>
 
     <h4>Transaction/Budget</h4>
-    These settings control the budget handling.
+    These settings control the transaction display and budget handling.
 
     <h4>Transaction Colors</h4>
     Allows the definition of individual colors, which can mark transactions. The <samp>Default</samp> button resets

--- a/src/mmhomepage.cpp
+++ b/src/mmhomepage.cpp
@@ -1,6 +1,7 @@
 /*******************************************************
 Copyright (C) 2014 - 2021 Nikolay Akimov
 Copyright (C) 2021-2023 Mark Whalley (mark@ipx.co.uk)
+Copyright (C) 2025 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -457,17 +458,19 @@ const wxString htmlWidgetStatistics::getHTMLText()
     json_writer.String(_t("Transaction Statistics").utf8_str());
 
     wxSharedPtr<mmDateRange> date_range;
-    if (Option::instance().getIgnoreFutureTransactions())
+    /*if (Option::instance().getIgnoreFutureTransactions())
         date_range = new mmCurrentMonthToDate;
     else
-        date_range = new mmCurrentMonth;
+        date_range = new mmCurrentMonth;*/
 
     Model_Checking::Data_Set all_trans;
-    if (Option::instance().getIgnoreFutureTransactions()) {
+    if (Option::instance().getIgnoreFutureTransactionsHomePage()) {
+        date_range = new mmCurrentMonthToDate;
         all_trans = Model_Checking::instance().find(
             Model_Checking::TRANSDATE(wxDateTime(23,59,59,999), LESS_OR_EQUAL));
     }
     else {
+        date_range = new mmCurrentMonth;
         all_trans = Model_Checking::instance().all();
     }
     int countFollowUp = 0;
@@ -658,19 +661,19 @@ void htmlWidgetAccounts::get_account_stats()
 {
 
     wxSharedPtr<mmDateRange> date_range;
-    if (Option::instance().getIgnoreFutureTransactions())
+    /*if (Option::instance().getIgnoreFutureTransactions())
         date_range = new mmCurrentMonthToDate;
     else
-        date_range = new mmCurrentMonth;
+        date_range = new mmCurrentMonth;*/
 
     Model_Checking::Data_Set all_trans;
-    if (Option::instance().getIgnoreFutureTransactions())
-    {
+    if (Option::instance().getIgnoreFutureTransactionsHomePage()) {
+        date_range = new mmCurrentMonthToDate;
         all_trans = Model_Checking::instance().find(Model_Checking::TRANSDATE(
             Option::instance().UseTransDateTime() ? wxDateTime::Now() : wxDateTime(23, 59, 59, 999), LESS_OR_EQUAL));
     }
-    else
-    {
+    else {
+        date_range = new mmCurrentMonth;
         all_trans = Model_Checking::instance().all();
     }
 

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -127,6 +127,7 @@ void Option::load(bool include_infotable)
     loadBudgetOverride();
     loadBudgetDeductMonthly();
     loadIgnoreFutureTransactions();
+    loadIgnoreFutureTransactionsHomePage();
     loadUseTransDateTime();
     loadTreatDateAsSN();
     loadDoNotColorFuture();
@@ -412,6 +413,16 @@ void Option::setIgnoreFutureTransactions(const bool value)
 {
     Model_Setting::instance().setBool("IGNORE_FUTURE_TRANSACTIONS", value);
     m_ignore_future_transactions = value;
+}
+
+void Option::loadIgnoreFutureTransactionsHomePage()
+{
+    m_ignore_future_transactions_home = Model_Setting::instance().getBool("IGNORE_FUTURE_TRANSACTIONS_HOMEPAGE", true);
+}
+void Option::setIgnoreFutureTransactionsHomePage(const bool value)
+{
+    Model_Setting::instance().setBool("IGNORE_FUTURE_TRANSACTIONS_HOMEPAGE", value);
+    m_ignore_future_transactions_home = value;
 }
 
 void Option::loadUseTransDateTime()

--- a/src/option.h
+++ b/src/option.h
@@ -243,6 +243,11 @@ public:
     void setIgnoreFutureTransactions(const bool value);
     bool getIgnoreFutureTransactions() const noexcept;
 
+    // m_ignore_future_transactions_homepage
+    void loadIgnoreFutureTransactionsHomePage();
+    void setIgnoreFutureTransactionsHomePage(const bool value);
+    bool getIgnoreFutureTransactionsHomePage() const noexcept;
+
     // m_doNotColorFuture
     void loadDoNotColorFuture();
     void setDoNotColorFuture(const bool value);
@@ -305,6 +310,7 @@ private:
     bool m_budget_override = false;                     // BUDGET_OVERRIDE
     bool m_budget_deduct_monthly = false;               // BUDGET_DEDUCT_MONTH_FROM_YEAR
     bool m_ignore_future_transactions = false;          // IGNORE_FUTURE_TRANSACTIONS
+    bool m_ignore_future_transactions_home = false;     // IGNORE_FUTURE_TRANSACTIONS_HOMEPAGE
     bool m_do_not_color_future = true;                  // DO_NOT_COLOR_FUTURE_TRANSACTIONS
     bool m_do_special_color_reconciled = true;          // SPECIAL_COLOR_RECONCILED_TRANSACTIONS
     bool m_store_account_specific_filter = false;       // USE_PER_ACCOUNT_FILTER
@@ -522,6 +528,11 @@ inline bool Option::doSendUsageStats() const noexcept
 inline bool Option::getIgnoreFutureTransactions() const noexcept
 {
     return m_ignore_future_transactions;
+}
+
+inline bool Option::getIgnoreFutureTransactionsHomePage() const noexcept
+{
+    return m_ignore_future_transactions_home;
 }
 
 inline bool Option::getDoNotColorFuture() const noexcept

--- a/src/optionsettingshome.cpp
+++ b/src/optionsettingshome.cpp
@@ -106,7 +106,20 @@ void OptionSettingsHome::Create()
         event.Skip();
     });
     totalsStaticBoxSizer->Add(nDays_, g_flagsH);
+
+    wxStaticBox* sBox = new wxStaticBox(home_panel, wxID_STATIC, _t("Miscellaneous"));
+    wxStaticBoxSizer* trxSizer = new wxStaticBoxSizer(sBox, wxVERTICAL);
+    homePanelSizer->Add(trxSizer, wxSizerFlags(g_flagsExpand).Proportion(0));
+    m_ignore_future_transactions_home = new wxCheckBox(
+    sBox, wxID_ANY,
+    _t("Ignore Future Transactions"),
+    wxDefaultPosition, wxDefaultSize, wxCHK_2STATE
+    );
+    m_ignore_future_transactions_home->SetValue(Option::instance().getIgnoreFutureTransactionsHomePage());
+    trxSizer->Add(m_ignore_future_transactions_home, g_flagsV);
+
     SetBoldFontToStaticBoxHeader(totalsStaticBox);
+    SetBoldFontToStaticBoxHeader(sBox);
     Fit();
     home_panel->SetMinSize(home_panel->GetBestVirtualSize());
     nDays_->Show(sel_id == 15);
@@ -120,6 +133,7 @@ bool OptionSettingsHome::SaveSettings()
     Option::instance().setHomePageIncExpRange(sel_id);
     if (sel_id == 15)
         Model_Infotable::instance().setInt("HOMEPAGE_INCEXP_DAYS", nDays_->GetValue());
+    Option::instance().setIgnoreFutureTransactionsHomePage(m_ignore_future_transactions_home->GetValue());
     return true;
 }
 

--- a/src/optionsettingshome.h
+++ b/src/optionsettingshome.h
@@ -1,6 +1,7 @@
 /*******************************************************
 Copyright (C) 2021 Mark Whalley (mark@ipx.co.uk)
- Copyright (C) 2021 Nikolay Akimov
+Copyright (C) 2021 Nikolay Akimov
+Copyright (C) 2025 Klaus Wich
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -47,6 +48,7 @@ private:
     void Create();
     wxSharedPtr<mmDateRange> m_inc_vs_exp_date_range;
     std::vector<wxSharedPtr<mmDateRange>> m_all_date_ranges;
+    wxCheckBox* m_ignore_future_transactions_home = nullptr;
 
 private:
     wxChoice* m_incExpChoice = nullptr;


### PR DESCRIPTION
Currently the flag "Ignore future transactions" in the transactions settings controls two settings:
- The display of the future transactions in the account panels
- If future transactions actions are included in the summary values of the dashboard.

This leads to some confusion, especially if the current account should be displayed on the dash board (flag = "False"), but also if in the account view the future transactions are desired (flag= "True"). 

This  feature separates the functionality in two flags, by introducing a  dedicated flag for the dashboard view, which allows a more granular configuration: 

<img width="500" height="589" alt="Additional ignore flag" src="https://github.com/user-attachments/assets/ceb66330-08ee-4ae2-8186-d49148b82619" />

For transactions the existing flag applies:

<img width="754" height="430" alt="Current ignore flag" src="https://github.com/user-attachments/assets/d3a1a822-7d9c-4512-ac3e-d19e09b22117" />

Note: mmex.po change is not needed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7947)
<!-- Reviewable:end -->
