### PR TITLE
wxTreeListItems is already defined by wx/treelist.h properly. 

### DIFF
--- a/src/generic/generictreelistdialog.h
+++ b/src/generic/generictreelistdialog.h
@@ -21,8 +21,6 @@
 #include "defs.h"
 
 
-typedef std::vector<wxTreeListItem> wxTreeListItems;
-
 
 class genericTreeListDialog: public wxDialog
 {

--- a/src/uicontrols/navigatordialog.h
+++ b/src/uicontrols/navigatordialog.h
@@ -23,8 +23,6 @@
 #include "generic/generictreelistdialog.h"
 
 
-typedef std::vector<wxTreeListItem> wxTreeListItems;
-
 
 class mmNavigatorDialog: public genericTreeListDialog
 {

--- a/src/uicontrols/navigatoreditdialog.h
+++ b/src/uicontrols/navigatoreditdialog.h
@@ -21,9 +21,6 @@
 #include "defs.h"
 #include "navigatortypes.h"
 
-typedef std::vector<wxTreeListItem> wxTreeListItems;
-
-
 class mmNavigatorEditDialog: public wxDialog
 {
     wxDECLARE_DYNAMIC_CLASS(mmNavigatorEditDialog);


### PR DESCRIPTION
Redefinition leads to compilation errors on some systems


Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8086)
<!-- Reviewable:end -->
