### PR TITLE
refine reportbase

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,12 +119,12 @@ add_executable(${MMEX_EXE} WIN32 MACOSX_BUNDLE
     filtertrans.h
     filtertransdialog.cpp
     filtertransdialog.h
-    fusedtransaction.cpp
-    fusedtransaction.h
     general_report_manager.cpp
     general_report_manager.h
     images_list.cpp
     images_list.h
+    journal.cpp
+    journal.h
     maincurrencydialog.cpp
     maincurrencydialog.h
     minimal_editor.cpp

--- a/src/daterange2.h
+++ b/src/daterange2.h
@@ -129,6 +129,7 @@ public:
         bool parseLabel(StringIt &buffer_i, StringIt buffer_end);
         void parseName(StringIt &buffer_i, StringIt buffer_end);
         bool parseLabelName(const wxString &buffer, const wxString &name_new = "");
+        int getF() const;
         const wxString getLabel() const;
         const wxString getName() const;
         const wxString getLabelName() const;
@@ -202,6 +203,9 @@ public:
     void setDefEndDateN(DateDayN defEndDateN_new = DateDayN());
     void setRange(const Range &range_new);
     void setReporting(const Reporting &reporting_new);
+    int getFirstDay() const;
+    wxDateTime::Month getFirstMonth() const;
+    wxDateTime::WeekDay getFirstWeekday() const;
     DateDayN getSDateN() const;
     DateDay  getTDate() const;
     DateDayN getDefStartDateN() const;
@@ -219,9 +223,9 @@ public:
     DateDayN rangeStart() const;
     DateDayN rangeEnd() const;
     DateDayN reportingNext() const;
-    const wxString rangeStartIsoStart() const;
-    const wxString rangeEndIsoEnd() const;
-    const wxString reportingNextIsoEnd() const;
+    const wxString rangeStartIsoStartN() const;
+    const wxString rangeEndIsoEndN() const;
+    const wxString reportingNextIsoEndN() const;
     const wxString checkingTooltip() const;
     const wxString reportingTooltip() const;
 
@@ -272,6 +276,11 @@ inline void DateRange2::Range::setName(const wxString &name_new)
     name = name_new;
 }
 
+inline int DateRange2::Range::getF() const
+{
+    return f;
+}
+
 inline const wxString DateRange2::Range::getName() const
 {
     return name;
@@ -318,6 +327,18 @@ inline void DateRange2::setReporting(const DateRange2::Reporting &reporting_new)
     reporting = reporting_new;
 }
 
+inline int DateRange2::getFirstDay() const
+{
+    return firstDay[range.f];
+}
+inline wxDateTime::Month DateRange2::getFirstMonth() const
+{
+    return firstMonth[range.f];
+}
+inline wxDateTime::WeekDay DateRange2::getFirstWeekday() const
+{
+    return firstWeekday;
+}
 inline DateDayN DateRange2::getSDateN() const
 {
     return sDateN;
@@ -360,15 +381,15 @@ inline const wxString DateRange2::reportingLabel() const
     return reporting.getLabel();
 }
 
-inline const wxString DateRange2::rangeStartIsoStart() const
+inline const wxString DateRange2::rangeStartIsoStartN() const
 {
     return rangeStart().isoStartN();
 }
-inline const wxString DateRange2::rangeEndIsoEnd() const
+inline const wxString DateRange2::rangeEndIsoEndN() const
 {
     return rangeEnd().isoEndN();
 }
-inline const wxString DateRange2::reportingNextIsoEnd() const
+inline const wxString DateRange2::reportingNextIsoEndN() const
 {
     return reportingNext().isoEndN();
 }

--- a/src/daterangedialog.h
+++ b/src/daterangedialog.h
@@ -21,15 +21,18 @@
 #include "daterange2.h"
 #include <wx/dataview.h>
 
