### PR TITLE
fix(#8175): refine labels in language menus

### DIFF
--- a/src/base/constants.cpp
+++ b/src/base/constants.cpp
@@ -21,12 +21,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "defs.h"
 #include <wx/string.h>
 #include <wx/filefn.h>
+#include <wx/regex.h>
 #include <curl/curl.h>
 #include <rapidjson/rapidjson.h>
 
 #include "constants.h"
 #include "build.h"
 #include "table/_TableUpgrade.h"
+
+#include <algorithm>
 
 /*************************************************************************
  MMEX_VERSION
@@ -399,5 +402,53 @@ const wxArrayString g_locales()
     list.Add("zh_TW");
     list.Add("zu_ZA");
     return list;
+}
 
+const std::vector<mm_language_t> g_translations()
+{
+    // A language canonical name is of the form "^([a-z][a-z])_([A-Z][A-Z])$",
+    // where the first part is the language code and the second is the country code.
+    // The pattern below is more liberal.
+    wxRegEx lang_re("^([A-Za-z][A-Za-z0-9]*)_(.*)$");
+
+    std::vector<mm_language_t> lang_a;
+
+    // Add wxLANGUAGE_DEFAULT
+    lang_a.push_back({wxLANGUAGE_DEFAULT, _t("System default"), ""});
+
+    // Add all known languages
+    wxArrayString lang_name_a = wxTranslations::Get()->GetAvailableTranslations("mmex");
+    for (const auto& lang_name : lang_name_a) {
+        const wxLanguageInfo* lang_info = wxLocale::FindLanguageInfo(lang_name);
+        if (!lang_info)
+            continue;
+        //wxString lang_desc = wxGetTranslation(lang_info->Description);
+        wxString lang_code = lang_info->CanonicalName;
+        if (lang_re.IsValid() && lang_re.Matches(lang_code))
+            lang_re.Replace(&lang_code, "\\1(\\2)");
+        wxString lang_label = lang_code + " " + L"\x00B7" + " " + lang_info->DescriptionNative;
+        lang_a.push_back({
+            lang_info->Language,     /* id (wxLANGUAGE_*) */
+            lang_label,              /* label (canonical name and description) */
+            lang_info->CanonicalName /* help message (canonical name) */
+        });
+    }
+
+    // Ensure that wxLANGUAGE_ENGLISH_US is included
+    if (std::find_if(lang_a.begin(), lang_a.end(),
+        [](const mm_language_t& lang) {
+            return std::get<0>(lang) == wxLANGUAGE_ENGLISH_US;
+        }
+    ) == lang_a.end()) {
+        lang_a.push_back({wxLANGUAGE_ENGLISH_US, "English (US)", "en_US"});
+    }
+
+    // Sort by label, keeping wxLANGUAGE_DEFAULT first
+    std::sort(lang_a.begin() + 1, lang_a.end(),
+        [](const mm_language_t& x, const mm_language_t& y) {
+            return std::get<1>(x) < std::get<1>(y);
+        }
+    );
+
+    return lang_a;
 }

--- a/src/base/constants.h
+++ b/src/base/constants.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "defs.h"
 #include "paths.h"
 #include "versions.h"
+#include <tuple>
 
 class wxString;
 
@@ -120,6 +121,13 @@ extern const wxDateTime DATE_MAX;
 
 extern const wxArrayString g_locales();
 extern const wxString g_fiat_curr();
