### PR TITLE
fix(#8175): show languages in their native name

### DIFF
--- a/src/dialog/StartupDialog.cpp
+++ b/src/dialog/StartupDialog.cpp
@@ -203,8 +203,11 @@ void StartupDialog::OnButtonAppstartChangeLanguage( wxCommandEvent& /*event*/ )
     for (auto &file : langFiles)
     {
         const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info)
-            langs[wxGetTranslation(info->Description)] = std::make_pair(info->Language, info->CanonicalName);
+        if (info) {
+            //wxString label = wxGetTranslation(info->Description);
+            wxString label = info->CanonicalName + " " + info->DescriptionNative;
+            langs[label] = std::make_pair(info->Language, info->CanonicalName);
+        }
     }
 
     langChoices.Add(_t("System default"));

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1962,8 +1962,11 @@ void mmGUIFrame::createMenu()
         ->Check(m_app->getGUILanguage() == wxLANGUAGE_DEFAULT);
     for (auto & file : lang_files) {
         const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info)
-            langs[wxGetTranslation(info->Description)] = std::make_pair(info->Language, info->CanonicalName);
+        if (info) {
+            //wxString label = wxGetTranslation(info->Description);
+            wxString label = info->CanonicalName + " " + info->DescriptionNative;
+            langs[label] = std::make_pair(info->Language, info->CanonicalName);
+        }
     }
     langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
     for (auto const& lang : langs) {

--- a/src/pref/GeneralPref.cpp
+++ b/src/pref/GeneralPref.cpp
@@ -350,8 +350,11 @@ void GeneralPref::OnMouseLeftDown(wxCommandEvent& event)
     for (auto & file : lang_files)
     {
         const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info)
-            langs[wxGetTranslation(info->Description)] = std::make_pair(info->Language, info->CanonicalName);
+        if (info) {
+            //wxString label = wxGetTranslation(info->Description);
+            wxString label = info->CanonicalName + " " + info->DescriptionNative;
+            langs[label] = std::make_pair(info->Language, info->CanonicalName);
+        }
     }
     langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
     for (auto const& lang : langs)


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8194)
<!-- Reviewable:end -->