-
 class mmDateRangeDialog: public wxDialog
 {
     wxDECLARE_DYNAMIC_CLASS(mmFilterTransactionsDialog);
     wxDECLARE_EVENT_TABLE();
 
 public:
-    mmDateRangeDialog();
-    mmDateRangeDialog(wxWindow* parent, std::vector<DateRange2::Range>* dateRangesPtr, int* subMenuBeginPtr);
+    enum TYPE_ID
+    {
+        TYPE_ID_DASHBOARD = 0,
+        TYPE_ID_CHECKING,
+        TYPE_ID_REPORTING
+    };
 
     enum
     {
@@ -44,10 +47,14 @@ public:
         BTN_DEFAULT
     };
 
+public:
+    mmDateRangeDialog();
+    mmDateRangeDialog(wxWindow* parent, TYPE_ID type_id);
+
 private:
-    std::vector<DateRange2::Range>* m_dateRangesPtr;
-    int* m_subMenuBeginPtr;
-    int m_subMenuBegin;
+    TYPE_ID m_type_id = TYPE_ID_CHECKING;
+    std::vector<DateRange2::Range> m_date_range_a;
+    int m_date_range_m;
     int m_selected_row;
     bool m_hasChanged = false;
     wxString m_subMenuHeader = "==== " + _tu("More date ranges…");
@@ -60,6 +67,7 @@ private:
     wxButton* m_down_bottom = nullptr;
     wxButton* m_delete = nullptr;
 
+private:
     void CreateControls();
     void fillControls();
     void updateButtonState(bool setselected = true);

--- a/src/daterangeeditdialog.cpp
+++ b/src/daterangeeditdialog.cpp
@@ -21,22 +21,21 @@
 #include "images_list.h"
 #include "util.h"
 
-
 wxIMPLEMENT_DYNAMIC_CLASS(mmDateRangeEditDialog, wxDialog);
 
 wxBEGIN_EVENT_TABLE(mmDateRangeEditDialog, wxDialog)
-  EVT_BUTTON(wxID_OK, mmDateRangeEditDialog::OnOk)
+  EVT_BUTTON(wxID_OK,      mmDateRangeEditDialog::OnOk)
   EVT_TEXT(TXT_CTRL_RANGE, mmDateRangeEditDialog::OnRange)
-  EVT_CHOICE(CTRL_ANY, mmDateRangeEditDialog::OnUpdateRangeFromControls)
+  EVT_CHOICE(CTRL_ANY,     mmDateRangeEditDialog::OnUpdateRangeFromControls)
 wxEND_EVENT_TABLE()
 
-
-const wxArrayString sTokenPeriods = { "", "A", "Y", "Q", "M", "W", "T", "S"};
-const char *sCountValues[] = {"-12", "-11", "-10", "-9", "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1",
-                              "",
-                              "+1", "+2", "+3", "+4", "+5", "+6", "+7", "+8", "9", "+10", "+11", "+12"};
-const wxArrayString sCount = {25, sCountValues};
-
+const wxArrayString sTokenPeriods = { "", "A", "Y", "Q", "M", "W", "T", "S" };
+const char *sCountValues[] = {
+    "-12", "-11", "-10", "-9", "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1",
+    "",
+    "+1", "+2", "+3", "+4", "+5", "+6", "+7", "+8", "9", "+10", "+11", "+12"
+};
+const wxArrayString sCount = { 25, sCountValues };
 
 mmDateRangeEditDialog::mmDateRangeEditDialog()
 {
@@ -45,7 +44,13 @@ mmDateRangeEditDialog::mmDateRangeEditDialog()
 mmDateRangeEditDialog::mmDateRangeEditDialog(wxWindow* parent, wxString* name_ptr, wxString* range_ptr)
 {
     this->SetFont(parent->GetFont());
-    Create(parent, -1, name_ptr->IsEmpty() ? _t("New date range") : _t("Edit date range"), wxDefaultPosition, wxSize(550, 250), wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX, "");
+    Create(
+        parent, -1,
+        name_ptr->IsEmpty() ? _t("New date range") : _t("Edit date range"),
+        wxDefaultPosition, wxSize(550, 250),
+        wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX,
+        ""
+    );
     m_name_ptr = name_ptr;
     m_range_ptr = range_ptr;
     CreateControls();
@@ -74,7 +79,11 @@ void mmDateRangeEditDialog::CreateControls()
     textPanelSizer->Add(new wxStaticText(this, wxID_STATIC, _("Name:")), g_flagsH);
     m_name_edit = new wxTextCtrl(this, TXT_CTRL_NAME, *m_name_ptr);
     textPanelSizer->AddSpacer(20);
-    textPanelSizer->Add(m_name_edit, wxSizerFlags().Align(wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL).Border(wxALL, 1).Proportion(1));
+    textPanelSizer->Add(
+        m_name_edit,
+        wxSizerFlags().Align(wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL)
+            .Border(wxALL, 1).Proportion(1)
+    );
     mainBoxSizer->Add(textPanelSizer, g_flagsExpand);
 
     wxBoxSizer* ctrlPanelSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -96,7 +105,11 @@ void mmDateRangeEditDialog::CreateControls()
     wxBoxSizer* rangePanelSizer = new wxBoxSizer(wxHORIZONTAL);
     rangePanelSizer->Add(new wxStaticText(this, wxID_STATIC, _("Range code:")), g_flagsH);
     m_range_edit = new wxTextCtrl(this, TXT_CTRL_RANGE, *m_range_ptr);
-    rangePanelSizer->Add(m_range_edit, wxSizerFlags().Align(wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL).Border(wxALL, 1).Proportion(1));
+    rangePanelSizer->Add(
+        m_range_edit,
+        wxSizerFlags().Align(wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL)
+            .Border(wxALL, 1).Proportion(1)
+    );
     mainBoxSizer->Add(rangePanelSizer, g_flagsExpand);
 
     m_status = new wxStaticText(this, wxID_STATIC, "");
@@ -130,8 +143,8 @@ bool mmDateRangeEditDialog::checkRange() {
             m_status->SetLabelText(_t("Range is ok:") + wxString::Format(" >%s - %s<",
                 sN.isoDateN(), eN.isoDateN()
             ));
-          m_status->SetBackgroundColour(m_defBColor);
-          rangeOk = true;
+            m_status->SetBackgroundColour(m_defBColor);
+            rangeOk = true;
         }
     }
 
@@ -147,21 +160,21 @@ void mmDateRangeEditDialog::OnOk(wxCommandEvent&)
     wxString msg = "";
     bool saveIt = true;
     if (m_name_edit->GetValue().IsEmpty()) {
-      msg << _t("Name must not be empty") << ("\n");
-      saveIt = false;
+        msg << _t("Name must not be empty") << ("\n");
+        saveIt = false;
     }
     if (!checkRange()) {
-      msg << _t("Invalid date range definition");
-      saveIt = false;
+        msg << _t("Invalid date range definition");
+        saveIt = false;
     }
 
-    if(saveIt) {
+    if (saveIt) {
         *m_name_ptr = m_name_edit->GetValue();
         *m_range_ptr = m_range_edit->GetValue();
         EndModal(wxID_OK);
     }
     else {
-      wxMessageBox(msg, _t("Definition error"), wxOK | wxICON_ERROR);
+        wxMessageBox(msg, _t("Definition error"), wxOK | wxICON_ERROR);
     }
 }
 
@@ -171,9 +184,12 @@ void mmDateRangeEditDialog::OnUpdateRangeFromControls(wxCommandEvent&)
     m_count2->Enable(m_period2->GetSelection() > 1);
 
     wxString result = "";
-    result << (m_count1->IsEnabled() ? m_count1->GetStringSelection() + " ": "") << sTokenPeriods[m_period1->GetSelection()];
+    result << (m_count1->IsEnabled() ? m_count1->GetStringSelection() + " ": "")
+        << sTokenPeriods[m_period1->GetSelection()];
     if (m_period2->GetSelection() > 0) {
-        result << " .. " << (m_count2->IsEnabled() ? m_count2->GetStringSelection() + " " : "") << sTokenPeriods[m_period2->GetSelection()];
+        result << " .. "
+            << (m_count2->IsEnabled() ? m_count2->GetStringSelection() + " " : "")
+            << sTokenPeriods[m_period2->GetSelection()];
     }
     m_range_edit->ChangeValue(result);
 
@@ -199,8 +215,7 @@ void mmDateRangeEditDialog::updateControlsFromRange(wxString range)
 
         bool firstselection = true;
         wxStringTokenizer tokenizer(range, " ");
-        while (tokenizer.HasMoreTokens())
-        {
+        while (tokenizer.HasMoreTokens()) {
             wxString token = tokenizer.GetNextToken();
             int idx;
             if (token.ToInt(&idx)) {

--- a/src/daterangeeditdialog.cpp
+++ b/src/daterangeeditdialog.cpp
@@ -33,7 +33,7 @@ const wxArrayString sTokenPeriods = { "", "A", "Y", "Q", "M", "W", "T", "S" };
 const char *sCountValues[] = {
     "-12", "-11", "-10", "-9", "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1",
     "",
-    "+1", "+2", "+3", "+4", "+5", "+6", "+7", "+8", "9", "+10", "+11", "+12"
+    "+1", "+2", "+3", "+4", "+5", "+6", "+7", "+8", "+9", "+10", "+11", "+12"
 };
 const wxArrayString sCount = { 25, sCountValues };
 
@@ -135,12 +135,12 @@ void mmDateRangeEditDialog::OnRange(wxCommandEvent&)
 
 bool mmDateRangeEditDialog::checkRange() {
     bool rangeOk = false;
-    DateRange2 rdata = DateRange2();
-    if (rdata.parseRange(m_range_edit->GetValue())) {
-        DateDayN sN = rdata.rangeStart();
-        DateDayN eN = rdata.rangeEnd();
+    DateRange2 date_range = DateRange2();
+    if (date_range.parseRange(m_range_edit->GetValue())) {
+        DateDayN sN = date_range.rangeStart();
+        DateDayN eN = date_range.rangeEnd();
         if (!sN.has_value() || !eN.has_value() || sN.value() <= eN.value()) {
-            m_status->SetLabelText(_t("Range is ok:") + wxString::Format(" >%s - %s<",
+            m_status->SetLabelText(_t("Range is ok:") + wxString::Format(" [%s .. %s]",
                 sN.isoDateN(), eN.isoDateN()
             ));
             m_status->SetBackgroundColour(m_defBColor);

--- a/src/filtertrans.h
+++ b/src/filtertrans.h
@@ -16,21 +16,19 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ********************************************************/
 
-#ifndef FILTERTRANS_H_
-#define FILTERTRANS_H_
+#pragma once
 
 #include "model/allmodel.h"
+#include "daterange2.h"
 
 class mmFilterTransactions
 {
-
 public:
-    // Constructors
     mmFilterTransactions();
 
-    void clear();
-
     // Filter setup methods
+    void clear();
+    void setDateRange(const DateRange2& date_range);
     void setDateRange(wxDateTime startDate, wxDateTime endDate);
     void setAccountList(wxSharedPtr<wxArrayString> accountList);
     void setPayeeList(const wxArrayInt64& payeeList);
@@ -38,28 +36,26 @@ public:
 
     // Apply Filter methods
     template<class MODEL, class DATA = typename MODEL::Data>
-    bool checkCategory(const DATA& tran, const std::map<int64, typename MODEL::Split_Data_Set> & splits);
-    bool mmIsRecordMatches(const Model_Checking::Data &tran
-        , const std::map<int64, Model_Splittransaction::Data_Set>& split);
+    bool checkCategory(
+        const DATA& tran,
+        const std::map<int64, typename MODEL::Split_Data_Set> & splits
+    );
+    bool mmIsRecordMatches(
+        const Model_Checking::Data &tran,
+        const std::map<int64, Model_Splittransaction::Data_Set>& split
+    );
 
     wxString getHTML();
 
 private:
-    // date range
-    bool m_dateFilter;
-    wxString m_startDate, m_endDate;
-    // account
-    bool m_accountFilter;
-    wxArrayInt64 m_accountList;
-    // payee
-    bool m_payeeFilter;
-    wxArrayInt64 m_payeeList;
-    // category
-    bool m_categoryFilter;
-    wxArrayInt64 m_categoryList;
-
+    bool m_filter_date;
+    bool m_filter_account;
+    bool m_filter_payee;
+    bool m_filter_category;
+    wxString m_start_date, m_end_date;
+    wxArrayInt64 m_account_a;
+    wxArrayInt64 m_payee_a;
+    wxArrayInt64 m_category_a;
     Model_Checking::Full_Data_Set m_trans;
 };
 
-#endif
-// FILTERTRANS_H_

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -22,9 +22,9 @@
 #include "model/Model_Splittransaction.h"
 #include "model/Model_Budgetsplittransaction.h"
 #include "model/Model_Taglink.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 
-Model_Checking::Data Fused_Transaction::execute_bill(const Model_Billsdeposits::Data& r, wxString date)
+Model_Checking::Data Journal::execute_bill(const Model_Billsdeposits::Data& r, wxString date)
 {
     Model_Checking::Data t;
     t.TRANSID           = 0;
@@ -44,7 +44,7 @@ Model_Checking::Data Fused_Transaction::execute_bill(const Model_Billsdeposits::
     return t;
 }
 
-Model_Checking::Full_Data Fused_Transaction::execute_bill_full(const Model_Billsdeposits::Data& r, wxString date)
+Model_Checking::Full_Data Journal::execute_bill_full(const Model_Billsdeposits::Data& r, wxString date)
 {
     Model_Checking::Full_Data t;
     t.TRANSID           = 0;
@@ -64,7 +64,7 @@ Model_Checking::Full_Data Fused_Transaction::execute_bill_full(const Model_Bills
     return t;
 }
 
-Model_Splittransaction::Data_Set Fused_Transaction::execute_splits(const Budgetsplit_Data_Set& rs)
+Model_Splittransaction::Data_Set Journal::execute_splits(const Budgetsplit_Data_Set& rs)
 {
     Model_Splittransaction::Data_Set ts;
     for (auto &rs1 : rs)
@@ -80,22 +80,22 @@ Model_Splittransaction::Data_Set Fused_Transaction::execute_splits(const Budgets
     return ts;
 }
 
-Fused_Transaction::Data::Data()
+Journal::Data::Data()
     : Model_Checking::Data(), m_bdid(0), m_repeat_num(0)
 {
 }
 
-Fused_Transaction::Data::Data(const Model_Checking::Data& t)
+Journal::Data::Data(const Model_Checking::Data& t)
     : Model_Checking::Data(t), m_bdid(0), m_repeat_num(0)
 {
 }
 
-Fused_Transaction::Data::Data(const Model_Billsdeposits::Data& r)
+Journal::Data::Data(const Model_Billsdeposits::Data& r)
     : Data(r, r.TRANSDATE, 1)
 {
 }
 
-Fused_Transaction::Data::Data(const Model_Billsdeposits::Data& r, wxString date, int repeat_num)
+Journal::Data::Data(const Model_Billsdeposits::Data& r, wxString date, int repeat_num)
     : Model_Checking::Data(execute_bill(r, date)), m_bdid(r.BDID), m_repeat_num(repeat_num)
 {
     if (m_repeat_num < 1) {
@@ -103,16 +103,16 @@ Fused_Transaction::Data::Data(const Model_Billsdeposits::Data& r, wxString date,
     }
 }
 
-Fused_Transaction::Data::~Data()
+Journal::Data::~Data()
 {
 }
 
-Fused_Transaction::Full_Data::Full_Data(const Model_Checking::Data& t)
+Journal::Full_Data::Full_Data(const Model_Checking::Data& t)
     : Model_Checking::Full_Data(t), m_bdid(0), m_repeat_num(0)
 {
 }
 
-Fused_Transaction::Full_Data::Full_Data(const Model_Checking::Data& t,
+Journal::Full_Data::Full_Data(const Model_Checking::Data& t,
     const std::map<int64 /* TRANSID */, Split_Data_Set>& splits,
     const std::map<int64 /* TRANSID */, Taglink_Data_Set>& tags)
 :
@@ -120,12 +120,12 @@ Fused_Transaction::Full_Data::Full_Data(const Model_Checking::Data& t,
 {
 }
 
-Fused_Transaction::Full_Data::Full_Data(const Model_Billsdeposits::Data& r)
+Journal::Full_Data::Full_Data(const Model_Billsdeposits::Data& r)
     : Full_Data(r, r.TRANSDATE, 1)
 {
 }
 
-Fused_Transaction::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
+Journal::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
     wxString date, int repeat_num)
 :
     Model_Checking::Full_Data(execute_bill_full(r, date), {}, {}),
@@ -143,7 +143,7 @@ Fused_Transaction::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
     displayID = wxString("");
 }
 
-Fused_Transaction::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
+Journal::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
     wxString date, int repeat_num,
     const std::map<int64 /* BDID */, Budgetsplit_Data_Set>& budgetsplits,
     const std::map<int64 /* BDID */, Taglink_Data_Set>& tags)
@@ -167,22 +167,22 @@ Fused_Transaction::Full_Data::Full_Data(const Model_Billsdeposits::Data& r,
     displayID = wxString("");
 }
 
-Fused_Transaction::Full_Data::~Full_Data()
+Journal::Full_Data::~Full_Data()
 {
 }
 
 
-void Fused_Transaction::getEmptyData(Fused_Transaction::Data &data, int64 accountID)
+void Journal::getEmptyData(Journal::Data &data, int64 accountID)
 {
     Model_Checking::getEmptyData(data, accountID);
     data.m_bdid = 0;
     data.m_repeat_num = 0;
 }
 
-bool Fused_Transaction::getFusedData(Fused_Transaction::Data &data, Fused_Transaction::IdB fused_id)
+bool Journal::getJournalData(Journal::Data &data, Journal::IdB journal_id)
 {
-    if (!fused_id.second) {
-        Model_Checking::Data *tran = Model_Checking::instance().get(fused_id.first);
+    if (!journal_id.second) {
+        Model_Checking::Data *tran = Model_Checking::instance().get(journal_id.first);
         if (!tran)
             return false;
         data.m_repeat_num = 0;
@@ -205,7 +205,7 @@ bool Fused_Transaction::getFusedData(Fused_Transaction::Data &data, Fused_Transa
         data.COLOR             = tran->COLOR;
     }
     else {
-        Model_Billsdeposits::Data *bill = Model_Billsdeposits::instance().get(fused_id.first);
+        Model_Billsdeposits::Data *bill = Model_Billsdeposits::instance().get(journal_id.first);
         if (!bill)
             return false;
         data.m_repeat_num = 1;
@@ -230,11 +230,11 @@ bool Fused_Transaction::getFusedData(Fused_Transaction::Data &data, Fused_Transa
     return true;
 }
 
-const Model_Splittransaction::Data_Set Fused_Transaction::split(Fused_Transaction::Data &r)
+const Model_Splittransaction::Data_Set Journal::split(Journal::Data &r)
 {
     return (r.m_repeat_num == 0) ?
         Model_Splittransaction::instance().find(
             Model_Splittransaction::TRANSID(r.TRANSID)) :
-        Fused_Transaction::execute_splits(Model_Budgetsplittransaction::instance().find(
+        Journal::execute_splits(Model_Budgetsplittransaction::instance().find(
             Model_Budgetsplittransaction::TRANSID(r.m_bdid)));
 }

--- a/src/journal.h
+++ b/src/journal.h
@@ -16,8 +16,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-#ifndef MM_EX_FUSED_TRANSACTION_H_
-#define MM_EX_FUSED_TRANSACTION_H_
+#pragma once
 
 #include "model/Model.h"
 #include "model/Model_Checking.h"
@@ -26,7 +25,7 @@
 #include "model/Model_Budgetsplittransaction.h"
 #include "model/Model_Taglink.h"
 
-class Fused_Transaction
+class Journal
 {
 public:
     // id represents TRANSID if !is_bill, or BDID otherwise
@@ -76,7 +75,7 @@ public:
     };
     typedef std::vector<Full_Data> Full_Data_Set;
 
-    struct SorterByFUSEDTRANSID
+    struct SorterByJOURNALID
     { 
         template<class DATA>
         bool operator()(const DATA& x, const DATA& y)
@@ -87,7 +86,7 @@ public:
         }
     };
 
-    struct SorterByFUSEDTRANSSN
+    struct SorterByJOURNALSN
     { 
         template<class DATA>
         bool operator()(const DATA& x, const DATA& y)
@@ -97,8 +96,7 @@ public:
     };
 
     static void getEmptyData(Data &data, int64 account_id);
-    static bool getFusedData(Data &data, IdB fused_id);
+    static bool getJournalData(Data &data, IdB journal_id);
     static const Model_Splittransaction::Data_Set split(Data &r);
 };
 
-#endif

--- a/src/mmTreeItemData.cpp
+++ b/src/mmTreeItemData.cpp
@@ -52,7 +52,7 @@ mmTreeItemData::mmTreeItemData(const wxString& data, ReportBase* report)
     , stringData_(data)
     , report_(report)
 {
-    const wxString& n = wxString::Format("REPORT_%d", report_->getTypeId());
+    const wxString& n = wxString::Format("REPORT_%d", report_->getReportId());
     const wxString& settings = Model_Infotable::instance().getString(n, "");
     report_->setReportSettings(settings);
 }

--- a/src/mmTreeItemData.cpp
+++ b/src/mmTreeItemData.cpp
@@ -47,17 +47,17 @@ mmTreeItemData::mmTreeItemData(int type, int64 id, const wxString& data)
     , report_(nullptr)
 {}
 
-mmTreeItemData::mmTreeItemData(const wxString& data, mmPrintableBase* report)
+mmTreeItemData::mmTreeItemData(const wxString& data, ReportBase* report)
     : type_(mmTreeItemData::REPORT)
     , stringData_(data)
     , report_(report)
 {
-    const wxString& n = wxString::Format("REPORT_%d", report_->getReportId());
+    const wxString& n = wxString::Format("REPORT_%d", report_->getTypeId());
     const wxString& settings = Model_Infotable::instance().getString(n, "");
-    report_->initReportSettings(settings);
+    report_->setReportSettings(settings);
 }
 
-mmTreeItemData::mmTreeItemData(mmPrintableBase* report, const wxString& data)
+mmTreeItemData::mmTreeItemData(ReportBase* report, const wxString& data)
     : type_(mmTreeItemData::GRM)
     , stringData_(data)
     , report_(report)

--- a/src/mmTreeItemData.h
+++ b/src/mmTreeItemData.h
@@ -52,28 +52,28 @@ private:
     int type_;
     int64 id_ = -1;
     wxString stringData_;
-    wxSharedPtr<mmPrintableBase> report_;
+    wxSharedPtr<ReportBase> report_;
 
 public:
     mmTreeItemData(int type, int64 id);
     mmTreeItemData(int type, const wxString& data);
     mmTreeItemData(int type, int64 id, const wxString& data);
-    mmTreeItemData(const wxString& data, mmPrintableBase* report);
-    mmTreeItemData(mmPrintableBase* report, const wxString& data);
+    mmTreeItemData(const wxString& data, ReportBase* report);
+    mmTreeItemData(ReportBase* report, const wxString& data);
     
     ~mmTreeItemData() {}
 
     int getType() const;
     int64 getId() const;
     const wxString getString() const;
-    mmPrintableBase* getReport() const;
+    ReportBase* getReport() const;
     bool isReadOnly() const;
 };
 
 inline int mmTreeItemData::getType() const { return type_; }
 inline int64 mmTreeItemData::getId() const { return id_; }
 inline const wxString mmTreeItemData::getString() const { return stringData_; }
-inline mmPrintableBase* mmTreeItemData::getReport() const { return report_.get(); }
+inline ReportBase* mmTreeItemData::getReport() const { return report_.get(); }
 
 inline bool operator==(const mmTreeItemData& lhs, const mmTreeItemData& rhs)
 {

--- a/src/mmchecking_list.h
+++ b/src/mmchecking_list.h
@@ -24,7 +24,7 @@ Copyright (C) 2021-2025 Mark Whalley (mark@ipx.co.uk)
 
 #include "mmpanelbase.h"
 #include "mmcheckingpanel.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 
 class mmCheckingPanel;
 
@@ -123,16 +123,16 @@ private:
     };
 
 private:
-    Fused_Transaction::Full_Data_Set m_trans;
+    Journal::Full_Data_Set m_trans;
     long m_topItemIndex = -1; // where to display the list again after refresh
     wxString m_today;
     bool m_firstSort = true;
     bool m_balance_valid = false;
     wxString rightClickFilter_;
     wxString copyText_;
-    std::vector<Fused_Transaction::IdRepeat> m_selectedForCopy; // copied transactions
-    std::vector<Fused_Transaction::IdRepeat> m_pasted_id;       // last pasted transactions
-    std::vector<Fused_Transaction::IdRepeat> m_selected_id;     // selected transactions
+    std::vector<Journal::IdRepeat> m_selectedForCopy; // copied transactions
+    std::vector<Journal::IdRepeat> m_pasted_id;       // last pasted transactions
+    std::vector<Journal::IdRepeat> m_selected_id;     // selected transactions
 
     DECLARE_NO_COPY_CLASS(TransactionListCtrl)
     wxDECLARE_EVENT_TABLE();
@@ -216,9 +216,9 @@ private:
     const wxString getItem(long item, int col_id) const;
     void setExtraTransactionData(const bool single);
     void markItem(long selectedItem);
-    void setSelectedId(Fused_Transaction::IdRepeat sel_id);
-    std::vector<Fused_Transaction::IdRepeat> getSelectedId() const;
-    std::vector<Fused_Transaction::IdRepeat> getSelectedForCopy() const;
+    void setSelectedId(Journal::IdRepeat sel_id);
+    std::vector<Journal::IdRepeat> getSelectedId() const;
+    std::vector<Journal::IdRepeat> getSelectedForCopy() const;
     void findSelectedTransactions();
     int getColNr_X(int xPos);
     void doSearchText(const wxString& value);
@@ -231,11 +231,11 @@ private:
 
 //----------------------------------------------------------------------------
 
-inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedId() const
+inline std::vector<Journal::IdRepeat> TransactionListCtrl::getSelectedId() const
 {
     return m_selected_id;
 }
-inline std::vector<Fused_Transaction::IdRepeat> TransactionListCtrl::getSelectedForCopy() const
+inline std::vector<Journal::IdRepeat> TransactionListCtrl::getSelectedForCopy() const
 {
     return m_selectedForCopy;
 }

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -664,7 +664,7 @@ void mmCheckingPanel::filterList()
         date_end_str = DateDayN(toDateCtrl->GetValue())
             .value_or(DateDay(date_end)).isoEnd();
     } else {
-        date_start_str = m_current_date_range.rangeStartIsoStart();
+        date_start_str = m_current_date_range.rangeStartIsoStartN();
         // find last un-deleted transaction and use that if later than current date + 30 days
         for (auto it = trans.rbegin(); it != trans.rend(); ++it) {
             const Model_Checking::Data* tran = &(*it);

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -55,39 +55,39 @@
 
 const std::vector<std::pair<mmCheckingPanel::FILTER_ID, wxString> > mmCheckingPanel::FILTER_NAME =
 {
-    { mmCheckingPanel::FILTER_ID_DATE,     wxString("Date") },
-    { mmCheckingPanel::FILTER_ID_DATE_RANGE, wxString("DateRange") },
+    { mmCheckingPanel::FILTER_ID_DATE,        wxString("Date") },
+    { mmCheckingPanel::FILTER_ID_DATE_RANGE,  wxString("DateRange") },
     { mmCheckingPanel::FILTER_ID_DATE_PICKER, wxString("DatePicker") },
 };
 
 //----------------------------------------------------------------------------
 
 wxBEGIN_EVENT_TABLE(mmCheckingPanel, wxPanel)
-    EVT_BUTTON(wxID_NEW,             mmCheckingPanel::onNewTransaction)
-    EVT_BUTTON(wxID_EDIT,            mmCheckingPanel::onEditTransaction)
-    EVT_BUTTON(wxID_DUPLICATE,       mmCheckingPanel::onDuplicateTransaction)
-    EVT_BUTTON(wxID_UNDELETE,        mmCheckingPanel::onRestoreTransaction)
-    EVT_BUTTON(wxID_REMOVE,          mmCheckingPanel::onDeleteTransaction)
-    EVT_BUTTON(wxID_PASTE,           mmCheckingPanel::onEnterScheduled)
-    EVT_BUTTON(wxID_IGNORE,          mmCheckingPanel::onSkipScheduled)
-    EVT_BUTTON(wxID_FILE,            mmCheckingPanel::onOpenAttachment)
-    EVT_BUTTON(mmID_FILTER,          mmCheckingPanel::onFilterPopup)
-    EVT_BUTTON(mmID_FILTER_TRANSACTION_DETAIL, mmCheckingPanel::onFilterAdvanced)
-    EVT_MENU(mmID_FILTER_ADVANCED,   mmCheckingPanel::onFilterAdvanced)
-    EVT_MENU(mmID_EDIT_DATE_RANGES,  mmCheckingPanel::onEditDateRanges)
-    EVT_TOGGLEBUTTON(mmID_SCHEDULED, mmCheckingPanel::onScheduled)
+    EVT_BUTTON(wxID_NEW,           mmCheckingPanel::onNewTransaction)
+    EVT_BUTTON(wxID_EDIT,          mmCheckingPanel::onEditTransaction)
+    EVT_BUTTON(wxID_DUPLICATE,     mmCheckingPanel::onDuplicateTransaction)
+    EVT_BUTTON(wxID_UNDELETE,      mmCheckingPanel::onRestoreTransaction)
+    EVT_BUTTON(wxID_REMOVE,        mmCheckingPanel::onDeleteTransaction)
+    EVT_BUTTON(wxID_PASTE,         mmCheckingPanel::onEnterScheduled)
+    EVT_BUTTON(wxID_IGNORE,        mmCheckingPanel::onSkipScheduled)
+    EVT_BUTTON(wxID_FILE,          mmCheckingPanel::onOpenAttachment)
+    EVT_BUTTON(ID_FILTER,          mmCheckingPanel::onFilterPopup)
+    EVT_BUTTON(ID_FILTER_TRANS,    mmCheckingPanel::onFilterAdvanced)
+    EVT_MENU(ID_FILTER_ADVANCED,   mmCheckingPanel::onFilterAdvanced)
+    EVT_MENU(ID_DATE_RANGE_EDIT,   mmCheckingPanel::onEditDateRanges)
+    EVT_TOGGLEBUTTON(ID_SCHEDULED, mmCheckingPanel::onScheduled)
     EVT_MENU_RANGE(
-        mmID_FILTER_DATE_MIN,
-        mmID_FILTER_DATE_MAX,
+        ID_DATE_RANGE_MIN,
+        ID_DATE_RANGE_MAX,
         mmCheckingPanel::onFilterDate)
     EVT_MENU_RANGE(
         Model_Checking::TYPE_ID_WITHDRAWAL,
         Model_Checking::TYPE_ID_TRANSFER,
         mmCheckingPanel::onNewTransaction
     )
-    EVT_SEARCHCTRL_SEARCH_BTN(wxID_FIND, mmCheckingPanel::onSearchTxtEntered)
-    EVT_DATE_CHANGED(mmID_DATE_PICK_LOW,  mmCheckingPanel::onDatePickLow)
-    EVT_DATE_CHANGED(mmID_DATE_PICK_HIGH,  mmCheckingPanel::onDatePickHigh)
+    EVT_SEARCHCTRL_SEARCH_BTN(wxID_FIND,  mmCheckingPanel::onSearchTxtEntered)
+    EVT_DATE_CHANGED(ID_DATE_PICKER_LOW,  mmCheckingPanel::onDatePickLow)
+    EVT_DATE_CHANGED(ID_DATE_PICKER_HIGH, mmCheckingPanel::onDatePickHigh)
     wxEND_EVENT_TABLE()
 
 //----------------------------------------------------------------------------
@@ -194,7 +194,7 @@ void mmCheckingPanel::createControls()
     sizerVHeader->Add(sizerHInfo, g_flagsBorder1V);
 
     wxBoxSizer* sizerHCtrl = new wxBoxSizer(wxHORIZONTAL);
-    m_bitmapTransFilter = new wxButton(this, mmID_FILTER);
+    m_bitmapTransFilter = new wxButton(this, ID_FILTER);
     m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
     sizerHCtrl->Add(m_bitmapTransFilter, g_flagsH);
 
@@ -203,20 +203,21 @@ void mmCheckingPanel::createControls()
     DateRange2 tmprange = DateRange2();
     tmprange.setRange(m_date_range_a[0]);  // set to all
 
-    fromDateCtrl = new wxDatePickerCtrl(this, mmID_DATE_PICK_LOW, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN|wxDP_ALLOWNONE);
+    fromDateCtrl = new wxDatePickerCtrl(this, ID_DATE_PICKER_LOW, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN|wxDP_ALLOWNONE);
     fromDateCtrl->SetValue(
         tmprange.rangeStart().value_or(DateDay::min()).getDateTime()
     );
     fromDateCtrl->SetRange(wxInvalidDateTime, wxDateTime::Now());
     sizerHCtrl->Add(fromDateCtrl, g_flagsH);
 
-    toDateCtrl = new wxDatePickerCtrl(this, mmID_DATE_PICK_HIGH, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN|wxDP_ALLOWNONE);
+    toDateCtrl = new wxDatePickerCtrl(this, ID_DATE_PICKER_HIGH, wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN|wxDP_ALLOWNONE);
     toDateCtrl->SetValue(
         tmprange.rangeEnd().value_or(DateDay::today()).getDateTime()
     );
     sizerHCtrl->Add(toDateCtrl, g_flagsH);
 
-    m_btnTransDetailFilter = new wxButton(this, mmID_FILTER_TRANSACTION_DETAIL, _tu("Filter…"));  // Filter for transaction details
+    // Filter for transaction details
+    m_btnTransDetailFilter = new wxButton(this, ID_FILTER_TRANS, _tu("Filter…"));
     m_btnTransDetailFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
     m_btnTransDetailFilter->SetMinSize(wxSize(150 + Option::instance().getIconSize() * 2, -1));
     sizerHCtrl->Add(m_btnTransDetailFilter, g_flagsH);
@@ -225,7 +226,7 @@ void mmCheckingPanel::createControls()
         sizerHCtrl->AddSpacer(15);
         const auto& size = m_bitmapTransFilter->GetSize().GetY();
         m_header_scheduled = new wxBitmapToggleButton(
-            this, mmID_SCHEDULED, mmBitmapBundle(png::RECURRING),
+            this, ID_SCHEDULED, mmBitmapBundle(png::RECURRING),
             wxDefaultPosition, wxSize(size, size)
         );
         sizerHCtrl->Add(m_header_scheduled, g_flagsH);
@@ -1092,7 +1093,7 @@ void mmCheckingPanel::onFilterPopup(wxCommandEvent& event)
     wxMenu menu;
     int i = 0;
     while (i < m_date_range_m) {
-        menu.Append(mmID_FILTER_DATE_MIN + i, m_date_range_a[i].getName());
+        menu.Append(ID_DATE_RANGE_MIN + i, m_date_range_a[i].getName());
         i++;
     }
 
@@ -1103,13 +1104,13 @@ void mmCheckingPanel::onFilterPopup(wxCommandEvent& event)
         wxMenu* menu_more(new wxMenu);
         menu.AppendSubMenu(menu_more, _tu("More date ranges…"));
         while (i < static_cast<int>(m_date_range_a.size())) {
-            menu_more->Append(mmID_FILTER_DATE_MIN + i, m_date_range_a[i].getName());
+            menu_more->Append(ID_DATE_RANGE_MIN + i, m_date_range_a[i].getName());
             i++;
         }
     }
 
     menu.AppendSeparator();
-    menu.Append(mmID_EDIT_DATE_RANGES, _tu("Edit date ranges…"));
+    menu.Append(ID_DATE_RANGE_EDIT, _tu("Edit date ranges…"));
 
     PopupMenu(&menu);
     m_bitmapTransFilter->Layout();
@@ -1118,7 +1119,7 @@ void mmCheckingPanel::onFilterPopup(wxCommandEvent& event)
 
 void mmCheckingPanel::onFilterDate(wxCommandEvent& event)
 {
-    int i = event.GetId() - mmID_FILTER_DATE_MIN;
+    int i = event.GetId() - ID_DATE_RANGE_MIN;
     if (i < 0 || i >= static_cast<int>(m_date_range_a.size()))
         return;
 
@@ -1200,38 +1201,25 @@ void mmCheckingPanel::onFilterAdvanced(wxCommandEvent& WXUNUSED(event))
 
 void mmCheckingPanel::onEditDateRanges(wxCommandEvent& WXUNUSED(event))
 {
-    mmDateRangeDialog dlg(this, &m_date_range_a, &m_date_range_m);
-    if (dlg.ShowModal() == wxID_OK) {
-        if (m_date_range_a.size() == 0) {
-            int src_i = 0;
-            int src_m = Option::instance().getCheckingRangeM();
-            for (const auto& range : Option::instance().getCheckingRangeA()) {
-                if (m_date_range_a.size() > mmID_FILTER_DATE_MAX - mmID_FILTER_DATE_MIN) {
-                    break;
-                }
-                if (src_i == src_m) {
-                    m_date_range_m = m_date_range_a.size();
-                }
-                if (isAccount() || !range.hasPeriodS()) {
-                    m_date_range_a.push_back(range);
-                }
-                src_i++;
+    mmDateRangeDialog dlg(this, mmDateRangeDialog::TYPE_ID_CHECKING);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    loadDateRanges(&m_date_range_a, &m_date_range_m, isAccount());
+
+    // Verify if current filter is still valid otherwise reset to "ALL"
+    if (m_filter_id == FILTER_ID_DATE_RANGE) {
+        wxString curname = m_current_date_range.rangeName();
+        bool isDeleted = true;
+        for (const auto& range : m_date_range_a) {
+            if (range.getName() == curname) {
+                isDeleted = false;
+                break;
             }
         }
-        // Verify if current filter is still valid otherwise reset to "ALL"
-        if (m_filter_id == FILTER_ID_DATE_RANGE) {
-            wxString curname = m_current_date_range.rangeName();
-            bool isDeleted = true;
-            for (const auto& range : m_date_range_a) {
-                if (range.getName() == curname) {
-                    isDeleted = false;
-                    break;
-                }
-            }
-            if (isDeleted) {
-                wxCommandEvent evt = wxCommandEvent(wxEVT_NULL, mmID_FILTER_DATE_MIN);
-                onFilterDate(evt);
-            }
+        if (isDeleted) {
+            wxCommandEvent evt = wxCommandEvent(wxEVT_NULL, ID_DATE_RANGE_MIN);
+            onFilterDate(evt);
         }
     }
 }
@@ -1306,8 +1294,8 @@ void mmCheckingPanel::onButtonRightDown(wxMouseEvent& event)
 {
     int id = event.GetId();
     switch (id) {
-    case mmID_FILTER: {
-        wxCommandEvent evt(wxID_ANY, mmID_FILTER_ADVANCED);
+    case ID_FILTER: {
+        wxCommandEvent evt(wxID_ANY, ID_FILTER_ADVANCED);
         onFilterAdvanced(evt);
         break;
     }
@@ -1455,24 +1443,29 @@ wxString mmCheckingPanel::getFilterName(FILTER_ID id) {
     return mmCheckingPanel::FILTER_NAME[id].second;
 }
 
-void mmCheckingPanel::loadDateRanges(std::vector<DateRange2::Range>* date_range_ptr, int* range_m, bool isaccount) {
-    date_range_ptr->clear();
-    *range_m = -1;
+void mmCheckingPanel::loadDateRanges(
+    std::vector<DateRange2::Range>* date_range_a,
+    int* date_range_m,
+    bool all_ranges
+) {
+    date_range_a->clear();
+    *date_range_m = -1;
     int src_i = 0;
     int src_m = Option::instance().getCheckingRangeM();
     for (const auto& range : Option::instance().getCheckingRangeA()) {
-        if (date_range_ptr->size() > mmID_FILTER_DATE_MAX - mmID_FILTER_DATE_MIN) {
+        if (date_range_a->size() > ID_DATE_RANGE_MAX - ID_DATE_RANGE_MIN) {
             break;
         }
         if (src_i == src_m) {
-            *range_m = date_range_ptr->size();
+            *date_range_m = date_range_a->size();
         }
-        if (isaccount || !range.hasPeriodS()) {
-            date_range_ptr->push_back(range);
+        if (all_ranges || !range.hasPeriodS()) {
+            date_range_a->push_back(range);
         }
         src_i++;
     }
-    if (*range_m < 0) {
-        *range_m = date_range_ptr->size();
+    if (*date_range_m < 0) {
+        *date_range_m = date_range_a->size();
     }
 }
+

--- a/src/mmcheckingpanel.cpp
+++ b/src/mmcheckingpanel.cpp
@@ -22,7 +22,7 @@
 #include "filtertransdialog.h"
 #include "mmcheckingpanel.h"
 #include "mmchecking_list.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 #include "paths.h"
 #include "constants.h"
 #include "images_list.h"
@@ -730,7 +730,7 @@ void mmCheckingPanel::filterList()
             bill_i = std::get<0>(*bills_it);
             tran_date = std::get<1>(*bills_it);
             repeat_num = std::get<2>(*bills_it);
-            bill_tran = Fused_Transaction::execute_bill(bills[bill_i], tran_date);
+            bill_tran = Journal::execute_bill(bills[bill_i], tran_date);
             tran = &bill_tran;
             bills_it++;
         }
@@ -760,9 +760,9 @@ void mmCheckingPanel::filterList()
         if (tran_date < date_start_str || tran_date > date_end_str)
             continue;
 
-        Fused_Transaction::Full_Data full_tran = (repeat_num == 0) ?
-            Fused_Transaction::Full_Data(*tran, trans_splits, trans_tags) :
-            Fused_Transaction::Full_Data(bills[bill_i], tran_date, repeat_num, bills_splits, bills_tags);
+        Journal::Full_Data full_tran = (repeat_num == 0) ?
+            Journal::Full_Data(*tran, trans_splits, trans_tags) :
+            Journal::Full_Data(bills[bill_i], tran_date, repeat_num, bills_splits, bills_tags);
 
         bool expandSplits = false;
         if (m_filter_advanced) {
@@ -912,7 +912,7 @@ void mmCheckingPanel::updateExtraTransactionData(bool single, int repeat_num, bo
                 break;
         }
 
-        Fused_Transaction::Full_Data full_tran(m_lc->m_trans[x]);
+        Journal::Full_Data full_tran(m_lc->m_trans[x]);
         wxString miniStr = full_tran.info();
         //Show only first line but full string set as tooltip
         if (miniStr.Find("\n") > 1 && !miniStr.IsEmpty()) {
@@ -1395,20 +1395,20 @@ void mmCheckingPanel::resetColumnView()
     m_lc->refreshVisualList();
 }
 
-void mmCheckingPanel::setSelectedTransaction(Fused_Transaction::IdRepeat fused_id)
+void mmCheckingPanel::setSelectedTransaction(Journal::IdRepeat journal_id)
 {
-    m_lc->setSelectedId(fused_id);
+    m_lc->setSelectedId(journal_id);
     refreshList();
     m_lc->SetFocus();
 }
 
-void mmCheckingPanel::displaySplitCategories(Fused_Transaction::IdB fused_id)
+void mmCheckingPanel::displaySplitCategories(Journal::IdB journal_id)
 {
-    Fused_Transaction::Data fused = !fused_id.second ?
-        Fused_Transaction::Data(*Model_Checking::instance().get(fused_id.first)) :
-        Fused_Transaction::Data(*Model_Billsdeposits::instance().get(fused_id.first));
+    Journal::Data journal = !journal_id.second ?
+        Journal::Data(*Model_Checking::instance().get(journal_id.first)) :
+        Journal::Data(*Model_Billsdeposits::instance().get(journal_id.first));
     std::vector<Split> splits;
-    for (const auto& split : Fused_Transaction::split(fused)) {
+    for (const auto& split : Journal::split(journal)) {
         Split s;
         s.CATEGID          = split.CATEGID;
         s.SPLITTRANSAMOUNT = split.SPLITTRANSAMOUNT;

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -26,7 +26,7 @@ Copyright (C) 2025 Klaus Wich
 #include <wx/tglbtn.h>
 #include "mmpanelbase.h"
 #include "constants.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 #include "model/Model_Account.h"
 #include <map>
 //----------------------------------------------------------------------------
@@ -76,8 +76,8 @@ public:
     void refreshList();
     wxString BuildPage() const;
     void resetColumnView();
-    void setSelectedTransaction(Fused_Transaction::IdRepeat fused_id);
-    void displaySplitCategories(Fused_Transaction::IdB fused_id);
+    void setSelectedTransaction(Journal::IdRepeat journal_id);
+    void displaySplitCategories(Journal::IdB journal_id);
 
     //static support function
     static wxString getFilterName(FILTER_ID id);

--- a/src/mmcheckingpanel.h
+++ b/src/mmcheckingpanel.h
@@ -81,9 +81,8 @@ public:
 
     //static support function
     static wxString getFilterName(FILTER_ID id);
-    static void loadDateRanges(std::vector<DateRange2::Range>* date_range_ptr, int* range_m, bool isaccount);
+    static void loadDateRanges(std::vector<DateRange2::Range>* date_range_a, int* date_range_m, bool all_ranges = false);
     double GetReconciledBalance() const;
-
 
 private:
     friend class TransactionListCtrl;
@@ -92,19 +91,18 @@ private:
     wxDECLARE_EVENT_TABLE();
     enum
     {
-        mmID_FILTER = wxID_HIGHEST + 50,
-        mmID_FILTER_DATE_MIN,
-        mmID_FILTER_DATE_MAX = mmID_FILTER_DATE_MIN + 99,
-        mmID_FILTER_ADVANCED,
-        mmID_FILTER_TRANSACTION_DETAIL,
-        mmID_DATE_PICK_LOW,
-        mmID_DATE_PICK_HIGH,
-        mmID_EDIT_DATE_RANGES,
-        mmID_SCHEDULED,
+        ID_FILTER = wxID_HIGHEST + 50,
+        ID_DATE_RANGE_MIN,
+        ID_DATE_RANGE_MAX = ID_DATE_RANGE_MIN + 99,
+        ID_FILTER_ADVANCED,
+        ID_FILTER_TRANS,
+        ID_DATE_PICKER_LOW,
+        ID_DATE_PICKER_HIGH,
+        ID_DATE_RANGE_EDIT,
+        ID_SCHEDULED,
     };
 
     static const std::vector<std::pair<FILTER_ID, wxString> > FILTER_NAME;
-    static const wxString FILTER_NAME_DATE;
 
 private:
     // set by constructor or loadAccount()

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -3095,7 +3095,7 @@ void mmGUIFrame::refreshPanelData()
     case mmID_REPORTS:
         if (activeReport_) {
             mmReportsPanel* reportsPanel = wxDynamicCast(panelCurrent_, mmReportsPanel);
-            if (reportsPanel) createReportsPage(reportsPanel->getPrintableBase(), false);
+            if (reportsPanel) createReportsPage(reportsPanel->getReportBase(), false);
         }
         break;
     default:
@@ -3307,10 +3307,7 @@ void mmGUIFrame::OnEmptyTreePopUp(wxCommandEvent& event)
 
 void mmGUIFrame::OnDateRangeManager(wxCommandEvent& WXUNUSED(event))
 {
-    std::vector<DateRange2::Range> m_date_range_a = {};
-    int m_date_range_m;
-    mmCheckingPanel::loadDateRanges(&m_date_range_a, &m_date_range_m, true);
-    mmDateRangeDialog dlg(this, &m_date_range_a, &m_date_range_m);
+    mmDateRangeDialog dlg(this, mmDateRangeDialog::TYPE_ID_CHECKING);
     if (dlg.ShowModal() == wxID_OK) {
         refreshPanelData();
     }
@@ -3397,7 +3394,7 @@ void mmGUIFrame::OnBeNotified(wxCommandEvent& /*event*/)
 
 void mmGUIFrame::OnReportBug(wxCommandEvent& WXUNUSED(event))
 {
-    mmPrintableBase* br = new mmBugReport();
+    ReportBase* br = new mmBugReport();
     setNavTreeSection(_t("Reports"));
     createReportsPage(br, true);
 }
@@ -3538,7 +3535,7 @@ void mmGUIFrame::createHomePage()
 }
 //----------------------------------------------------------------------------
 
-void mmGUIFrame::createReportsPage(mmPrintableBase* rs, bool cleanup)
+void mmGUIFrame::createReportsPage(ReportBase* rs, bool cleanup)
 {
     if (!rs) return;
     m_nav_tree_ctrl->SetEvtHandlerEnabled(false);

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -4244,10 +4244,10 @@ void mmGUIFrame::OnClearRecentFiles(wxCommandEvent& /*event*/)
     m_recentFiles->AddFileToHistory(m_filename);
 }
 
-void mmGUIFrame::setGotoAccountID(int64 account_id, Fused_Transaction::IdRepeat fused_id)
+void mmGUIFrame::setGotoAccountID(int64 account_id, Journal::IdRepeat journal_id)
 {
     gotoAccountID_ = account_id;
-    gotoTransID_ = fused_id;
+    gotoTransID_ = journal_id;
 }
 
 void mmGUIFrame::OnToggleFullScreen(wxCommandEvent& WXUNUSED(event))

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -38,7 +38,7 @@ Copyright (C) 2025, 2026 Klaus Wich
 
 //----------------------------------------------------------------------------
 class wxSQLite3Database;
-class mmPrintableBase;
+class ReportBase;
 class mmPanelBase;
 class mmHomePagePanel;
 class mmTreeItemData;
@@ -169,7 +169,7 @@ private:
     bool createDataStore(const wxString& fileName, const wxString &passwd, bool openingNew);
     void createMenu();
     void createToolBar();
-    void createReportsPage(mmPrintableBase* rb, bool cleanup);
+    void createReportsPage(ReportBase* rb, bool cleanup);
     void createHelpPage(int index = mmex::HTML_INDEX);
     void refreshPanelData();
     wxTreeItemId findItemByData(wxTreeItemId itemId, mmTreeItemData& searchData);

--- a/src/mmframe.h
+++ b/src/mmframe.h
@@ -34,7 +34,7 @@ Copyright (C) 2025, 2026 Klaus Wich
 #include "util.h"
 #include "paths.h"
 #include "model/Model_Account.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 
 //----------------------------------------------------------------------------
 class wxSQLite3Database;
@@ -80,7 +80,7 @@ public:
     ~mmGUIFrame();
 
 public:
-    void setGotoAccountID(int64 account_id, Fused_Transaction::IdRepeat fused_id = {-1, 0});
+    void setGotoAccountID(int64 account_id, Journal::IdRepeat journal_id = {-1, 0});
     bool financialYearIsDifferent()
     {
         return Option::instance().getFinancialFirstDay() != 1 ||
@@ -127,7 +127,7 @@ private:
     bool db_lockInPlace;
 
     int64 gotoAccountID_ = -1;
-    Fused_Transaction::IdRepeat gotoTransID_ = { -1, 0 };
+    Journal::IdRepeat gotoTransID_ = { -1, 0 };
 
     /* There are 2 kinds of reports */
     bool activeReport_ = false;

--- a/src/mmframereport.cpp
+++ b/src/mmframereport.cpp
@@ -75,10 +75,10 @@ const char *group_report_template = R"(
 </html>
 )";
 
-class mmGeneralGroupReport : public mmPrintableBase
+class mmGeneralGroupReport : public ReportBase
 {
 public:
-    mmGeneralGroupReport(const wxString& groupname) : mmPrintableBase(_n("General Group Report"))
+    mmGeneralGroupReport(const wxString& groupname) : ReportBase(_n("General Group Report"))
         , m_group_name(groupname)
     {
         m_sub_reports = Model_Report::instance().find(Model_Report::GROUPNAME(groupname));
@@ -91,7 +91,7 @@ public:
             contents += report.to_row_t();
         wxString report_template = group_report_template;
         mm_html_template report(formatHTML(report_template));
-        report(L"REPORTNAME") = this->getReportTitle() + " For " + this->m_group_name;
+        report(L"REPORTNAME") = this->getTitle() + " For " + this->m_group_name;
         report(L"CONTENTS") = contents;
 
         wxString out = wxEmptyString;
@@ -197,10 +197,20 @@ void mmGUIFrame::DoUpdateReportNavigation(wxTreeItemId& parent_item)
         m_nav_tree_ctrl->SetItemData(reportsSummary, new mmTreeItemData(mmTreeItemData::MENU_REPORT, "Summary of Accounts"));
 
         wxTreeItemId accMonthly = m_nav_tree_ctrl->AppendItem(reportsSummary, _t("Monthly"), img::PIECHART_PNG, img::PIECHART_PNG);
-        m_nav_tree_ctrl->SetItemData(accMonthly, new mmTreeItemData("Monthly Summary of Accounts", new mmReportSummaryByDateMontly()));
+        m_nav_tree_ctrl->SetItemData(
+            accMonthly,
+            new mmTreeItemData("Monthly Summary of Accounts",
+                new mmReportSummaryByDate(mmReportSummaryByDate::PERIOD_ID::MONTH)
+            )
+        );
 
         wxTreeItemId accYearly = m_nav_tree_ctrl->AppendItem(reportsSummary, _t("Yearly"), img::PIECHART_PNG, img::PIECHART_PNG);
-        m_nav_tree_ctrl->SetItemData(accYearly, new mmTreeItemData("Yearly Summary of Accounts", new mmReportSummaryByDateYearly()));
+        m_nav_tree_ctrl->SetItemData(
+            accYearly,
+            new mmTreeItemData("Yearly Summary of Accounts",
+                new mmReportSummaryByDate(mmReportSummaryByDate::PERIOD_ID::YEAR)
+            )
+        );
     }
 
     //////////////////////////////////////////////////////////////////

--- a/src/mmframereport.cpp
+++ b/src/mmframereport.cpp
@@ -186,7 +186,7 @@ void mmGUIFrame::DoUpdateReportNavigation(wxTreeItemId& parent_item)
     if (hidden_reports.Index("Payees") == wxNOT_FOUND)
     {
         wxTreeItemId payeesOverTime = m_nav_tree_ctrl->AppendItem(parent_item, _t("Payees"), img::PIECHART_PNG, img::PIECHART_PNG);
-        m_nav_tree_ctrl->SetItemData(payeesOverTime, new mmTreeItemData("Payee Report", new mmReportPayeeExpenses()));
+        m_nav_tree_ctrl->SetItemData(payeesOverTime, new mmTreeItemData("Payee Report", new ReportFlowByPayee()));
     }
 
     //////////////////////////////////////////////////////////////////

--- a/src/mmpanelbase.cpp
+++ b/src/mmpanelbase.cpp
@@ -742,7 +742,7 @@ mmPanelBase::~mmPanelBase()
 wxString mmPanelBase::BuildPage() const
 {
     mmReportsPanel* rp = wxDynamicCast(this, mmReportsPanel);
-    return rp ? rp->getPrintableBase()->getHTMLText() : "TBD";
+    return rp ? rp->getReportBase()->getHTMLText() : "TBD";
 }
 
 void mmPanelBase::PrintPage()

--- a/src/mmpanelbase.h
+++ b/src/mmpanelbase.h
@@ -53,7 +53,9 @@ class mmListCtrl : public wxListCtrl
 {
 protected:
     wxDECLARE_EVENT_TABLE();
-    enum {
+
+    enum
+    {
         MENU_HEADER_SORT = wxID_HIGHEST + 2000,
         MENU_HEADER_TOGGLE_MIN,
         MENU_HEADER_TOGGLE_MAX = MENU_HEADER_TOGGLE_MIN + 99,

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -107,7 +107,7 @@ bool mmReportsPanel::Create(
 
     saveReportText();
 
-    ReportBase::TYPE_ID id = m_rb->getTypeId();
+    ReportBase::REPORT_ID id = m_rb->getReportId();
     this->SetLabel(id < 0 ? "Custom Report" : m_rb->getTitle(false));
 
     return true;
@@ -177,7 +177,7 @@ void mmSetOwnFont(wxStaticText* w, const wxFont& font)
 // function only used for new filter
 void mmReportsPanel::loadFilterSettings() {
     wxString key = m_use_account_specific_filter
-        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
+        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getReportId())
         : "REPORT_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
 
@@ -235,7 +235,7 @@ void mmReportsPanel::loadFilterSettings() {
 
 void mmReportsPanel::saveFilterSettings() {
     wxString key = m_use_account_specific_filter
-        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
+        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getReportId())
         : "REPORT_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
     Model_Infotable::saveFilterInt(j_doc, "FILTER_ID", m_filter_id);
@@ -460,7 +460,7 @@ void mmReportsPanel::CreateControls()
                 const wxString& name = e.BUDGETYEARNAME;
 
                 // Only years for performance report
-                if (m_rb->getTypeId() == ReportBase::TYPE_ID::BudgetCategorySummary ||
+                if (m_rb->getReportId() == ReportBase::REPORT_ID::BudgetCategorySummary ||
                     name.length() == 4
                 ) {
                     w_year_choice->Append(name, new wxStringClientData(wxString::Format("%lld", e.BUDGETYEARID)));

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -192,8 +192,12 @@ void mmReportsPanel::loadFilterSettings() {
 
     loadDateRanges(&m_date_range_a, &m_date_range_m);
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
-        // Load m_date_range from settings.
-        // The start/end date pickers are configured later in updateFilter().
+        // recreate m_date_range in order to reload parameters from setting,
+        // refresh the date of today, and clear the default start/end dates
+        m_date_range = DateRange2();
+
+        // load m_date_range from settings.
+        // the start/end date pickers are configured later in updateFilter().
         wxString j_filter;
         bool found = false;
         if (JSON_GetStringValue(j_doc, "FILTER_DATE", j_filter)) {
@@ -210,9 +214,6 @@ void mmReportsPanel::loadFilterSettings() {
             // init with 'All'
             m_date_range.setRange(m_date_range_a[0]);
         }
-        // clear default start/end dates
-        m_date_range.setDefStartDateN();
-        m_date_range.setDefEndDateN();
     }
     else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
         // Load start/end date pickers from settings.
@@ -293,7 +294,8 @@ void mmReportsPanel::updateFilter()
             png::TRANSFILTER_ACTIVE,
             mmBitmapButtonSize
         ));
-        // set date range to default ('All') and copy default start/end dates from pickers
+        // set date range to default ('All') and copy default start/end dates from pickers.
+        m_date_range = DateRange2();
         m_date_range.setRange(DateRange2::Range());
         m_date_range.setDefStartDateN(DateDayN(w_start_date_picker->GetValue()));
         m_date_range.setDefEndDateN(DateDayN(w_end_date_picker->GetValue()));
@@ -861,9 +863,10 @@ void mmReportsPanel::onDateRangeSelect(wxCommandEvent& event)
         return;
     }
 
+    // recreate m_date_range in order to reload parameters from setting,
+    // refresh the date of today, and clear the default start/end dates
+    m_date_range = DateRange2();
     m_date_range.setRange(m_date_range_a[i]);
-    m_date_range.setDefStartDateN();
-    m_date_range.setDefEndDateN();
 
     m_filter_id = mmCheckingPanel::FILTER_ID_DATE_RANGE;
     updateFilter();
@@ -879,6 +882,10 @@ void mmReportsPanel::onDateRangeEdit(wxCommandEvent& WXUNUSED(event))
     loadDateRanges(&m_date_range_a, &m_date_range_m);
 
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
+        // recreate m_date_range in order to reload parameters from setting,
+        // refresh the date of today, and clear the default start/end dates
+        m_date_range = DateRange2();
+
         // find and reload the range specification (it may have been changed)
         bool found = false;
         for (const auto& range : m_date_range_a) {
@@ -892,10 +899,6 @@ void mmReportsPanel::onDateRangeEdit(wxCommandEvent& WXUNUSED(event))
             // set range to 'All'
             m_date_range.setRange(m_date_range_a[0]);
         }
-
-        // clear default start/end dates
-        m_date_range.setDefStartDateN();
-        m_date_range.setDefEndDateN();
 
         updateFilter();
         saveFilterSettings();

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -41,116 +41,101 @@
 #include <iomanip>
 #include "uicontrols/navigatortypes.h"
 
-
 wxBEGIN_EVENT_TABLE(mmReportsPanel, wxPanel)
-    EVT_CHOICE(ID_CHOICE_YEAR, mmReportsPanel::OnYearChanged)
-    EVT_CHOICE(ID_CHOICE_BUDGET, mmReportsPanel::OnBudgetChanged)
-    EVT_CHOICE(ID_CHOICE_ACCOUNTS, mmReportsPanel::OnAccountChanged)
-    EVT_DATE_CHANGED(ID_CHOICE_START_DATE, mmReportsPanel::OnStartEndDateChanged)
-    EVT_TIME_CHANGED(ID_CHOICE_START_DATE, mmReportsPanel::OnStartEndDateChanged)
-    EVT_DATE_CHANGED(ID_CHOICE_END_DATE, mmReportsPanel::OnStartEndDateChanged)
-    EVT_TIME_CHANGED(ID_CHOICE_END_DATE, mmReportsPanel::OnStartEndDateChanged)
-    EVT_DATE_CHANGED(ID_CHOICE_SINGLE_DATE, mmReportsPanel::OnSingleDateChanged)
-    EVT_TIME_CHANGED(ID_CHOICE_SINGLE_DATE, mmReportsPanel::OnSingleDateChanged)
-    EVT_CHOICE(ID_CHOICE_CHART, mmReportsPanel::OnChartChanged)
-    EVT_SPINCTRL(ID_CHOICE_FORWARD_MONTHS, mmReportsPanel::OnForwardMonthsChangedSpin)
-    EVT_TEXT_ENTER(ID_CHOICE_FORWARD_MONTHS, mmReportsPanel::OnForwardMonthsChangedText)
-    EVT_BUTTON(ID_FILTER_PERIOD, mmReportsPanel::OnPeriodSelectPopup)
-    EVT_MENU(ID_EDIT_DATE_RANGES,  mmReportsPanel::onEditDateRanges)
+    EVT_CHOICE(ID_YEAR_CHOICE,              mmReportsPanel::onYearChanged)
+    EVT_CHOICE(ID_BUDGET_CHOICE,            mmReportsPanel::onBudgetChanged)
+    EVT_CHOICE(ID_ACCOUNT_CHOICE,           mmReportsPanel::onAccountChanged)
+    EVT_DATE_CHANGED(ID_START_DATE_PICKER,  mmReportsPanel::onStartEndDateChanged)
+    EVT_TIME_CHANGED(ID_START_DATE_PICKER,  mmReportsPanel::onStartEndDateChanged)
+    EVT_DATE_CHANGED(ID_END_DATE_PICKER,    mmReportsPanel::onStartEndDateChanged)
+    EVT_TIME_CHANGED(ID_END_DATE_PICKER,    mmReportsPanel::onStartEndDateChanged)
+    EVT_DATE_CHANGED(ID_SINGLE_DATE_PICKER, mmReportsPanel::onSingleDateChanged)
+    EVT_TIME_CHANGED(ID_SINGLE_DATE_PICKER, mmReportsPanel::onSingleDateChanged)
+    EVT_CHOICE(ID_CHART_CHOICE,             mmReportsPanel::onChartChanged)
+    EVT_SPINCTRL(ID_FORWARD_MONTHS,         mmReportsPanel::onForwardMonthsChangedSpin)
+    EVT_TEXT_ENTER(ID_FORWARD_MONTHS,       mmReportsPanel::onForwardMonthsChangedText)
+    EVT_BUTTON(ID_DATE_RANGE_BUTTON,        mmReportsPanel::onDateRangePopup)
+    EVT_MENU(ID_DATE_RANGE_EDIT,            mmReportsPanel::onDateRangeEdit)
     EVT_MENU_RANGE(
-        ID_FILTER_DATE_MIN,
-        ID_FILTER_DATE_MAX,
-        mmReportsPanel::onFilterDateMenu)
-    EVT_BUTTON(wxID_ANY, mmReportsPanel::OnShiftPressed)
-
+        ID_DATE_RANGE_MIN,
+        ID_DATE_RANGE_MAX,
+        mmReportsPanel::onDateRangeSelect)
+    EVT_BUTTON(wxID_ANY, mmReportsPanel::onShiftPressed)
 wxEND_EVENT_TABLE()
 
 mmReportsPanel::mmReportsPanel(
-    mmPrintableBase* rb, bool cleanupReport, wxWindow *parent, mmGUIFrame* frame,
+    ReportBase* rb, bool cleanup, wxWindow *parent, mmGUIFrame* frame,
     wxWindowID winid, const wxPoint& pos,
     const wxSize& size, long style,
-    const wxString& name)
-    : m_frame(frame)
-    , rb_(rb)
-    , cleanup_(cleanupReport)
+    const wxString& name
+) :
+    w_frame(frame),
+    m_rb(rb),
+    m_cleanup(cleanup)
 {
     Create(parent, winid, pos, size, style, name);
 }
 
 mmReportsPanel::~mmReportsPanel()
 {
-    if (cleanup_ && rb_) {
-        delete rb_;
+    if (m_cleanup && m_rb) {
+        delete m_rb;
     }
 
-    m_all_date_ranges.clear();
     clearVFprintedFiles("rep");
 }
 
-bool mmReportsPanel::Create(wxWindow *parent, wxWindowID winid
-    , const wxPoint& pos, const wxSize& size, long style
-    , const wxString& name)
-{
+bool mmReportsPanel::Create(
+    wxWindow *parent, wxWindowID winid,
+    const wxPoint& pos, const wxSize& size, long style,
+    const wxString& name
+) {
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
     wxPanel::Create(parent, winid, pos, size, style, name);
 
     m_use_account_specific_filter = Option::instance().getUsePerAccountFilter();
 
-    rb_->restoreReportSettings();
+    m_rb->restoreReportSettings();
 
     CreateControls();
-    if (rb_->report_parameters() & rb_->RepParams::DATE_RANGE) {
+    if (m_rb->getParameters() & ReportBase::M_DATE_RANGE) {
         loadFilterSettings();
         updateFilter();
-        // FIXME: get[ST]Date are not the start and end date
-        if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
-            m_start_date->SetValue(
-                m_current_date_range.getSDateN().getDateTimeN()
-            );
-            m_end_date->SetValue(
-                m_current_date_range.getTDate().getDateTime()
-            );
-            m_bitmapDataPeriodFilterBtn->SetLabel(_t("Date range"));
-        }
     }
     GetSizer()->Fit(this);
     GetSizer()->SetSizeHints(this);
 
     saveReportText();
 
-    int id = rb_->getReportId();
-    this->SetLabel(id < 0 ? "Custom Report" : rb_->getReportTitle(false));
+    ReportBase::TYPE_ID id = m_rb->getTypeId();
+    this->SetLabel(id < 0 ? "Custom Report" : m_rb->getTitle(false));
 
     return true;
 }
 
 bool mmReportsPanel::saveReportText(bool initial)
 {
-    if (!rb_) return false;
+    if (!m_rb)
+        return false;
 
-    rb_->initial_report(initial);
-
-
-    if (rb_->report_parameters() & mmPrintableBase::RepParams::DATE_RANGE)
-    {
+    if (m_rb->getParameters() & ReportBase::M_DATE_RANGE) {
         mmDateRange* date_range = new mmDateRange();
-        wxDateTime td = m_start_date->GetValue();
+        wxDateTime td = w_start_date_picker->GetValue();
         date_range->start_date(td.ResetTime()); // Start of Day
-        td = m_end_date->GetValue();
+        td = w_end_date_picker->GetValue();
         date_range->end_date(td.ResetTime().Add(wxTimeSpan(23,59,59,999))); // End of Day
-        rb_->date_range(date_range, 0);
+        m_rb->setDateRange(date_range);
+        m_rb->setDateSelection(0);
     }
 
-
-    if (rb_->report_parameters() & (mmPrintableBase::RepParams::BUDGET_DATES | mmPrintableBase::RepParams::ONLY_YEARS))
-    {
-        int selectedItem = m_date_ranges->GetSelection();
+    if (m_rb->getParameters() & (ReportBase::M_BUDGET | ReportBase::M_YEAR)) {
+        int selectedItem = w_year_choice->GetSelection();
         wxString id_str = "0";
         wxStringClientData* obj =
-            static_cast<wxStringClientData*>(m_date_ranges->GetClientObject(selectedItem));
+            static_cast<wxStringClientData*>(w_year_choice->GetClientObject(selectedItem));
         if (obj) id_str = obj->GetData();
         int64 id = std::stoll(id_str.ToStdString());
-        rb_->setSelection(id);
+        m_rb->setDateSelection(id);
     }
 
     StringBuffer json_buffer;
@@ -160,12 +145,12 @@ bool mmReportsPanel::saveReportText(bool initial)
     json_writer.Key("module");
     json_writer.String(wxTRANSLATE("Report"));
     json_writer.Key("name");
-    json_writer.String(rb_->getReportTitle(false).utf8_str());
+    json_writer.String(m_rb->getTitle(false).utf8_str());
 
     const auto time = wxDateTime::UNow();
 
-    const auto& name = getVFname4print("rep", rb_->getHTMLText());
-    browser_->LoadURL(name);
+    const auto& name = getVFname4print("rep", m_rb->getHTMLText());
+    w_browser->LoadURL(name);
 
     json_writer.Key("seconds");
     json_writer.Double((wxDateTime::UNow() - time).GetMilliseconds().ToDouble() / 1000);
@@ -174,7 +159,7 @@ bool mmReportsPanel::saveReportText(bool initial)
     const auto t = wxString::FromUTF8(json_buffer.GetString());
     wxLogDebug("%s", t);
     Model_Usage::instance().AppendToUsage(t);
-    Model_Usage::instance().pageview(this, rb_, (wxDateTime::UNow() - time).GetMilliseconds().ToLong());
+    Model_Usage::instance().pageview(this, m_rb, (wxDateTime::UNow() - time).GetMilliseconds().ToLong());
 
     return true;
 }
@@ -189,93 +174,130 @@ void mmSetOwnFont(wxStaticText* w, const wxFont& font)
         w->SetInitialSize(w->GetTextExtent(label));
 }
 
-
 // function only used for new filter
 void mmReportsPanel::loadFilterSettings() {
-    m_date_range_a.clear();
-    m_date_range_m = -1;
-    int src_i = 0;
-    int src_m = Option::instance().getCheckingRangeM();
-    for (const auto& range : Option::instance().getCheckingRangeA()) {
-        if (m_date_range_a.size() > ID_FILTER_DATE_MAX - ID_FILTER_DATE_MIN) {
-            break;
-        }
-        if (src_i == src_m) {
-            m_date_range_m = m_date_range_a.size();
-        }
-        if (!range.hasPeriodS()) {
-            m_date_range_a.push_back(range);
-        }
-        src_i++;
-    }
-    if (m_date_range_m < 0) {
-        m_date_range_m = m_date_range_a.size();
-    }
-
-    wxString key = m_use_account_specific_filter ? wxString::Format("REPORT_FILTER_DEDICATED_%d", rb_->getReportId()) : "CHECK_FILTER_ALL";
+    wxString key = m_use_account_specific_filter
+        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
+        : "CHECK_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
 
     int fid = 0;
     if (JSON_GetIntValue(j_doc, "FILTER_ID", fid)) {
         m_filter_id = static_cast<mmCheckingPanel::FILTER_ID>(fid);
     }
-    else { // no filter found => set to all
+    else {
+        // no filter found => set to date range
         m_filter_id = mmCheckingPanel::FILTER_ID_DATE_RANGE;
     }
 
+    loadDateRanges(&m_date_range_a, &m_date_range_m);
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
+        // Load m_date_range from settings.
+        // The start/end date pickers are configured later in updateFilter().
         wxString j_filter;
-        bool notfound = true;
+        bool found = false;
         if (JSON_GetStringValue(j_doc, "FILTER_DATE", j_filter)) {
-            // get range specification:
+            // find range specification
             for (const auto& range : m_date_range_a) {
                 if (range.getName() == j_filter) {
-                    m_current_date_range.setRange(range);
-                    notfound = false;
+                    m_date_range.setRange(range);
+                    found = true;
                     break;
                 }
             }
         }
-        if (notfound) {
-            m_current_date_range.setRange(m_date_range_a[0]); // init with 'all'
+        if (!found) {
+            // init with 'All'
+            m_date_range.setRange(m_date_range_a[0]);
         }
+        // clear default start/end dates
+        m_date_range.setDefStartDateN();
+        m_date_range.setDefEndDateN();
     }
     else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
-        wxString p_filter;
-        wxDateTime newdate;
+        // Load start/end date pickers from settings.
+        // The date range is configured later in updateFilter().
+        wxString date_str;
         wxString::const_iterator end;
-        if (JSON_GetStringValue(j_doc, "FILTER_DATE_BEGIN", p_filter)) {
-            // FIXME: setSDateN is the account statement date, not the start date
-            m_current_date_range.setSDateN(
-                newdate.ParseFormat(p_filter, "%Y-%m-%d", &end)
-                ? DateDay(newdate)
-                : DateDayN()
-            );
+        wxDateTime start_dateTime, end_dateTime;
+        if (JSON_GetStringValue(j_doc, "FILTER_DATE_BEGIN", date_str)) {
+            start_dateTime.ParseFormat(date_str, "%Y-%m-%d", &end);
         }
-        if (JSON_GetStringValue(j_doc, "FILTER_DATE_END", p_filter)) {
-            // FIXME: setTDate is the date of today, should not be changed here
-            m_current_date_range.setTDate(
-                newdate.ParseFormat(p_filter, "%Y-%m-%d", &end)
-                ? DateDay(newdate)
-                : DateDay::today()
-            );
+        if (JSON_GetStringValue(j_doc, "FILTER_DATE_END", date_str)) {
+            end_dateTime.ParseFormat(date_str, "%Y-%m-%d", &end);
         }
+        // initialize pickers (also when start/end dates are undefined)
+        w_start_date_picker->SetValue(start_dateTime);
+        w_end_date_picker->SetValue(end_dateTime);
     }
 }
 
 void mmReportsPanel::saveFilterSettings() {
-    wxString key = m_use_account_specific_filter ? wxString::Format("REPORT_FILTER_DEDICATED_%d", rb_->getReportId()) : "CHECK_FILTER_ALL";
+    wxString key = m_use_account_specific_filter
+        ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
+        : "CHECK_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
     Model_Infotable::saveFilterInt(j_doc, "FILTER_ID", m_filter_id);
-    Model_Infotable::saveFilterString(j_doc, "FILTER_NAME", mmCheckingPanel::getFilterName(m_filter_id));
-    Model_Infotable::saveFilterString(j_doc, "FILTER_DATE", m_current_date_range.getRange().getName());
-    if (m_start_date) {
-        Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_BEGIN", m_start_date->GetValue().IsValid() ? m_start_date->GetValue().FormatISODate() : "");
+    Model_Infotable::saveFilterString(j_doc, "FILTER_NAME",
+        mmCheckingPanel::getFilterName(m_filter_id)
+    );
+
+    if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
+        if (!m_date_range.rangeName().IsEmpty())
+            Model_Infotable::saveFilterString(j_doc, "FILTER_DATE", m_date_range.rangeName());
+        else
+            wxLogError("mmReportsPanel::saveFilterSettings(): m_date_range.rangeName() is empty");
     }
-    if (m_end_date) {
-        Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_END", m_end_date->GetValue().IsValid() ? m_end_date->GetValue().FormatISODate() : "");
+    else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
+        if (w_start_date_picker)
+            Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_BEGIN",
+                DateDayN(w_start_date_picker->GetValue()).isoDateN()
+            );
+        else
+            wxLogError("mmReportsPanel::saveFilterSettings(): w_start_date_picker is null");
+
+        if (w_end_date_picker)
+            Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_END",
+                DateDayN(w_end_date_picker->GetValue()).isoDateN()
+            );
+        else
+            wxLogError("mmReportsPanel::saveFilterSettings(): w_end_date_picker is null");
     }
+
     Model_Infotable::instance().setJdoc(key, j_doc);
+}
+
+void mmReportsPanel::updateFilter()
+{
+    if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
+        w_date_range_button->SetLabel(m_date_range.rangeName());
+        w_date_range_button->SetBitmap(mmBitmapBundle(
+            (m_date_range.rangeName() != m_date_range_a[0].getName()
+                ? png::TRANSFILTER_ACTIVE
+                : png::TRANSFILTER
+            ),
+            mmBitmapButtonSize
+        ));
+        // copy from date range to start/end pickers
+        // TODO: calculate default start/end dates from model
+        w_start_date_picker->SetValue(
+            m_date_range.rangeStart().value_or(DateDay::min()).getDateTime()
+        );
+        w_end_date_picker->SetValue(
+            m_date_range.rangeEnd().value_or(DateDay::max()).getDateTime()
+        );
+    }
+    else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
+        w_date_range_button->SetLabel(_t("Date range"));
+        w_date_range_button->SetBitmap(mmBitmapBundle(
+            png::TRANSFILTER_ACTIVE,
+            mmBitmapButtonSize
+        ));
+        // set date range to default ('All') and copy default start/end dates from pickers
+        m_date_range.setRange(DateRange2::Range());
+        m_date_range.setDefStartDateN(DateDayN(w_start_date_picker->GetValue()));
+        m_date_range.setDefEndDateN(DateDayN(w_end_date_picker->GetValue()));
+    }
 }
 
 void mmReportsPanel::CreateControls()
@@ -294,331 +316,242 @@ void mmReportsPanel::CreateControls()
 
     //int sel_id = -1;
 
-    if (rb_)
-    {
-        int rp = rb_->report_parameters();
+    if (m_rb) {
+        int rp = m_rb->getParameters();
 
         if (rp == 0) {
             itemPanel3->SetMinSize(wxSize(0, 0));
             itemPanel3->Fit();
         }
 
-        if (rp & rb_->RepParams::DATE_RANGE)
-        {
-            m_bitmapDataPeriodFilterBtn = new wxButton(itemPanel3, ID_FILTER_PERIOD, _tu("Period…"));
-            m_bitmapDataPeriodFilterBtn->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
-            m_bitmapDataPeriodFilterBtn->SetMinSize(
+        if (rp & ReportBase::M_DATE_RANGE) {
+            w_date_range_button = new wxButton(itemPanel3, ID_DATE_RANGE_BUTTON, _tu("Period…"));
+            w_date_range_button->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
+            w_date_range_button->SetMinSize(
                 wxSize(200 + Option::instance().getIconSize() * 2, -1)
             );
-            itemBoxSizerHeader->Add(m_bitmapDataPeriodFilterBtn, g_flagsH);
+            itemBoxSizerHeader->Add(w_date_range_button, g_flagsH);
             itemBoxSizerHeader->AddSpacer(5);
 
-            m_start_date = new mmDatePickerCtrl(itemPanel3, ID_CHOICE_START_DATE
-                , wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN | wxDP_SHOWCENTURY);
-            itemBoxSizerHeader->Add(m_start_date, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            w_start_date_picker = new mmDatePickerCtrl(
+                itemPanel3, ID_START_DATE_PICKER,
+                wxDefaultDateTime, wxDefaultPosition, wxDefaultSize,
+                wxDP_DROPDOWN | wxDP_SHOWCENTURY
+            );
+            itemBoxSizerHeader->Add(w_start_date_picker, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
 
-            m_end_date = new mmDatePickerCtrl(itemPanel3, ID_CHOICE_END_DATE
-                , wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN | wxDP_SHOWCENTURY);
-            itemBoxSizerHeader->Add(m_end_date, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            w_end_date_picker = new mmDatePickerCtrl(
+                itemPanel3, ID_END_DATE_PICKER,
+                wxDefaultDateTime, wxDefaultPosition, wxDefaultSize,
+                wxDP_DROPDOWN | wxDP_SHOWCENTURY
+            );
+            itemBoxSizerHeader->Add(w_end_date_picker, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
-        else if (rp & rb_->RepParams::SINGLE_DATE)
-        {
+        else if (rp & ReportBase::M_SINGLE_DATE) {
             wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
                 , wxID_ANY, _t("Date:"));
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
             long date_style = wxDP_DROPDOWN | wxDP_SHOWCENTURY;
-            m_single_date = new mmDatePickerCtrl(itemPanel3, ID_CHOICE_SINGLE_DATE
-                , wxDefaultDateTime, wxDefaultPosition, wxDefaultSize, date_style);
-            m_single_date->SetValue(wxDateTime::Today());
-            m_single_date->Enable(true);
+            w_single_date_picker = new mmDatePickerCtrl(
+                itemPanel3, ID_SINGLE_DATE_PICKER,
+                wxDefaultDateTime, wxDefaultPosition, wxDefaultSize,
+                date_style
+            );
+            w_single_date_picker->SetValue(wxDateTime::Today());
+            w_single_date_picker->Enable(true);
 
-            itemBoxSizerHeader->Add(m_single_date, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_single_date_picker, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
-        else if (rp & rb_->RepParams::MONTHES)
-        {
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Date:"));
+        else if (rp & ReportBase::M_MONTHS) {
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Date:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
 
             mmDateYearMonth* up_down_month = new mmDateYearMonth(itemPanel3);
-            up_down_month->Connect(wxEVT_BUTTON, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(mmDateYearMonth::OnButtonPress), nullptr, this);
-            rb_->setSelection(m_shift);
+            up_down_month->Connect(
+                wxEVT_BUTTON, wxEVT_COMMAND_BUTTON_CLICKED,
+                wxCommandEventHandler(mmDateYearMonth::OnButtonPress),
+                nullptr, this
+            );
+            m_rb->setDateSelection(m_shift);
 
             itemBoxSizerHeader->Add(up_down_month, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
 
-        if (rp & rb_->RepParams::TIME)
-        {
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Time:"));
+        if (rp & ReportBase::M_TIME) {
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Time:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
 
-            m_time = new wxTimePickerCtrl(itemPanel3, ID_CHOICE_TIME);
+            w_time_picker = new wxTimePickerCtrl(itemPanel3, ID_TIME_PICKER);
 
-            itemBoxSizerHeader->Add(m_time, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_time_picker, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
 
-        if (rp & rb_->RepParams::ONLY_YEARS)
-        {
-            cleanupmem_ = true;
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Year:"));
+        if (rp & ReportBase::M_YEAR) {
+            u_cleanup_mem = true;
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Year:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
 
-            m_date_ranges = new wxChoice(itemPanel3, ID_CHOICE_YEAR, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_SORT);
+            w_year_choice = new wxChoice(
+                itemPanel3, ID_YEAR_CHOICE,
+                wxDefaultPosition, wxDefaultSize, 0,
+                nullptr, wxCB_SORT
+            );
 
             const int y = wxDateTime::Today().GetYear();
-            for (int i = y - 100; i <= y + 100; i++)
-            {
+            for (int i = y - 100; i <= y + 100; ++i) {
                 const wxString name = wxString::Format("%i", i);
-                m_date_ranges->Append(name, new wxStringClientData(name));
+                w_year_choice->Append(name, new wxStringClientData(name));
             }
 
-            m_date_ranges->SetStringSelection(wxString::Format("%i", y));
+            w_year_choice->SetStringSelection(wxString::Format("%i", y));
 
-            itemBoxSizerHeader->Add(m_date_ranges, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_year_choice, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
-        else if (rp & rb_->RepParams::BUDGET_DATES)
-        {
-            cleanupmem_ = true;
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Budget:"));
+        else if (rp & ReportBase::M_BUDGET) {
+            u_cleanup_mem = true;
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Budget:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
 
-            m_date_ranges = new wxChoice(itemPanel3, ID_CHOICE_BUDGET, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_SORT);
+            w_year_choice = new wxChoice(
+                itemPanel3, ID_BUDGET_CHOICE,
+                wxDefaultPosition, wxDefaultSize, 0,
+                nullptr, wxCB_SORT
+            );
 
-            int64 sel_id = rb_->getDateSelection();
+            int64 sel_id = m_rb->getDateSelection();
             wxString sel_name;
-            for (const auto& e : Model_Budgetyear::instance().all(Model_Budgetyear::COL_BUDGETYEARNAME))
-            {
+            for (const auto& e : Model_Budgetyear::instance().all(
+                Model_Budgetyear::COL_BUDGETYEARNAME
+            )) {
                 const wxString& name = e.BUDGETYEARNAME;
 
-                if (rb_->getReportId() == mmPrintableBase::Reports::BudgetCategorySummary || name.length() == 4) // Only years for performance report
-                {
-                    m_date_ranges->Append(name, new wxStringClientData(wxString::Format("%lld", e.BUDGETYEARID)));
+                // Only years for performance report
+                if (m_rb->getTypeId() == ReportBase::TYPE_ID::BudgetCategorySummary ||
+                    name.length() == 4
+                ) {
+                    w_year_choice->Append(name, new wxStringClientData(wxString::Format("%lld", e.BUDGETYEARID)));
                     if (sel_id == e.BUDGETYEARID)
                         sel_name = e.BUDGETYEARNAME;
                 }
             }
 
             if (!sel_name.IsEmpty())
-                m_date_ranges->SetStringSelection(sel_name);
+                w_year_choice->SetStringSelection(sel_name);
             else
-                m_date_ranges->SetSelection(0);
+                w_year_choice->SetSelection(0);
 
-            itemBoxSizerHeader->Add(m_date_ranges, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_year_choice, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
 
-        if (rp & rb_->RepParams::ACCOUNTS_LIST)
-        {
+        if (rp & ReportBase::M_ACCOUNT) {
             wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3, wxID_ANY, _t("Accounts:"));
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
-            m_accounts = new wxChoice(itemPanel3, ID_CHOICE_ACCOUNTS);
-            m_accounts->Append(_t("All Accounts"));
-            m_accounts->Append(_tu("Specific Accounts…"));
-            m_accounts->Append(NavigatorTypes::instance().getUsedAccountTypeNames());
-            m_accounts->SetSelection(rb_->getAccountSelection());
+            w_account_choice = new wxChoice(itemPanel3, ID_ACCOUNT_CHOICE);
+            w_account_choice->Append(_t("All Accounts"));
+            w_account_choice->Append(_tu("Specific Accounts…"));
+            w_account_choice->Append(NavigatorTypes::instance().getUsedAccountTypeNames());
+            w_account_choice->SetSelection(m_rb->getAccountSelection());
 
-            itemBoxSizerHeader->Add(m_accounts, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_account_choice, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
 
-        if (rp & rb_->RepParams::FORWARD_MONTHS)
-        {
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Future Months:"));
+        if (rp & ReportBase::M_FORWARD_MONTHS) {
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Future Months:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
-            m_forwardMonths = new wxSpinCtrl(itemPanel3, ID_CHOICE_FORWARD_MONTHS
-                ,wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
-            m_forwardMonths->SetRange(1, 120);
-            m_forwardMonths->SetValue(rb_->getForwardMonths());
-            itemBoxSizerHeader->Add(m_forwardMonths, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            w_forward_months = new wxSpinCtrl(
+                itemPanel3, ID_FORWARD_MONTHS,
+                wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER
+            );
+            w_forward_months->SetRange(1, 120);
+            w_forward_months->SetValue(m_rb->getForwardMonths());
+            itemBoxSizerHeader->Add(w_forward_months, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
 
-        if (rp & rb_->RepParams::CHART)
-        {
-            wxStaticText* itemStaticTextH1 = new wxStaticText(itemPanel3
-                , wxID_ANY, _t("Chart:"));
+        if (rp & ReportBase::M_CHART) {
+            wxStaticText* itemStaticTextH1 = new wxStaticText(
+                itemPanel3, wxID_ANY, _t("Chart:")
+            );
             mmSetOwnFont(itemStaticTextH1, GetFont().Larger());
             itemBoxSizerHeader->Add(itemStaticTextH1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(5);
-            m_chart = new wxChoice(itemPanel3, ID_CHOICE_CHART);
-            m_chart->Append(_t("Show"));
-            m_chart->Append(_t("Hide"));
-            m_chart->SetSelection(rb_->getChartSelection());
+            w_chart_choice = new wxChoice(itemPanel3, ID_CHART_CHOICE);
+            w_chart_choice->Append(_t("Show"));
+            w_chart_choice->Append(_t("Hide"));
+            w_chart_choice->SetSelection(m_rb->getChartSelection());
 
-            itemBoxSizerHeader->Add(m_chart, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+            itemBoxSizerHeader->Add(w_chart_choice, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
             itemBoxSizerHeader->AddSpacer(30);
         }
     }
 
-    browser_ = wxWebView::New();
+    w_browser = wxWebView::New();
 #ifdef __WXMAC__
     // With WKWebView handlers need to be registered before creation
-    browser_->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewFSHandler("memory")));
-    browser_->Create(this, mmID_BROWSER);
+    w_browser->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewFSHandler("memory")));
+    w_browser->Create(this, mmID_BROWSER);
 #else
-    browser_->Create(this, mmID_BROWSER);
-    browser_->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewFSHandler("memory")));
+    w_browser->Create(this, mmID_BROWSER);
+    w_browser->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewFSHandler("memory")));
 #endif
-    Bind(wxEVT_WEBVIEW_NEWWINDOW, &mmReportsPanel::OnNewWindow, this, mmID_BROWSER);
+    Bind(wxEVT_WEBVIEW_NEWWINDOW, &mmReportsPanel::onNewWindow, this, mmID_BROWSER);
 
-    itemBoxSizer2->Add(browser_, 1, wxGROW | wxALL, 1);
+    itemBoxSizer2->Add(w_browser, 1, wxGROW | wxALL, 1);
 }
 
 void mmReportsPanel::PrintPage()
 {
-    browser_->Print();
+    w_browser->Print();
 }
 
-void mmReportsPanel::OnYearChanged(wxCommandEvent& event)
-{
-    const auto i = event.GetString();
-    wxLogDebug("-------- %s", i);
-    saveReportText(false);
-}
-
-void mmReportsPanel::OnBudgetChanged(wxCommandEvent& event)
-{
-    const auto i = event.GetString();
-    wxLogDebug("-------- %s", i);
-    saveReportText(false);
-    rb_->setReportSettings();
-}
-
-void mmReportsPanel::OnAccountChanged(wxCommandEvent& WXUNUSED(event))
-{
-    if (rb_) {
-        int sel = m_accounts->GetSelection();
-        if ((sel == 1) || (sel != rb_->getAccountSelection())) {
-            rb_->setAccounts(sel, NavigatorTypes::instance().getAccountDbTypeFromName(m_accounts->GetString(sel)));
-            saveReportText(false);
-            rb_->setReportSettings();
-        }
-    }
-}
-
-void mmReportsPanel::OnSingleDateChanged(wxDateEvent& WXUNUSED(event))
-{
-    if (rb_) {
-        saveReportText(false);
-        rb_->setReportSettings();
-    }
-}
-
-void mmReportsPanel::OnStartEndDateChanged(wxDateEvent& event)
-{
-    wxObject* eo = event.GetEventObject();
-    if (eo) {
-        if (m_start_date->isItMyDateControl(eo)) {
-            //wxLogDebug("Start date changed to %s", m_start_date->GetValue().FormatISODate());
-            if (m_start_date->GetValue() > m_end_date->GetValue()) {
-                m_end_date->SetValue(m_start_date->GetValue());
-                wxLogDebug("End date changed to %s", m_start_date->GetValue().FormatISODate());
-            }
-        }
-        else if (m_end_date->isItMyDateControl(eo)) {
-            if (m_start_date->GetValue() > m_end_date->GetValue()) {
-                m_start_date->SetValue(m_end_date->GetValue());
-                wxLogDebug("Start date changed to %s", m_start_date->GetValue().FormatISODate());
-            }
-        }
-    }
-
-    m_filter_id = mmCheckingPanel::FILTER_ID_DATE_PICKER;
-    updateFilter();
-    saveFilterSettings();
-
-    if (rb_) {
-        saveReportText(false);
-        rb_->setReportSettings();
-    }
-}
-
-void mmReportsPanel::OnChartChanged(wxCommandEvent& WXUNUSED(event))
-{
-    if (rb_) {
-        int sel = m_chart->GetSelection();
-        if ((sel == 1) || (sel != rb_->getChartSelection()))
-        {
-            rb_->chart(sel);
-            saveReportText(false);
-            rb_->setReportSettings();
-        }
-    }
-}
-
-void mmReportsPanel::OnForwardMonthsChangedSpin(wxSpinEvent& WXUNUSED(event))
-{
-    if (rb_) {
-        int sel = m_forwardMonths->GetValue();
-        if (sel != rb_->getForwardMonths())
-        {
-            rb_->setForwardMonths(sel);
-            saveReportText(false);
-            rb_->setReportSettings();
-        }
-    }
-}
-
-void mmReportsPanel::OnForwardMonthsChangedText(wxCommandEvent& event)
-{
-    m_forwardMonths->SetValue(event.GetString());
-    wxSpinEvent evt;
-    OnForwardMonthsChangedSpin(evt);
-}
-
-
-void mmReportsPanel::OnShiftPressed(wxCommandEvent& event)
-{
-    if (rb_)
-    {
-        m_shift = event.GetInt();
-        rb_->setSelection(m_shift);
-        saveReportText(false);
-    }
-}
-
-void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
+void mmReportsPanel::onNewWindow(wxWebViewEvent& evt)
 {
     const wxURI escapedURI(evt.GetURL());
     const wxString uri = escapedURI.BuildUnescapedURI();
     wxString sData;
 
     wxRegEx pattern(R"(^(https?:)|(file:)\/\/)");
-    if (pattern.Matches(uri))
-    {
+    if (pattern.Matches(uri)) {
         wxLaunchDefaultBrowser(uri);
         evt.Veto();
     }
-    else if (uri.StartsWith("back:", &sData))
-    {
-        browser_->GoBack();
+    else if (uri.StartsWith("back:", &sData)) {
+        w_browser->GoBack();
     }
-    else if (uri.StartsWith("viewtrans:", &sData))
-    {
+    else if (uri.StartsWith("viewtrans:", &sData)) {
         wxStringTokenizer tokenizer(sData, ":");
         int i =0;
         int64 catID = -1;
@@ -626,8 +559,7 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
         int64 payeeID = -1;
         // categoryID, subcategoryID, payeeID
         //      subcategoryID = -2 means inlude all sub categories for the given category
-        while ( tokenizer.HasMoreTokens() )
-        {
+        while ( tokenizer.HasMoreTokens() ) {
             switch (i++) {
             case 0:
                 catID = std::stoll(tokenizer.GetNextToken().ToStdString());
@@ -643,112 +575,95 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
             }
         }
 
-        if (catID > 0)
-        {
+        if (catID > 0) {
             std::vector<int64> cats;
-            if (-2 == subCatID) // include all sub categories
-            {
-                for (const auto& subCategory : Model_Category::sub_tree(Model_Category::instance().get(catID)))
-                {
+            // include all sub categories
+            if (-2 == subCatID) {
+                for (const auto& subCategory :
+                    Model_Category::sub_tree(Model_Category::instance().get(catID))
+                ) {
                     cats.push_back(subCategory.CATEGID);
                 }
             }
             cats.push_back(catID);
-            rb_->m_filter.setCategoryList(cats);
+            m_rb->m_filter.setCategoryList(cats);
         }
 
-        if (payeeID > 0)
-        {
+        if (payeeID > 0) {
             wxArrayInt64 payees;
             payees.push_back(payeeID);
-            rb_->m_filter.setPayeeList(payees);
+            m_rb->m_filter.setPayeeList(payees);
         }
 
-        const wxString report = rb_->m_filter.getHTML();
+        const wxString report = m_rb->m_filter.getHTML();
         const auto name = getVFname4print("repdetail", report);
-        browser_->LoadURL(name);
+        w_browser->LoadURL(name);
     }
-    else if (uri.StartsWith("trxid:", &sData))
-    {
+    else if (uri.StartsWith("trxid:", &sData)) {
         long long transID = -1;
         if (sData.ToLongLong(&transID)) {
             const Model_Checking::Data* transaction = Model_Checking::instance().get(transID);
-            if (transaction && transaction->TRANSID > -1)
-            {
+            if (transaction && transaction->TRANSID > -1) {
                 const Model_Account::Data* account = Model_Account::instance().get(transaction->ACCOUNTID);
                 if (account) {
-                    m_frame->selectNavTreeItem(account->ACCOUNTNAME);
-                    m_frame->setGotoAccountID(transaction->ACCOUNTID, { transID, 0 });
+                    w_frame->selectNavTreeItem(account->ACCOUNTNAME);
+                    w_frame->setGotoAccountID(transaction->ACCOUNTID, { transID, 0 });
                     wxCommandEvent event(wxEVT_COMMAND_MENU_SELECTED, MENU_GOTOACCOUNT);
-                    m_frame->GetEventHandler()->AddPendingEvent(event);
+                    w_frame->GetEventHandler()->AddPendingEvent(event);
                 }
             }
         }
     }
-    else if (uri.StartsWith("trx:", &sData))
-    {
+    else if (uri.StartsWith("trx:", &sData)) {
         long long transId = -1;
-        if (sData.ToLongLong(&transId))
-        {
+        if (sData.ToLongLong(&transId)) {
             Model_Checking::Data* transaction = Model_Checking::instance().get(transId);
-            if (transaction && transaction->TRANSID > -1)
-            {
-                if (Model_Checking::foreignTransaction(*transaction))
-                {
+            if (transaction && transaction->TRANSID > -1) {
+                if (Model_Checking::foreignTransaction(*transaction)) {
                     Model_Translink::Data translink = Model_Translink::TranslinkRecord(transId);
-                    if (translink.LINKTYPE == Model_Stock::refTypeName)
-                    {
-                        ShareTransactionDialog dlg(m_frame, &translink, transaction);
-                        if (dlg.ShowModal() == wxID_OK)
-                        {
-                            rb_->getHTMLText();
+                    if (translink.LINKTYPE == Model_Stock::refTypeName) {
+                        ShareTransactionDialog dlg(w_frame, &translink, transaction);
+                        if (dlg.ShowModal() == wxID_OK) {
+                            m_rb->getHTMLText();
                             saveReportText();
                         }
                     }
-                    else
-                    {
-                        mmAssetDialog dlg(m_frame, &translink, transaction);
-                        if (dlg.ShowModal() == wxID_OK)
-                        {
-                            rb_->getHTMLText();
+                    else {
+                        mmAssetDialog dlg(w_frame, &translink, transaction);
+                        if (dlg.ShowModal() == wxID_OK) {
+                            m_rb->getHTMLText();
                             saveReportText();
                         }
                     }
                 }
-                else
-                {
-                    mmTransDialog dlg(m_frame, -1, {transId, false});
-                    if (dlg.ShowModal() != wxID_CANCEL)
-                    {
-                        rb_->getHTMLText();
+                else {
+                    mmTransDialog dlg(w_frame, -1, {transId, false});
+                    if (dlg.ShowModal() != wxID_CANCEL) {
+                        m_rb->getHTMLText();
                         saveReportText();
                     }
                 }
-                const auto name = getVFname4print("rep", getPrintableBase()->getHTMLText());
-                browser_->LoadURL(name);
+                const auto name = getVFname4print("rep", getReportBase()->getHTMLText());
+                w_browser->LoadURL(name);
             }
         }
     }
-    else if (uri.StartsWith("attachment:", &sData))
-    {
+    else if (uri.StartsWith("attachment:", &sData)) {
         const wxString RefType = sData.BeforeFirst('|');
         long long refId;
         sData.AfterFirst('|').ToLongLong(&refId);
 
-        if (Model_Attachment::reftype_id(RefType) != -1 && refId > 0)
-        {
-            mmAttachmentManage::OpenAttachmentFromPanelIcon(m_frame, RefType, refId);
-            const auto name = getVFname4print("rep", getPrintableBase()->getHTMLText());
-            browser_->LoadURL(name);
+        if (Model_Attachment::reftype_id(RefType) != -1 && refId > 0) {
+            mmAttachmentManage::OpenAttachmentFromPanelIcon(w_frame, RefType, refId);
+            const auto name = getVFname4print("rep", getReportBase()->getHTMLText());
+            w_browser->LoadURL(name);
         }
     }
-    else if (uri.StartsWith("budget:", &sData))
-    {
+    else if (uri.StartsWith("budget:", &sData)) {
 
         std::vector<std::string> parms;
         wxStringTokenizer tokenizer(sData, "|");
-        while (tokenizer.HasMoreTokens())
-        {
+        while (tokenizer.HasMoreTokens()) {
             //"budget: " << estimateVal << "|" << Model_Currency::toString(actual, Model_Currency::GetBaseCurrency()) << "|" << catID << "|" << budget_year << "|" << month + 1;
             wxString token = tokenizer.GetNextToken();
             parms.push_back(std::string(token.mb_str()));
@@ -763,8 +678,7 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
         int64 budgetYearID = Model_Budgetyear::instance().Get(parms[3] + "-" + formattedMonth);
 
         //if budgetYearID doesn't exist then return
-        if (budgetYearID == -1)
-        {
+        if (budgetYearID == -1) {
             wxLogInfo("Monthly budget not found!");
             return;
         }
@@ -773,8 +687,7 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
         Model_Budget::Data_Set budget = Model_Budget::instance().find(Model_Budget::BUDGETYEARID(budgetYearID), Model_Budget::CATEGID(std::stoll(parms[2])));
 
         Model_Budget::Data* entry = 0;
-        if (budget.empty())
-        {
+        if (budget.empty()) {
             entry = Model_Budget::instance().create();
             entry->BUDGETYEARID = budgetYearID;
             entry->CATEGID = std::stoll(parms[2]);
@@ -792,12 +705,11 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
         Model_Currency::fromString(parms[1], actual, Model_Currency::GetBaseCurrency());
 
         //open budgetEntry dialog
-        mmBudgetEntryDialog dlg(m_frame, entry, Model_Currency::toCurrency(estimated), Model_Currency::toCurrency(actual));
-        if (dlg.ShowModal() == wxID_OK)
-        {
+        mmBudgetEntryDialog dlg(w_frame, entry, Model_Currency::toCurrency(estimated), Model_Currency::toCurrency(actual));
+        if (dlg.ShowModal() == wxID_OK) {
             //refresh report
             saveReportText(false);
-            rb_ ->setReportSettings();
+            m_rb ->saveReportSettings();
 
         }
     }
@@ -805,105 +717,214 @@ void mmReportsPanel::OnNewWindow(wxWebViewEvent& evt)
     evt.Skip();
 }
 
-void mmReportsPanel::OnPeriodSelectPopup(wxCommandEvent& event)
+void mmReportsPanel::onYearChanged(wxCommandEvent& event)
+{
+    const auto i = event.GetString();
+    wxLogDebug("-------- %s", i);
+    saveReportText(false);
+}
+
+void mmReportsPanel::onBudgetChanged(wxCommandEvent& event)
+{
+    const auto i = event.GetString();
+    wxLogDebug("-------- %s", i);
+    saveReportText(false);
+    m_rb->saveReportSettings();
+}
+
+void mmReportsPanel::onAccountChanged(wxCommandEvent& WXUNUSED(event))
+{
+    if (m_rb) {
+        int sel = w_account_choice->GetSelection();
+        if ((sel == 1) || (sel != m_rb->getAccountSelection())) {
+            m_rb->setAccounts(sel, NavigatorTypes::instance().getAccountDbTypeFromName(w_account_choice->GetString(sel)));
+            saveReportText(false);
+            m_rb->saveReportSettings();
+        }
+    }
+}
+
+void mmReportsPanel::onSingleDateChanged(wxDateEvent& WXUNUSED(event))
+{
+    if (m_rb) {
+        saveReportText(false);
+        m_rb->saveReportSettings();
+    }
+}
+
+void mmReportsPanel::onStartEndDateChanged(wxDateEvent& event)
+{
+    wxObject* eo = event.GetEventObject();
+    if (eo) {
+        wxDateTime start_dateTime = w_start_date_picker->GetValue();
+        wxDateTime end_dateTime = w_end_date_picker->GetValue();
+        if (w_start_date_picker->isItMyDateControl(eo)) {
+            //wxLogDebug("Start date changed to %s", start_dateTime.FormatISODate());
+            if (start_dateTime > end_dateTime) {
+                w_end_date_picker->SetValue(start_dateTime);
+                wxLogDebug("End date changed to %s", start_dateTime.FormatISODate());
+            }
+        }
+        else if (w_end_date_picker->isItMyDateControl(eo)) {
+            if (start_dateTime > end_dateTime) {
+                w_start_date_picker->SetValue(end_dateTime);
+                wxLogDebug("Start date changed to %s", end_dateTime.FormatISODate());
+            }
+        }
+    }
+
+    m_filter_id = mmCheckingPanel::FILTER_ID_DATE_PICKER;
+    updateFilter();
+    saveFilterSettings();
+
+    if (m_rb) {
+        saveReportText(false);
+        m_rb->saveReportSettings();
+    }
+}
+
+void mmReportsPanel::onChartChanged(wxCommandEvent& WXUNUSED(event))
+{
+    if (!m_rb)
+        return;
+
+    int sel = w_chart_choice->GetSelection();
+    if (sel == 1 || sel != m_rb->getChartSelection()) {
+        m_rb->setChartSelection(sel);
+        saveReportText(false);
+        m_rb->saveReportSettings();
+    }
+}
+
+void mmReportsPanel::onForwardMonthsChangedSpin(wxSpinEvent& WXUNUSED(event))
+{
+    if (!m_rb)
+        return;
+
+    int sel = w_forward_months->GetValue();
+    if (sel != m_rb->getForwardMonths()) {
+        m_rb->setForwardMonths(sel);
+        saveReportText(false);
+        m_rb->saveReportSettings();
+    }
+}
+
+void mmReportsPanel::onForwardMonthsChangedText(wxCommandEvent& event)
+{
+    w_forward_months->SetValue(event.GetString());
+    wxSpinEvent evt;
+    onForwardMonthsChangedSpin(evt);
+}
+
+void mmReportsPanel::onShiftPressed(wxCommandEvent& event)
+{
+    if (!m_rb)
+        return;
+
+    m_shift = event.GetInt();
+    m_rb->setDateSelection(m_shift);
+    saveReportText(false);
+}
+
+void mmReportsPanel::onDateRangePopup(wxCommandEvent& event)
 {
     wxMenu menu;
     int i = 0;
     while (i < m_date_range_m) {
-        menu.Append(ID_FILTER_DATE_MIN + i, m_date_range_a[i].getName());
+        menu.Append(ID_DATE_RANGE_MIN + i, m_date_range_a[i].getName());
         i++;
     }
 
-    if (i +1 < static_cast<int>(m_date_range_a.size())) { //only add separator if there are more entries
+    // add separator if there are more entries
+    if (i + 1 < static_cast<int>(m_date_range_a.size())) {
         menu.AppendSeparator();
     }
     if (i < static_cast<int>(m_date_range_a.size())) {
         wxMenu* menu_more(new wxMenu);
         menu.AppendSubMenu(menu_more, _tu("More date ranges…"));
         while (i < static_cast<int>(m_date_range_a.size())) {
-            menu_more->Append(ID_FILTER_DATE_MIN + i, m_date_range_a[i].getName());
+            menu_more->Append(ID_DATE_RANGE_MIN + i, m_date_range_a[i].getName());
             i++;
         }
     }
     menu.AppendSeparator();
-    menu.Append(ID_EDIT_DATE_RANGES, _tu("Edit date ranges…"));
+    menu.Append(ID_DATE_RANGE_EDIT, _tu("Edit date ranges…"));
 
     PopupMenu(&menu);
     event.Skip();
 }
 
-void mmReportsPanel::onFilterDateMenu(wxCommandEvent& event)
+void mmReportsPanel::onDateRangeSelect(wxCommandEvent& event)
 {
-    int i = event.GetId() - ID_FILTER_DATE_MIN;
+    int i = event.GetId() - ID_DATE_RANGE_MIN;
     if (i < 0 || i >= static_cast<int>(m_date_range_a.size())) {
         return;
     }
 
-    m_current_date_range = DateRange2();
-    m_current_date_range.setRange(m_date_range_a[i]);
+    m_date_range.setRange(m_date_range_a[i]);
+    m_date_range.setDefStartDateN();
+    m_date_range.setDefEndDateN();
 
     m_filter_id = mmCheckingPanel::FILTER_ID_DATE_RANGE;
     updateFilter();
     saveFilterSettings();
 }
 
-void mmReportsPanel::updateFilter()
+void mmReportsPanel::onDateRangeEdit(wxCommandEvent& WXUNUSED(event))
 {
+    mmDateRangeDialog dlg(this, mmDateRangeDialog::TYPE_ID_REPORTING);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    loadDateRanges(&m_date_range_a, &m_date_range_m);
+
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
-        m_bitmapDataPeriodFilterBtn->SetLabel(m_current_date_range.rangeName());
-        m_bitmapDataPeriodFilterBtn->SetBitmap(mmBitmapBundle((m_current_date_range.rangeName() != m_date_range_a[0].getName() ? png::TRANSFILTER_ACTIVE : png::TRANSFILTER), mmBitmapButtonSize));
+        // find and reload the range specification (it may have been changed)
+        bool found = false;
+        for (const auto& range : m_date_range_a) {
+            if (range.getName() == m_date_range.rangeName()) {
+                m_date_range.setRange(range);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            // set range to 'All'
+            m_date_range.setRange(m_date_range_a[0]);
+        }
 
-        m_start_date->SetValue(
-            m_current_date_range.rangeStart().value_or(DateDay::min()).getDateTime()
-        );
-        m_end_date->SetValue(
-            m_current_date_range.rangeEnd().value_or(DateDay::max()).getDateTime()
-        );
-    }
-    else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
-        m_bitmapDataPeriodFilterBtn->SetLabel(_t("Date range"));
-        m_bitmapDataPeriodFilterBtn->SetBitmap(mmBitmapBundle(png::TRANSFILTER_ACTIVE, mmBitmapButtonSize));
+        // clear default start/end dates
+        m_date_range.setDefStartDateN();
+        m_date_range.setDefEndDateN();
+
+        updateFilter();
+        saveFilterSettings();
     }
 }
 
-void mmReportsPanel::onEditDateRanges(wxCommandEvent& WXUNUSED(event))
-{
-    mmDateRangeDialog dlg(this, &m_date_range_a, &m_date_range_m);
-    if (dlg.ShowModal() == wxID_OK) {
-        if (m_date_range_a.size() == 0) {
-            int src_i = 0;
-            int src_m = Option::instance().getCheckingRangeM();
-            for (const auto& range : Option::instance().getCheckingRangeA()) {
-                if (m_date_range_a.size() > ID_FILTER_DATE_MAX - ID_FILTER_DATE_MIN) {
-                    break;
-                }
-                if (src_i == src_m) {
-                    m_date_range_m = m_date_range_a.size();
-                }
-                if (!range.hasPeriodS()) {
-                    m_date_range_a.push_back(range);
-                }
-                src_i++;
-            }
+void mmReportsPanel::loadDateRanges(
+    std::vector<DateRange2::Range>* date_range_a,
+    int* date_range_m,
+    bool all_ranges
+) {
+    date_range_a->clear();
+    *date_range_m = -1;
+    int src_i = 0;
+    int src_m = Option::instance().getReportingRangeM();
+    for (const auto& range : Option::instance().getReportingRangeA()) {
+        if (date_range_a->size() > ID_DATE_RANGE_MAX - ID_DATE_RANGE_MIN) {
+            break;
         }
-        // Verify if current filter is still valid otherwise reset to "ALL"
-        if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
-            wxString curname = m_current_date_range.rangeName();
-            bool isDeleted = true;
-            for (const auto& range : m_date_range_a) {
-                if (range.getName() == curname) {
-                    isDeleted = false;
-                    break;
-                }
-            }
-            if (isDeleted) {
-                m_current_date_range = DateRange2();
-                m_current_date_range.setRange(m_date_range_a[0]);
-
-                m_filter_id = mmCheckingPanel::FILTER_ID_DATE_RANGE;
-                updateFilter();
-                saveFilterSettings();
-            }
+        if (src_i == src_m) {
+            *date_range_m = date_range_a->size();
         }
+        if (all_ranges || !range.hasPeriodS()) {
+            date_range_a->push_back(range);
+        }
+        src_i++;
+    }
+    if (*date_range_m < 0) {
+        *date_range_m = date_range_a->size();
     }
 }
+

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -273,6 +273,7 @@ void mmReportsPanel::saveFilterSettings() {
 
 void mmReportsPanel::updateFilter()
 {
+    wxLogDebug("mmReportsPanel::updateFilter(): m_filter_id=%d", int(m_filter_id));
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
         w_date_range_button->SetLabel(m_date_range.rangeName());
         w_date_range_button->SetBitmap(mmBitmapBundle(
@@ -283,13 +284,15 @@ void mmReportsPanel::updateFilter()
             ),
             mmBitmapButtonSize
         ));
-        // copy from date range to start/end pickers
         // TODO: calculate default start/end dates from model
+        m_date_range.setDefStartDateN(DateDay::min());
+        m_date_range.setDefEndDateN(DateDay::max());
+        // copy from date range to start/end pickers
         w_start_date_picker->SetValue(
-            m_date_range.rangeStart().value_or(DateDay::min()).getDateTime()
+            m_date_range.rangeStart().value().getDateTime()
         );
         w_end_date_picker->SetValue(
-            m_date_range.rangeEnd().value_or(DateDay::max()).getDateTime()
+            m_date_range.rangeEnd().value().getDateTime()
         );
     }
     else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -119,12 +119,7 @@ bool mmReportsPanel::saveReportText(bool initial)
         return false;
 
     if (m_rb->getParameters() & ReportBase::M_DATE_RANGE) {
-        mmDateRange* date_range = new mmDateRange();
-        wxDateTime td = w_start_date_picker->GetValue();
-        date_range->start_date(td.ResetTime()); // Start of Day
-        td = w_end_date_picker->GetValue();
-        date_range->end_date(td.ResetTime().Add(wxTimeSpan(23,59,59,999))); // End of Day
-        m_rb->setDateRange(date_range);
+        m_rb->setDateRange(m_date_range);
         m_rb->setDateSelection(0);
     }
 

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -276,6 +276,7 @@ void mmReportsPanel::updateFilter()
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
         w_date_range_button->SetLabel(m_date_range.rangeName());
         w_date_range_button->SetBitmap(mmBitmapBundle(
+            // FIXME: refine the condition below
             (m_date_range.rangeName() != m_date_range_a[0].getName()
                 ? png::TRANSFILTER_ACTIVE
                 : png::TRANSFILTER
@@ -299,7 +300,9 @@ void mmReportsPanel::updateFilter()
         ));
         // set date range to default ('All') and copy default start/end dates from pickers.
         m_date_range = DateRange2();
-        m_date_range.setRange(DateRange2::Range());
+        DateRange2::Range range = m_date_range.getRange();
+        range.setName(_t("Date range"));
+        m_date_range.setRange(range);
         m_date_range.setDefStartDateN(DateDayN(w_start_date_picker->GetValue()));
         m_date_range.setDefEndDateN(DateDayN(w_end_date_picker->GetValue()));
     }

--- a/src/mmreportspanel.cpp
+++ b/src/mmreportspanel.cpp
@@ -178,7 +178,7 @@ void mmSetOwnFont(wxStaticText* w, const wxFont& font)
 void mmReportsPanel::loadFilterSettings() {
     wxString key = m_use_account_specific_filter
         ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
-        : "CHECK_FILTER_ALL";
+        : "REPORT_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
 
     int fid = 0;
@@ -236,7 +236,7 @@ void mmReportsPanel::loadFilterSettings() {
 void mmReportsPanel::saveFilterSettings() {
     wxString key = m_use_account_specific_filter
         ? wxString::Format("REPORT_FILTER_DEDICATED_%d", m_rb->getTypeId())
-        : "CHECK_FILTER_ALL";
+        : "REPORT_FILTER_ALL";
     Document j_doc = Model_Infotable::instance().getJdoc(key, "{}");
     Model_Infotable::saveFilterInt(j_doc, "FILTER_ID", m_filter_id);
     Model_Infotable::saveFilterString(j_doc, "FILTER_NAME",
@@ -244,25 +244,33 @@ void mmReportsPanel::saveFilterSettings() {
     );
 
     if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_RANGE) {
-        if (!m_date_range.rangeName().IsEmpty())
+        if (!m_date_range.rangeName().IsEmpty()) {
             Model_Infotable::saveFilterString(j_doc, "FILTER_DATE", m_date_range.rangeName());
-        else
+            Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_BEGIN", "");
+            Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_END", "");
+        }
+        else {
             wxLogError("mmReportsPanel::saveFilterSettings(): m_date_range.rangeName() is empty");
+        }
     }
     else if (m_filter_id == mmCheckingPanel::FILTER_ID_DATE_PICKER) {
-        if (w_start_date_picker)
+        if (w_start_date_picker) {
             Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_BEGIN",
                 DateDayN(w_start_date_picker->GetValue()).isoDateN()
             );
-        else
+        }
+        else {
             wxLogError("mmReportsPanel::saveFilterSettings(): w_start_date_picker is null");
-
-        if (w_end_date_picker)
+        }
+        if (w_end_date_picker) {
             Model_Infotable::saveFilterString(j_doc, "FILTER_DATE_END",
                 DateDayN(w_end_date_picker->GetValue()).isoDateN()
             );
-        else
+        }
+        else {
             wxLogError("mmReportsPanel::saveFilterSettings(): w_end_date_picker is null");
+        }
+        Model_Infotable::saveFilterString(j_doc, "FILTER_DATE", "");
     }
 
     Model_Infotable::instance().setJdoc(key, j_doc);
@@ -754,37 +762,6 @@ void mmReportsPanel::onSingleDateChanged(wxDateEvent& WXUNUSED(event))
     }
 }
 
-void mmReportsPanel::onStartEndDateChanged(wxDateEvent& event)
-{
-    wxObject* eo = event.GetEventObject();
-    if (eo) {
-        wxDateTime start_dateTime = w_start_date_picker->GetValue();
-        wxDateTime end_dateTime = w_end_date_picker->GetValue();
-        if (w_start_date_picker->isItMyDateControl(eo)) {
-            //wxLogDebug("Start date changed to %s", start_dateTime.FormatISODate());
-            if (start_dateTime > end_dateTime) {
-                w_end_date_picker->SetValue(start_dateTime);
-                wxLogDebug("End date changed to %s", start_dateTime.FormatISODate());
-            }
-        }
-        else if (w_end_date_picker->isItMyDateControl(eo)) {
-            if (start_dateTime > end_dateTime) {
-                w_start_date_picker->SetValue(end_dateTime);
-                wxLogDebug("Start date changed to %s", end_dateTime.FormatISODate());
-            }
-        }
-    }
-
-    m_filter_id = mmCheckingPanel::FILTER_ID_DATE_PICKER;
-    updateFilter();
-    saveFilterSettings();
-
-    if (m_rb) {
-        saveReportText(false);
-        m_rb->saveReportSettings();
-    }
-}
-
 void mmReportsPanel::onChartChanged(wxCommandEvent& WXUNUSED(event))
 {
     if (!m_rb)
@@ -902,6 +879,37 @@ void mmReportsPanel::onDateRangeEdit(wxCommandEvent& WXUNUSED(event))
 
         updateFilter();
         saveFilterSettings();
+    }
+}
+
+void mmReportsPanel::onStartEndDateChanged(wxDateEvent& event)
+{
+    wxObject* eo = event.GetEventObject();
+    if (eo) {
+        wxDateTime start_dateTime = w_start_date_picker->GetValue();
+        wxDateTime end_dateTime = w_end_date_picker->GetValue();
+        if (w_start_date_picker->isItMyDateControl(eo)) {
+            //wxLogDebug("Start date changed to %s", start_dateTime.FormatISODate());
+            if (start_dateTime > end_dateTime) {
+                w_end_date_picker->SetValue(start_dateTime);
+                wxLogDebug("End date changed to %s", start_dateTime.FormatISODate());
+            }
+        }
+        else if (w_end_date_picker->isItMyDateControl(eo)) {
+            if (start_dateTime > end_dateTime) {
+                w_start_date_picker->SetValue(end_dateTime);
+                wxLogDebug("Start date changed to %s", end_dateTime.FormatISODate());
+            }
+        }
+    }
+
+    m_filter_id = mmCheckingPanel::FILTER_ID_DATE_PICKER;
+    updateFilter();
+    saveFilterSettings();
+
+    if (m_rb) {
+        saveReportText(false);
+        m_rb->saveReportSettings();
     }
 }
 

--- a/src/mmreportspanel.h
+++ b/src/mmreportspanel.h
@@ -18,8 +18,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-#ifndef MM_EX_REPORTSPANEL_H_
-#define MM_EX_REPORTSPANEL_H_
+#pragma once
 
 #include "mmpanelbase.h"
 #include "mmSimpleDialogs.h"
@@ -35,95 +34,99 @@ class mmReportsPanel : public mmPanelBase
     wxDECLARE_EVENT_TABLE();
 
 public:
-    mmReportsPanel(mmPrintableBase* rb,
-        bool cleanupReport,
+    enum RepPanel
+    {
+        ID_UNUSED = wxID_HIGHEST + 555,
+        ID_ACCOUNT_CHOICE,
+        ID_SINGLE_DATE_PICKER,
+        ID_START_DATE_PICKER,
+        ID_END_DATE_PICKER,
+        ID_TIME_PICKER,
+        ID_YEAR_CHOICE,
+        ID_BUDGET_CHOICE,
+        ID_CHART_CHOICE,
+        ID_FORWARD_MONTHS,
+        ID_DATE_RANGE_BUTTON,
+        ID_DATE_RANGE_MIN,
+        ID_DATE_RANGE_MAX = ID_DATE_RANGE_MIN + 99,
+        ID_DATE_RANGE_EDIT,
+    };
+
+private:
+    ReportBase* m_rb = nullptr;
+    std::vector<DateRange2::Range> m_date_range_a = {};
+    int m_date_range_m = -1;
+    DateRange2 m_date_range = DateRange2();
+    mmCheckingPanel::FILTER_ID m_filter_id;
+    bool m_cleanup;
+    int m_shift = 0;
+    bool m_use_account_specific_filter;
+    wxString u_html_report;
+    bool u_cleanup_mem = false;
+
+private:
+    mmGUIFrame*       w_frame              = nullptr;
+    wxWebView*        w_browser            = nullptr;
+    wxButton*         w_date_range_button  = nullptr;
+    mmDatePickerCtrl* w_single_date_picker = nullptr;
+    mmDatePickerCtrl* w_start_date_picker  = nullptr;
+    mmDatePickerCtrl* w_end_date_picker    = nullptr;
+    wxTimePickerCtrl* w_time_picker        = nullptr;
+    wxChoice*         w_year_choice        = nullptr;
+    wxSpinCtrl*       w_forward_months     = nullptr;
+    wxChoice*         w_account_choice     = nullptr;
+    wxChoice*         w_chart_choice       = nullptr;
+
+public:
+    mmReportsPanel(
+        ReportBase* rb,
+        bool cleanup,
         wxWindow *parent,
         mmGUIFrame *frame,
         wxWindowID winid = wxID_ANY,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = wxTAB_TRAVERSAL | wxNO_BORDER,
-        const wxString& name = "mmReportsPanel");
+        const wxString& name = "mmReportsPanel"
+    );
     ~mmReportsPanel();
 
-    bool Create(wxWindow *parent, wxWindowID winid,
+public:
+    bool Create(
+        wxWindow *parent, wxWindowID winid,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = wxTAB_TRAVERSAL | wxNO_BORDER,
-        const wxString& name = "mmReportsPanel");
-
+        const wxString& name = "mmReportsPanel"
+    );
     void CreateControls();
     void loadFilterSettings();
     void saveFilterSettings();
     void sortList() {}
-
     bool saveReportText(bool initial = true);
-    mmPrintableBase* getPrintableBase();
+    ReportBase* getReportBase();
     void PrintPage();
 
-    mmGUIFrame *m_frame = nullptr;
-
-    enum RepPanel
-    {
-        ID_CHOICE_DATE_RANGE = wxID_HIGHEST + 555,
-        ID_CHOICE_ACCOUNTS,
-        ID_CHOICE_SINGLE_DATE,
-        ID_CHOICE_START_DATE,
-        ID_CHOICE_END_DATE,
-        ID_CHOICE_TIME,
-        ID_CHOICE_YEAR,
-        ID_CHOICE_BUDGET,
-        ID_CHOICE_CHART,
-        ID_CHOICE_FORWARD_MONTHS,
-        ID_FILTER_PERIOD,
-        ID_FILTER_DATE_MIN,
-        ID_FILTER_DATE_MAX = ID_FILTER_DATE_MIN + 99,
-        ID_EDIT_DATE_RANGES,
-    };
+public:
+    static void loadDateRanges(std::vector<DateRange2::Range>* date_range_a, int* date_range_m, bool all_ranges = false);
 
 private:
-    void OnNewWindow(wxWebViewEvent& evt);
-    std::vector<wxSharedPtr<mmDateRange>> m_all_date_ranges;
-    std::vector<DateRange2::Range> m_date_range_a = {};
-    wxChoice* m_date_ranges = nullptr;
-    mmDatePickerCtrl *m_single_date = nullptr, *m_start_date = nullptr, *m_end_date = nullptr;
-    wxTimePickerCtrl *m_time = nullptr;
-    wxWebView * browser_ = nullptr;
-    mmPrintableBase* rb_ = nullptr;
-    wxChoice* m_accounts = nullptr;
-    wxChoice* m_chart = nullptr;
-    wxSpinCtrl *m_forwardMonths = nullptr;
-
-    wxButton* m_bitmapDataPeriodFilterBtn = nullptr;
-    DateRange2 m_current_date_range = DateRange2();
-    mmCheckingPanel::FILTER_ID m_filter_id;
-
-private:
-    void OnYearChanged(wxCommandEvent& event);
-    void OnBudgetChanged(wxCommandEvent & event);
-    void OnStartEndDateChanged(wxDateEvent& event);
-    void OnSingleDateChanged(wxDateEvent& event);
-    void OnAccountChanged(wxCommandEvent& event);
-    void OnChartChanged(wxCommandEvent& event);
-    void OnForwardMonthsChangedSpin(wxSpinEvent& event);
-    void OnForwardMonthsChangedText(wxCommandEvent& event);
-    void OnShiftPressed(wxCommandEvent& event);
-    void OnPeriodSelectPopup(wxCommandEvent& event);
-    void onFilterDateMenu(wxCommandEvent& event);
-    void onEditDateRanges(wxCommandEvent& event);
+    void onNewWindow(wxWebViewEvent& evt);
+    void onYearChanged(wxCommandEvent& event);
+    void onBudgetChanged(wxCommandEvent & event);
+    void onStartEndDateChanged(wxDateEvent& event);
+    void onSingleDateChanged(wxDateEvent& event);
+    void onAccountChanged(wxCommandEvent& event);
+    void onChartChanged(wxCommandEvent& event);
+    void onForwardMonthsChangedSpin(wxSpinEvent& event);
+    void onForwardMonthsChangedText(wxCommandEvent& event);
+    void onShiftPressed(wxCommandEvent& event);
+    void onDateRangePopup(wxCommandEvent& event);
+    void onDateRangeSelect(wxCommandEvent& event);
+    void onDateRangeEdit(wxCommandEvent& event);
 
     void updateFilter();
-
-    bool cleanup_;
-    bool cleanupmem_ = false;
-    int m_shift = 0;
-
-    // New filtering
-    bool m_use_account_specific_filter;
-    int m_date_range_m = -1;
-    wxString htmlreport_;
-
 };
 
-inline mmPrintableBase* mmReportsPanel::getPrintableBase() { return rb_; }
-#endif
+inline ReportBase* mmReportsPanel::getReportBase() { return m_rb; }
+

--- a/src/model/Model_Account.h
+++ b/src/model/Model_Account.h
@@ -124,7 +124,6 @@ public:
 
     static bool BoolOf(int64 value);
     static bool is_positive(int value);
-    static wxDateTime get_date_by_string(const wxString& date_str);
 
     const Data_Set FilterAccounts(const wxString& account_pattern, bool skip_closed = false);
 
@@ -165,11 +164,6 @@ inline Model_Account::STATUS_ID Model_Account::status_id(const Data* account)
 inline Model_Account::STATUS_ID Model_Account::status_id(const Data& account)
 {
     return status_id(&account);
-}
-
-inline wxDateTime Model_Account::get_date_by_string(const wxString& date_str)
-{
-    return parseDateTime(date_str);
 }
 
 inline bool Model_Account::is_positive(int value)

--- a/src/model/Model_Report.cpp
+++ b/src/model/Model_Report.cpp
@@ -83,11 +83,16 @@ const std::vector<Model_Report::Values> Model_Report::SqlPlaceHolders()
     const wxString def_time = wxDateTime::Now().FormatISOTime();
 
     const std::vector<Model_Report::Values> v = {
-    {"&begin_date", "mmDatePickerCtrl", def_date, mmReportsPanel::RepPanel::ID_CHOICE_START_DATE, _t("Begin date:")},
-    {"&end_date", "mmDatePickerCtrl", def_date, mmReportsPanel::RepPanel::ID_CHOICE_END_DATE, _t("End date:")},
-    {"&single_date", "mmDatePickerCtrl", def_date, mmReportsPanel::RepPanel::ID_CHOICE_SINGLE_DATE, _t("Date:")},
-    {"&single_time", "wxTimePickerCtrl", def_time, mmReportsPanel::RepPanel::ID_CHOICE_TIME, _t("Time:")},
-    {"&only_years", "wxChoice", def_date, mmReportsPanel::RepPanel::ID_CHOICE_YEAR, _t("Year:")},
+        { "&begin_date", "mmDatePickerCtrl", def_date,
+            mmReportsPanel::ID_START_DATE_PICKER, _t("Begin date:") },
+        { "&end_date", "mmDatePickerCtrl", def_date,
+            mmReportsPanel::ID_END_DATE_PICKER, _t("End date:") },
+        { "&single_date", "mmDatePickerCtrl", def_date,
+            mmReportsPanel::RepPanel::ID_SINGLE_DATE_PICKER, _t("Date:") },
+        { "&single_time", "wxTimePickerCtrl", def_time,
+            mmReportsPanel::ID_TIME_PICKER, _t("Time:") },
+        { "&only_years", "wxChoice", def_date,
+            mmReportsPanel::ID_YEAR_CHOICE, _t("Year:")},
     };
     return v;
 }

--- a/src/model/Model_Usage.cpp
+++ b/src/model/Model_Usage.cpp
@@ -184,14 +184,14 @@ void Model_Usage::pageview(const wxWindow* window, long plt /* = 0 msec*/)
     pageview(wxURI(documentPath).BuildURI(), documentTitle, plt);
 }
 
-void Model_Usage::pageview(const wxWindow* window, const mmPrintableBase* rb, long plt /* = 0 msec*/)
+void Model_Usage::pageview(const wxWindow* window, const ReportBase* rb, long plt /* = 0 msec*/)
 {
     if (!window) return;
     if (window->GetName().IsEmpty()) return;
 
     const wxWindow *current = window;
 
-    wxString documentTitle = rb->getReportTitle(false);
+    wxString documentTitle = rb->getTitle(false);
 
     wxString documentPath;
     while (current)

--- a/src/model/Model_Usage.h
+++ b/src/model/Model_Usage.h
@@ -21,7 +21,7 @@ Copyright (C) 2018 Stefano Giorgio (stef145g)
 #include "Model.h"
 #include "db/DB_Table_Usage_V1.h"
 
-class mmPrintableBase;
+class ReportBase;
 
 class Model_Usage : public Model<DB_Table_USAGE_V1>
 {
@@ -61,5 +61,5 @@ public:
 public:
     void pageview(const wxString& documentPath, const wxString& documentTitle, long plt = 0 /*msec*/);
     void pageview(const wxWindow* window, long plt = 0 /*msec*/);
-    void pageview(const wxWindow* window, const mmPrintableBase* rb, long plt = 0 /*msec*/);
+    void pageview(const wxWindow* window, const ReportBase* rb, long plt = 0 /*msec*/);
 };

--- a/src/option.h
+++ b/src/option.h
@@ -43,6 +43,7 @@ public:
     static const std::vector<std::pair<COMPOUNDING_ID, wxString> > COMPOUNDING_NAME;
     static const std::vector<std::pair<COMPOUNDING_ID, int> > COMPOUNDING_N;
     static const std::vector<std::pair<wxString, wxString> > CHECKING_RANGE_DEFAULT;
+    static const std::vector<std::pair<wxString, wxString> > REPORTING_RANGE_DEFAULT;
 
 public:
     Option();
@@ -281,6 +282,14 @@ public:
     const std::vector<DateRange2::Range> getCheckingRangeA() const noexcept;
     int getCheckingRangeM() const noexcept;
 
+    // m_reporting_range, m_reporting_range_a, m_reporting_range_m
+    void loadReportingRange();
+    void setReportingRange(const wxArrayString &a);
+    void parseReportingRange();
+    const wxArrayString getReportingRange() const noexcept;
+    const std::vector<DateRange2::Range> getReportingRangeA() const noexcept;
+    int getReportingRangeM() const noexcept;
+
     // m_show_navigator_cashLedger
     void loadShowNavigatorCashLedger();
     void setShowNavigatorCashLedger(const bool value);
@@ -340,10 +349,13 @@ private:
     int m_toolbar_icon_size = 32;                       // TOOLBARICONSIZE
     int m_navigation_icon_size = 24;                    // NAVIGATIONICONSIZE
     wxArrayString m_checking_range;                     // CHECKING_RANGE
+    wxArrayString m_reporting_range;                    // REPORTING_RANGE
 
     // derived
     std::vector<DateRange2::Range> m_checking_range_a;  // m_checking_range
     int m_checking_range_m;                             // m_checking_range
+    std::vector<DateRange2::Range> m_reporting_range_a; // m_reporting_range
+    int m_reporting_range_m;                            // m_reporting_range
 };
 
 inline void Option::setDatabaseUpdated(const bool value)
@@ -581,6 +593,21 @@ inline const std::vector<DateRange2::Range> Option::getCheckingRangeA() const no
 inline int Option::getCheckingRangeM() const noexcept
 {
     return m_checking_range_m;
+}
+
+inline const wxArrayString Option::getReportingRange() const noexcept
+{
+    return m_reporting_range;
+}
+
+inline const std::vector<DateRange2::Range> Option::getReportingRangeA() const noexcept
+{
+    return m_reporting_range_a;
+}
+
+inline int Option::getReportingRangeM() const noexcept
+{
+    return m_reporting_range_m;
 }
 
 inline bool Option::getShowNavigatorCashLedger() const noexcept

--- a/src/reports/budget.cpp
+++ b/src/reports/budget.cpp
@@ -25,7 +25,7 @@
 
 mmReportBudget::mmReportBudget(): ReportBase("mmReportBudget")
 {
-    setReportParameters(TYPE_ID::UNUSED);
+    setReportParameters(REPORT_ID::NONE);
 }
 
 mmReportBudget::~mmReportBudget()

--- a/src/reports/budget.cpp
+++ b/src/reports/budget.cpp
@@ -23,9 +23,9 @@
 #include "mmframe.h"
 #include "htmlbuilder.h"
 
-mmReportBudget::mmReportBudget(): mmPrintableBase("mmReportBudget")
+mmReportBudget::mmReportBudget(): ReportBase("mmReportBudget")
 {
-    setReportParameters(Reports::UNUSED);
+    setReportParameters(TYPE_ID::UNUSED);
 }
 
 mmReportBudget::~mmReportBudget()

--- a/src/reports/budget.h
+++ b/src/reports/budget.h
@@ -27,7 +27,7 @@ class mmHTMLBuilder;
  Class: mmReportBudget : This class is a base class for Budget Reports.
         This class should not be used to create objects.
  *************************************************************************/
-class mmReportBudget : public mmPrintableBase
+class mmReportBudget : public ReportBase
 {
 public:
     mmReportBudget();

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -128,7 +128,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     headingStr = wxString::Format(headerStartupMsg
         , headingStr + "<br>" + _t("(Estimated vs. Actual)"));
     hb.addReportHeader(headingStr, 1, Option::instance().getIgnoreFutureTransactions());
-    hb.DisplayDateHeading(yearBegin, yearEnd);
+    hb.displayDateHeading(yearBegin, yearEnd);
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(yearBegin, yearEnd);

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -33,7 +33,7 @@
 mmReportBudgetCategorySummary::mmReportBudgetCategorySummary()
 {
     m_chart_selection = 1;
-    setReportParameters(Reports::BudgetCategorySummary);
+    setReportParameters(TYPE_ID::BudgetCategorySummary);
 }
 
 mmReportBudgetCategorySummary::~mmReportBudgetCategorySummary()

--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -33,7 +33,7 @@
 mmReportBudgetCategorySummary::mmReportBudgetCategorySummary()
 {
     m_chart_selection = 1;
-    setReportParameters(TYPE_ID::BudgetCategorySummary);
+    setReportParameters(REPORT_ID::BudgetCategorySummary);
 }
 
 mmReportBudgetCategorySummary::~mmReportBudgetCategorySummary()

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 mmReportBudgetingPerformance::mmReportBudgetingPerformance()
 {
-    setReportParameters(Reports::BudgetPerformance);
+    setReportParameters(TYPE_ID::BudgetPerformance);
 }
 
 mmReportBudgetingPerformance::~mmReportBudgetingPerformance()
@@ -92,7 +92,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
 
     std::map<int64, std::map<int, double> > categoryStats;
     Model_Category::instance().getCategoryStats(categoryStats
-        , accountArray_
+        , m_account_a
         , &date_range
         , Option::instance().getIgnoreFutureTransactions()
         , true
@@ -118,7 +118,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(yearBegin, yearEnd);
-    m_filter.setAccountList(accountArray_);
+    m_filter.setAccountList(m_account_a);
 
     hb.addDivContainer("shadow");
     {

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 mmReportBudgetingPerformance::mmReportBudgetingPerformance()
 {
-    setReportParameters(TYPE_ID::BudgetPerformance);
+    setReportParameters(REPORT_ID::BudgetPerformance);
 }
 
 mmReportBudgetingPerformance::~mmReportBudgetingPerformance()

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -114,7 +114,7 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     hb.init();
 
     hb.addReportHeader(headingStr, 1, Option::instance().getIgnoreFutureTransactions());
-    hb.DisplayDateHeading(yearBegin, yearEnd);
+    hb.displayDateHeading(yearBegin, yearEnd);
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(yearBegin, yearEnd);

--- a/src/reports/bugreport.h
+++ b/src/reports/bugreport.h
@@ -41,7 +41,7 @@ const char* bugreport_template = R"(
 </html>
 )";
 
-class mmBugReport: public mmPrintableBase
+class mmBugReport: public ReportBase
 {
 public:
     mmBugReport();
@@ -53,7 +53,7 @@ private:
 };
 
 mmBugReport::mmBugReport()
-    : mmPrintableBase(_n("Bug Report"))
+    : ReportBase(_n("Bug Report"))
 {
 }
 
@@ -92,7 +92,7 @@ wxString mmBugReport::getHTMLText()
 
     wxString report_template = bugreport_template;
     mm_html_template report(formatHTML(report_template));
-    report(L"REPORTNAME") = this->getReportTitle();
+    report(L"REPORTNAME") = this->getTitle();
     report(L"HEADER") = _t("Please, follow these instructions before submitting a new bug report:");
     report(L"CONTENTS") = msg;
     report(L"HTMLSCALE") = wxString::Format("%d", Option::instance().getHtmlScale() * 3 / 2);

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 // --------- CashFlow base class
 
 mmReportCashFlow::mmReportCashFlow(const wxString& name)
-    : mmPrintableBase(name), m_today(wxDateTime::Now().ResetTime())
+    : ReportBase(name), m_today(wxDateTime::Now().ResetTime())
 {
     m_only_active = true;
 }
@@ -82,7 +82,10 @@ void mmReportCashFlow::getTransactions()
         Model_Account::ACCOUNTTYPE(NavigatorTypes::instance().getInvestmentAccountStr(), NOT_EQUAL),
         Model_Account::STATUS(Model_Account::STATUS_ID_CLOSED, NOT_EQUAL)
     )) {
-        if (accountArray_ && std::find(accountArray_->begin(), accountArray_->end(), account.ACCOUNTNAME) == accountArray_->end()) {
+        if (m_account_a &&
+            std::find(m_account_a->begin(), m_account_a->end(), account.ACCOUNTNAME) ==
+                m_account_a->end()
+        ) {
             continue;
         }
 
@@ -243,8 +246,10 @@ wxString mmReportCashFlow::getHTMLText_DayOrMonth(bool monthly)
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format(wxPLURAL("%1$s (%2$i month)", "%1$s (%2$i months)" , getForwardMonths())
-        , getReportTitle(), getForwardMonths());
+    const wxString& headingStr = wxString::Format(
+        wxPLURAL("%1$s (%2$i month)", "%1$s (%2$i months)", getForwardMonths()),
+        getTitle(), getForwardMonths()
+    );
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());
 
@@ -334,7 +339,7 @@ mmReportCashFlowDaily::mmReportCashFlowDaily()
     : mmReportCashFlow(_n("Cash Flow - Daily"))
 {
     this->setForwardMonths(12);
-    setReportParameters(Reports::DailyCashFlow);
+    setReportParameters(TYPE_ID::DailyCashFlow);
 }
 
 wxString mmReportCashFlowDaily::getHTMLText()
@@ -348,7 +353,7 @@ mmReportCashFlowMonthly::mmReportCashFlowMonthly()
     : mmReportCashFlow(_n("Cash Flow - Monthly"))
 {
     this->setForwardMonths(120);
-    setReportParameters(Reports::MonthlyCashFlow);
+    setReportParameters(TYPE_ID::MonthlyCashFlow);
 }
 
 wxString mmReportCashFlowMonthly::getHTMLText()
@@ -361,7 +366,7 @@ wxString mmReportCashFlowMonthly::getHTMLText()
 mmReportCashFlowTransactions::mmReportCashFlowTransactions()
     : mmReportCashFlow(_n("Cash Flow - Transactions"))
 {
-    setReportParameters(Reports::TransactionsCashFlow);
+    setReportParameters(TYPE_ID::TransactionsCashFlow);
 }
 
 wxString mmReportCashFlowTransactions::getHTMLText()
@@ -372,8 +377,10 @@ wxString mmReportCashFlowTransactions::getHTMLText()
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    const wxString& headingStr = wxString::Format(wxPLURAL("%1$s (%2$i month)", "%1$s (%2$i months)" , getForwardMonths())
-        , getReportTitle(), getForwardMonths());
+    const wxString& headingStr = wxString::Format(
+        wxPLURAL("%1$s (%2$i month)", "%1$s (%2$i months)" , getForwardMonths()),
+        getTitle(), getForwardMonths()
+    );
     hb.addReportHeader(headingStr, 1, false);
     hb.DisplayFooter(getAccountNames());
 

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -251,7 +251,7 @@ wxString mmReportCashFlow::getHTMLText_DayOrMonth(bool monthly)
         getTitle(), getForwardMonths()
     );
     hb.addReportHeader(headingStr, 1, false);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayFooter(getAccountNames());
 
     GraphData gd;
     GraphSeries gs;
@@ -382,7 +382,7 @@ wxString mmReportCashFlowTransactions::getHTMLText()
         getTitle(), getForwardMonths()
     );
     hb.addReportHeader(headingStr, 1, false);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayFooter(getAccountNames());
 
     // Display graph
     GraphData gd;

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -339,7 +339,7 @@ mmReportCashFlowDaily::mmReportCashFlowDaily()
     : mmReportCashFlow(_n("Cash Flow - Daily"))
 {
     this->setForwardMonths(12);
-    setReportParameters(TYPE_ID::DailyCashFlow);
+    setReportParameters(REPORT_ID::DailyCashFlow);
 }
 
 wxString mmReportCashFlowDaily::getHTMLText()
@@ -353,7 +353,7 @@ mmReportCashFlowMonthly::mmReportCashFlowMonthly()
     : mmReportCashFlow(_n("Cash Flow - Monthly"))
 {
     this->setForwardMonths(120);
-    setReportParameters(TYPE_ID::MonthlyCashFlow);
+    setReportParameters(REPORT_ID::MonthlyCashFlow);
 }
 
 wxString mmReportCashFlowMonthly::getHTMLText()
@@ -366,7 +366,7 @@ wxString mmReportCashFlowMonthly::getHTMLText()
 mmReportCashFlowTransactions::mmReportCashFlowTransactions()
     : mmReportCashFlow(_n("Cash Flow - Transactions"))
 {
-    setReportParameters(TYPE_ID::TransactionsCashFlow);
+    setReportParameters(REPORT_ID::TransactionsCashFlow);
 }
 
 wxString mmReportCashFlowTransactions::getHTMLText()

--- a/src/reports/cashflow.h
+++ b/src/reports/cashflow.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <vector>
 #include "util.h"
 
-class mmReportCashFlow : public mmPrintableBase
+class mmReportCashFlow : public ReportBase
 {
 public:
     explicit mmReportCashFlow(const wxString& name);

--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -65,7 +65,7 @@ void  mmReportCategoryExpenses::refreshData()
     Model_Category::instance().getCategoryStats(
         categoryStats,
         m_account_a,
-        const_cast<mmDateRange*>(m_date_range),
+        m_date_range,
         Option::instance().getIgnoreFutureTransactions(),
         false
     );
@@ -174,8 +174,8 @@ wxString mmReportCategoryExpenses::getHTMLText()
     hb.init();
 
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayDateHeading(m_date_range);
+    hb.displayFooter(getAccountNames());
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(m_date_range->start_date(), m_date_range->end_date());
@@ -391,8 +391,8 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(sd, ed, true);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayDateHeading(sd, ed, true);
+    hb.displayFooter(getAccountNames());
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(sd, ed);

--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -304,20 +304,20 @@ wxString mmReportCategoryExpenses::getHTMLText()
 mmReportCategoryExpensesGoes::mmReportCategoryExpensesGoes()
     : mmReportCategoryExpenses(_n("Where the Money Goes"), TYPE::GOES)
 {
-    setReportParameters(TYPE_ID::WheretheMoneyGoes);
+    setReportParameters(REPORT_ID::WheretheMoneyGoes);
 }
 
 mmReportCategoryExpensesComes::mmReportCategoryExpensesComes()
     : mmReportCategoryExpenses(_n("Where the Money Comes From"), TYPE::COME)
 {
-    setReportParameters(TYPE_ID::WheretheMoneyComesFrom);
+    setReportParameters(REPORT_ID::WheretheMoneyComesFrom);
 }
 
 mmReportCategoryExpensesCategories::mmReportCategoryExpensesCategories()
     : mmReportCategoryExpenses(_n("Categories Summary"), TYPE::MONTHLY)
 {
     m_chart_selection = 1;
-    setReportParameters(TYPE_ID::CategoriesMonthly);
+    setReportParameters(REPORT_ID::CategoriesMonthly);
 }
 
 //----------------------------------------------------------------------------
@@ -326,7 +326,7 @@ mmReportCategoryOverTimePerformance::mmReportCategoryOverTimePerformance()
     : ReportBase(_n("Category Income/Expenses"))
 {
     m_date_range = new mmLast12Months();
-    setReportParameters(TYPE_ID::CategoryOverTimePerformance);
+    setReportParameters(REPORT_ID::CategoryOverTimePerformance);
 }
 //----------------------------------------------------------------------------
 mmReportCategoryOverTimePerformance::~mmReportCategoryOverTimePerformance()

--- a/src/reports/categexp.h
+++ b/src/reports/categexp.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include "model/Model_Category.h"
 
-class mmReportCategoryExpenses : public mmPrintableBase
+class mmReportCategoryExpenses : public ReportBase
 {
 public:
     // structure for sorting of data
@@ -35,7 +35,7 @@ public:
     explicit mmReportCategoryExpenses(const wxString& title, enum TYPE type);
     virtual ~mmReportCategoryExpenses();
 
-    virtual void RefreshData();
+    virtual void refreshData();
     double AppendData(const std::vector<data_holder>& data, std::map<int64, std::map<int, double>>& categoryStats,
         const DB_Table_CATEGORY_V1::Data* category, int64 groupID, int level);
     virtual wxString getHTMLText();
@@ -67,7 +67,7 @@ public:
 
 //----------------------------------------------------------------------------
 
-class mmReportCategoryOverTimePerformance : public mmPrintableBase
+class mmReportCategoryOverTimePerformance : public ReportBase
 {
 public:
     mmReportCategoryOverTimePerformance();

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -67,7 +67,7 @@ wxString mmReportForecast::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
+    hb.displayDateHeading(m_date_range);
 
     GraphData gd;
     GraphSeries gsWithdrawal, gsDeposit;

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -29,7 +29,7 @@ class mm_html_template;
 
 mmReportForecast::mmReportForecast(): ReportBase(_n("Forecast"))
 {
-    setReportParameters(TYPE_ID::ForecastReport);
+    setReportParameters(REPORT_ID::ForecastReport);
 }
 
 mmReportForecast::~mmReportForecast()

--- a/src/reports/forecast.h
+++ b/src/reports/forecast.h
@@ -19,7 +19,7 @@
 #pragma once
 #include "reportbase.h"
 
-class mmReportForecast: public mmPrintableBase 
+class mmReportForecast: public ReportBase 
 {
 public:
     mmReportForecast();

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -183,7 +183,7 @@ void mmHTMLBuilder::showUserName()
 
 void mmHTMLBuilder::addReportHeader(const wxString& name, int startDay, bool futureIgnored)
 {
-    wxLogDebug("futureIgnored: %d",futureIgnored);
+    wxLogDebug("mmHTMLBuilder::addReportHeader(): futureIgnored: %d",futureIgnored);
     addDivContainer("shadowTitle");
     {
         addText("<header>");
@@ -194,8 +194,10 @@ void mmHTMLBuilder::addReportHeader(const wxString& name, int startDay, bool fut
         {
             showUserName();
             addText("<TMPL_VAR DATE_HEADING>");
-            addOffsetIndication(startDay);
-            addFutureIgnoredIndication(futureIgnored);
+            if (startDay > 1)
+                addOffsetIndication(startDay);
+            if (futureIgnored)
+                addFutureIgnoredIndication();
             addReportCurrency();
             addDateNow();
         }
@@ -275,16 +277,12 @@ void mmHTMLBuilder::addReportCurrency()
 
 void mmHTMLBuilder::addOffsetIndication(int startDay)
 {
-    if (startDay > 1)
-        addHeader(5, wxString::Format ("%s: %d"
-            , _t("User specified start day")
-            , startDay));
+    addHeader(5, wxString::Format("%s: %d", _t("User specified start day"), startDay));
 }
 
-void mmHTMLBuilder::addFutureIgnoredIndication(bool ignore)
+void mmHTMLBuilder::addFutureIgnoredIndication()
 {
-    if (ignore)
-        addHeader(5, _t("Future Transactions have been ignored"));
+    addHeader(5, _t("Future Transactions have been ignored"));
 }
 
 void mmHTMLBuilder::addDateNow()

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -29,7 +29,6 @@
 #include <ios>
 #include <float.h>
 
-
 namespace tags
 {
     static const char END_SIMPLE[] = R"(</body>)";
@@ -226,6 +225,11 @@ void mmHTMLBuilder::DisplayDateHeading(const wxDateTime& startDate, const wxDate
 
     wxString t = wxString::Format(tags::HEADER, 4, sDate, 4);
     this->html_.Replace("<TMPL_VAR DATE_HEADING>", t);
+}
+
+void mmHTMLBuilder::DisplayDateHeading(const mmDateRange* date_range)
+{
+    DisplayDateHeading(date_range->start_date(), date_range->end_date(), date_range->is_with_date());
 }
 
 void mmHTMLBuilder::DisplayFooter(const wxString& footer)

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -208,31 +208,54 @@ void mmHTMLBuilder::addReportHeader(const wxString& name, int startDay, bool fut
     endDiv();
 }
 
-void mmHTMLBuilder::DisplayDateHeading(const wxDateTime& startDate, const wxDateTime& endDate, bool withDateRange, bool withNoEndDate)
+void mmHTMLBuilder::displayDateHeading(const wxString& header)
 {
-    wxString sDate;
+    wxString t = wxString::Format(tags::HEADER, 4, header, 4);
+    this->html_.Replace("<TMPL_VAR DATE_HEADING>", t);
+}
+
+void mmHTMLBuilder::displayDateHeading(const wxDateTime& startDate, const wxDateTime& endDate, bool withDateRange, bool withNoEndDate)
+{
+    wxString header;
     if (withDateRange && startDate.IsValid() && endDate.IsValid()) {
-        sDate << wxString::Format(_t("From %1$s till %2$s")
+        header << wxString::Format(_t("From %1$s till %2$s")
             , mmGetDateTimeForDisplay(startDate.FormatISODate())
             , withNoEndDate ? _t("Future") : mmGetDateTimeForDisplay(endDate.FormatISODate()));
     }
     else if (!withDateRange) {
-        sDate << _t("Over Time");
+        header << _t("Over Time");
     }
     else {
         wxASSERT(false);
     }
-
-    wxString t = wxString::Format(tags::HEADER, 4, sDate, 4);
-    this->html_.Replace("<TMPL_VAR DATE_HEADING>", t);
+    displayDateHeading(header);
 }
 
-void mmHTMLBuilder::DisplayDateHeading(const mmDateRange* date_range)
+void mmHTMLBuilder::displayDateHeading(const mmDateRange* date_range)
 {
-    DisplayDateHeading(date_range->start_date(), date_range->end_date(), date_range->is_with_date());
+    displayDateHeading(date_range->start_date(), date_range->end_date(), date_range->is_with_date());
 }
 
-void mmHTMLBuilder::DisplayFooter(const wxString& footer)
+void mmHTMLBuilder::displayDateHeading(const DateRange2& date_range)
+{
+    DateDayN range_start = date_range.rangeStart();
+    DateDayN range_end = date_range.rangeEnd();
+    wxString header;
+    if (range_start.has_value() || range_end.has_value()) {
+        header << wxString::Format(_t("From %1$s till %2$s"),
+            range_start.has_value() ? mmGetDateTimeForDisplay(range_start.value().isoDate())
+                : _t("Past"),
+            range_end.has_value() ? mmGetDateTimeForDisplay(range_end.value().isoDate())
+                : _t("Future")
+        );
+    }
+    else {
+        header << _t("Over Time");
+    }
+    displayDateHeading(header);
+}
+
+void mmHTMLBuilder::displayFooter(const wxString& footer)
 {
     this->html_.Replace("<TMPL_VAR FOOTER>", footer);
 }

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -73,7 +73,7 @@ public:
     void addReportCurrency();
     void addDateNow();
     void addOffsetIndication(int startDay);
-    void addFutureIgnoredIndication(bool ignore);
+    void addFutureIgnoredIndication();
 
     /** Start a table element */
     void startTable();

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -26,6 +26,7 @@
 #include "model/Model_Currency.h"
 #include <html_template.h>
 #include "util.h"
+#include "mmDateRange.h"
 
 struct GraphSeries
 {
@@ -51,6 +52,7 @@ public:
     ~mmHTMLBuilder() {}
 
     void DisplayDateHeading(const wxDateTime& startDate, const wxDateTime& endDate, bool withDateRange = true, bool withNoEndDate = false);
+    void DisplayDateHeading(const mmDateRange* date_range);
     void DisplayFooter(const wxString& footer);
     /** Starts a new HMTL report */
     void init(bool simple = false, const wxString& extra_style = "");

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -27,6 +27,7 @@
 #include <html_template.h>
 #include "util.h"
 #include "mmDateRange.h"
+#include "daterange2.h"
 
 struct GraphSeries
 {
@@ -51,9 +52,11 @@ public:
     mmHTMLBuilder();
     ~mmHTMLBuilder() {}
 
-    void DisplayDateHeading(const wxDateTime& startDate, const wxDateTime& endDate, bool withDateRange = true, bool withNoEndDate = false);
-    void DisplayDateHeading(const mmDateRange* date_range);
-    void DisplayFooter(const wxString& footer);
+    void displayDateHeading(const wxString& header);
+    void displayDateHeading(const wxDateTime& startDate, const wxDateTime& endDate, bool withDateRange = true, bool withNoEndDate = false);
+    void displayDateHeading(const mmDateRange* date_range);
+    void displayDateHeading(const DateRange2& date_range);
+    void displayFooter(const wxString& footer);
     /** Starts a new HMTL report */
     void init(bool simple = false, const wxString& extra_style = "");
 

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 mmReportIncomeExpenses::mmReportIncomeExpenses()
     : ReportBase(_n("Income vs. Expenses Summary"))
 {
-    setReportParameters(TYPE_ID::IncomevsExpensesSummary);
+    setReportParameters(REPORT_ID::IncomevsExpensesSummary);
 }
 
 mmReportIncomeExpenses::~mmReportIncomeExpenses()
@@ -136,7 +136,7 @@ wxString mmReportIncomeExpenses::getHTMLText()
 mmReportIncomeExpensesMonthly::mmReportIncomeExpensesMonthly()
     : ReportBase(_n("Income vs. Expenses Monthly"))
 {
-    setReportParameters(TYPE_ID::IncomevsExpensesMonthly);
+    setReportParameters(REPORT_ID::IncomevsExpensesMonthly);
 }
 
 mmReportIncomeExpensesMonthly::~mmReportIncomeExpensesMonthly()

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -78,8 +78,8 @@ wxString mmReportIncomeExpenses::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayDateHeading(m_date_range);
+    hb.displayFooter(getAccountNames());
 
     // Chart
     GraphData gd;
@@ -187,8 +187,8 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
-    hb.DisplayFooter(getAccountNames());
+    hb.displayDateHeading(m_date_range);
+    hb.displayFooter(getAccountNames());
 
     // Chart
     wxDateSpan s = m_date_range->end_date().GetLastMonthDay().DiffAsDateSpan(start_date);

--- a/src/reports/incexpenses.h
+++ b/src/reports/incexpenses.h
@@ -22,7 +22,7 @@
 
 #include "reportbase.h"
 
-class mmReportIncomeExpenses : public mmPrintableBase
+class mmReportIncomeExpenses : public ReportBase
 {
 public:
     mmReportIncomeExpenses();
@@ -31,7 +31,7 @@ public:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////
-class mmReportIncomeExpensesMonthly : public mmPrintableBase
+class mmReportIncomeExpensesMonthly : public ReportBase
 {
 public:
     mmReportIncomeExpensesMonthly();

--- a/src/reports/mmDateRange.cpp
+++ b/src/reports/mmDateRange.cpp
@@ -23,10 +23,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "option.h"
 #include <wx/intl.h>
 
-mmDateRange::mmDateRange() : today_(wxDateTime::Today())
-    , today_end_(wxDateTime(23, 59, 59, 999))
-    , future_(DATE_MAX)
-    , futureIgnored_(false)
+mmDateRange::mmDateRange() :
+    today_(wxDateTime::Today()),
+    today_end_(wxDateTime(23, 59, 59, 999)),
+    future_(DATE_MAX),
+    futureIgnored_(false)
 {
     start_date_ = today_;
     end_date_ = today_end_;

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -121,7 +121,7 @@ wxString mmReportMyUsage::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
+    hb.displayDateHeading(m_date_range);
 
     if (getChartSelection() == 0)
     {

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 mmReportMyUsage::mmReportMyUsage()
 : ReportBase(_n("MMEX Usage Frequency"))
 {
-    setReportParameters(TYPE_ID::MyUsage);
+    setReportParameters(REPORT_ID::MyUsage);
 }
 
 mmReportMyUsage::~mmReportMyUsage()

--- a/src/reports/myusage.h
+++ b/src/reports/myusage.h
@@ -19,7 +19,7 @@
 #pragma once
 #include "reportbase.h"
 
-class mmReportMyUsage: public mmPrintableBase
+class mmReportMyUsage: public ReportBase
 {
 public:
     mmReportMyUsage();

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -29,12 +29,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <algorithm>
 
-mmReportPayeeExpenses::mmReportPayeeExpenses()
-    : ReportBase(_n("Payee Report"))
-    , positiveTotal_(0.0)
-    , negativeTotal_(0.0)
+mmReportPayeeExpenses::mmReportPayeeExpenses() :
+    ReportBase(_n("Payee Report")),
+    positiveTotal_(0.0),
+    negativeTotal_(0.0)
 {
-    setReportParameters(TYPE_ID::Payees);
+    setReportParameters(REPORT_ID::Payees);
 }
 
 mmReportPayeeExpenses::~mmReportPayeeExpenses()

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -160,11 +160,11 @@ wxString ReportFlowByPayee::getHTMLText()
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
+    hb.addReportHeader(getTitle(), m_date_range2.getFirstDay());
     hb.displayDateHeading(m_date_range2);
     // Prime the filter
     m_filter.clear();
-    m_filter.setDateRange(m_date_range->start_date(), m_date_range->end_date());
+    m_filter.setDateRange(m_date_range2);
 
     // Add the chart
     if (!m_order_abs_flow.empty() && (getChartSelection() == 0)) {

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -161,7 +161,7 @@ wxString ReportFlowByPayee::getHTMLText()
     mmHTMLBuilder hb;
     hb.init();
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
-    hb.DisplayDateHeading(m_date_range);
+    hb.displayDateHeading(m_date_range2);
     // Prime the filter
     m_filter.clear();
     m_filter.setDateRange(m_date_range->start_date(), m_date_range->end_date());

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -30,6 +30,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <algorithm>
 
+ReportFlowByPayee::Data::Data() :
+    payee_name(""),
+    inflow(0.0),
+    outflow(0.0),
+    flow(0.0)
+{
+}
+
 ReportFlowByPayee::ReportFlowByPayee() :
     ReportBase(_n("Payee Report"))
 {
@@ -114,7 +122,7 @@ void  ReportFlowByPayee::refreshData()
     );
 
     m_order_net_flow.clear();
-    m_total = Data{"", 0.0, 0.0, 0.0};
+    m_total = Data();
     for (const auto& it : m_id_data) {
         m_order_net_flow.push_back(it.first);
         m_order_abs_flow.push_back(it.first);

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -95,6 +95,7 @@ void ReportFlowByPayee::loadData(mmDateRange* date_range, bool WXUNUSED(ignoreFu
         }
 
         // NOTE: call to getDayRate() in every transaction is slow
+        // if "Use historical currency" is enabled in settings
         const double convRate = Model_CurrencyHistory::getDayRate(
             Model_Account::instance().get(trx.ACCOUNTID)->CURRENCYID,
             trx.TRANSDATE

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -32,8 +32,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 ReportFlowByPayee::Data::Data() :
     payee_name(""),
-    inflow(0.0),
-    outflow(0.0),
+    flow_pos(0.0),
+    flow_neg(0.0),
     flow(0.0)
 {
 }
@@ -52,9 +52,9 @@ void ReportFlowByPayee::updateData(Data& data, Model_Checking::TYPE_ID type_id, 
 {
     double flow = (type_id == Model_Checking::TYPE_ID_DEPOSIT) ? amount : -amount;
     if (flow > 0.0)
-        data.inflow += flow;
+        data.flow_pos += flow;
     else if (flow < 0.0)
-        data.outflow += -flow;
+        data.flow_neg += flow;
     data.flow += flow;
 }
 
@@ -89,8 +89,8 @@ void ReportFlowByPayee::loadData(mmDateRange* date_range, bool WXUNUSED(ignoreFu
         if (new_payee) {
             Model_Payee::Data* payee = Model_Payee::instance().get(payee_id);
             data.payee_name = payee ? payee->PAYEENAME : "";
-            data.inflow = 0.0;
-            data.outflow = 0.0;
+            data.flow_pos = 0.0;
+            data.flow_neg = 0.0;
             data.flow = 0.0;
         }
 
@@ -127,9 +127,9 @@ void  ReportFlowByPayee::refreshData()
     for (const auto& it : m_id_data) {
         m_order_net_flow.push_back(it.first);
         m_order_abs_flow.push_back(it.first);
-        m_total.inflow  += it.second.inflow;
-        m_total.outflow += it.second.outflow;
-        m_total.flow    += it.second.flow;
+        m_total.flow_pos += it.second.flow_pos;
+        m_total.flow_neg += it.second.flow_neg;
+        m_total.flow     += it.second.flow;
     }
 
     // order by net flow
@@ -211,8 +211,8 @@ wxString ReportFlowByPayee::getHTMLText()
                             wxString::Format("viewtrans:-1:-1:%lld", payee_id),
                             data.payee_name
                         );
-                        hb.addMoneyCell(data.inflow);
-                        hb.addMoneyCell(data.outflow);
+                        hb.addMoneyCell(data.flow_pos);
+                        hb.addMoneyCell(data.flow_neg);
                         hb.addMoneyCell(data.flow);
                     }
                     hb.endTableRow();
@@ -223,8 +223,8 @@ wxString ReportFlowByPayee::getHTMLText()
             hb.startTfoot();
             {
                 std::vector<double> total;
-                total.push_back(m_total.inflow);
-                total.push_back(m_total.outflow);
+                total.push_back(m_total.flow_pos);
+                total.push_back(m_total.flow_neg);
                 total.push_back(m_total.flow);
                 hb.addMoneyTotalRow(_t("Total:"), 4, total);
             }

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -58,16 +58,14 @@ void ReportFlowByPayee::updateData(Data& data, Model_Checking::TYPE_ID type_id, 
     data.flow += flow;
 }
 
-void ReportFlowByPayee::loadData(mmDateRange* date_range, bool WXUNUSED(ignoreFuture))
+void ReportFlowByPayee::loadData()
 {
-    // FIXME: do not ignore ignoreFuture param
-
     m_id_data.clear();
 
     const auto all_splits = Model_Splittransaction::instance().get_all();
     const auto &trx_a = Model_Checking::instance().find(
-        Model_Checking::TRANSDATE(DateDay(date_range->start_date()), GREATER_OR_EQUAL),
-        Model_Checking::TRANSDATE(DateDay(date_range->end_date()), LESS_OR_EQUAL),
+        Model_Checking::TRANSDATE(m_date_range2.rangeStart().value(), GREATER_OR_EQUAL),
+        Model_Checking::TRANSDATE(m_date_range2.rangeEnd().value(), LESS_OR_EQUAL),
         Model_Checking::DELETEDTIME(wxEmptyString, EQUAL),
         Model_Checking::STATUS(Model_Checking::STATUS_ID_VOID, NOT_EQUAL)
     );
@@ -117,10 +115,7 @@ void ReportFlowByPayee::loadData(mmDateRange* date_range, bool WXUNUSED(ignoreFu
 
 void  ReportFlowByPayee::refreshData()
 {
-    loadData(
-        const_cast<mmDateRange*>(m_date_range),
-        Option::instance().getIgnoreFutureTransactions()
-    );
+    loadData();
 
     m_order_net_flow.clear();
     m_total = Data();

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -54,6 +54,6 @@ private:
     static void updateData(Data& data, Model_Checking::TYPE_ID type_id, double amount);
 
 private:
-    void loadData(mmDateRange* date_range, bool ignoreFuture);
+    void loadData();
 };
 

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -23,7 +23,7 @@
 #include <map>
 #include <vector>
 
-class mmReportPayeeExpenses : public ReportBase
+class ReportFlowByPayee : public ReportBase
 {
 public:
     enum TYPE {
@@ -34,32 +34,32 @@ public:
 
 private:
     // structure for sorting of data
-    struct data_holder
+    struct PayeeData
     {
         wxString name;
-        int64 payee;
+        int64 id;
         double incomes;
         double expenses;
     };
 
+private:
+    std::vector<PayeeData> m_payee_data_a;
+    std::vector<ValuePair> m_name_flow_a;
+    double m_flow_pos;
+    double m_flow_neg;
+
 public:
-    mmReportPayeeExpenses();
-    virtual ~mmReportPayeeExpenses();
+    ReportFlowByPayee();
+    virtual ~ReportFlowByPayee();
 
 public:
     virtual void refreshData();
     virtual wxString getHTMLText();
 
 protected:
-    void getPayeeStats(
-        std::map<int64, std::pair<double, double> > &payeeStats,
+    void loadPayeeFlow(
+        std::map<int64, std::pair<double, double>> &payee_flow_a,
         mmDateRange* date_range, bool ignoreFuture
     ) const;
-
-private:
-    std::vector<data_holder> data_;
-    std::vector<ValuePair> valueList_;
-    double positiveTotal_;
-    double negativeTotal_;
 };
 

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -32,6 +32,8 @@ private:
         double inflow;
         double outflow;
         double flow;
+
+        Data();
     };
 
 private:

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -25,28 +25,20 @@
 
 class ReportFlowByPayee : public ReportBase
 {
-public:
-    enum TYPE {
-        INCOME = 0,
-        EXPENSES,
-        MAX
-    };
-
 private:
-    // structure for sorting of data
-    struct PayeeData
+    struct Data
     {
-        wxString name;
-        int64 id;
-        double incomes;
-        double expenses;
+        wxString payee_name;
+        double inflow;
+        double outflow;
+        double flow;
     };
 
 private:
-    std::vector<PayeeData> m_payee_data_a;
-    std::vector<ValuePair> m_name_flow_a;
-    double m_flow_pos;
-    double m_flow_neg;
+    std::map<int64, Data> m_id_data;
+    std::vector<int64> m_order_net_flow;
+    std::vector<int64> m_order_abs_flow;
+    Data m_total;
 
 public:
     ReportFlowByPayee();
@@ -56,10 +48,10 @@ public:
     virtual void refreshData();
     virtual wxString getHTMLText();
 
-protected:
-    void loadPayeeFlow(
-        std::map<int64, std::pair<double, double>> &payee_flow_a,
-        mmDateRange* date_range, bool ignoreFuture
-    ) const;
+private:
+    static void updateData(Data& data, Model_Checking::TYPE_ID type_id, double amount);
+
+private:
+    void loadData(mmDateRange* date_range, bool ignoreFuture);
 };
 

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -16,8 +16,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-#ifndef MM_EX_REPORTPAYEE_H_
-#define MM_EX_REPORTPAYEE_H_
+#pragma once
 
 #include "reportbase.h"
 #include "util.h"
@@ -27,25 +26,40 @@
 class mmReportPayeeExpenses : public ReportBase
 {
 public:
+    enum TYPE {
+        INCOME = 0,
+        EXPENSES,
+        MAX
+    };
+
+private:
+    // structure for sorting of data
+    struct data_holder
+    {
+        wxString name;
+        int64 payee;
+        double incomes;
+        double expenses;
+    };
+
+public:
     mmReportPayeeExpenses();
     virtual ~mmReportPayeeExpenses();
 
+public:
     virtual void refreshData();
     virtual wxString getHTMLText();
 
 protected:
-    void getPayeeStats(std::map<int64, std::pair<double, double> > &payeeStats
-        , mmDateRange* date_range, bool ignoreFuture) const;
-
-    enum TYPE {INCOME = 0, EXPENSES, MAX};
+    void getPayeeStats(
+        std::map<int64, std::pair<double, double> > &payeeStats,
+        mmDateRange* date_range, bool ignoreFuture
+    ) const;
 
 private:
-    // structure for sorting of data
-    struct data_holder { wxString name; int64 payee; double incomes; double expenses; };
     std::vector<data_holder> data_;
     std::vector<ValuePair> valueList_;
     double positiveTotal_;
     double negativeTotal_;
 };
 
-#endif //MM_EX_REPORTPAYEE_H_

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -24,13 +24,13 @@
 #include <map>
 #include <vector>
 
-class mmReportPayeeExpenses : public mmPrintableBase
+class mmReportPayeeExpenses : public ReportBase
 {
 public:
     mmReportPayeeExpenses();
     virtual ~mmReportPayeeExpenses();
 
-    virtual void RefreshData();
+    virtual void refreshData();
     virtual wxString getHTMLText();
 
 protected:

--- a/src/reports/payee.h
+++ b/src/reports/payee.h
@@ -29,8 +29,8 @@ private:
     struct Data
     {
         wxString payee_name;
-        double inflow;
-        double outflow;
+        double flow_pos;
+       double flow_neg;
         double flow;
 
         Data();

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -36,11 +36,11 @@ ReportBase::~ReportBase()
 {
 }
 
-void ReportBase::setReportParameters(ReportBase::TYPE_ID type_id)
+void ReportBase::setReportParameters(ReportBase::REPORT_ID report_id)
 {
-    m_type_id = type_id;
+    m_report_id = report_id;
 
-    switch (type_id) {
+    switch (report_id) {
     case MyUsage:                     m_parameters = M_DATE_RANGE | M_CHART; break;
     case MonthlySummaryofAccounts:    m_parameters = M_CHART; break;
     case YearlySummaryofAccounts:     m_parameters = M_CHART; break;
@@ -67,9 +67,9 @@ void ReportBase::setReportParameters(ReportBase::TYPE_ID type_id)
 
 void ReportBase::saveReportSettings()
 {
-    TYPE_ID type_id = getTypeId();
-    wxLogDebug("%d - %s", type_id, m_title);
-    if (type_id < 0)
+    REPORT_ID report_id = getReportId();
+    wxLogDebug("%d - %s", report_id, m_title);
+    if (report_id < 0)
         return;
 
     Document j_doc;
@@ -115,7 +115,7 @@ void ReportBase::saveReportSettings()
     json_writer.EndObject();
 
     if (isActive) {
-        const wxString& rj_key = wxString::Format("REPORT_%d", type_id);
+        const wxString& rj_key = wxString::Format("REPORT_%d", report_id);
         const wxString& rj_value = wxString::FromUTF8(json_buffer.GetString());
         Model_Infotable::instance().setString(rj_key, rj_value);
         m_settings = rj_value;
@@ -267,8 +267,8 @@ mmGeneralReport::mmGeneralReport(const Model_Report::Data* report) :
     m_report(report)
 {
     // Store reportid if no id is provided
-    if (m_type_id == -1 && report->REPORTID >= LONG_MIN && report->REPORTID <= LONG_MAX) {
-        m_type_id = static_cast<ReportBase::TYPE_ID>(int(report->REPORTID.ToLong()));
+    if (m_report_id == -1 && report->REPORTID >= LONG_MIN && report->REPORTID <= LONG_MAX) {
+        m_report_id = static_cast<ReportBase::REPORT_ID>(int(report->REPORTID.ToLong()));
     }
 }
 

--- a/src/reports/reportbase.cpp
+++ b/src/reports/reportbase.cpp
@@ -39,8 +39,9 @@ ReportBase::~ReportBase()
 const wxString ReportBase::getTitle(bool translate) const
 {
     wxString title = getTranslation(translate, m_title);
-    if (m_date_range) {
-        title += " - " + getTranslation(translate, m_date_range->title());
+    if (!m_date_range2.rangeName().empty()) {
+        // range name is already translated
+        title += " - " + m_date_range2.rangeName();
     }
     return title;
 }

--- a/src/reports/reportbase.h
+++ b/src/reports/reportbase.h
@@ -30,7 +30,7 @@ class wxArrayString;
 class ReportBase
 {
 public:
-    enum TYPE_ID {
+    enum REPORT_ID {
         MyUsage = 0,
         MonthlySummaryofAccounts,
         YearlySummaryofAccounts,
@@ -51,7 +51,7 @@ public:
         ForecastReport,
         BugReport,
         CategoryOverTimePerformance,
-        UNUSED = -1
+        NONE = -1
     };
 
     enum PARAM_MASK
@@ -69,7 +69,7 @@ public:
     };
 
 protected:
-    TYPE_ID m_type_id = TYPE_ID::UNUSED;
+    REPORT_ID m_report_id = REPORT_ID::NONE;
     wxString m_title;
     int m_parameters = 0;
     wxString m_settings = "";
@@ -96,7 +96,7 @@ public:
     virtual void refreshData() {}
     virtual wxString getHTMLText() = 0;
 
-    void setReportParameters(TYPE_ID type_id);
+    void setReportParameters(REPORT_ID report_id);
     void setReportSettings(const wxString& settings);
     void setDateRange(const mmDateRange* date_range);
     void setDateSelection(int64 sel);
@@ -104,7 +104,7 @@ public:
     void setAccounts(int selection, const wxString& type_name);
     void setChartSelection(int selection);
 
-    TYPE_ID getTypeId() const;
+    REPORT_ID getReportId() const;
     const wxString getReportSettings() const;
     int64 getDateSelection() const;
     int getForwardMonths() const;
@@ -127,7 +127,7 @@ inline void ReportBase::setForwardMonths(int sel) { m_forward_months = sel; }
 inline void ReportBase::setChartSelection(int selection) { m_chart_selection = selection; }
 
 // get
-inline ReportBase::TYPE_ID ReportBase::getTypeId() const { return m_type_id; }
+inline ReportBase::REPORT_ID ReportBase::getReportId() const { return m_report_id; }
 inline const wxString ReportBase::getReportSettings() const { return m_settings; }
 inline int64 ReportBase::getDateSelection() const { return this->m_date_selection; }
 inline int ReportBase::getForwardMonths() const { return this->m_forward_months; }

--- a/src/reports/reportbase.h
+++ b/src/reports/reportbase.h
@@ -22,6 +22,7 @@
 
 #include "filtertrans.h"
 #include "mmDateRange.h"
+#include "daterange2.h"
 #include "option.h"
 #include "model/Model_Report.h"
 class wxString;
@@ -73,7 +74,8 @@ protected:
     wxString m_title;
     int m_parameters = 0;
     wxString m_settings = "";
-    const mmDateRange* m_date_range = nullptr;
+    mmDateRange* m_date_range = nullptr;
+    DateRange2 m_date_range2;
     int64 m_date_selection = 0;
     int m_forward_months = 24;
     wxSharedPtr<wxArrayString> m_account_a;
@@ -96,9 +98,10 @@ public:
     virtual void refreshData() {}
     virtual wxString getHTMLText() = 0;
 
+public:
     void setReportParameters(REPORT_ID report_id);
     void setReportSettings(const wxString& settings);
-    void setDateRange(const mmDateRange* date_range);
+    void setDateRange(const DateRange2& date_range2);
     void setDateSelection(int64 sel);
     void setForwardMonths(int sel);
     void setAccounts(int selection, const wxString& type_name);
@@ -121,7 +124,17 @@ inline int ReportBase::getParameters() { return m_parameters; }
 
 // set
 inline void ReportBase::setReportSettings(const wxString & settings) { m_settings = settings; }
-inline void ReportBase::setDateRange(const mmDateRange* date_range) { m_date_range = date_range; }
+inline void ReportBase::setDateRange(const DateRange2& date_range2)
+{
+    m_date_range2 = date_range2;
+    m_date_range = new mmDateRange();
+    m_date_range->start_date(date_range2.rangeStart().value().getDateTime()
+        .ResetTime()
+    );
+    m_date_range->end_date(date_range2.rangeEnd().value().getDateTime()
+        .ResetTime().Add(wxTimeSpan(23,59,59,999))
+    );
+}
 inline void ReportBase::setDateSelection(int64 sel) { m_date_selection = sel; }
 inline void ReportBase::setForwardMonths(int sel) { m_forward_months = sel; }
 inline void ReportBase::setChartSelection(int selection) { m_chart_selection = selection; }

--- a/src/reports/reportbase.h
+++ b/src/reports/reportbase.h
@@ -18,64 +18,19 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-//----------------------------------------------------------------------------
-#ifndef MM_EX_REPORTBASE_H_
-#define MM_EX_REPORTBASE_H_
-//----------------------------------------------------------------------------
+#pragma once
+
 #include "filtertrans.h"
 #include "mmDateRange.h"
 #include "option.h"
 #include "model/Model_Report.h"
 class wxString;
 class wxArrayString;
-//----------------------------------------------------------------------------
 
-class mmPrintableBase
+class ReportBase
 {
 public:
-    mmPrintableBase(const wxString& title);
-    virtual ~mmPrintableBase();
-    virtual wxString getHTMLText() = 0;
-    virtual void RefreshData() {}
-    virtual const wxString getReportTitle(bool translate = true) const;
-    virtual int report_parameters();
-    int getReportId() { return m_id; }
-    void date_range(const mmDateRange* date_range, int selection);
-    void initial_report(bool initial);
-
-    int64 getDateSelection() const;
-    int getAccountSelection() const;
-    int getChartSelection() const;
-    int getForwardMonths() const;
-    const wxString getAccountNames() const;
-    void chart(int selection);
-    void setAccounts(int selection, const wxString& name);
-    void setSelection(int64 sel);
-    void setForwardMonths(int sel);
-    void setReportSettings();
-    void setReportParameters(int id);
-    const wxString getReportSettings() const;
-    void restoreReportSettings();
-    void initReportSettings(const wxString& settings);
-
-public:
-    mmFilterTransactions m_filter;
-    static const char * m_template;
-    enum RepParams
-    {
-        NONE = 0
-        , SINGLE_DATE = 1
-        , DATE_RANGE = 2
-        , TIME = 4
-        , MONTHES = 8
-        , BUDGET_DATES = 16
-        , ONLY_YEARS = 32
-        , ACCOUNTS_LIST = 64
-        , CHART = 128
-        , FORWARD_MONTHS = 256
-    };
-
-    enum Reports {
+    enum TYPE_ID {
         MyUsage = 0,
         MonthlySummaryofAccounts,
         YearlySummaryofAccounts,
@@ -99,44 +54,94 @@ public:
         UNUSED = -1
     };
 
-protected:
-    int m_chart_selection = 0;
-    int64 m_date_selection = 0;
-    int m_forward_months = 24;
-    wxString m_title;
-    const mmDateRange* m_date_range = nullptr;
-    wxSharedPtr<wxArrayString> accountArray_;
-    wxSharedPtr<wxArrayString> selectedAccountArray_;
-    bool m_only_active = false;
-    int m_id = -1;
+    enum PARAM_MASK
+    {
+        M_NONE           = 0,
+        M_SINGLE_DATE    = 1,
+        M_DATE_RANGE     = 2,
+        M_TIME           = 4,
+        M_MONTHS         = 8,
+        M_BUDGET         = 16,
+        M_YEAR           = 32,
+        M_ACCOUNT        = 64,
+        M_CHART          = 128,
+        M_FORWARD_MONTHS = 256
+    };
 
-private:
-    bool m_initial = true;
-    int m_account_selection = 0;
+protected:
+    TYPE_ID m_type_id = TYPE_ID::UNUSED;
+    wxString m_title;
     int m_parameters = 0;
     wxString m_settings = "";
+    const mmDateRange* m_date_range = nullptr;
+    int64 m_date_selection = 0;
+    int m_forward_months = 24;
+    wxSharedPtr<wxArrayString> m_account_a;
+    wxSharedPtr<wxArrayString> m_account_selected_a;
+    int m_account_selection = 0;
+    bool m_only_active = false;
+    int m_chart_selection = 0;
+
+public:
+    mmFilterTransactions m_filter;
+    static const char * m_template;
+
+public:
+    ReportBase(const wxString& title);
+    virtual ~ReportBase();
+
+public:
+    virtual const wxString getTitle(bool translate = true) const;
+    virtual int getParameters();
+    virtual void refreshData() {}
+    virtual wxString getHTMLText() = 0;
+
+    void setReportParameters(TYPE_ID type_id);
+    void setReportSettings(const wxString& settings);
+    void setDateRange(const mmDateRange* date_range);
+    void setDateSelection(int64 sel);
+    void setForwardMonths(int sel);
+    void setAccounts(int selection, const wxString& type_name);
+    void setChartSelection(int selection);
+
+    TYPE_ID getTypeId() const;
+    const wxString getReportSettings() const;
+    int64 getDateSelection() const;
+    int getForwardMonths() const;
+    int getAccountSelection() const;
+    const wxString getAccountNames() const;
+    int getChartSelection() const;
+
+    void saveReportSettings();
+    void restoreReportSettings();
 };
 
-inline void mmPrintableBase::setSelection(int64 sel) { m_date_selection = sel; }
-inline int64 mmPrintableBase::getDateSelection() const { return this->m_date_selection; }
-inline void mmPrintableBase::setForwardMonths(int sel) { m_forward_months = sel; }
-inline int mmPrintableBase::getForwardMonths() const { return this->m_forward_months; }
-inline int mmPrintableBase::getAccountSelection() const { return this->m_account_selection; }
-inline int mmPrintableBase::getChartSelection() const { return this->m_chart_selection; }
-inline void mmPrintableBase::chart(int selection) { m_chart_selection = selection; }
-inline void mmPrintableBase::initial_report(bool initial) { m_initial = initial; }
-inline  int mmPrintableBase::report_parameters() { return m_parameters; }
-inline  const wxString mmPrintableBase::getReportSettings() const { return m_settings; }
-inline void mmPrintableBase::initReportSettings(const wxString & settings) { m_settings = settings; }
+// virtual
+inline int ReportBase::getParameters() { return m_parameters; }
 
-class mmGeneralReport : public mmPrintableBase
+// set
+inline void ReportBase::setReportSettings(const wxString & settings) { m_settings = settings; }
+inline void ReportBase::setDateRange(const mmDateRange* date_range) { m_date_range = date_range; }
+inline void ReportBase::setDateSelection(int64 sel) { m_date_selection = sel; }
+inline void ReportBase::setForwardMonths(int sel) { m_forward_months = sel; }
+inline void ReportBase::setChartSelection(int selection) { m_chart_selection = selection; }
+
+// get
+inline ReportBase::TYPE_ID ReportBase::getTypeId() const { return m_type_id; }
+inline const wxString ReportBase::getReportSettings() const { return m_settings; }
+inline int64 ReportBase::getDateSelection() const { return this->m_date_selection; }
+inline int ReportBase::getForwardMonths() const { return this->m_forward_months; }
+inline int ReportBase::getAccountSelection() const { return this->m_account_selection; }
+inline int ReportBase::getChartSelection() const { return this->m_chart_selection; }
+
+class mmGeneralReport : public ReportBase
 {
 public:
     explicit mmGeneralReport(const Model_Report::Data* report);
 
 public:
     wxString getHTMLText();
-    virtual int report_parameters();
+    virtual int getParameters();
 
 private:
     const Model_Report::Data* m_report;
@@ -152,5 +157,3 @@ private:
     void load_context();
 };
 
-//----------------------------------------------------------------------------
-#endif // MM_EX_REPORTBASE_H_

--- a/src/reports/summary.cpp
+++ b/src/reports/summary.cpp
@@ -39,8 +39,8 @@ mmReportSummaryByDate::mmReportSummaryByDate(mmReportSummaryByDate::PERIOD_ID pe
     m_period_id(period_id)
 {
     setReportParameters((period_id == PERIOD_ID::MONTH)
-        ? TYPE_ID::MonthlySummaryofAccounts
-        : TYPE_ID::YearlySummaryofAccounts
+        ? REPORT_ID::MonthlySummaryofAccounts
+        : REPORT_ID::YearlySummaryofAccounts
     );
 }
 

--- a/src/reports/summary.h
+++ b/src/reports/summary.h
@@ -16,8 +16,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-#ifndef _MM_EX_REPORTSUMMARY_H_
-#define _MM_EX_REPORTSUMMARY_H_
+#pragma once
 
 #include "reportbase.h"
 #include <vector>
@@ -25,57 +24,43 @@
 #include "model/Model.h"
 #include "model/Model_Account.h"
 
-
 class mmHistoryItem
 {
 public:
     mmHistoryItem();
 
-    int64       acctId;
-    int64       stockId;
-    wxDate      purchaseDate;
-    wxString    purchaseDateStr;
-    double      purchasePrice;
-    double      numShares;
+    int64    acctId;
+    int64    stockId;
+    wxDate   purchaseDate;
+    wxString purchaseDateStr;
+    double   purchasePrice;
+    double   numShares;
     Model_StockHistory::Data_Set stockHist;
 };
 
-/*class mmHistoryData : public std::vector<mmHistoryItem>
+class mmReportSummaryByDate : public ReportBase
 {
 public:
-    //double getDailyBalanceAt(const Model_Account::Data* account, const wxDate& date);
-};*/
+    enum PERIOD_ID
+    {
+        MONTH = 0,
+        YEAR
+    };
 
-class mmReportSummaryByDate : public mmPrintableBase
-{
-public:
-    mmReportSummaryByDate(int mode);
-    wxString getHTMLText();
-protected:
-    enum TYPE { MONTHLY = 0, YEARLY };
 private:
-    int mode_;
-    std::map<int64, std::map<wxDate, double>> accountsBalanceMap;
-    std::vector<mmHistoryItem> arHistory;
-    std::map<wxString, double> currencyDateRateCache;
+    PERIOD_ID m_period_id;
+    std::map<int64, std::map<wxDate, double>> m_account_date_balance;
+    std::vector<mmHistoryItem> m_stock_a;
+    std::map<wxString, double> m_currencyDateRateCache;
 
-    std::map<wxDate, double> createCheckingBalanceMap(const Model_Account::Data& account);
-    double getCheckingDailyBalanceAt(const Model_Account::Data* account, const wxDate& date);
-    //double getInvestingDailyBalanceAt(const Model_Account::Data* account, const wxDate& date);
-    std::pair<double, double> getDailyBalanceAt(const Model_Account::Data* account, const wxDate& date);
-    double getDayRate(int64 currencyid, const wxDate& date);
-};
-
-class mmReportSummaryByDateMontly : public mmReportSummaryByDate
-{
 public:
-    mmReportSummaryByDateMontly();
+    mmReportSummaryByDate(PERIOD_ID period_id);
+    wxString getHTMLText();
+
+private:
+    std::map<wxDate, double> loadCheckingDateBalance(const Model_Account::Data& account);
+    double getCheckingBalance(const Model_Account::Data* account, const wxDate& date);
+    std::pair<double, double> getBalance(const Model_Account::Data* account, const wxDate& date);
+    double getCurrencyDateRate(int64 currencyid, const wxDate& date);
 };
 
-class mmReportSummaryByDateYearly : public mmReportSummaryByDate
-{
-public:
-    mmReportSummaryByDateYearly();
-};
-
-#endif //_MM_EX_REPORTSUMMARY_H_

--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -34,12 +34,12 @@
 #include <algorithm>
 
 mmReportSummaryStocks::mmReportSummaryStocks()
-    : mmPrintableBase(_n("Summary of Stocks"))
+    : ReportBase(_n("Summary of Stocks"))
 {
-    setReportParameters(Reports::StocksReportSummary);
+    setReportParameters(TYPE_ID::StocksReportSummary);
 }
 
-void  mmReportSummaryStocks::RefreshData()
+void  mmReportSummaryStocks::refreshData()
 {
     m_stocks.clear();
     m_real_gain_loss_sum_total = 0.0;
@@ -95,12 +95,12 @@ void  mmReportSummaryStocks::RefreshData()
 wxString mmReportSummaryStocks::getHTMLText()
 {
     // Grab the data  
-    RefreshData();
+    refreshData();
 
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    hb.addReportHeader(getReportTitle());
+    hb.addReportHeader(getTitle());
 
     hb.addDivContainer("shadow");
     {
@@ -242,9 +242,9 @@ wxString mmReportSummaryStocks::getHTMLText()
 }
 
 mmReportChartStocks::mmReportChartStocks()
-    : mmPrintableBase(_n("Stocks Performance Charts"))
+    : ReportBase(_n("Stocks Performance Charts"))
 {
-    setReportParameters(Reports::StocksReportPerformance);
+    setReportParameters(TYPE_ID::StocksReportPerformance);
 }
 
 mmReportChartStocks::~mmReportChartStocks()
@@ -256,7 +256,7 @@ wxString mmReportChartStocks::getHTMLText()
     // Build the report
     mmHTMLBuilder hb;
     hb.init();
-    hb.addReportHeader(getReportTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
+    hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
     wxTimeSpan dtDiff = m_date_range->end_date() - m_date_range->start_date();
     if (m_date_range->is_with_date() && dtDiff.GetDays() <= 366)
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), true);
@@ -271,7 +271,8 @@ wxString mmReportChartStocks::getHTMLText()
 
         symbols.Add(stock.SYMBOL);
         int dataCount = 0, freq = 1;
-        auto histData = Model_StockHistory::instance().find(Model_StockHistory::SYMBOL(stock.SYMBOL),
+        auto histData = Model_StockHistory::instance().find(
+            Model_StockHistory::SYMBOL(stock.SYMBOL),
             Model_StockHistory::DATE(m_date_range->start_date(), GREATER_OR_EQUAL),
             Model_StockHistory::DATE(m_date_range->end_date(), LESS_OR_EQUAL));
         std::stable_sort(histData.begin(), histData.end(), SorterByDATE());

--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -36,7 +36,7 @@
 mmReportSummaryStocks::mmReportSummaryStocks()
     : ReportBase(_n("Summary of Stocks"))
 {
-    setReportParameters(TYPE_ID::StocksReportSummary);
+    setReportParameters(REPORT_ID::StocksReportSummary);
 }
 
 void  mmReportSummaryStocks::refreshData()
@@ -244,7 +244,7 @@ wxString mmReportSummaryStocks::getHTMLText()
 mmReportChartStocks::mmReportChartStocks()
     : ReportBase(_n("Stocks Performance Charts"))
 {
-    setReportParameters(TYPE_ID::StocksReportPerformance);
+    setReportParameters(REPORT_ID::StocksReportPerformance);
 }
 
 mmReportChartStocks::~mmReportChartStocks()

--- a/src/reports/summarystocks.cpp
+++ b/src/reports/summarystocks.cpp
@@ -259,7 +259,7 @@ wxString mmReportChartStocks::getHTMLText()
     hb.addReportHeader(getTitle(), m_date_range->startDay(), m_date_range->isFutureIgnored());
     wxTimeSpan dtDiff = m_date_range->end_date() - m_date_range->start_date();
     if (m_date_range->is_with_date() && dtDiff.GetDays() <= 366)
-        hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), true);
+        hb.displayDateHeading(m_date_range->start_date(), m_date_range->end_date(), true);
 
     wxTimeSpan dist;
     wxArrayString symbols;

--- a/src/reports/summarystocks.h
+++ b/src/reports/summarystocks.h
@@ -24,11 +24,11 @@
 
 class mmHTMLBuilder;
 
-class mmReportSummaryStocks : public mmPrintableBase
+class mmReportSummaryStocks : public ReportBase
 {
 public:
     mmReportSummaryStocks();
-    virtual void RefreshData();
+    virtual void refreshData();
     virtual wxString getHTMLText();
 
 private:
@@ -43,7 +43,7 @@ private:
     double m_stock_balance = 0.0;
 };
 
-class mmReportChartStocks : public mmPrintableBase
+class mmReportChartStocks : public ReportBase
 {
 public:
     mmReportChartStocks();

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -31,7 +31,7 @@
 #include <float.h>
 
 mmReportTransactions::mmReportTransactions(wxSharedPtr<mmFilterTransactionsDialog>& transDialog)
-    : mmPrintableBase("Transaction Report")
+    : ReportBase("Transaction Report")
     , trans_()
     , m_transDialog(transDialog)
 {
@@ -114,9 +114,16 @@ table {
 
     hb.init(false, extra_style);
     wxString label = m_transDialog->mmGetLabelString();
-    hb.addReportHeader(wxString::Format("%s %s%s", getReportTitle(), !label.IsEmpty() ? ": " : "", label),
+    hb.addReportHeader(
+        wxString::Format(
+            "%s %s%s",
+            getTitle(),
+            !label.IsEmpty() ? ": " : "",
+            label
+        ),
         ((m_transDialog->mmIsRangeChecked()) ? m_transDialog->mmGetStartDay() : 1),
-        ((m_transDialog->mmIsRangeChecked()) ? m_transDialog->mmIsFutureIgnored() : false ));
+        ((m_transDialog->mmIsRangeChecked()) ? m_transDialog->mmIsFutureIgnored() : false )
+    );
     wxDateTime start,end;
     start.ParseISODate(m_transDialog->mmGetBeginDate());
     end.ParseISODate(m_transDialog->mmGetEndDate());

--- a/src/reports/transactions.cpp
+++ b/src/reports/transactions.cpp
@@ -127,9 +127,9 @@ table {
     wxDateTime start,end;
     start.ParseISODate(m_transDialog->mmGetBeginDate());
     end.ParseISODate(m_transDialog->mmGetEndDate());
-    hb.DisplayDateHeading(start, end
+    hb.displayDateHeading(start, end
         , m_transDialog->mmIsRangeChecked() || m_transDialog->mmIsDateRangeChecked());
-    hb.DisplayFooter(_t("Accounts: ") + accounts_label);
+    hb.displayFooter(_t("Accounts: ") + accounts_label);
 
     m_noOfCols = (m_transDialog->mmIsHideColumnsChecked()) ? m_transDialog->mmGetHideColumnsID().GetCount() : 11;
     const wxString& AttRefType = Model_Checking::refTypeName;

--- a/src/reports/transactions.h
+++ b/src/reports/transactions.h
@@ -25,7 +25,7 @@
 
 class mmBankTransaction;
 
-class mmReportTransactions : public mmPrintableBase
+class mmReportTransactions : public ReportBase
 {
 public:
     ~mmReportTransactions();

--- a/src/transdialog.h
+++ b/src/transdialog.h
@@ -26,7 +26,7 @@
 #include "mmcustomdata.h"
 #include "defs.h"
 #include "mmSimpleDialogs.h"
-#include "fusedtransaction.h"
+#include "journal.h"
 
 #include "model/Model_Checking.h"
 #include "model/Model_Payee.h"
@@ -46,11 +46,13 @@ public:
     mmTransDialog() {}
     virtual ~mmTransDialog();
 
-    mmTransDialog(wxWindow* parent
-        , int64 account_id
-        , Fused_Transaction::IdB fused_id
-        , bool duplicate = false
-        , int type = Model_Checking::TYPE_ID_WITHDRAWAL);
+    mmTransDialog(
+        wxWindow* parent,
+        int64 account_id,
+        Journal::IdB journal_id,
+        bool duplicate = false,
+        int type = Model_Checking::TYPE_ID_WITHDRAWAL
+    );
 
     bool Create(wxWindow* parent
         , wxWindowID id = wxID_ANY
@@ -62,9 +64,9 @@ public:
     );
 
     void SetDialogTitle(const wxString& title);
-    int64 GetAccountID() { return m_fused_data.ACCOUNTID; }
-    int64 GetToAccountID() { return m_fused_data.TOACCOUNTID; }
-    int64 GetTransactionID() { return m_fused_data.TRANSID; }
+    int64 GetAccountID() { return m_journal_data.ACCOUNTID; }
+    int64 GetToAccountID() { return m_journal_data.TOACCOUNTID; }
+    int64 GetTransactionID() { return m_journal_data.TRANSID; }
 
 private:
     wxSharedPtr<mmCustomData> m_custom_fields;
@@ -132,7 +134,7 @@ private:
     int64 m_account_id = -1;
     wxString m_status;
 
-    Fused_Transaction::Data m_fused_data;
+    Journal::Data m_journal_data;
     std::vector<Split> m_local_splits;
 
     std::vector<wxString> frequentNotes_;

--- a/src/util.h
+++ b/src/util.h
@@ -65,6 +65,8 @@ struct WebsiteNews
     wxString Description;
 };
 
+//----------------------------------------------------------------------------
+
 class mmListBoxItem: public wxClientData
 {
 public:
@@ -91,6 +93,11 @@ void correctEmptyFileExt(const wxString& ext, wxString & fileName );
 
 void mmLoadColorsFromDatabase(const bool def = false);
 wxString formatHTML(wxString& html);
+
+inline wxString getTranslation(bool translate, const wxString& text)
+{
+    return translate ? wxGetTranslation(text) : text;
+}
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR is a preparation to switch from `mmDateRange` to `DateRange2` in reports.

### File changes
* rename `src/fusedtransaction.{h,cpp}` -> `src/journal.{h,cpp}`

### Changes in settings
* add `REPORTING_RANGE` (similar to `CHECKING_RANGE`) in settings, to separate the ranges for checking and reporting panels (ranges for dashboard to be added in the future)

### Changes
* add `m_type_id` in mmDateRangeDialog
* when editing date ranges, load all ranges stored in settings (do not skip S)
* fix issues with date range and pickers in mmReportsPanel
* rename `mmPrintableBase` -> `ReportBase`
* rename and refine `mmReportPayeeExpenses` -> `ReportFlowByPayee`
* rename `Fused_Transaction` -> `Journal`
* several other renames (too many to list here)

### Naming conventions in mmReportsPanel
* member variable not derived from wxWidgets have prefix `m_`
* member variables derived from wxWidgets have prefix `w_`
* unused variables have prefix `u_`

### Control logic between data range and start/end pickers in mmReportsPanel
The active filter is indicated by `m_filter_id`, which is also stored in settings.
* If the active filter is `FILTER_ID_DATE_RANGE`, then `m_date_range` contains the range spec and it has empty (null) default start/end dates, while `w_{start,end}_date_picker` are derived from `m_date_range` (or set to a default value when the range is open).
* If the active filter is `FILTER_ID_DATE_PICKER`, then `w_{start,end}_date_picker` are the primary source of information, while `m_date_range` has the default range (All) and the default start/end dates are copied from the pickers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8132)
<!-- Reviewable:end -->
