### PR TITLE
Fix localization of Trade Type in Stock Transactions view

### DIFF
--- a/src/stockspanel.cpp
+++ b/src/stockspanel.cpp
@@ -314,7 +314,7 @@ void mmStocksPanel::FillListRow(wxListCtrl* listCtrl, long index, const Model_Ch
 
     int precision = share_entry.SHARENUMBER == floor(share_entry.SHARENUMBER) ? 0 : Option::instance().getSharePrecision();
     listCtrl->SetItem(index, 2, wxString::FromDouble(share_entry.SHARENUMBER, precision));
-    listCtrl->SetItem(index, 3, Model_Checking::trade_type_name(Model_Checking::type_id(txn.TRANSCODE)));
+    listCtrl->SetItem(index, 3, wxGetTranslation(Model_Checking::trade_type_name(Model_Checking::type_id(txn.TRANSCODE))));
     listCtrl->SetItem(index, 4, wxString::FromDouble(share_entry.SHAREPRICE, Option::instance().getSharePrecision()));
     listCtrl->SetItem(index, 5, wxString::FromDouble(share_entry.SHARECOMMISSION, 2));
     double total = share_entry.SHARENUMBER * share_entry.SHAREPRICE + share_entry.SHARECOMMISSION;


### PR DESCRIPTION
This PR fixes the localization of the **Trade Type** column in Stock Portfolios → View Stock Transactions.

The trade type values (Buy / Sell / Revalue) were always shown in English because they were not passed through the translation system when displayed in the list control.

This change applies `wxGetTranslation()` to the trade type value before setting it in the UI, ensuring proper localization.

- No functional changes
- Localization-only fix

Fixes #8038

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8041)
<!-- Reviewable:end -->
