### PR TITLE
Error fixed: Category change is ignored in edit stock transactions

### DIFF
--- a/src/usertransactionpanel.cpp
+++ b/src/usertransactionpanel.cpp
@@ -263,7 +263,7 @@ void UserTransactionPanel::DataToControls()
     m_payee->SetLabelText(Model_Payee::get_payee_name(m_payee_id));
 
     m_category_id = m_checking_entry->CATEGID;
-    m_category->SetLabelText(Model_Category::full_name(m_category_id));
+    m_category->SetValue(Model_Category::full_name(m_category_id));
 
     m_entered_number->SetValue(m_checking_entry->TRANSACTIONNUMBER);
     m_entered_notes->SetValue(m_checking_entry->NOTES);


### PR DESCRIPTION
Fixes: If in the edit share transaction dialog the category of the transaction is changed, the new category is not stored.

…also relates to #7809: In the current implementation the category is always -1 (if not used before),  which triggers the reported  message "Invalid Transaction"

2nd error fixed : In the edit share transaction dialog the current category is not shown.  (Regression due to new wxWidget version?) 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8010)
<!-- Reviewable:end -->
