### PR TITLE
fix(#8000): hide reconcile calc on MacOS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Version 1.9.2 RC 2
 Released: 2025-11-27
 
 Features:
+* #7980 Refine scheduled transactions panel
 * #7946 Transaction dialog Save and new enhancements
 * #7947 Dedicated Flag to show/hide future transactions on dashboard
 * #7821 2-digit years are interpreted as the first century, instead of being in the closest century
@@ -22,6 +23,7 @@ Features:
 * #7923 Header of MMEX
 
 Bugfixes:
+* #7975 Add descriptive tooltips to budget status icons in the Budgeting Panel
 * #7984 Cash Flow -> Transactions - Current Day Transactions are displayed as if not already reconciled
 * #7972 Cannot invoke Theme Manager from menus
 * #7863 error occurred when saving the transaction

--- a/contrib.txt
+++ b/contrib.txt
@@ -203,6 +203,11 @@ kolmo7
 ---------------------------------------
 ## Sponsors
 
+### 2026
+Renato
+Michael Ellis
+Glenn Howe
+
 ### 2025
 Renato
 Michael Ellis

--- a/src/uicontrols/reconciledialog.cpp
+++ b/src/uicontrols/reconciledialog.cpp
@@ -73,6 +73,7 @@ void mmReconcileDialog::CreateControls()
 
     topSizer->Add(m_amountCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
 
+#ifndef __WXOSX__   // Issue https://github.com/moneymanagerex/moneymanagerex/issues/8000
     m_btnCalc = new wxBitmapButton(topPanel, wxID_ANY, mmBitmapBundle(png::CALCULATOR, mmBitmapButtonSize));
     m_btnCalc->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &mmReconcileDialog::OnCalculator, this);
     m_btnCalc->SetCanFocus(false);
@@ -80,6 +81,7 @@ void mmReconcileDialog::CreateControls()
     topSizer->Add(m_btnCalc, 0, wxRIGHT, 20);
     m_calculaterPopup = new mmCalculatorPopup(m_btnCalc, m_amountCtrl, true);
     m_calculaterPopup->SetCanFocus(false);
+#endif
 
     topSizer->AddStretchSpacer();
     m_btnEdit = new wxButton(topPanel, wxID_ANY, _t("&Edit"));


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8001)
<!-- Reviewable:end -->
