### PR TITLE
Fix dashboard Income vs Expenses ignoring selected date range

### DIFF
--- a/src/optionsettingshome.cpp
+++ b/src/optionsettingshome.cpp
@@ -43,7 +43,7 @@ OptionSettingsHome::OptionSettingsHome()
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmLastFinancialYear()));
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmAllTime()));
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmLast365Days()));
-    m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmLastNDays(Model_Infotable::instance().getInt("HOMEPAGE_INCEXP_DAYS", 14))));
+    m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmLastNDays(0)));
 
     int sel_id = Option::instance().getHomePageIncExpRange();
     if (sel_id >= static_cast<int>(m_all_date_ranges.size()))


### PR DESCRIPTION
This PR fixes an issue where the Income vs Expenses widget on the dashboard
did not respect the selected date range, especially “Last N days”.

The root cause was that OptionSettingsHome cached the mmDateRange at construction
time, so changes to the selected period were saved but not reflected on the
dashboard until application restart.

The date range is now rebuilt dynamically in
OptionSettingsHome::get_inc_vs_exp_date_range(), ensuring the dashboard always
uses the current settings.

Fixes #8087

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8096)
<!-- Reviewable:end -->
