### PR TITLE
fix bug in REFTYPE_CHOICES

### DIFF
--- a/src/model/_ModelBase.cpp
+++ b/src/model/_ModelBase.cpp
@@ -26,7 +26,7 @@ mmChoiceNameA ModelBase::REFTYPE_CHOICES = mmChoiceNameA({
     { REFTYPE_ID_BANKACCOUNT,       _n("BankAccount") },
     { REFTYPE_ID_BILLSDEPOSIT,      _n("RecurringTransaction") },
     { REFTYPE_ID_PAYEE,             _n("Payee") },
-    { REFTYPE_ID_TRANSACTIONSPLIT,  _n("TrxSplit") },
+    { REFTYPE_ID_TRANSACTIONSPLIT,  _n("TransactionSplit") },
     { REFTYPE_ID_BILLSDEPOSITSPLIT, _n("RecurringTransactionSplit") },
 }, -1, true);
 


### PR DESCRIPTION
This PR fixes a bug introduced during previous refactoring.

### Bug

In `ModelBase::REFTYPE_CHOICES`, the string value of `REFTYPE_ID_TRANSACTIONSPLIT` was changed by mistake from `"TransactionSplit"` to `"TrxSplit"` (during multiple search-and-replace of the class with the same name).

### Impact

* A wrong keyword is written in the database file, which makes a record invalid.
* Existing records with reference type `"TransactionSplit"` are not recognized as valid records.

### Fix

* In `ModelBase::REFTYPE_CHOICES`, change `"TrxSplit"` -> `"TransactionSplit"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8203)
<!-- Reviewable:end -->
