### PR TITLE
Add tooltips to toolbar configuration buttons

### DIFF
--- a/src/uicontrols/toolbardialog.cpp
+++ b/src/uicontrols/toolbardialog.cpp
@@ -97,7 +97,6 @@ void mmToolbarDialog::createBottomElements(wxBoxSizer* itemBox)
 
     itemBox->Add(stretchBtn, g_flagsV);
     Bind(wxEVT_BUTTON, &mmToolbarDialog::OnNew, this, BTN_NEW_STRETCHER);
-}
 
 
     itemBox->AddSpacer(10);


### PR DESCRIPTION
This PR adds descriptive tooltips to the toolbar configuration dialog
for the following buttons:

- Add separator
- Add space
- Add stretch space

The tooltips explain the actual behavior of each element, including
the difference between fixed spaces and stretchable spaces.

![tooltip](https://github.com/user-attachments/assets/e5131100-9412-4cd1-b77d-1a85831ab8b9)

Tooltips are applied using FindWindow() and guarded by an if check
to avoid altering the existing button creation code and to safely
handle cases where a window might not be found.

No changes were made to the existing layout or event binding logic.
The patch only adds user-facing documentation via tooltips.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8088)
<!-- Reviewable:end -->