+
+typedef std::tuple<
+    int,      /* language id (wxLANGUAGE_*) */
+    wxString, /* language label (canonical name and description) */
+    wxString  /* help message (canonical name) */
+> mm_language_t;
+extern const std::vector<mm_language_t> g_translations();
 
 enum id
 {

--- a/src/dialog/StartupDialog.cpp
+++ b/src/dialog/StartupDialog.cpp
@@ -195,45 +195,38 @@ void StartupDialog::OnButtonAppstartOpenDatabaseClick( wxCommandEvent& /*event*/
 
 void StartupDialog::OnButtonAppstartChangeLanguage( wxCommandEvent& /*event*/ )
 {
-    wxArrayString langFiles = wxTranslations::Get()->GetAvailableTranslations("mmex");
-    wxArrayString langChoices;
-    std::map<wxString, std::pair<int, wxString>> langs;
-
-    langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
-    for (auto &file : langFiles)
-    {
-        const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info) {
-            //wxString label = wxGetTranslation(info->Description);
-            wxString label = info->CanonicalName + " " + info->DescriptionNative;
-            langs[label] = std::make_pair(info->Language, info->CanonicalName);
-        }
+    const std::vector<mm_language_t> lang_a = g_translations();
+    wxArrayString lang_label_a;
+    int current_i = -1;
+    int i = 0;
+    for (auto const& lang : lang_a) {
+        lang_label_a.Add(std::get<1>(lang));
+        if (current_i < 0 && std::get<0>(lang) == m_app->getGUILanguage())
+            current_i = i;
+        ++i;
+    }
+    if (current_i < 0) {
+        // 0 index must be wxLANGUAGE_DEFAULT
+        current_i = 0;
     }
 
-    langChoices.Add(_t("System default"));
-    int current = -1;
-    int i = 1;
-    for (auto &lang : langs)
-    {
-        langChoices.Add(lang.first);
-        if ((current < 0) && (lang.second.first == m_app->getGUILanguage()))
-            current = i;
-        i++;
-    }
-    if ((current < 0)) // Must be wxLANGUAGE_DEFAULT
-        current = 0;
+    mmSingleChoiceDialog lang_choice(this,
+        _t("Change user interface language"),
+        _t("User Interface Language"),
+        lang_label_a
+    );
+    if (lang_choice.ShowModal() != wxID_OK)
+        return;
 
-    mmSingleChoiceDialog lang_choice(this, _t("Change user interface language"), _t("User Interface Language"), langChoices);
-    if (lang_choice.ShowModal() == wxID_OK)
-    {
-        auto selected = lang_choice.GetStringSelection();
-        int langNo = (langs.count(selected) == 1) ? langs[selected].first : wxLANGUAGE_DEFAULT;
-        wxLanguage lang = static_cast<wxLanguage>(langNo);
-        if (lang != m_app->getGUILanguage() && m_app->setGUILanguage(lang))
-        mmErrorDialogs::MessageWarning(this
-            , _t("The language for this application has been changed. "
-                "The change will take effect the next time the application is started.")
-            , _t("Language change"));
+    std::size_t lang_i = static_cast<std::size_t>(lang_choice.GetSelection());
+    wxLanguage lang_id = static_cast<wxLanguage>(std::get<0>(lang_a[lang_i]));
+    if (lang_id != m_app->getGUILanguage() && m_app->setGUILanguage(lang_id)) {
+        mmErrorDialogs::MessageWarning(this,
+            _t("The language for this application has been changed. "
+                "The change will take effect the next time the application is started."
+            ),
+            _t("Language change")
+        );
     }
 }
 

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -75,9 +75,8 @@ wxLanguage mmGUIApp::getGUILanguage() const
 bool mmGUIApp::setGUILanguage(wxLanguage lang)
 {
     if (lang == this->m_lang && lang != wxLANGUAGE_UNKNOWN)
-    {
         return false;
-    }
+
     wxTranslations* trans = new wxTranslations;
 
     // Add the common UI Language translation catalog
@@ -86,38 +85,34 @@ bool mmGUIApp::setGUILanguage(wxLanguage lang)
 
     trans->SetLanguage(lang);
     trans->AddStdCatalog();
-    if (trans->AddCatalog("mmex", wxLANGUAGE_ENGLISH_US) || lang == wxLANGUAGE_ENGLISH_US || lang == wxLANGUAGE_DEFAULT)
-    {
+    if (trans->AddCatalog("mmex", wxLANGUAGE_ENGLISH_US) ||
+        lang == wxLANGUAGE_ENGLISH_US || lang == wxLANGUAGE_DEFAULT
+    ) {
         wxTranslations::Set(trans);
         this->m_lang = lang;
         PrefModel::instance().setLanguage(lang);
         return true;
     }
-    else
-    {
+    else {
         wxArrayString lang_files = trans->GetAvailableTranslations("mmex");
         if (lang_files.Index("en_US") == wxNOT_FOUND)
             lang_files.Add("en_US");
         wxArrayString lang_names;
-        for (const auto& file : lang_files)
-        {
+        for (const auto& file : lang_files) {
             const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-            if (info)
-            {
+            if (info) {
                 lang_names.Add(wxGetTranslation(info->Description));
             }
         }
         lang_names.Sort();
 
         wxString languages_list;
-        for (const auto& name : lang_names)
-        {
+        for (const auto& name : lang_names) {
             languages_list += (languages_list.empty() ? "" : ", ") + name;
         }
 
         wxString msg;
-        if (lang != wxLANGUAGE_UNKNOWN)
-        {
+        if (lang != wxLANGUAGE_UNKNOWN) {
             wxString best;
 #if wxCHECK_VERSION(3, 1, 2) && !wxCHECK_VERSION(3, 1, 3)
             // workaround for https://github.com/wxWidgets/wxWidgets/pull/1082
@@ -129,12 +124,13 @@ bool mmGUIApp::setGUILanguage(wxLanguage lang)
             msg = wxString::Format("Cannot load a translation for the language: %s", best);
             lang = wxLANGUAGE_UNKNOWN;
         }
-        if (lang == wxLANGUAGE_UNKNOWN)
-        {
+        if (lang == wxLANGUAGE_UNKNOWN) {
             msg += "\n\n";
-            msg += wxString::Format("Please use the Switch Application Language option in "
-                                    "View menu to select one of the following available languages:\n\n%s",
-                                    languages_list);
+            msg += wxString::Format(
+                "Please use the Switch Application Language option in "
+                "View menu to select one of the following available languages:\n\n%s",
+                languages_list
+            );
             m_lang = wxLANGUAGE_DEFAULT;
             PrefModel::instance().setLanguage(m_lang);
         }

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -1955,23 +1955,15 @@ void mmGUIFrame::createMenu()
         _t("Change user interface language")
     );
     wxMenu* menuLang = new wxMenu;
-
-    wxArrayString lang_files = wxTranslations::Get()->GetAvailableTranslations("mmex");
-    std::map<wxString, std::pair<int, wxString>> langs;
-    menuLang->AppendRadioItem(MENU_LANG + 1 + wxLANGUAGE_DEFAULT, _t("System default"))
-        ->Check(m_app->getGUILanguage() == wxLANGUAGE_DEFAULT);
-    for (auto & file : lang_files) {
-        const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info) {
-            //wxString label = wxGetTranslation(info->Description);
-            wxString label = info->CanonicalName + " " + info->DescriptionNative;
-            langs[label] = std::make_pair(info->Language, info->CanonicalName);
-        }
-    }
-    langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
-    for (auto const& lang : langs) {
-        menuLang->AppendRadioItem(MENU_LANG + 1 + lang.second.first, lang.first, lang.second.second)
-            ->Check(lang.second.first == m_app->getGUILanguage());
+    for (auto const& lang : g_translations()) {
+        int            lang_id    = std::get<0>(lang);
+        const wxString lang_label = std::get<1>(lang);
+        const wxString lang_help  = std::get<2>(lang);
+        menuLang->AppendRadioItem(
+            MENU_LANG + 1 + lang_id, lang_label, lang_help
+        )->Check(
+            lang_id == m_app->getGUILanguage()
+        );
     }
     menuItemLanguage->SetSubMenu(menuLang);
     menuView->Append(menuItemLanguage);

--- a/src/pref/GeneralPref.cpp
+++ b/src/pref/GeneralPref.cpp
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ********************************************************/
 
 #include "base/defs.h"
+#include "base/constants.h"
 #include <wx/spinctrl.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
@@ -343,24 +344,15 @@ void GeneralPref::OnChangeGUILanguage(wxCommandEvent& event)
 void GeneralPref::OnMouseLeftDown(wxCommandEvent& event)
 {
     wxMenu menuLang;
-    wxArrayString lang_files = wxTranslations::Get()->GetAvailableTranslations("mmex");
-    std::map<wxString, std::pair<int, wxString>> langs;
-    menuLang.AppendRadioItem(wxID_LAST + 1 + wxLANGUAGE_DEFAULT, _t("System default"))
-        ->Check(m_app->getGUILanguage() == wxLANGUAGE_DEFAULT);
-    for (auto & file : lang_files)
-    {
-        const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-        if (info) {
-            //wxString label = wxGetTranslation(info->Description);
-            wxString label = info->CanonicalName + " " + info->DescriptionNative;
-            langs[label] = std::make_pair(info->Language, info->CanonicalName);
-        }
-    }
-    langs[wxGetTranslation(wxLocale::GetLanguageName(wxLANGUAGE_ENGLISH_US))] = std::make_pair(wxLANGUAGE_ENGLISH_US, "en_US");
-    for (auto const& lang : langs)
-    {
-        menuLang.AppendRadioItem(wxID_LAST + 1 + lang.second.first, lang.first, lang.second.second)
-            ->Check(lang.second.first == m_app->getGUILanguage());
+    for (auto const& lang : g_translations()) {
+        int            lang_id    = std::get<0>(lang);
+        const wxString lang_label = std::get<1>(lang);
+        const wxString lang_help  = std::get<2>(lang);
+        menuLang.AppendRadioItem(
+            wxID_LAST + 1 + lang_id, lang_label, lang_help
+        )->Check(
+            lang_id == m_app->getGUILanguage()
+        );
     }
     PopupMenu(&menuLang);
 


### PR DESCRIPTION
Changes:
* refactor `g_translations()` in `base/constants`
* format language code as "hu(HU)" instead of the default "hu_HU"
* add dot separator between language code and language description
* ensure but do not duplicate English (US)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8198)
<!-- Reviewable:end -->
