### PR TITLE
add sort by Autorepeat in Scheduled Transactions panel

### DIFF
--- a/src/billsdepositspanel.cpp
+++ b/src/billsdepositspanel.cpp
@@ -843,6 +843,15 @@ void mmBillsDepositsPanel::sortList()
                 return xn == Model_Billsdeposits::REPEAT_NUM_INFINITY && yn == Model_Billsdeposits::REPEAT_NUM_UNKNOWN;
         });
         break;
+    case billsDepositsListCtrl::LIST_ID_AUTO:
+        std::stable_sort(bills_.begin(), bills_.end()
+            , [&](const Model_Billsdeposits::Full_Data& x, const Model_Billsdeposits::Full_Data& y)
+        {
+            int x_auto = x.REPEATS.GetValue() / BD_REPEATS_MULTIPLEX_BASE;
+            int y_auto = y.REPEATS.GetValue() / BD_REPEATS_MULTIPLEX_BASE;
+            return x_auto < y_auto;
+        });
+        break;
     case billsDepositsListCtrl::LIST_ID_REMAINING:
         // in almost all cases, sorting by remaining days is equivalent to sorting by TRANSDATE
         std::stable_sort(bills_.begin(), bills_.end(), SorterByTRANSDATE());


### PR DESCRIPTION
This PR adds sorting by Autorepeat in Scheduled Transactions panel (which was missing).

The order is based on the auto-execution code (enum REPEAT_AUTO) and not on the alphabetic order of the label shown in the panel. When sorted in increasing order, the order is: Manual, Suggested, Automated (i.e., from less automatic to more automatic).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/7991)
<!-- Reviewable:end -->
