### PR TITLE
Clarify CSV field labels for real and unreal gains

### DIFF
--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -124,8 +124,8 @@ mmUnivCSVDialog::mmUnivCSVDialog(
     CSVFieldName_[UNIV_CSV_CURRENT_PRICE].first         = _n("Current Price");
     CSVFieldName_[UNIV_CSV_AVG_SHARE_PRICE].first       = _n("Avg Share Price");
     CSVFieldName_[UNIV_CSV_TOTAL_COST].first            = _n("Total Cost");
-    CSVFieldName_[UNIV_CSV_REAL_GAIN].first             = _n("Real Gain");
-    CSVFieldName_[UNIV_CSV_UNREAL_GAIN].first           = _n("Unreal Gain");
+    CSVFieldName_[UNIV_CSV_REAL_GAIN].first             = _n("Realized Gain/Loss");
+    CSVFieldName_[UNIV_CSV_UNREAL_GAIN].first           = _n("Unrealized Gain/Loss");
     CSVFieldName_[UNIV_CSV_CURRENT_TOTAL_VALUE].first   = _n("Current Total Value");
     CSVFieldName_[UNIV_CSV_COMMISSION].first            = _n("Commission");
 


### PR DESCRIPTION
This change is related to issue #8071.

While importing transactions from a CSV file into a new account, I noticed duplicated field labels ("Don't Care" and "Withdrawal") in the CSV import mapping UI, causing ambiguity.

This commit assigns distinct and meaningful labels to UNIV_CSV_REAL_GAIN and UNIV_CSV_UNREAL_GAIN, resolving the duplication and improving clarity during CSV import.


Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8072)
<!-- Reviewable:end -->
