### PR TITLE
refine data and model (part 3)

### DIFF
--- a/src/_readme.txt
+++ b/src/_readme.txt
@@ -1,13 +1,13 @@
 Common prefix symbols (to avoid name collision with methods):
   prefix e_ : enumeration case
   prefix m_ : member variable
-  prefix s_ : static
+  prefix s_ : static (non-instance) constant or variable
   prefix w_ : widget member variable (derived from wxWidgets class)
 
 Common suffix symols (to indicate the variable content):
   suffix _a : array
   suffix _c : count (int, size_t)
-  suffix _d : *Data
+  suffix _d : *Data (this is not a pointer; use _p or _n for pointer to *Data)
   suffix _m : ordered map, unordered map, set
   suffix _n : nullable (e.g., nullptr, nullopt, value out of range)
   suffix _p : non-null (e.g., pointer which is always non-null)

--- a/src/data/AccountData.cpp
+++ b/src/data/AccountData.cpp
@@ -68,27 +68,27 @@ AccountRow AccountData::to_row() const
 // Convert AccountRow to AccountData
 AccountData& AccountData::from_row(const AccountRow& row)
 {
-    m_id                 = row.ACCOUNTID;                     // int64
-    m_name               = row.ACCOUNTNAME;                   // wxString
-    m_type_              = row.ACCOUNTTYPE;                   // wxString
-    m_currency_id        = row.CURRENCYID;                    // int64
-    m_status             = AccountStatus(row.STATUS);         // wxString
-    m_favorite           = AccountFavorite(row.FAVORITEACCT); // wxString
-    m_num                = row.ACCOUNTNUM;                    // wxString
-    m_notes              = row.NOTES;                         // wxString
-    m_held_at            = row.HELDAT;                        // wxString
-    m_website            = row.WEBSITE;                       // wxString
-    m_contact_info       = row.CONTACTINFO;                   // wxString
-    m_access_info        = row.ACCESSINFO;                    // wxString
-    m_open_date          = mmDate(row.INITIALDATE);           // wxString
-    m_open_balance       = row.INITIALBAL;                    // double
-    m_stmt_locked        = (row.STATEMENTLOCKED > 0);         // int64
-    m_stmt_date_n        = mmDateN(row.STATEMENTDATE);        // wxString
-    m_min_balance        = row.MINIMUMBALANCE;                // double
-    m_credit_limit       = row.CREDITLIMIT;                   // double
-    m_interest_rate      = row.INTERESTRATE;                  // double
-    m_payment_due_date_n = mmDateN(row.PAYMENTDUEDATE);       // wxString
-    m_min_payment        = row.MINIMUMPAYMENT;                // double
+    m_id                 = row.ACCOUNTID;
+    m_name               = row.ACCOUNTNAME;
+    m_type_              = row.ACCOUNTTYPE;
+    m_currency_id        = row.CURRENCYID;
+    m_status             = AccountStatus(row.STATUS);
+    m_favorite           = AccountFavorite(row.FAVORITEACCT);
+    m_num                = row.ACCOUNTNUM;
+    m_notes              = row.NOTES;
+    m_held_at            = row.HELDAT;
+    m_website            = row.WEBSITE;
+    m_contact_info       = row.CONTACTINFO;
+    m_access_info        = row.ACCESSINFO;
+    m_open_date          = mmDate(row.INITIALDATE);
+    m_open_balance       = row.INITIALBAL;
+    m_stmt_locked        = (row.STATEMENTLOCKED > 0);
+    m_stmt_date_n        = mmDateN(row.STATEMENTDATE);
+    m_min_balance        = row.MINIMUMBALANCE;
+    m_credit_limit       = row.CREDITLIMIT;
+    m_interest_rate      = row.INTERESTRATE;
+    m_payment_due_date_n = mmDateN(row.PAYMENTDUEDATE);
+    m_min_payment        = row.MINIMUMPAYMENT;
 
     return *this;
 }

--- a/src/data/AssetData.cpp
+++ b/src/data/AssetData.cpp
@@ -54,17 +54,17 @@ AssetRow AssetData::to_row() const
 // Convert AssetRow to AssetData
 AssetData& AssetData::from_row(const AssetRow& row)
 {
-    m_id            = row.ASSETID;                          // int64
-    m_type          = AssetType(row.ASSETTYPE);             // wxString
-    m_status        = AssetStatus(row.ASSETSTATUS);         // wxString
-    m_name          = row.ASSETNAME;                        // wxString
-    m_start_date    = mmDate(row.STARTDATE);                // wxString
-    m_currency_id_n = row.CURRENCYID;                       // int64
-    m_value         = row.VALUE;                            // double
-    m_change        = AssetChange(row.VALUECHANGE);         // wxString
-    m_change_mode   = AssetChangeMode(row.VALUECHANGEMODE); // wxString
-    m_change_rate   = row.VALUECHANGERATE;                  // double
-    m_notes         = row.NOTES;                            // wxString
+    m_id            = row.ASSETID;
+    m_type          = AssetType(row.ASSETTYPE);
+    m_status        = AssetStatus(row.ASSETSTATUS);
+    m_name          = row.ASSETNAME;
+    m_start_date    = mmDate(row.STARTDATE);
+    m_currency_id_n = row.CURRENCYID;
+    m_value         = row.VALUE;
+    m_change        = AssetChange(row.VALUECHANGE);
+    m_change_mode   = AssetChangeMode(row.VALUECHANGEMODE);
+    m_change_rate   = row.VALUECHANGERATE;
+    m_notes         = row.NOTES;
 
     return *this;
 }

--- a/src/data/AttachmentData.cpp
+++ b/src/data/AttachmentData.cpp
@@ -16,15 +16,13 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-// This is only sample code re-used from "table/AttachmentTable.cpp".
-
 #include "AttachmentData.h"
 
-AttachmentData::AttachmentData()
+AttachmentData::AttachmentData() :
+    m_id(-1),
+    m_ref_type_n(RefTypeN()),
+    m_ref_id(-1)
 {
-    ATTACHMENTID = -1;
-    REFID = -1;
 }
 
 // Convert AttachmentData to AttachmentRow
@@ -32,11 +30,11 @@ AttachmentRow AttachmentData::to_row() const
 {
     AttachmentRow row;
 
-    row.ATTACHMENTID = ATTACHMENTID;
-    row.REFTYPE = REFTYPE;
-    row.REFID = REFID;
-    row.DESCRIPTION = DESCRIPTION;
-    row.FILENAME = FILENAME;
+    row.ATTACHMENTID = m_id;
+    row.REFTYPE      = m_ref_type_n.name_n();
+    row.REFID        = m_ref_id;
+    row.DESCRIPTION  = m_description;
+    row.FILENAME     = m_filename;
 
     return row;
 }
@@ -44,22 +42,22 @@ AttachmentRow AttachmentData::to_row() const
 // Convert AttachmentRow to AttachmentData
 AttachmentData& AttachmentData::from_row(const AttachmentRow& row)
 {
-    ATTACHMENTID = row.ATTACHMENTID; // int64
-    REFTYPE = row.REFTYPE; // wxString
-    REFID = row.REFID; // int64
-    DESCRIPTION = row.DESCRIPTION; // wxString
-    FILENAME = row.FILENAME; // wxString
+    m_id          = row.ATTACHMENTID;      // int64
+    m_ref_type_n  = RefTypeN(row.REFTYPE); // wxString
+    m_ref_id      = row.REFID;             // int64
+    m_description = row.DESCRIPTION;       // wxString
+    m_filename    = row.FILENAME;          // wxString
 
     return *this;
 }
 
 bool AttachmentData::equals(const AttachmentData* other) const
 {
-    if ( ATTACHMENTID != other->ATTACHMENTID) return false;
-    if (!REFTYPE.IsSameAs(other->REFTYPE)) return false;
-    if ( REFID != other->REFID) return false;
-    if (!DESCRIPTION.IsSameAs(other->DESCRIPTION)) return false;
-    if (!FILENAME.IsSameAs(other->FILENAME)) return false;
+    if ( m_id                 != other->m_id)                return false;
+    if ( m_ref_type_n.id_n()  != other->m_ref_type_n.id_n()) return false;
+    if ( m_ref_id             != other->m_ref_id)            return false;
+    if (!m_description.IsSameAs( other->m_description))      return false;
+    if (!m_filename.IsSameAs(    other->m_filename))         return false;
 
     return true;
 }

--- a/src/data/AttachmentData.cpp
+++ b/src/data/AttachmentData.cpp
@@ -42,11 +42,11 @@ AttachmentRow AttachmentData::to_row() const
 // Convert AttachmentRow to AttachmentData
 AttachmentData& AttachmentData::from_row(const AttachmentRow& row)
 {
-    m_id          = row.ATTACHMENTID;      // int64
-    m_ref_type_n  = RefTypeN(row.REFTYPE); // wxString
-    m_ref_id      = row.REFID;             // int64
-    m_description = row.DESCRIPTION;       // wxString
-    m_filename    = row.FILENAME;          // wxString
+    m_id          = row.ATTACHMENTID;
+    m_ref_type_n  = RefTypeN(row.REFTYPE);
+    m_ref_id      = row.REFID;
+    m_description = row.DESCRIPTION;
+    m_filename    = row.FILENAME;
 
     return *this;
 }

--- a/src/data/AttachmentData.h
+++ b/src/data/AttachmentData.h
@@ -16,41 +16,27 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-//
-// This is only sample code re-used from "table/AttachmentTable.h".
-//
-// The data structure can be refined by:
-// * using more user-frielndly filed name
-// * using stronger field types
-// * adding enumerations for fields with limited choices
-// * demultiplexing composite values in database columns
-//
-// See also an implementation in Swift:
-//   https://github.com/moneymanagerex/mmex-ios/tree/master/MMEX/Data
-// and an implementation in Java:
-//   https://github.com/moneymanagerex/android-money-manager-ex/tree/master/app/src/main/java/com/money/manager/ex/domainmodel
-
 #pragma once
 
+#include "_DataEnum.h"
 #include "table/_TableBase.h"
 #include "table/AttachmentTable.h"
 
 // User-friendly representation of a record in table ATTACHMENT_V1.
 struct AttachmentData
 {
-    int64 ATTACHMENTID; // primary key
-    wxString REFTYPE;
-    int64 REFID;
-    wxString DESCRIPTION;
-    wxString FILENAME;
+    int64    m_id;
+    RefTypeN m_ref_type_n;  // non-null after initialization; null value is an error
+    int64    m_ref_id;      // non-null (> 0) after initialization
+    wxString m_description;
+    wxString m_filename;
 
     explicit AttachmentData();
     explicit AttachmentData(wxSQLite3ResultSet& q);
     AttachmentData(const AttachmentData& other) = default;
 
-    int64 id() const { return ATTACHMENTID; }
-    void id(const int64 id) { ATTACHMENTID = id; }
+    int64 id() const { return m_id; }
+    void id(const int64 id) { m_id = id; }
     AttachmentRow to_row() const;
     AttachmentData& from_row(const AttachmentRow& row);
     void to_insert_stmt(wxSQLite3Statement& stmt, int64 id) const;
@@ -71,7 +57,7 @@ struct AttachmentData
     {
         bool operator()(const AttachmentData& x, const AttachmentData& y)
         {
-            return x.ATTACHMENTID < y.ATTACHMENTID;
+            return x.m_id < y.m_id;
         }
     };
 
@@ -79,7 +65,7 @@ struct AttachmentData
     {
         bool operator()(const AttachmentData& x, const AttachmentData& y)
         {
-            return x.REFTYPE < y.REFTYPE;
+            return x.m_ref_type_n.id_n() < y.m_ref_type_n.id_n();
         }
     };
 
@@ -87,7 +73,7 @@ struct AttachmentData
     {
         bool operator()(const AttachmentData& x, const AttachmentData& y)
         {
-            return x.REFID < y.REFID;
+            return x.m_ref_id < y.m_ref_id;
         }
     };
 
@@ -95,7 +81,7 @@ struct AttachmentData
     {
         bool operator()(const AttachmentData& x, const AttachmentData& y)
         {
-            return x.DESCRIPTION < y.DESCRIPTION;
+            return x.m_description < y.m_description;
         }
     };
 
@@ -103,7 +89,7 @@ struct AttachmentData
     {
         bool operator()(const AttachmentData& x, const AttachmentData& y)
         {
-            return x.FILENAME < y.FILENAME;
+            return x.m_filename < y.m_filename;
         }
     };
 };

--- a/src/data/BudgetData.cpp
+++ b/src/data/BudgetData.cpp
@@ -18,14 +18,14 @@
 
 #include "BudgetData.h"
 
-BudgetData::BudgetData()
+BudgetData::BudgetData() :
+    m_id(-1),
+    m_period_id(-1),
+    m_category_id(-1),
+    m_frequency(BudgetFrequency()),
+    m_amount(0.0),
+    m_active(true)
 {
-    m_id          = -1;
-    m_period_id   = -1;
-    m_category_id = -1;
-    m_frequency   = BudgetFrequency();
-    m_amount      = 0.0;
-    m_active      = true;
 }
 
 // Convert BudgetData to BudgetRow
@@ -47,13 +47,13 @@ BudgetRow BudgetData::to_row() const
 // Convert BudgetRow to BudgetData
 BudgetData& BudgetData::from_row(const BudgetRow& row)
 {
-    m_id          = row.BUDGETENTRYID;           // int64
-    m_period_id   = row.BUDGETYEARID;            // int64
-    m_category_id = row.CATEGID;                 // int64
-    m_frequency   = BudgetFrequency(row.PERIOD); // wxString
-    m_amount      = row.AMOUNT;                  // double
-    m_notes       = row.NOTES;                   // wxString
-    m_active      = (row.ACTIVE != 0);           // int64
+    m_id          = row.BUDGETENTRYID;
+    m_period_id   = row.BUDGETYEARID;
+    m_category_id = row.CATEGID;
+    m_frequency   = BudgetFrequency(row.PERIOD);
+    m_amount      = row.AMOUNT;
+    m_notes       = row.NOTES;
+    m_active      = (row.ACTIVE != 0);
 
     return *this;
 }

--- a/src/data/BudgetData.h
+++ b/src/data/BudgetData.h
@@ -55,9 +55,11 @@ struct BudgetData
     bool operator< (const BudgetData& other) const { return id() < other.id(); }
     bool operator< (const BudgetData* other) const { return id() < other->id(); }
 
-    double get_estimate(bool monthly) const {
-        double estimate = m_amount * m_frequency.times_per_year();
-        return monthly ? estimate / 12 : estimate;
+    double amount_per_year() const {
+        return m_amount * m_frequency.times_per_year();
+    }
+    double amount_per_month() const {
+        return m_amount * m_frequency.times_per_month();
     }
 
     struct SorterByBUDGETENTRYID

--- a/src/data/BudgetPeriodData.cpp
+++ b/src/data/BudgetPeriodData.cpp
@@ -18,9 +18,9 @@
 
 #include "BudgetPeriodData.h"
 
-BudgetPeriodData::BudgetPeriodData()
+BudgetPeriodData::BudgetPeriodData() :
+    m_id(-1)
 {
-    m_id = -1;
 }
 
 // Convert BudgetPeriodData to BudgetPeriodRow
@@ -37,8 +37,8 @@ BudgetPeriodRow BudgetPeriodData::to_row() const
 // Convert BudgetPeriodRow to BudgetPeriodData
 BudgetPeriodData& BudgetPeriodData::from_row(const BudgetPeriodRow& row)
 {
-    m_id   = row.BUDGETYEARID;   // int64
-    m_name = row.BUDGETYEARNAME; // wxString
+    m_id   = row.BUDGETYEARID;
+    m_name = row.BUDGETYEARNAME;
 
     return *this;
 }

--- a/src/data/CategoryData.cpp
+++ b/src/data/CategoryData.cpp
@@ -18,11 +18,11 @@
 
 #include "CategoryData.h"
 
-CategoryData::CategoryData()
+CategoryData::CategoryData() :
+    m_id(-1),
+    m_parent_id_n(-1),
+    m_active(true)
 {
-    m_id          = -1;
-    m_parent_id_n = -1;
-    m_active      = true;
 }
 
 // Convert CategoryData to CategoryRow
@@ -41,10 +41,10 @@ CategoryRow CategoryData::to_row() const
 // Convert CategoryRow to CategoryData
 CategoryData& CategoryData::from_row(const CategoryRow& row)
 {
-    m_id          = row.CATEGID;       // int64
-    m_name        = row.CATEGNAME;     // wxString
-    m_active      = (row.ACTIVE != 0); // int64
-    m_parent_id_n = row.PARENTID;      // int64
+    m_id          = row.CATEGID;
+    m_name        = row.CATEGNAME;
+    m_active      = (row.ACTIVE != 0);
+    m_parent_id_n = row.PARENTID;
 
     return *this;
 }

--- a/src/data/CurrencyData.cpp
+++ b/src/data/CurrencyData.cpp
@@ -18,12 +18,12 @@
 
 #include "CurrencyData.h"
 
-CurrencyData::CurrencyData()
+CurrencyData::CurrencyData() :
+    m_id(-1),
+    m_type(CurrencyType()),
+    m_scale(-1),
+    m_base_conv_rate(0.0)
 {
-    m_id             = -1;
-    m_type           = CurrencyType();
-    m_scale          = -1;
-    m_base_conv_rate = 0.0;
 }
 
 // Convert CurrencyData to CurrencyRow
@@ -50,18 +50,18 @@ CurrencyRow CurrencyData::to_row() const
 // Convert CurrencyRow to CurrencyData
 CurrencyData& CurrencyData::from_row(const CurrencyRow& row)
 {
-    m_id              = row.CURRENCYID;                  // int64
-    m_symbol          = row.CURRENCY_SYMBOL;             // wxString
-    m_name            = row.CURRENCYNAME;                // wxString
-    m_type            = CurrencyType(row.CURRENCY_TYPE); // wxString
-    m_prefix_symbol   = row.PFX_SYMBOL;                  // wxString
-    m_suffix_symbol   = row.SFX_SYMBOL;                  // wxString
-    m_decimal_point   = row.DECIMAL_POINT;               // wxString
-    m_group_separator = row.GROUP_SEPARATOR;             // wxString
-    m_unit_name       = row.UNIT_NAME;                   // wxString
-    m_cent_name       = row.CENT_NAME;                   // wxString
-    m_scale           = row.SCALE;                       // int64
-    m_base_conv_rate  = row.BASECONVRATE;                // double
+    m_id              = row.CURRENCYID;
+    m_symbol          = row.CURRENCY_SYMBOL;
+    m_name            = row.CURRENCYNAME;
+    m_type            = CurrencyType(row.CURRENCY_TYPE);
+    m_prefix_symbol   = row.PFX_SYMBOL;
+    m_suffix_symbol   = row.SFX_SYMBOL;
+    m_decimal_point   = row.DECIMAL_POINT;
+    m_group_separator = row.GROUP_SEPARATOR;
+    m_unit_name       = row.UNIT_NAME;
+    m_cent_name       = row.CENT_NAME;
+    m_scale           = row.SCALE;
+    m_base_conv_rate  = row.BASECONVRATE;
 
     return *this;
 }

--- a/src/data/CurrencyHistoryData.cpp
+++ b/src/data/CurrencyHistoryData.cpp
@@ -44,11 +44,11 @@ CurrencyHistoryRow CurrencyHistoryData::to_row() const
 // Convert CurrencyHistoryRow to CurrencyHistoryData
 CurrencyHistoryData& CurrencyHistoryData::from_row(const CurrencyHistoryRow& row)
 {
-    m_id             = row.CURRHISTID;              // int64
-    m_currency_id    = row.CURRENCYID;              // int64
-    m_date           = mmDate(row.CURRDATE);        // wxString
-    m_base_conv_rate = row.CURRVALUE;               // double
-    m_update_type    = UpdateType(row.CURRUPDTYPE); // int64
+    m_id             = row.CURRHISTID;
+    m_currency_id    = row.CURRENCYID;
+    m_date           = mmDate(row.CURRDATE);
+    m_base_conv_rate = row.CURRVALUE;
+    m_update_type    = UpdateType(row.CURRUPDTYPE);
 
     return *this;
 }

--- a/src/data/CurrencyHistoryData.cpp
+++ b/src/data/CurrencyHistoryData.cpp
@@ -36,7 +36,7 @@ CurrencyHistoryRow CurrencyHistoryData::to_row() const
     row.CURRENCYID  = m_currency_id;
     row.CURRDATE    = m_date.isoDate();
     row.CURRVALUE   = m_base_conv_rate;
-    row.CURRUPDTYPE = m_update_type.value();
+    row.CURRUPDTYPE = static_cast<int64>(m_update_type.code());
 
     return row;
 }
@@ -48,7 +48,9 @@ CurrencyHistoryData& CurrencyHistoryData::from_row(const CurrencyHistoryRow& row
     m_currency_id    = row.CURRENCYID;
     m_date           = mmDate(row.CURRDATE);
     m_base_conv_rate = row.CURRVALUE;
-    m_update_type    = UpdateType(row.CURRUPDTYPE);
+    m_update_type    = UpdateType::from_code(
+        static_cast<int>(row.CURRUPDTYPE.GetValue())
+    );
 
     return *this;
 }

--- a/src/data/FieldData.cpp
+++ b/src/data/FieldData.cpp
@@ -18,9 +18,9 @@
 
 #include "FieldData.h"
 
-FieldData::FieldData()
+FieldData::FieldData() :
+    m_id(-1)
 {
-    m_id = -1;
 }
 
 // Convert FieldData to FieldRow
@@ -40,11 +40,11 @@ FieldRow FieldData::to_row() const
 // Convert FieldRow to FieldData
 FieldData& FieldData::from_row(const FieldRow& row)
 {
-    m_id          = row.FIELDID;           // int64
-    m_ref_type    = RefTypeN(row.REFTYPE); // wxString
-    m_description = row.DESCRIPTION;       // wxString
-    m_type_n      = FieldTypeN(row.TYPE);  // wxString
-    m_properties  = row.PROPERTIES;        // wxString
+    m_id          = row.FIELDID;
+    m_ref_type    = RefTypeN(row.REFTYPE);
+    m_description = row.DESCRIPTION;
+    m_type_n      = FieldTypeN(row.TYPE);
+    m_properties  = row.PROPERTIES;
 
     return *this;
 }

--- a/src/data/FieldData.cpp
+++ b/src/data/FieldData.cpp
@@ -16,14 +16,11 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-// This is only sample code re-used from "table/FieldTable.cpp".
-
 #include "FieldData.h"
 
 FieldData::FieldData()
 {
-    FIELDID = -1;
+    m_id = -1;
 }
 
 // Convert FieldData to FieldRow
@@ -31,11 +28,11 @@ FieldRow FieldData::to_row() const
 {
     FieldRow row;
 
-    row.FIELDID = FIELDID;
-    row.REFTYPE = REFTYPE;
-    row.DESCRIPTION = DESCRIPTION;
-    row.TYPE = TYPE;
-    row.PROPERTIES = PROPERTIES;
+    row.FIELDID     = m_id;
+    row.REFTYPE     = m_ref_type.name_n();
+    row.DESCRIPTION = m_description;
+    row.TYPE        = m_type_n.name_n();
+    row.PROPERTIES  = m_properties;
 
     return row;
 }
@@ -43,22 +40,22 @@ FieldRow FieldData::to_row() const
 // Convert FieldRow to FieldData
 FieldData& FieldData::from_row(const FieldRow& row)
 {
-    FIELDID = row.FIELDID; // int64
-    REFTYPE = row.REFTYPE; // wxString
-    DESCRIPTION = row.DESCRIPTION; // wxString
-    TYPE = row.TYPE; // wxString
-    PROPERTIES = row.PROPERTIES; // wxString
+    m_id          = row.FIELDID;           // int64
+    m_ref_type    = RefTypeN(row.REFTYPE); // wxString
+    m_description = row.DESCRIPTION;       // wxString
+    m_type_n      = FieldTypeN(row.TYPE);  // wxString
+    m_properties  = row.PROPERTIES;        // wxString
 
     return *this;
 }
 
 bool FieldData::equals(const FieldData* other) const
 {
-    if ( FIELDID != other->FIELDID) return false;
-    if (!REFTYPE.IsSameAs(other->REFTYPE)) return false;
-    if (!DESCRIPTION.IsSameAs(other->DESCRIPTION)) return false;
-    if (!TYPE.IsSameAs(other->TYPE)) return false;
-    if (!PROPERTIES.IsSameAs(other->PROPERTIES)) return false;
+    if ( m_id                 != other->m_id)              return false;
+    if ( m_ref_type.id_n()    != other->m_ref_type.id_n()) return false;
+    if (!m_description.IsSameAs( other->m_description))    return false;
+    if ( m_type_n.id_n()      != other->m_type_n.id_n())   return false;
+    if (!m_properties.IsSameAs(  other->m_properties))     return false;
 
     return true;
 }

--- a/src/data/FieldData.h
+++ b/src/data/FieldData.h
@@ -16,41 +16,27 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-//
-// This is only sample code re-used from "table/FieldTable.h".
-//
-// The data structure can be refined by:
-// * using more user-frielndly filed name
-// * using stronger field types
-// * adding enumerations for fields with limited choices
-// * demultiplexing composite values in database columns
-//
-// See also an implementation in Swift:
-//   https://github.com/moneymanagerex/mmex-ios/tree/master/MMEX/Data
-// and an implementation in Java:
-//   https://github.com/moneymanagerex/android-money-manager-ex/tree/master/app/src/main/java/com/money/manager/ex/domainmodel
-
 #pragma once
 
+#include "_DataEnum.h"
 #include "table/_TableBase.h"
 #include "table/FieldTable.h"
 
 // User-friendly representation of a record in table CUSTOMFIELD_V1.
 struct FieldData
 {
-    int64 FIELDID; // primary key
-    wxString REFTYPE;
-    wxString DESCRIPTION;
-    wxString TYPE;
-    wxString PROPERTIES;
+    int64      m_id;
+    RefTypeN   m_ref_type;    // one of [e_trx, e_sched] after initialization
+    wxString   m_description;
+    FieldTypeN m_type_n;      // check for null
+    wxString   m_properties;
 
     explicit FieldData();
     explicit FieldData(wxSQLite3ResultSet& q);
     FieldData(const FieldData& other) = default;
 
-    int64 id() const { return FIELDID; }
-    void id(const int64 id) { FIELDID = id; }
+    int64 id() const { return m_id; }
+    void id(const int64 id) { m_id = id; }
     FieldRow to_row() const;
     FieldData& from_row(const FieldRow& row);
     void to_insert_stmt(wxSQLite3Statement& stmt, int64 id) const;
@@ -71,7 +57,7 @@ struct FieldData
     {
         bool operator()(const FieldData& x, const FieldData& y)
         {
-            return x.FIELDID < y.FIELDID;
+            return x.m_id < y.m_id;
         }
     };
 
@@ -79,7 +65,7 @@ struct FieldData
     {
         bool operator()(const FieldData& x, const FieldData& y)
         {
-            return x.REFTYPE < y.REFTYPE;
+            return x.m_ref_type.id_n() < y.m_ref_type.id_n();
         }
     };
 
@@ -87,7 +73,7 @@ struct FieldData
     {
         bool operator()(const FieldData& x, const FieldData& y)
         {
-            return x.DESCRIPTION < y.DESCRIPTION;
+            return x.m_description < y.m_description;
         }
     };
 
@@ -95,7 +81,7 @@ struct FieldData
     {
         bool operator()(const FieldData& x, const FieldData& y)
         {
-            return x.TYPE < y.TYPE;
+            return x.m_type_n.id_n() < y.m_type_n.id_n();
         }
     };
 
@@ -103,7 +89,7 @@ struct FieldData
     {
         bool operator()(const FieldData& x, const FieldData& y)
         {
-            return x.PROPERTIES < y.PROPERTIES;
+            return x.m_properties < y.m_properties;
         }
     };
 };

--- a/src/data/FieldData.h
+++ b/src/data/FieldData.h
@@ -28,7 +28,7 @@ struct FieldData
     int64      m_id;
     RefTypeN   m_ref_type;    // one of [e_trx, e_sched] after initialization
     wxString   m_description;
-    FieldTypeN m_type_n;      // check for null
+    FieldTypeN m_type_n;      // can be null
     wxString   m_properties;
 
     explicit FieldData();

--- a/src/data/FieldValueData.cpp
+++ b/src/data/FieldValueData.cpp
@@ -16,16 +16,14 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-// This is only sample code re-used from "table/FieldValueTable.cpp".
-
 #include "FieldValueData.h"
 
-FieldValueData::FieldValueData()
+FieldValueData::FieldValueData() :
+    m_id(-1),
+    m_field_id(-1),
+    m_ref_type(RefTypeN()),
+    m_ref_id(-1)
 {
-    FIELDATADID = -1;
-    FIELDID = -1;
-    REFID = -1;
 }
 
 // Convert FieldValueData to FieldValueRow
@@ -33,10 +31,11 @@ FieldValueRow FieldValueData::to_row() const
 {
     FieldValueRow row;
 
-    row.FIELDATADID = FIELDATADID;
-    row.FIELDID = FIELDID;
-    row.REFID = REFID;
-    row.CONTENT = CONTENT;
+
+    row.FIELDATADID = m_id;
+    row.FIELDID     = m_field_id;
+    row.REFID       = FieldValueData::encode_REFID(m_ref_type, m_ref_id);
+    row.CONTENT     = m_content;
 
     return row;
 }
@@ -44,20 +43,22 @@ FieldValueRow FieldValueData::to_row() const
 // Convert FieldValueRow to FieldValueData
 FieldValueData& FieldValueData::from_row(const FieldValueRow& row)
 {
-    FIELDATADID = row.FIELDATADID; // int64
-    FIELDID = row.FIELDID; // int64
-    REFID = row.REFID; // int64
-    CONTENT = row.CONTENT; // wxString
+    m_id       = row.FIELDATADID;
+    m_field_id = row.FIELDID;
+    m_ref_type = FieldValueData::decode_ref_type(row.REFID);
+    m_ref_id   = FieldValueData::decode_ref_id(row.REFID);
+    m_content  = row.CONTENT;
 
     return *this;
 }
 
 bool FieldValueData::equals(const FieldValueData* other) const
 {
-    if ( FIELDATADID != other->FIELDATADID) return false;
-    if ( FIELDID != other->FIELDID) return false;
-    if ( REFID != other->REFID) return false;
-    if (!CONTENT.IsSameAs(other->CONTENT)) return false;
+    if ( m_id              != other->m_id)              return false;
+    if ( m_field_id        != other->m_field_id)        return false;
+    if ( m_ref_type.id_n() != other->m_ref_type.id_n()) return false;
+    if ( m_ref_id          != other->m_ref_id)          return false;
+    if (!m_content.IsSameAs(  other->m_content))        return false;
 
     return true;
 }

--- a/src/data/FieldValueData.h
+++ b/src/data/FieldValueData.h
@@ -16,40 +16,27 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-//
-// This is only sample code re-used from "table/FieldValueTable.h".
-//
-// The data structure can be refined by:
-// * using more user-frielndly filed name
-// * using stronger field types
-// * adding enumerations for fields with limited choices
-// * demultiplexing composite values in database columns
-//
-// See also an implementation in Swift:
-//   https://github.com/moneymanagerex/mmex-ios/tree/master/MMEX/Data
-// and an implementation in Java:
-//   https://github.com/moneymanagerex/android-money-manager-ex/tree/master/app/src/main/java/com/money/manager/ex/domainmodel
-
 #pragma once
 
+#include "_DataEnum.h"
 #include "table/_TableBase.h"
 #include "table/FieldValueTable.h"
 
 // User-friendly representation of a record in table CUSTOMFIELDDATA_V1.
 struct FieldValueData
 {
-    int64 FIELDATADID; // primary key
-    int64 FIELDID;
-    int64 REFID;
-    wxString CONTENT;
+    int64    m_id;
+    int64    m_field_id; // non-null (> 0) after initialization
+    RefTypeN m_ref_type; // one of (e_trx, e_sched) after initialization
+    int64    m_ref_id;   // non-null (> 0) after initialization
+    wxString m_content;
 
     explicit FieldValueData();
     explicit FieldValueData(wxSQLite3ResultSet& q);
     FieldValueData(const FieldValueData& other) = default;
 
-    int64 id() const { return FIELDATADID; }
-    void id(const int64 id) { FIELDATADID = id; }
+    int64 id() const { return m_id; }
+    void id(const int64 id) { m_id = id; }
     FieldValueRow to_row() const;
     FieldValueData& from_row(const FieldValueRow& row);
     void to_insert_stmt(wxSQLite3Statement& stmt, int64 id) const;
@@ -66,11 +53,21 @@ struct FieldValueData
     bool operator< (const FieldValueData& other) const { return id() < other.id(); }
     bool operator< (const FieldValueData* other) const { return id() < other->id(); }
 
+    static RefTypeN decode_ref_type(int64 row_REFID) {
+        return RefTypeN((row_REFID < 0) ? RefTypeN::e_sched : RefTypeN::e_trx);
+    }
+    static int64 decode_ref_id(int64 row_REFID) {
+        return (row_REFID < 0) ? -row_REFID : row_REFID;
+    }
+    static int64 encode_REFID(RefTypeN ref_type, int64 ref_id) {
+        return (ref_type.id_n() == RefTypeN::e_sched) ? -ref_id : ref_id;
+    }
+
     struct SorterByFIELDATADID
     {
         bool operator()(const FieldValueData& x, const FieldValueData& y)
         {
-            return x.FIELDATADID < y.FIELDATADID;
+            return x.m_id < y.m_id;
         }
     };
 
@@ -78,7 +75,15 @@ struct FieldValueData
     {
         bool operator()(const FieldValueData& x, const FieldValueData& y)
         {
-            return x.FIELDID < y.FIELDID;
+            return x.m_field_id < y.m_field_id;
+        }
+    };
+
+    struct SorterByREFTYPE
+    {
+        bool operator()(const FieldValueData& x, const FieldValueData& y)
+        {
+            return x.m_ref_type.id_n() < y.m_ref_type.id_n();
         }
     };
 
@@ -86,7 +91,7 @@ struct FieldValueData
     {
         bool operator()(const FieldValueData& x, const FieldValueData& y)
         {
-            return x.REFID < y.REFID;
+            return x.m_ref_id < y.m_ref_id;
         }
     };
 
@@ -94,7 +99,7 @@ struct FieldValueData
     {
         bool operator()(const FieldValueData& x, const FieldValueData& y)
         {
-            return x.CONTENT < y.CONTENT;
+            return x.m_content < y.m_content;
         }
     };
 };

--- a/src/data/FieldValueData.h
+++ b/src/data/FieldValueData.h
@@ -27,7 +27,7 @@ struct FieldValueData
 {
     int64    m_id;
     int64    m_field_id; // non-null (> 0) after initialization
-    RefTypeN m_ref_type; // one of (e_trx, e_sched) after initialization
+    RefTypeN m_ref_type; // one of [e_trx, e_sched] after initialization
     int64    m_ref_id;   // non-null (> 0) after initialization
     wxString m_content;
 

--- a/src/data/InfoData.cpp
+++ b/src/data/InfoData.cpp
@@ -18,9 +18,9 @@
 
 #include "InfoData.h"
 
-InfoData::InfoData()
+InfoData::InfoData() :
+    m_id(-1)
 {
-    m_id = -1;
 }
 
 // Convert InfoData to InfoRow
@@ -38,9 +38,9 @@ InfoRow InfoData::to_row() const
 // Convert InfoRow to InfoData
 InfoData& InfoData::from_row(const InfoRow& row)
 {
-    m_id    = row.INFOID;    // int64
-    m_name  = row.INFONAME;  // wxString
-    m_value = row.INFOVALUE; // wxString
+    m_id    = row.INFOID;
+    m_name  = row.INFONAME;
+    m_value = row.INFOVALUE;
 
     return *this;
 }

--- a/src/data/PayeeData.cpp
+++ b/src/data/PayeeData.cpp
@@ -45,14 +45,14 @@ PayeeRow PayeeData::to_row() const
 // Convert PayeeRow to PayeeData
 PayeeData& PayeeData::from_row(const PayeeRow& row)
 {
-    m_id            = row.PAYEEID;       // int64
-    m_name          = row.PAYEENAME;     // wxString
-    m_category_id_n = row.CATEGID;       // int64
-    m_number        = row.NUMBER;        // wxString
-    m_website       = row.WEBSITE;       // wxString
-    m_notes         = row.NOTES;         // wxString
-    m_active        = (row.ACTIVE != 0); // int64
-    m_pattern       = row.PATTERN;       // wxString
+    m_id            = row.PAYEEID;
+    m_name          = row.PAYEENAME;
+    m_category_id_n = row.CATEGID;
+    m_number        = row.NUMBER;
+    m_website       = row.WEBSITE;
+    m_notes         = row.NOTES;
+    m_active        = (row.ACTIVE != 0);
+    m_pattern       = row.PATTERN;
 
     return *this;
 }

--- a/src/data/ReportData.cpp
+++ b/src/data/ReportData.cpp
@@ -18,10 +18,10 @@
 
 #include "ReportData.h"
 
-ReportData::ReportData()
+ReportData::ReportData() :
+    m_id(-1),
+    m_active(true)
 {
-    m_id     = -1;
-    m_active = true;
 }
 
 // Convert ReportData to ReportRow
@@ -44,14 +44,14 @@ ReportRow ReportData::to_row() const
 // Convert ReportRow to ReportData
 ReportData& ReportData::from_row(const ReportRow& row)
 {
-    m_id               = row.REPORTID;        // int64
-    m_name             = row.REPORTNAME;      // wxString
-    m_group_name       = row.GROUPNAME;       // wxString
-    m_active           = (row.ACTIVE != 0);   // int64
-    m_sql_content      = row.SQLCONTENT;      // wxString
-    m_lua_content      = row.LUACONTENT;      // wxString
-    m_template_content = row.TEMPLATECONTENT; // wxString
-    m_description      = row.DESCRIPTION;     // wxString
+    m_id               = row.REPORTID;
+    m_name             = row.REPORTNAME;
+    m_group_name       = row.GROUPNAME;
+    m_active           = (row.ACTIVE != 0);
+    m_sql_content      = row.SQLCONTENT;
+    m_lua_content      = row.LUACONTENT;
+    m_template_content = row.TEMPLATECONTENT;
+    m_description      = row.DESCRIPTION;
 
     return *this;
 }

--- a/src/data/SchedData.cpp
+++ b/src/data/SchedData.cpp
@@ -62,23 +62,23 @@ SchedRow SchedData::to_row() const
 // Convert SchedRow to SchedData
 SchedData& SchedData::from_row(const SchedRow& row)
 {
-    m_id               = row.BDID;               // int64
-    m_account_id       = row.ACCOUNTID;          // int64
-    m_to_account_id_n  = row.TOACCOUNTID;        // int64
-    m_payee_id_n       = row.PAYEEID;            // int64
-    TRANSCODE          = row.TRANSCODE;          // wxString
-    m_amount           = row.TRANSAMOUNT;        // double
-    STATUS             = row.STATUS;             // wxString
-    m_number           = row.TRANSACTIONNUMBER;  // wxString
-    m_notes            = row.NOTES;              // wxString
-    m_category_id_n    = row.CATEGID;            // int64
-    TRANSDATE          = row.TRANSDATE;          // wxString
-    m_followup_id      = row.FOLLOWUPID;         // int64
-    m_to_amount        = row.TOTRANSAMOUNT;      // double
-    REPEATS            = row.REPEATS;            // int64
-    NEXTOCCURRENCEDATE = row.NEXTOCCURRENCEDATE; // wxString
-    NUMOCCURRENCES     = row.NUMOCCURRENCES;     // int64
-    m_color            = row.COLOR;              // int64
+    m_id               = row.BDID;
+    m_account_id       = row.ACCOUNTID;
+    m_to_account_id_n  = row.TOACCOUNTID;
+    m_payee_id_n       = row.PAYEEID;
+    TRANSCODE          = row.TRANSCODE;
+    m_amount           = row.TRANSAMOUNT;
+    STATUS             = row.STATUS;
+    m_number           = row.TRANSACTIONNUMBER;
+    m_notes            = row.NOTES;
+    m_category_id_n    = row.CATEGID;
+    TRANSDATE          = row.TRANSDATE;
+    m_followup_id      = row.FOLLOWUPID;
+    m_to_amount        = row.TOTRANSAMOUNT;
+    REPEATS            = row.REPEATS;
+    NEXTOCCURRENCEDATE = row.NEXTOCCURRENCEDATE;
+    NUMOCCURRENCES     = row.NUMOCCURRENCES;
+    m_color            = row.COLOR;
 
     return *this;
 }

--- a/src/data/SchedSplitData.cpp
+++ b/src/data/SchedSplitData.cpp
@@ -18,12 +18,12 @@
 
 #include "SchedSplitData.h"
 
-SchedSplitData::SchedSplitData()
+SchedSplitData::SchedSplitData() :
+    m_id(-1),
+    m_sched_id(-1),
+    m_category_id(-1),
+    m_amount(0.0)
 {
-    m_id          = -1;
-    m_sched_id    = -1;
-    m_category_id = -1;
-    m_amount      = 0.0;
 }
 
 // Convert SchedSplitData to SchedSplitRow
@@ -43,11 +43,11 @@ SchedSplitRow SchedSplitData::to_row() const
 // Convert SchedSplitRow to SchedSplitData
 SchedSplitData& SchedSplitData::from_row(const SchedSplitRow& row)
 {
-    m_id          = row.SPLITTRANSID;     // int64
-    m_sched_id    = row.TRANSID;          // int64
-    m_category_id = row.CATEGID;          // int64
-    m_amount      = row.SPLITTRANSAMOUNT; // double
-    m_notes       = row.NOTES;            // wxString
+    m_id          = row.SPLITTRANSID;
+    m_sched_id    = row.TRANSID;
+    m_category_id = row.CATEGID;
+    m_amount      = row.SPLITTRANSAMOUNT;
+    m_notes       = row.NOTES;
 
     return *this;
 }

--- a/src/data/SettingData.cpp
+++ b/src/data/SettingData.cpp
@@ -18,9 +18,9 @@
 
 #include "SettingData.h"
 
-SettingData::SettingData()
+SettingData::SettingData() :
+    m_id(-1)
 {
-    m_id = -1;
 }
 
 // Convert SettingData to SettingRow
@@ -38,9 +38,9 @@ SettingRow SettingData::to_row() const
 // Convert SettingRow to SettingData
 SettingData& SettingData::from_row(const SettingRow& row)
 {
-    m_id    = row.SETTINGID;    // int64
-    m_name  = row.SETTINGNAME;  // wxString
-    m_value = row.SETTINGVALUE; // wxString
+    m_id    = row.SETTINGID;
+    m_name  = row.SETTINGNAME;
+    m_value = row.SETTINGVALUE;
 
     return *this;
 }

--- a/src/data/StockData.cpp
+++ b/src/data/StockData.cpp
@@ -53,17 +53,17 @@ StockRow StockData::to_row() const
 // Convert StockRow to StockData
 StockData& StockData::from_row(const StockRow& row)
 {
-    m_id             = row.STOCKID;              // int64
-    m_account_id_n   = row.HELDAT;               // int64
-    m_name           = row.STOCKNAME;            // wxString
-    m_symbol         = row.SYMBOL;               // wxString
-    m_num_shares     = row.NUMSHARES;            // double
-    m_purchase_date  = mmDate(row.PURCHASEDATE); // wxString
-    m_purchase_price = row.PURCHASEPRICE;        // double
-    m_current_price  = row.CURRENTPRICE;         // double
-    m_purchase_value = row.VALUE;                // double
-    m_commission     = row.COMMISSION;           // double
-    m_notes          = row.NOTES;                // wxString
+    m_id             = row.STOCKID;
+    m_account_id_n   = row.HELDAT;
+    m_name           = row.STOCKNAME;
+    m_symbol         = row.SYMBOL;
+    m_num_shares     = row.NUMSHARES;
+    m_purchase_date  = mmDate(row.PURCHASEDATE);
+    m_purchase_price = row.PURCHASEPRICE;
+    m_current_price  = row.CURRENTPRICE;
+    m_purchase_value = row.VALUE;
+    m_commission     = row.COMMISSION;
+    m_notes          = row.NOTES;
 
     return *this;
 }

--- a/src/data/StockData.h
+++ b/src/data/StockData.h
@@ -59,6 +59,8 @@ struct StockData
     bool operator< (const StockData& other) const { return id() < other.id(); }
     bool operator< (const StockData* other) const { return id() < other->id(); }
 
+    double current_value() const { return m_num_shares * m_current_price; }
+
     struct SorterBySTOCKID
     {
         bool operator()(const StockData& x, const StockData& y)

--- a/src/data/StockHistoryData.cpp
+++ b/src/data/StockHistoryData.cpp
@@ -35,7 +35,7 @@ StockHistoryRow StockHistoryData::to_row() const
     row.SYMBOL  = m_symbol;
     row.DATE    = m_date.isoDate();
     row.VALUE   = m_price;
-    row.UPDTYPE = m_update_type.value();
+    row.UPDTYPE = static_cast<int64>(m_update_type.code());
 
     return row;
 }
@@ -47,7 +47,9 @@ StockHistoryData& StockHistoryData::from_row(const StockHistoryRow& row)
     m_symbol      = row.SYMBOL;
     m_date        = mmDate(row.DATE);
     m_price       = row.VALUE;
-    m_update_type = UpdateType(row.UPDTYPE);
+    m_update_type = UpdateType::from_code(
+        static_cast<int>(row.UPDTYPE.GetValue())
+    );
 
     return *this;
 }

--- a/src/data/StockHistoryData.cpp
+++ b/src/data/StockHistoryData.cpp
@@ -43,11 +43,11 @@ StockHistoryRow StockHistoryData::to_row() const
 // Convert StockHistoryRow to StockHistoryData
 StockHistoryData& StockHistoryData::from_row(const StockHistoryRow& row)
 {
-    m_id          = row.HISTID;              // int64
-    m_symbol      = row.SYMBOL;              // wxString
-    m_date        = mmDate(row.DATE);        // wxString
-    m_price       = row.VALUE;               // double
-    m_update_type = UpdateType(row.UPDTYPE); // int64
+    m_id          = row.HISTID;
+    m_symbol      = row.SYMBOL;
+    m_date        = mmDate(row.DATE);
+    m_price       = row.VALUE;
+    m_update_type = UpdateType(row.UPDTYPE);
 
     return *this;
 }

--- a/src/data/TagData.cpp
+++ b/src/data/TagData.cpp
@@ -18,10 +18,10 @@
 
 #include "TagData.h"
 
-TagData::TagData()
+TagData::TagData() :
+    m_id(-1),
+    m_active(true)
 {
-    m_id     = -1;
-    m_active = true;
 }
 
 // Convert TagData to TagRow
@@ -39,9 +39,9 @@ TagRow TagData::to_row() const
 // Convert TagRow to TagData
 TagData& TagData::from_row(const TagRow& row)
 {
-    m_id     = row.TAGID;         // int64
-    m_name   = row.TAGNAME;       // wxString
-    m_active = (row.ACTIVE != 0); // int64
+    m_id     = row.TAGID;
+    m_name   = row.TAGNAME;
+    m_active = (row.ACTIVE != 0);
 
     return *this;
 }

--- a/src/data/TagLinkData.cpp
+++ b/src/data/TagLinkData.cpp
@@ -16,16 +16,14 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-// This is only sample code re-used from "table/TagLinkTable.cpp".
-
 #include "TagLinkData.h"
 
-TagLinkData::TagLinkData()
+TagLinkData::TagLinkData() :
+    m_id(-1),
+    m_tag_id(-1),
+    m_ref_type(RefTypeN()),
+    m_ref_id(-1)
 {
-    TAGLINKID = -1;
-    REFID = -1;
-    TAGID = -1;
 }
 
 // Convert TagLinkData to TagLinkRow
@@ -33,10 +31,10 @@ TagLinkRow TagLinkData::to_row() const
 {
     TagLinkRow row;
 
-    row.TAGLINKID = TAGLINKID;
-    row.REFTYPE = REFTYPE;
-    row.REFID = REFID;
-    row.TAGID = TAGID;
+    row.TAGLINKID = m_id;
+    row.REFTYPE   = m_ref_type.name_n();
+    row.REFID     = m_ref_id;
+    row.TAGID     = m_tag_id;
 
     return row;
 }
@@ -44,20 +42,20 @@ TagLinkRow TagLinkData::to_row() const
 // Convert TagLinkRow to TagLinkData
 TagLinkData& TagLinkData::from_row(const TagLinkRow& row)
 {
-    TAGLINKID = row.TAGLINKID; // int64
-    REFTYPE = row.REFTYPE; // wxString
-    REFID = row.REFID; // int64
-    TAGID = row.TAGID; // int64
+    m_id       = row.TAGLINKID;
+    m_tag_id   = row.TAGID;
+    m_ref_type = RefTypeN(row.REFTYPE);
+    m_ref_id   = row.REFID;
 
     return *this;
 }
 
 bool TagLinkData::equals(const TagLinkData* other) const
 {
-    if ( TAGLINKID != other->TAGLINKID) return false;
-    if (!REFTYPE.IsSameAs(other->REFTYPE)) return false;
-    if ( REFID != other->REFID) return false;
-    if ( TAGID != other->TAGID) return false;
+    if ( m_id              != other->m_id)              return false;
+    if ( m_tag_id          != other->m_tag_id)          return false;
+    if ( m_ref_type.id_n() != other->m_ref_type.id_n()) return false;
+    if ( m_ref_id          != other->m_ref_id)          return false;
 
     return true;
 }

--- a/src/data/TagLinkData.h
+++ b/src/data/TagLinkData.h
@@ -27,7 +27,7 @@ struct TagLinkData
 {
     int64 m_id;
     int64 m_tag_id;      // non-null (> 0) after initialization
-    RefTypeN m_ref_type; // one of (e_trx*, e_sched*) after initialization
+    RefTypeN m_ref_type; // one of [e_trx*, e_sched*] after initialization
     int64 m_ref_id;      // non-null (> 0) after initialization
 
     explicit TagLinkData();

--- a/src/data/TagLinkData.h
+++ b/src/data/TagLinkData.h
@@ -16,40 +16,26 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-//
-// This is only sample code re-used from "table/TagLinkTable.h".
-//
-// The data structure can be refined by:
-// * using more user-frielndly filed name
-// * using stronger field types
-// * adding enumerations for fields with limited choices
-// * demultiplexing composite values in database columns
-//
-// See also an implementation in Swift:
-//   https://github.com/moneymanagerex/mmex-ios/tree/master/MMEX/Data
-// and an implementation in Java:
-//   https://github.com/moneymanagerex/android-money-manager-ex/tree/master/app/src/main/java/com/money/manager/ex/domainmodel
-
 #pragma once
 
+#include "_DataEnum.h"
 #include "table/_TableBase.h"
 #include "table/TagLinkTable.h"
 
 // User-friendly representation of a record in table TAGLINK_V1.
 struct TagLinkData
 {
-    int64 TAGLINKID; // primary key
-    wxString REFTYPE;
-    int64 REFID;
-    int64 TAGID;
+    int64 m_id;
+    int64 m_tag_id;      // non-null (> 0) after initialization
+    RefTypeN m_ref_type; // one of (e_trx*, e_sched*) after initialization
+    int64 m_ref_id;      // non-null (> 0) after initialization
 
     explicit TagLinkData();
     explicit TagLinkData(wxSQLite3ResultSet& q);
     TagLinkData(const TagLinkData& other) = default;
 
-    int64 id() const { return TAGLINKID; }
-    void id(const int64 id) { TAGLINKID = id; }
+    int64 id() const { return m_id; }
+    void id(const int64 id) { m_id = id; }
     TagLinkRow to_row() const;
     TagLinkData& from_row(const TagLinkRow& row);
     void to_insert_stmt(wxSQLite3Statement& stmt, int64 id) const;
@@ -70,7 +56,7 @@ struct TagLinkData
     {
         bool operator()(const TagLinkData& x, const TagLinkData& y)
         {
-            return x.TAGLINKID < y.TAGLINKID;
+            return x.m_id < y.m_id;
         }
     };
 
@@ -78,7 +64,7 @@ struct TagLinkData
     {
         bool operator()(const TagLinkData& x, const TagLinkData& y)
         {
-            return x.REFTYPE < y.REFTYPE;
+            return x.m_ref_type.id_n() < y.m_ref_type.id_n();
         }
     };
 
@@ -86,7 +72,7 @@ struct TagLinkData
     {
         bool operator()(const TagLinkData& x, const TagLinkData& y)
         {
-            return x.REFID < y.REFID;
+            return x.m_ref_id < y.m_ref_id;
         }
     };
 
@@ -94,7 +80,7 @@ struct TagLinkData
     {
         bool operator()(const TagLinkData& x, const TagLinkData& y)
         {
-            return x.TAGID < y.TAGID;
+            return x.m_tag_id < y.m_tag_id;
         }
     };
 };

--- a/src/data/TrxData.cpp
+++ b/src/data/TrxData.cpp
@@ -59,22 +59,22 @@ TrxRow TrxData::to_row() const
 // Convert TrxRow to TrxData
 TrxData& TrxData::from_row(const TrxRow& row)
 {
-    m_id              = row.TRANSID;           // int64
-    m_account_id      = row.ACCOUNTID;         // int64
-    m_to_account_id_n = row.TOACCOUNTID;       // int64
-    m_payee_id_n      = row.PAYEEID;           // int64
-    TRANSCODE         = row.TRANSCODE;         // wxString
-    m_amount          = row.TRANSAMOUNT;       // double
-    STATUS            = row.STATUS;            // wxString
-    m_number          = row.TRANSACTIONNUMBER; // wxString
-    m_notes           = row.NOTES;             // wxString
-    m_category_id_n   = row.CATEGID;           // int64
-    TRANSDATE         = row.TRANSDATE;         // wxString
-    LASTUPDATEDTIME   = row.LASTUPDATEDTIME;   // wxString
-    DELETEDTIME       = row.DELETEDTIME;       // wxString
-    m_followup_id     = row.FOLLOWUPID;        // int64
-    m_to_amount       = row.TOTRANSAMOUNT;     // double
-    m_color           = row.COLOR;             // int64
+    m_id              = row.TRANSID;
+    m_account_id      = row.ACCOUNTID;
+    m_to_account_id_n = row.TOACCOUNTID;
+    m_payee_id_n      = row.PAYEEID;
+    TRANSCODE         = row.TRANSCODE;
+    m_amount          = row.TRANSAMOUNT;
+    STATUS            = row.STATUS;
+    m_number          = row.TRANSACTIONNUMBER;
+    m_notes           = row.NOTES;
+    m_category_id_n   = row.CATEGID;
+    TRANSDATE         = row.TRANSDATE;
+    LASTUPDATEDTIME   = row.LASTUPDATEDTIME;
+    DELETEDTIME       = row.DELETEDTIME;
+    m_followup_id     = row.FOLLOWUPID;
+    m_to_amount       = row.TOTRANSAMOUNT;
+    m_color           = row.COLOR;
 
     return *this;
 }

--- a/src/data/TrxLinkData.cpp
+++ b/src/data/TrxLinkData.cpp
@@ -16,15 +16,13 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-// This is only sample code re-used from "table/TrxLinkTable.cpp".
-
 #include "TrxLinkData.h"
 
 TrxLinkData::TrxLinkData() :
-    TRANSLINKID(-1),
-    CHECKINGACCOUNTID(-1),
-    LINKRECORDID(-1)
+    m_id(-1),
+    m_trx_id(-1),
+    m_ref_type(RefTypeN()),
+    m_ref_id(-1)
 {
 }
 
@@ -33,10 +31,10 @@ TrxLinkRow TrxLinkData::to_row() const
 {
     TrxLinkRow row;
 
-    row.TRANSLINKID       = TRANSLINKID;
-    row.CHECKINGACCOUNTID = CHECKINGACCOUNTID;
-    row.LINKTYPE          = LINKTYPE;
-    row.LINKRECORDID      = LINKRECORDID;
+    row.TRANSLINKID       = m_id;
+    row.CHECKINGACCOUNTID = m_trx_id;
+    row.LINKTYPE          = m_ref_type.name_n();
+    row.LINKRECORDID      = m_ref_id;
 
     return row;
 }
@@ -44,20 +42,20 @@ TrxLinkRow TrxLinkData::to_row() const
 // Convert TrxLinkRow to TrxLinkData
 TrxLinkData& TrxLinkData::from_row(const TrxLinkRow& row)
 {
-    TRANSLINKID = row.TRANSLINKID;
-    CHECKINGACCOUNTID = row.CHECKINGACCOUNTID;
-    LINKTYPE = row.LINKTYPE;
-    LINKRECORDID = row.LINKRECORDID;
+    m_id       = row.TRANSLINKID;
+    m_trx_id   = row.CHECKINGACCOUNTID;
+    m_ref_type = RefTypeN(row.LINKTYPE);
+    m_ref_id   = row.LINKRECORDID;
 
     return *this;
 }
 
 bool TrxLinkData::equals(const TrxLinkData* other) const
 {
-    if ( TRANSLINKID != other->TRANSLINKID) return false;
-    if ( CHECKINGACCOUNTID != other->CHECKINGACCOUNTID) return false;
-    if (!LINKTYPE.IsSameAs(other->LINKTYPE)) return false;
-    if ( LINKRECORDID != other->LINKRECORDID) return false;
+    if ( m_id              != other->m_id)              return false;
+    if ( m_trx_id          != other->m_trx_id)          return false;
+    if ( m_ref_type.id_n() != other->m_ref_type.id_n()) return false;
+    if ( m_ref_id          != other->m_ref_id)          return false;
 
     return true;
 }

--- a/src/data/TrxLinkData.cpp
+++ b/src/data/TrxLinkData.cpp
@@ -21,11 +21,11 @@
 
 #include "TrxLinkData.h"
 
-TrxLinkData::TrxLinkData()
+TrxLinkData::TrxLinkData() :
+    TRANSLINKID(-1),
+    CHECKINGACCOUNTID(-1),
+    LINKRECORDID(-1)
 {
-    TRANSLINKID = -1;
-    CHECKINGACCOUNTID = -1;
-    LINKRECORDID = -1;
 }
 
 // Convert TrxLinkData to TrxLinkRow
@@ -33,10 +33,10 @@ TrxLinkRow TrxLinkData::to_row() const
 {
     TrxLinkRow row;
 
-    row.TRANSLINKID = TRANSLINKID;
+    row.TRANSLINKID       = TRANSLINKID;
     row.CHECKINGACCOUNTID = CHECKINGACCOUNTID;
-    row.LINKTYPE = LINKTYPE;
-    row.LINKRECORDID = LINKRECORDID;
+    row.LINKTYPE          = LINKTYPE;
+    row.LINKRECORDID      = LINKRECORDID;
 
     return row;
 }
@@ -44,10 +44,10 @@ TrxLinkRow TrxLinkData::to_row() const
 // Convert TrxLinkRow to TrxLinkData
 TrxLinkData& TrxLinkData::from_row(const TrxLinkRow& row)
 {
-    TRANSLINKID = row.TRANSLINKID; // int64
-    CHECKINGACCOUNTID = row.CHECKINGACCOUNTID; // int64
-    LINKTYPE = row.LINKTYPE; // wxString
-    LINKRECORDID = row.LINKRECORDID; // int64
+    TRANSLINKID = row.TRANSLINKID;
+    CHECKINGACCOUNTID = row.CHECKINGACCOUNTID;
+    LINKTYPE = row.LINKTYPE;
+    LINKRECORDID = row.LINKRECORDID;
 
     return *this;
 }

--- a/src/data/TrxLinkData.h
+++ b/src/data/TrxLinkData.h
@@ -27,7 +27,7 @@ struct TrxLinkData
 {
     int64 m_id;
     int64 m_trx_id;      // non-null (> 0) after initialization
-    RefTypeN m_ref_type; // one of (e_asset, e_stock) after initialization
+    RefTypeN m_ref_type; // one of [e_asset, e_stock] after initialization
     int64 m_ref_id;      // non-null (> 0) after initialization
 
     explicit TrxLinkData();

--- a/src/data/TrxLinkData.h
+++ b/src/data/TrxLinkData.h
@@ -16,40 +16,26 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
-// PLEASE EDIT!
-//
-// This is only sample code re-used from "table/TrxLinkTable.h".
-//
-// The data structure can be refined by:
-// * using more user-frielndly filed name
-// * using stronger field types
-// * adding enumerations for fields with limited choices
-// * demultiplexing composite values in database columns
-//
-// See also an implementation in Swift:
-//   https://github.com/moneymanagerex/mmex-ios/tree/master/MMEX/Data
-// and an implementation in Java:
-//   https://github.com/moneymanagerex/android-money-manager-ex/tree/master/app/src/main/java/com/money/manager/ex/domainmodel
-
 #pragma once
 
+#include "_DataEnum.h"
 #include "table/_TableBase.h"
 #include "table/TrxLinkTable.h"
 
 // User-friendly representation of a record in table TRANSLINK_V1.
 struct TrxLinkData
 {
-    int64 TRANSLINKID; // primary key
-    int64 CHECKINGACCOUNTID;
-    wxString LINKTYPE;
-    int64 LINKRECORDID;
+    int64 m_id;
+    int64 m_trx_id;      // non-null (> 0) after initialization
+    RefTypeN m_ref_type; // one of (e_asset, e_stock) after initialization
+    int64 m_ref_id;      // non-null (> 0) after initialization
 
     explicit TrxLinkData();
     explicit TrxLinkData(wxSQLite3ResultSet& q);
     TrxLinkData(const TrxLinkData& other) = default;
 
-    int64 id() const { return TRANSLINKID; }
-    void id(const int64 id) { TRANSLINKID = id; }
+    int64 id() const { return m_id; }
+    void id(const int64 id) { m_id = id; }
     TrxLinkRow to_row() const;
     TrxLinkData& from_row(const TrxLinkRow& row);
     void to_insert_stmt(wxSQLite3Statement& stmt, int64 id) const;
@@ -70,7 +56,7 @@ struct TrxLinkData
     {
         bool operator()(const TrxLinkData& x, const TrxLinkData& y)
         {
-            return x.TRANSLINKID < y.TRANSLINKID;
+            return x.m_id < y.m_id;
         }
     };
 
@@ -78,7 +64,7 @@ struct TrxLinkData
     {
         bool operator()(const TrxLinkData& x, const TrxLinkData& y)
         {
-            return x.CHECKINGACCOUNTID < y.CHECKINGACCOUNTID;
+            return x.m_trx_id < y.m_trx_id;
         }
     };
 
@@ -86,7 +72,7 @@ struct TrxLinkData
     {
         bool operator()(const TrxLinkData& x, const TrxLinkData& y)
         {
-            return x.LINKTYPE < y.LINKTYPE;
+            return x.m_ref_type.id_n() < y.m_ref_type.id_n();
         }
     };
 
@@ -94,7 +80,7 @@ struct TrxLinkData
     {
         bool operator()(const TrxLinkData& x, const TrxLinkData& y)
         {
-            return x.LINKRECORDID < y.LINKRECORDID;
+            return x.m_ref_id < y.m_ref_id;
         }
     };
 };

--- a/src/data/TrxShareData.cpp
+++ b/src/data/TrxShareData.cpp
@@ -45,12 +45,12 @@ TrxShareRow TrxShareData::to_row() const
 // Convert TrxShareRow to TrxShareData
 TrxShareData& TrxShareData::from_row(const TrxShareRow& row)
 {
-    m_id         = row.SHAREINFOID;       // int64
-    m_trx_id     = row.CHECKINGACCOUNTID; // int64
-    m_number     = row.SHARENUMBER;       // double
-    m_price      = row.SHAREPRICE;        // double
-    m_commission = row.SHARECOMMISSION;   // double
-    m_lot        = row.SHARELOT;          // wxString
+    m_id         = row.SHAREINFOID;
+    m_trx_id     = row.CHECKINGACCOUNTID;
+    m_number     = row.SHARENUMBER;
+    m_price      = row.SHAREPRICE;
+    m_commission = row.SHARECOMMISSION;
+    m_lot        = row.SHARELOT;
 
     return *this;
 }

--- a/src/data/TrxSplitData.cpp
+++ b/src/data/TrxSplitData.cpp
@@ -18,12 +18,12 @@
 
 #include "TrxSplitData.h"
 
-TrxSplitData::TrxSplitData()
+TrxSplitData::TrxSplitData() :
+    m_id(-1),
+    m_trx_id(-1),
+    m_category_id(-1),
+    m_amount(0.0)
 {
-    m_id          = -1;
-    m_trx_id      = -1;
-    m_category_id = -1;
-    m_amount      = 0.0;
 }
 
 // Convert TrxSplitData to TrxSplitRow
@@ -43,11 +43,11 @@ TrxSplitRow TrxSplitData::to_row() const
 // Convert TrxSplitRow to TrxSplitData
 TrxSplitData& TrxSplitData::from_row(const TrxSplitRow& row)
 {
-    m_id          = row.SPLITTRANSID;     // int64
-    m_trx_id      = row.TRANSID;          // int64
-    m_category_id = row.CATEGID;          // int64
-    m_amount      = row.SPLITTRANSAMOUNT; // double
-    m_notes       = row.NOTES;            // wxString
+    m_id          = row.SPLITTRANSID;
+    m_trx_id      = row.TRANSID;
+    m_category_id = row.CATEGID;
+    m_amount      = row.SPLITTRANSAMOUNT;
+    m_notes       = row.NOTES;
 
     return *this;
 }

--- a/src/data/UsageData.cpp
+++ b/src/data/UsageData.cpp
@@ -18,9 +18,9 @@
 
 #include "UsageData.h"
 
-UsageData::UsageData()
+UsageData::UsageData() :
+    m_id(-1)
 {
-    m_id = -1;
 }
 
 // Convert UsageData to UsageRow
@@ -38,9 +38,9 @@ UsageRow UsageData::to_row() const
 // Convert UsageRow to UsageData
 UsageData& UsageData::from_row(const UsageRow& row)
 {
-    m_id           = row.USAGEID;     // int64
-    m_date         = row.USAGEDATE;   // wxString
-    m_json_content = row.JSONCONTENT; // wxString
+    m_id           = row.USAGEID;
+    m_date         = row.USAGEDATE;
+    m_json_content = row.JSONCONTENT;
 
     return *this;
 }

--- a/src/data/_DataEnum.cpp
+++ b/src/data/_DataEnum.cpp
@@ -74,6 +74,17 @@ mmChoiceNameA CurrencyType::s_choice_a = mmChoiceNameA({
     { e_crypto, _n("Crypto") },
 }, e_fiat, true);
 
+mmChoiceNameA FieldTypeN::s_choice_a = mmChoiceNameA({
+    { e_string,        _n("String") },
+    { e_integer,       _n("Integer") },
+    { e_decimal,       _n("Decimal") },
+    { e_boolean,       _n("Boolean") },
+    { e_date,          _n("Date") },
+    { e_time,          _n("Time") },
+    { e_single_choice, _n("SingleChoice") },
+    { e_multi_choice,  _n("MultiChoice") },
+}, -1, true);
+
 mmChoiceNameA RefTypeN::s_choice_a = mmChoiceNameA({
     { e_trx,         _n("Transaction") },
     { e_stock,       _n("Stock") },

--- a/src/data/_DataEnum.cpp
+++ b/src/data/_DataEnum.cpp
@@ -96,9 +96,9 @@ mmChoiceNameA RefTypeN::s_choice_a = mmChoiceNameA({
     { e_sched_split, _n("RecurringTransactionSplit") },
 }, -1, true);
 
-mmChoiceNameA UpdateType::s_choice_a = mmChoiceNameA({
-    { e_none,   _n("None") },
-    { e_online, _n("Online") },
-    { e_manual, _n("Manual") },
+mmChoiceCodeNameA UpdateType::s_choice_a = mmChoiceCodeNameA({
+    { e_none,   0, _n("None") },
+    { e_online, 1, _n("Online") },
+    { e_manual, 2, _n("Manual") },
 }, e_none, true);
 

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -340,9 +340,7 @@ public:
     UpdateType(mmChoiceId id = s_choice_a.default_id_n()) :
         m_id(s_choice_a.valid_id_n(id)) {}
     static UpdateType from_code(int code) {
-        return UpdateType(static_cast<mmChoiceId>(
-            UpdateType::s_choice_a.find_code_n(code)
-        ));
+        return UpdateType(UpdateType::s_choice_a.find_code_n(code));
     }
 
     mmChoiceId id() const { return m_id; }

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -297,8 +297,8 @@ public:
     static mmChoiceIdN field_id_n(mmChoiceIdN id_n) {
         switch (id_n) {
         case e_sched:
-        case e_trx_split:
-        case e_sched_split:
+        //case e_trx_split:
+        //case e_sched_split:
             return e_trx;
         default:
             return id_n;
@@ -331,7 +331,7 @@ public:
         e_manual,
         size
     };
-    static mmChoiceNameA s_choice_a;
+    static mmChoiceCodeNameA s_choice_a;
 
 private:
     mmChoiceId m_id;
@@ -339,11 +339,14 @@ private:
 public:
     UpdateType(mmChoiceId id = s_choice_a.default_id_n()) :
         m_id(s_choice_a.valid_id_n(id)) {}
-    UpdateType(int64 value) :
-        UpdateType(static_cast<mmChoiceId>(value.GetValue())) {}
+    static UpdateType from_code(int code) {
+        return UpdateType(static_cast<mmChoiceId>(
+            UpdateType::s_choice_a.find_code_n(code)
+        ));
+    }
 
     mmChoiceId id() const { return m_id; }
-    const int64 value() const { return static_cast<int64>(m_id); }
+    int code() const { return UpdateType::s_choice_a.get_code(m_id); }
     const wxString name() const { return UpdateType::s_choice_a.get_name(m_id); }
 };
 

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -206,6 +206,9 @@ public:
         int a[size] = { 0, 52, 26, 12, 6, 4, 2, 1, 365 };
         return a[m_id];
     }
+    double times_per_month() const {
+        return double(times_per_year()) / 12.0;
+    }
 };
 
 struct CurrencyType

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -232,6 +232,39 @@ public:
     const wxString name() const { return CurrencyType::s_choice_a.get_name(m_id); }
 };
 
+struct FieldTypeN
+{
+public:
+    enum
+    {
+        e_string = 0,
+        e_integer,
+        e_decimal,
+        e_boolean,
+        e_date,
+        e_time,
+        e_single_choice,
+        e_multi_choice,
+        size
+    };
+    static mmChoiceNameA s_choice_a;
+
+private:
+    mmChoiceId m_id_n;
+
+public:
+    FieldTypeN(mmChoiceId id_n = s_choice_a.default_id_n()) :
+        m_id_n(s_choice_a.valid_id_n(id_n)) {}
+    FieldTypeN(const wxString& name) :
+        m_id_n(FieldTypeN::s_choice_a.find_name_n(name)) {}
+
+    bool has_value() const { return m_id_n >= 0; }
+    mmChoiceId id_n() const { return m_id_n; }
+    const wxString name_n() const {
+        return has_value() ? FieldTypeN::s_choice_a.get_name(m_id_n) : "";
+    }
+};
+
 struct RefTypeN
 {
 public:

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -310,6 +310,9 @@ public:
     const wxString name_n() const {
         return has_value() ? RefTypeN::s_choice_a.get_name(m_id_n) : "";
     }
+    bool operator== (const RefTypeN& other) const {
+        return id_n() == other.id_n();
+    }
 };
 
 struct UpdateType

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -313,6 +313,9 @@ public:
     bool operator== (const RefTypeN& other) const {
         return id_n() == other.id_n();
     }
+    bool operator< (const RefTypeN& other) const {
+        return id_n() < other.id_n();
+    }
 };
 
 struct UpdateType

--- a/src/data/_DataEnum.h
+++ b/src/data/_DataEnum.h
@@ -250,16 +250,16 @@ public:
     static mmChoiceNameA s_choice_a;
 
 private:
-    mmChoiceId m_id_n;
+    mmChoiceIdN m_id_n;
 
 public:
-    FieldTypeN(mmChoiceId id_n = s_choice_a.default_id_n()) :
+    FieldTypeN(mmChoiceIdN id_n = s_choice_a.default_id_n()) :
         m_id_n(s_choice_a.valid_id_n(id_n)) {}
     FieldTypeN(const wxString& name) :
         m_id_n(FieldTypeN::s_choice_a.find_name_n(name)) {}
 
     bool has_value() const { return m_id_n >= 0; }
-    mmChoiceId id_n() const { return m_id_n; }
+    mmChoiceIdN id_n() const { return m_id_n; }
     const wxString name_n() const {
         return has_value() ? FieldTypeN::s_choice_a.get_name(m_id_n) : "";
     }
@@ -283,16 +283,30 @@ public:
     static mmChoiceNameA s_choice_a;
 
 private:
-    mmChoiceId m_id_n;
+    mmChoiceIdN m_id_n;
 
 public:
-    RefTypeN(mmChoiceId id_n = s_choice_a.default_id_n()) :
+    RefTypeN(mmChoiceIdN id_n = s_choice_a.default_id_n()) :
         m_id_n(s_choice_a.valid_id_n(id_n)) {}
     RefTypeN(const wxString& name) :
         m_id_n(RefTypeN::s_choice_a.find_name_n(name)) {}
 
+    static mmChoiceIdN field_id_n(mmChoiceIdN id_n) {
+        switch (id_n) {
+        case e_sched:
+        case e_trx_split:
+        case e_sched_split:
+            return e_trx;
+        default:
+            return id_n;
+        }
+    }
+    static RefTypeN field_ref_type_n(RefTypeN ref_type_n) {
+        return RefTypeN(RefTypeN::field_id_n(ref_type_n.m_id_n));
+    }
+
     bool has_value() const { return m_id_n >= 0; }
-    mmChoiceId id_n() const { return m_id_n; }
+    mmChoiceIdN id_n() const { return m_id_n; }
     const wxString name_n() const {
         return has_value() ? RefTypeN::s_choice_a.get_name(m_id_n) : "";
     }

--- a/src/dialog/AccountDialog.cpp
+++ b/src/dialog/AccountDialog.cpp
@@ -425,8 +425,7 @@ void AccountDialog::OnCurrency(wxCommandEvent& /*event*/)
 
 void AccountDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    wxString RefType = AccountModel::refTypeName;
-    AttachmentDialog dlg(this, RefType, m_account_n->m_id);
+    AttachmentDialog dlg(this, AccountModel::s_ref_type, m_account_n->m_id);
     dlg.ShowModal();
 }
 

--- a/src/dialog/AssetDialog.cpp
+++ b/src/dialog/AssetDialog.cpp
@@ -440,8 +440,10 @@ void AssetDialog::OnOk(wxCommandEvent& /*event*/)
     int64 new_asset_id = m_asset_n->id();
 
     if (old_asset_id < 0) {
-        const wxString& RefType = AssetModel::refTypeName;
-        mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, new_asset_id);
+        mmAttachmentManage::RelocateAllAttachments(
+            AssetModel::s_ref_type, 0,
+            AssetModel::s_ref_type, new_asset_id
+        );
     }
     if (w_transaction_panel->ValidCheckingAccountEntry()) {
         int64 checking_id = w_transaction_panel->SaveChecking();
@@ -504,31 +506,24 @@ void AssetDialog::OnCancel(wxCommandEvent& /*event*/)
     if (m_asset_rich_text)
         return;
 
-    const wxString& RefType = AssetModel::refTypeName;
+    // FIXME: temporary records (with id <= 0) are not stored in database
     if (!m_asset_n)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(AssetModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 
 void AssetDialog::OnQuit(wxCloseEvent& /*event*/)
 {
-    const wxString& RefType = AssetModel::refTypeName;
+    // FIXME: temporary records (with id <= 0) are not stored in database
     if (!m_asset_n)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(AssetModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 
 void AssetDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    const wxString& RefType = AssetModel::refTypeName;
-    int64 RefId;
-
-    if (!m_asset_n)
-        RefId = 0;
-    else
-        RefId= m_asset_n->m_id;
-
-    AttachmentDialog dlg(this, RefType, RefId);
+    int64 ref_id = m_asset_n ? m_asset_n->m_id : 0;
+    AttachmentDialog dlg(this, AssetModel::refTypeName, ref_id);
     dlg.ShowModal();
 }
 

--- a/src/dialog/AssetDialog.cpp
+++ b/src/dialog/AssetDialog.cpp
@@ -526,7 +526,7 @@ void AssetDialog::OnQuit(wxCloseEvent& /*event*/)
 void AssetDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
     int64 ref_id = m_asset_n ? m_asset_n->m_id : 0;
-    AttachmentDialog dlg(this, AssetModel::refTypeName, ref_id);
+    AttachmentDialog dlg(this, AssetModel::s_ref_type, ref_id);
     dlg.ShowModal();
 }
 

--- a/src/dialog/AssetDialog.cpp
+++ b/src/dialog/AssetDialog.cpp
@@ -66,17 +66,17 @@ AssetDialog::AssetDialog(
 
 AssetDialog::AssetDialog(
     wxWindow* parent,
-    const TrxLinkData* transfer_entry,
+    const TrxLinkData* tl_d,
     TrxData* checking_entry
 ) :
-    m_transfer_entry(transfer_entry),
+    m_transfer_entry(tl_d),
     m_checking_entry(checking_entry),
     m_dialog_heading(_t("Add Asset Transaction")),
     m_hidden_trans_entry(false)
 {
-    if (transfer_entry) {
+    if (tl_d) {
         m_dialog_heading = _t("Edit Asset Transaction");
-        m_asset_n = AssetModel::instance().unsafe_get_id_data_n(transfer_entry->LINKRECORDID);
+        m_asset_n = AssetModel::instance().unsafe_get_id_data_n(tl_d->m_ref_id);
     }
 
     Create(parent, wxID_ANY, m_dialog_heading);
@@ -138,12 +138,14 @@ void AssetDialog::dataToControls()
 
     w_notes->SetValue(m_asset_n->m_notes);
 
-    TrxLinkModel::DataA translink = TrxLinkModel::TranslinkList<AssetModel>(m_asset_n->m_id);
-    if (!translink.empty())
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        AssetModel::s_ref_type, m_asset_n->m_id
+    );
+    if (!tl_a.empty())
         w_value->Enable(false);
 
     // Set up the transaction if this is the first entry.
-    if (translink.empty())
+    if (tl_a.empty())
         w_transaction_panel->SetTransactionValue(bal.first);
 
     if (!m_hidden_trans_entry) {
@@ -446,13 +448,14 @@ void AssetDialog::OnOk(wxCommandEvent& /*event*/)
         );
     }
     if (w_transaction_panel->ValidCheckingAccountEntry()) {
-        int64 checking_id = w_transaction_panel->SaveChecking();
-        if (checking_id < 0)
+        int64 trx_id = w_transaction_panel->SaveChecking();
+        if (trx_id < 0)
             return;
 
         if (!m_transfer_entry) {
-            TrxLinkModel::SetAssetTranslink(
-                new_asset_id, checking_id, w_transaction_panel->CheckingType()
+            TrxLinkModel::instance().SetAssetTranslink(
+                trx_id, new_asset_id,
+                w_transaction_panel->CheckingType()
             );
         }
         TrxLinkModel::UpdateAssetValue(m_asset_n);

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -88,40 +88,32 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
 
     wxString WindowTitle;
     if (m_ref_id > 0) {
-        int refEnum = 0;
-        for (int i = 0; i < ModelBase::REFTYPE_ID_size; ++i) {
-            wxString reftype = ModelBase::reftype_name(i);
-            if (reftype == m_ref_type.name_n())
-                break;
-            refEnum++;
-        }
-        wxString RefName;
-        switch (refEnum)
-        {
-        case ModelBase::REFTYPE_ID_STOCK:
-            RefName = StockModel::get_id_name(m_ref_id);
+        wxString ref_name;
+        switch (m_ref_type.id_n()) {
+        case RefTypeN::e_stock:
+            ref_name = StockModel::get_id_name(m_ref_id);
             break;
-        case ModelBase::REFTYPE_ID_ASSET:
-            RefName = AssetModel::instance().get_id_name(m_ref_id);
+        case RefTypeN::e_asset:
+            ref_name = AssetModel::instance().get_id_name(m_ref_id);
             break;
-        case ModelBase::REFTYPE_ID_BANKACCOUNT:
-            RefName = AccountModel::instance().get_id_name(m_ref_id);
+        case RefTypeN::e_account:
+            ref_name = AccountModel::instance().get_id_name(m_ref_id);
             break;
-        case ModelBase::REFTYPE_ID_PAYEE:
-            RefName = PayeeModel::instance().get_id_name(m_ref_id);
+        case RefTypeN::e_payee:
+            ref_name = PayeeModel::instance().get_id_name(m_ref_id);
             break;
-        case ModelBase::REFTYPE_ID_TRANSACTION:
-        case ModelBase::REFTYPE_ID_BILLSDEPOSIT:
+        case RefTypeN::e_trx:
+        case RefTypeN::e_sched:
         default:
-            RefName = "";
+            ref_name = "";
         }       
-        if (RefName.IsEmpty())
+        if (ref_name.IsEmpty())
             WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$lld"),
                 wxGetTranslation(m_ref_type.name_n()), m_ref_id
             );
         else
             WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$s"),
-                wxGetTranslation(m_ref_type.name_n()), RefName
+                wxGetTranslation(m_ref_type.name_n()), ref_name
             );
     } else
         WindowTitle = wxString::Format(_t("Attachment Manager | New %s"),
@@ -674,7 +666,7 @@ void mmAttachmentManage::OpenAttachmentFromPanelIcon(
         mmAttachmentManage::OpenAttachment(file_path);
     }
     else {
-        AttachmentDialog dlg(parent, ref_type.name_n(), ref_id);
+        AttachmentDialog dlg(parent, ref_type, ref_id);
         dlg.ShowModal();
     }
 }

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -48,7 +48,12 @@ wxBEGIN_EVENT_TABLE( AttachmentDialog, wxDialog )
     )
 wxEND_EVENT_TABLE()
 
-AttachmentDialog::AttachmentDialog (wxWindow* parent, const wxString& RefType, int64 RefId, const wxString& name) :
+AttachmentDialog::AttachmentDialog(
+    wxWindow* parent,
+    const wxString& RefType,
+    int64 RefId,
+    const wxString& name
+) :
     m_RefType(RefType),
     m_RefId(RefId)
 {
@@ -177,7 +182,9 @@ void AttachmentDialog::fillControls()
 {    
     attachmentListBox_->DeleteAllItems();
 
-    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(m_RefType), m_RefId);
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_ref_data_a(
+        RefTypeN(m_RefType), m_RefId
+    );
     if (att_a.empty())
         return;
 
@@ -226,7 +233,7 @@ void AttachmentDialog::AddAttachment(wxString file_path)
     const wxString desc = dlg.getText();
 
     const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
-    int last_num = AttachmentModel::instance().find_id_last_num(RefTypeN(m_RefType), m_RefId);
+    int last_num = AttachmentModel::instance().find_ref_last_num(RefTypeN(m_RefType), m_RefId);
 
     wxString importedFileName = m_RefType + "_" + wxString::Format("%lld", m_RefId) + "_Attach"
         + wxString::Format("%i", last_num + 1);
@@ -555,32 +562,31 @@ bool mmAttachmentManage::OpenAttachment(const wxString& FileToOpen)
     return wxLaunchDefaultApplication(FileToOpen);;
 }
 
-bool mmAttachmentManage::DeleteAllAttachments(const wxString& ref_type, int64 ref_id)
+bool mmAttachmentManage::DeleteAllAttachments(RefTypeN ref_type, int64 ref_id)
 {
-    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(ref_type), ref_id);
     wxString folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + m_PathSep + ref_type;
+    ) + m_PathSep + ref_type.name_n();
 
-    for (const auto& att_d : att_a) {
+    for (const AttachmentData& att_d : AttachmentModel::instance().find_ref_data_a(
+        ref_type, ref_id
+    )) {
         mmAttachmentManage::DeleteAttachment(folder + m_PathSep + att_d.m_filename);
         AttachmentModel::instance().purge_id(att_d.m_id);
     }
 
-    if (RefTypeN(ref_type).id_n() == RefTypeN::e_trx)
+    if (ref_type.id_n() == TrxModel::s_ref_type.id_n())
         TrxModel::instance().save_timestamp(ref_id);
 
     return true;
 }
 
 bool mmAttachmentManage::RelocateAllAttachments(
-    const wxString& old_ref_type,
-    int64 old_ref_id,
-    const wxString& new_ref_type,
-    int64 new_ref_id
+    RefTypeN old_ref_type, int64 old_ref_id,
+    RefTypeN new_ref_type, int64 new_ref_id
 ) {
     auto att_a = AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(old_ref_type),
+        AttachmentCol::REFTYPE(old_ref_type.name_n()),
         AttachmentCol::REFID(old_ref_id)
     );
 
@@ -589,84 +595,86 @@ bool mmAttachmentManage::RelocateAllAttachments(
 
     const wxString old_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + old_ref_type + m_PathSep;
+    ) + old_ref_type.name_n() + m_PathSep;
     const wxString new_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + new_ref_type + m_PathSep;
+    ) + new_ref_type.name_n() + m_PathSep;
 
     for (auto& att_d : att_a) {
         wxString newFileName = att_d.m_filename;
         newFileName.Replace(
             att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
-            new_ref_type + "_" + wxString::Format("%lld", new_ref_id)
+            new_ref_type.name_n() + "_" + wxString::Format("%lld", new_ref_id)
         );
         wxRenameFile(
             old_folder + att_d.m_filename,
             new_folder + newFileName
         );
-        att_d.m_ref_type_n = RefTypeN(new_ref_type);
+        att_d.m_ref_type_n = new_ref_type;
         att_d.m_ref_id     = new_ref_id;
         att_d.m_filename   = newFileName;
     }
     AttachmentModel::instance().save_data_a(att_a);
 
-    if (RefTypeN(old_ref_type).id_n() == RefTypeN::e_trx)
+    if (old_ref_type.id_n() == TrxModel::s_ref_type.id_n())
         TrxModel::instance().save_timestamp(old_ref_id);
-    if (RefTypeN(new_ref_type).id_n() == RefTypeN::e_trx)
+    if (new_ref_type.id_n() == TrxModel::s_ref_type.id_n())
         TrxModel::instance().save_timestamp(new_ref_id);
 
     return true;
 }
 
 bool mmAttachmentManage::CloneAllAttachments(
-    const wxString& ref_type,
-    int64 ref_id,
-    int64 new_ref_id
+    RefTypeN ref_type,
+    int64 src_ref_id,
+    int64 dst_ref_id
 ) {
     const wxString folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + ref_type + m_PathSep;
+    ) + ref_type.name_n() + m_PathSep;
 
-    for (auto& att_d : AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(ref_type),
-        AttachmentCol::REFID(ref_id)
+    for (auto& src_att_d : AttachmentModel::instance().find(
+        AttachmentCol::REFTYPE(ref_type.name_n()),
+        AttachmentCol::REFID(src_ref_id)
     )) {
-        wxString new_filename = att_d.m_filename;
-        new_filename.Replace(
-            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
-            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", new_ref_id)
+        wxString dst_filename = src_att_d.m_filename;
+        dst_filename.Replace(
+            src_att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", src_att_d.m_ref_id),
+            src_att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", dst_ref_id)
         );
-        wxCopyFile(folder + att_d.m_filename, folder + new_filename);
+        wxCopyFile(folder + src_att_d.m_filename, folder + dst_filename);
         AttachmentData new_att_d = AttachmentData();
-        new_att_d.m_ref_type_n  = RefTypeN(ref_type);
-        new_att_d.m_ref_id      = new_ref_id;
-        new_att_d.m_filename    = new_filename;
-        new_att_d.m_description = att_d.m_description;
+        new_att_d.m_ref_type_n  = ref_type;
+        new_att_d.m_ref_id      = dst_ref_id;
+        new_att_d.m_filename    = dst_filename;
+        new_att_d.m_description = src_att_d.m_description;
         AttachmentModel::instance().add_data_n(new_att_d);
     }
 
-    if (RefTypeN(ref_type).id_n() == RefTypeN::e_trx)
-        TrxModel::instance().save_timestamp(new_ref_id);
+    if (ref_type.id_n() == TrxModel::s_ref_type.id_n())
+        TrxModel::instance().save_timestamp(dst_ref_id);
 
     return true;
 }
 
 void mmAttachmentManage::OpenAttachmentFromPanelIcon(
     wxWindow* parent,
-    const wxString& ref_type,
+    RefTypeN ref_type,
     int64 ref_id
 ) {
-    int att_c = AttachmentModel::instance().find_id_c(RefTypeN(ref_type), ref_id);
+    int att_c = AttachmentModel::instance().find_ref_c(ref_type, ref_id);
 
     if (att_c == 1) {
-        AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(ref_type), ref_id);
+        AttachmentModel::DataA att_a = AttachmentModel::instance().find_ref_data_a(
+            ref_type, ref_id
+        );
         wxString file_path = mmex::getPathAttachment(
             mmAttachmentManage::InfotablePathSetting()
         ) + att_a[0].m_ref_type_n.name_n() + m_PathSep + att_a[0].m_filename;
         mmAttachmentManage::OpenAttachment(file_path);
     }
     else {
-        AttachmentDialog dlg(parent, ref_type, ref_id);
+        AttachmentDialog dlg(parent, ref_type.name_n(), ref_id);
         dlg.ShowModal();
     }
 }

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -37,39 +37,39 @@
 wxIMPLEMENT_DYNAMIC_CLASS(AttachmentDialog, wxDialog);
 
 wxBEGIN_EVENT_TABLE( AttachmentDialog, wxDialog )
-    EVT_BUTTON(wxID_CANCEL, AttachmentDialog::OnCancel)
-    EVT_BUTTON(wxID_OK, AttachmentDialog::OnOk)
-    EVT_BUTTON(wxID_APPLY, AttachmentDialog::OnMagicButton)
+    EVT_BUTTON(wxID_CANCEL,                  AttachmentDialog::OnCancel)
+    EVT_BUTTON(wxID_OK,                      AttachmentDialog::OnOk)
+    EVT_BUTTON(wxID_APPLY,                   AttachmentDialog::OnMagicButton)
     EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, AttachmentDialog::OnListItemSelected)
     EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, AttachmentDialog::OnItemRightClick)
-    EVT_MENU_RANGE(MENU_NEW_ATTACHMENT, MENU_DELETE_ATTACHMENT, AttachmentDialog::OnMenuSelected)
-    EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, AttachmentDialog::OnListItemActivated)
+    EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY,    AttachmentDialog::OnListItemActivated)
+    EVT_MENU_RANGE(MENU_NEW_ATTACHMENT, MENU_DELETE_ATTACHMENT,
+        AttachmentDialog::OnMenuSelected
+    )
 wxEND_EVENT_TABLE()
 
-
 AttachmentDialog::AttachmentDialog (wxWindow* parent, const wxString& RefType, int64 RefId, const wxString& name) :
-    m_RefType(RefType)
-    , m_RefId(RefId)
+    m_RefType(RefType),
+    m_RefId(RefId)
 {
-    if (debug_) ColName_[ATTACHMENT_ID] = "#";
+    if (debug_)
+        ColName_[ATTACHMENT_ID] = "#";
     ColName_[ATTACHMENT_DESCRIPTION] = _t("Description");
     ColName_[ATTACHMENT_FILENAME] = _t("File");
 
     Create(parent, name);
     mmThemeAutoColour(this);
 
-    const wxString AttachmentsFolder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
+    const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
 
-    if (AttachmentsFolder == wxEmptyString)
-    {
+    if (folder == wxEmptyString) {
         wxString msgStr = wxString() << _t("Attachment folder not defined.") << "\n"
             << _tu("Please set it in Tools → Settings… → Attachments") << "\n";
         wxMessageBox(msgStr, _t("Attachment folder not defined"), wxICON_ERROR);
     }
-    else if (!wxDirExists(AttachmentsFolder))
-    {
+    else if (!wxDirExists(folder)) {
         wxString msgStr = wxString() << _t("Unable to find attachments folder:") << "\n"
-            << "'" << AttachmentsFolder << "'" << "\n"
+            << "'" << folder << "'" << "\n"
             << "\n"
             << _t("Please verify that above path is correct") << "\n";
         wxMessageBox(msgStr, _t("Attachments folder not found."), wxICON_ERROR);
@@ -82,8 +82,7 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
     long style = wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER;
 
     wxString WindowTitle;
-    if (m_RefId > 0)
-    {
+    if (m_RefId > 0) {
         int refEnum = 0;
         for (int i = 0; i < ModelBase::REFTYPE_ID_size; ++i) {
             wxString reftype = ModelBase::reftype_name(i);
@@ -112,13 +111,22 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
             RefName = "";
         }       
         if (RefName.IsEmpty())
-            WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$lld"), wxGetTranslation(m_RefType), m_RefId);
+            WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$lld"),
+                wxGetTranslation(m_RefType), m_RefId
+            );
         else
-            WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$s"), wxGetTranslation(m_RefType), RefName);
+            WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$s"),
+                wxGetTranslation(m_RefType), RefName
+            );
     } else
-        WindowTitle = wxString::Format(_t("Attachment Manager | New %s"), wxGetTranslation(m_RefType));
+        WindowTitle = wxString::Format(_t("Attachment Manager | New %s"),
+            wxGetTranslation(m_RefType)
+        );
 
-    if (!wxDialog::Create(parent, wxID_ANY, WindowTitle, wxDefaultPosition, wxDefaultSize, style, name))
+    if (!wxDialog::Create(
+        parent, wxID_ANY, WindowTitle,
+        wxDefaultPosition, wxDefaultSize, style, name
+    ))
         return;
 
     CreateControls();
@@ -134,10 +142,12 @@ void AttachmentDialog::CreateControls()
 {
     wxBoxSizer* mainBoxSizer = new wxBoxSizer(wxVERTICAL);
 
-    attachmentListBox_ = new wxDataViewListCtrl( this
-        , wxID_ANY, wxDefaultPosition, wxSize(460, 500)/*, wxDV_HORIZ_RULES*/);
+    attachmentListBox_ = new wxDataViewListCtrl(this, wxID_ANY,
+        wxDefaultPosition, wxSize(460, 500)/*, wxDV_HORIZ_RULES*/
+    );
 
-    if (debug_) attachmentListBox_->AppendTextColumn(ColName_[ATTACHMENT_ID], wxDATAVIEW_CELL_INERT, 30);
+    if (debug_)
+        attachmentListBox_->AppendTextColumn(ColName_[ATTACHMENT_ID], wxDATAVIEW_CELL_INERT, 30);
     attachmentListBox_->AppendTextColumn(ColName_[ATTACHMENT_DESCRIPTION], wxDATAVIEW_CELL_INERT, 150);
     attachmentListBox_->AppendTextColumn(ColName_[ATTACHMENT_FILENAME], wxDATAVIEW_CELL_INERT, 300);
     attachmentListBox_->DragAcceptFiles(true);
@@ -167,67 +177,75 @@ void AttachmentDialog::fillControls()
 {    
     attachmentListBox_->DeleteAllItems();
 
-    AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(m_RefType, m_RefId);
-    if (attachments.size() == 0) return;
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(m_RefType), m_RefId);
+    if (att_a.empty())
+        return;
 
     int64 firstInTheListAttachentID = -1;
-    for (const auto &entry : attachments)
-    {
-        if (firstInTheListAttachentID == -1) firstInTheListAttachentID = entry.ATTACHMENTID;
+    for (const auto& att_d : att_a) {
+        if (firstInTheListAttachentID == -1)
+            firstInTheListAttachentID = att_d.m_id;
         wxVector<wxVariant> data;
-        if (debug_) data.push_back(wxVariant(wxString::Format("%lld", entry.ATTACHMENTID)));
-        data.push_back(wxVariant(entry.DESCRIPTION));
-        data.push_back(wxVariant(entry.REFTYPE + m_PathSep + entry.FILENAME));
-        attachmentListBox_->AppendItem(data, static_cast<wxUIntPtr>(entry.ATTACHMENTID.GetValue()));
+        if (debug_)
+            data.push_back(wxVariant(wxString::Format("%lld", att_d.m_id)));
+        data.push_back(wxVariant(att_d.m_description));
+        data.push_back(wxVariant(att_d.m_ref_type_n.name_n() + m_PathSep + att_d.m_filename));
+        attachmentListBox_->AppendItem(data, static_cast<wxUIntPtr>(att_d.m_id.GetValue()));
     }
 
     m_attachment_id = firstInTheListAttachentID;
 }
 
-void AttachmentDialog::AddAttachment(wxString FilePath)
+void AttachmentDialog::AddAttachment(wxString file_path)
 {
-    if (FilePath.empty())
-    {
-        FilePath = wxFileSelector(_t("Import attachment:")
-            , wxEmptyString, wxEmptyString, wxEmptyString
-            , "All Files |*.*"
-            , wxFD_FILE_MUST_EXIST);
-
-        if (FilePath.empty()) return;
+    if (file_path.empty()) {
+        file_path = wxFileSelector(
+            _t("Import attachment:"),
+            wxEmptyString, wxEmptyString, wxEmptyString,
+            "All Files |*.*",
+            wxFD_FILE_MUST_EXIST
+        );
+        if (file_path.empty())
+            return;
     }
 
-    const wxString attachmentFileName = wxFileName(FilePath).GetName();
-    const wxString attachmentFileExtension = wxFileName(FilePath).GetExt().MakeLower();
+    const wxString file_name = wxFileName(file_path).GetName();
+    const wxString file_ext = wxFileName(file_path).GetExt().MakeLower();
     
-    mmDialogComboBoxAutocomplete dlg(this, _t("Enter a description for the new attachment:") + wxString::Format("\n(%s)", FilePath),
-        _t("Attachment Manager: Add Attachment"), attachmentFileName, AttachmentModel::instance().allDescriptions());
+    mmDialogComboBoxAutocomplete dlg(this,
+        _t("Enter a description for the new attachment:") +
+            wxString::Format("\n(%s)", file_path),
+        _t("Attachment Manager: Add Attachment"),
+        file_name,
+        AttachmentModel::instance().find_all_desc_a()
+    );
 
     if (dlg.ShowModal() != wxID_OK)
         return;
 
-    const wxString attachmentDescription = dlg.getText();
+    const wxString desc = dlg.getText();
 
-    const wxString attachmentsFolder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
-    int attachmentLastNumber = AttachmentModel::LastAttachmentNumber(m_RefType, m_RefId);
+    const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
+    int last_num = AttachmentModel::instance().find_id_last_num(RefTypeN(m_RefType), m_RefId);
 
     wxString importedFileName = m_RefType + "_" + wxString::Format("%lld", m_RefId) + "_Attach"
-        + wxString::Format("%i", attachmentLastNumber + 1);
-    if (!attachmentFileExtension.empty())
-        importedFileName += "." + attachmentFileExtension;
+        + wxString::Format("%i", last_num + 1);
+    if (!file_ext.empty())
+        importedFileName += "." + file_ext;
 
     if (mmAttachmentManage::CopyAttachment(
-        FilePath,
-        attachmentsFolder + m_RefType + m_PathSep + importedFileName
+        file_path,
+        folder + m_RefType + m_PathSep + importedFileName
     )) {
         AttachmentData new_att_d = AttachmentData();
-        new_att_d.REFTYPE     = m_RefType;
-        new_att_d.REFID       = m_RefId;
-        new_att_d.DESCRIPTION = attachmentDescription;
-        new_att_d.FILENAME    = importedFileName;
+        new_att_d.m_ref_type_n  = RefTypeN(m_RefType);
+        new_att_d.m_ref_id      = m_RefId;
+        new_att_d.m_description = desc;
+        new_att_d.m_filename    = importedFileName;
         AttachmentModel::instance().add_data_n(new_att_d);
         m_attachment_id = new_att_d.id();
 
-        if (m_RefType == TrxModel::refTypeName)
+        if (RefTypeN(m_RefType).id_n() == RefTypeN::e_trx)
             TrxModel::instance().save_timestamp(m_RefId);
     }
 
@@ -236,11 +254,10 @@ void AttachmentDialog::AddAttachment(wxString FilePath)
 
 void AttachmentDialog::OpenAttachment()
 {
-    const AttachmentData *data_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
-    wxString path = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting())
-        + data_n->REFTYPE + m_PathSep + data_n->FILENAME;
-
-    mmAttachmentManage::OpenAttachment(path);
+    const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
+    wxString file_path = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting())
+        + att_n->m_ref_type_n.name_n() + m_PathSep + att_n->m_filename;
+    mmAttachmentManage::OpenAttachment(file_path);
 }
 
 void AttachmentDialog::EditAttachment()
@@ -252,47 +269,47 @@ void AttachmentDialog::EditAttachment()
     mmDialogComboBoxAutocomplete dlg(this,
         _t("Enter a new description for the attachment:"),
         _t("Attachment Manager: Edit Attachment"),
-        att_n->DESCRIPTION,
-        AttachmentModel::instance().allDescriptions()
+        att_n->m_description,
+        AttachmentModel::instance().find_all_desc_a()
     );
 
     if (dlg.ShowModal() != wxID_OK)
         return;
 
-    const wxString description = dlg.getText();
-    if (description == att_n->DESCRIPTION)
+    const wxString desc = dlg.getText();
+    if (desc == att_n->m_description)
         return;
 
-    att_n->DESCRIPTION = description;
+    att_n->m_description = desc;
     AttachmentModel::instance().unsafe_update_data_n(att_n);
     m_attachment_id = att_n->id();
 
-    if (att_n->REFTYPE == TrxModel::refTypeName)
-        TrxModel::instance().save_timestamp(att_n->REFID);
+    if (att_n->m_ref_type_n.id_n() == RefTypeN::e_trx)
+        TrxModel::instance().save_timestamp(att_n->m_ref_id);
 
     fillControls();
 }
 
 void AttachmentDialog::DeleteAttachment()
 {
-    const AttachmentData *data_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
-    if (!data_n)
+    const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
+    if (!att_n)
         return;
 
     int deleteResponse = wxMessageBox(
-        _t("Do you want to delete this attachment?")
-        , _t("Confirm Attachment Deletion")
-        , wxYES_NO | wxNO_DEFAULT | wxICON_ERROR);
-    if (deleteResponse == wxYES)
-    {
+        _t("Do you want to delete this attachment?"),
+        _t("Confirm Attachment Deletion"),
+        wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
+    );
+    if (deleteResponse == wxYES) {
         const wxString AttachmentsFolder = mmex::getPathAttachment(
             mmAttachmentManage::InfotablePathSetting()
-        ) + data_n->REFTYPE;
+        ) + att_n->m_ref_type_n.name_n();
         if (mmAttachmentManage::DeleteAttachment(
-            AttachmentsFolder + m_PathSep + data_n->FILENAME
+            AttachmentsFolder + m_PathSep + att_n->m_filename
         )) {
-            if (data_n->REFTYPE == TrxModel::refTypeName)
-                TrxModel::instance().save_timestamp(data_n->REFID);
+            if (att_n->m_ref_type_n.id_n() == RefTypeN::e_trx)
+                TrxModel::instance().save_timestamp(att_n->m_ref_id);
             AttachmentModel::instance().purge_id(m_attachment_id);
         }
         m_attachment_id = -1;
@@ -302,14 +319,12 @@ void AttachmentDialog::DeleteAttachment()
 
 void AttachmentDialog::OnDropFiles(wxDropFilesEvent& event)
 {
-    if (event.GetNumberOfFiles() > 0)
-    {
+    if (event.GetNumberOfFiles() > 0) {
         wxString* dropped = event.GetFiles();
-        for (int i = 0; i < event.GetNumberOfFiles(); i++)
-        {
-            wxString FilePath = dropped[i];
-            if (wxFileExists(FilePath))
-                AddAttachment(FilePath);
+        for (int i = 0; i < event.GetNumberOfFiles(); i++) {
+            wxString file_path = dropped[i];
+            if (wxFileExists(file_path))
+                AddAttachment(file_path);
         }
     }
 }
@@ -325,10 +340,10 @@ void AttachmentDialog::OnListItemSelected(wxDataViewEvent& event)
 
 void AttachmentDialog::OnListItemActivated(wxDataViewEvent& WXUNUSED(event))
 {
-    const AttachmentData* data_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
+    const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
     const wxString path = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + data_n->REFTYPE + m_PathSep + data_n->FILENAME;
+    ) + att_n->m_ref_type_n.name_n() + m_PathSep + att_n->m_filename;
 
     mmAttachmentManage::OpenAttachment(path);
 }
@@ -356,16 +371,16 @@ void AttachmentDialog::OnItemRightClick(wxDataViewEvent& event)
     wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, wxID_ANY) ;
     evt.SetEventObject( this );
 
-    const AttachmentData* data_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
+    const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
 
     wxMenu* mainMenu = new wxMenu;
-    if (data_n)
-        mainMenu->SetTitle(data_n->DESCRIPTION);
+    if (att_n)
+        mainMenu->SetTitle(att_n->m_description);
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_NEW_ATTACHMENT, _t("&Add ")));
     mainMenu->AppendSeparator();
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_OPEN_ATTACHMENT, _t("&Open ")));
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_EDIT_ATTACHMENT, _t("&Edit ")));
-    if (!data_n)
+    if (!att_n)
         mainMenu->Enable(MENU_EDIT_ATTACHMENT, false);
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_DELETE_ATTACHMENT, _t("&Remove ")));
     
@@ -376,7 +391,7 @@ void AttachmentDialog::OnItemRightClick(wxDataViewEvent& event)
     if (AttachmentsFolder == wxEmptyString || !wxDirExists(AttachmentsFolder))
         mainMenu->Enable(MENU_NEW_ATTACHMENT, false);
 
-    if (!data_n) {
+    if (!att_n) {
         mainMenu->Enable(MENU_OPEN_ATTACHMENT, false);
         mainMenu->Enable(MENU_EDIT_ATTACHMENT, false);
         mainMenu->Enable(MENU_DELETE_ATTACHMENT, false);
@@ -413,42 +428,38 @@ const wxString mmAttachmentManage::GetAttachmentNoteSign()
     return wxString::Format("[%s] ",_t("Att."));
 }
 
-bool mmAttachmentManage::CreateReadmeFile(const wxString& FolderPath)
+bool mmAttachmentManage::CreateReadmeFile(const wxString& folder)
 {
-    wxString ReadmeFilePath = FolderPath + m_PathSep + "readme.txt";
-    wxString ReadmeText;
-    ReadmeText << _t("This directory and its files are automatically managed by MMEX.") << wxTextFile::GetEOL();
-    ReadmeText << wxTextFile::GetEOL();
-    ReadmeText << _t("Please do not remove, rename or modify manually directories and files.") << wxTextFile::GetEOL();
-
-    if (wxFileExists(ReadmeFilePath))
-    {
+    wxString readme_path = folder + m_PathSep + "readme.txt";
+    if (wxFileExists(readme_path))
         return true;
-    }
-    else
-    {
-        try
-        {
-            wxFile file(ReadmeFilePath, wxFile::write);
 
-            if (file.IsOpened())
-            {
-                file.Write(ReadmeText);
-                file.Close();
-                return true;
-            }
-        }
-        catch (...)
-        {
-            return false;
+    wxString readme_text;
+    readme_text << _t("This directory and its files are automatically managed by MMEX.")
+        << wxTextFile::GetEOL();
+    readme_text << wxTextFile::GetEOL();
+    readme_text << _t("Please do not remove, rename or modify manually directories and files.")
+        << wxTextFile::GetEOL();
+
+    bool ok = false;
+    try {
+        wxFile file(readme_path, wxFile::write);
+        if (file.IsOpened()) {
+            file.Write(readme_text);
+            file.Close();
+            ok = true;
         }
     }
+    catch (...) {
+    }
 
-    return false;
+    return ok;
 }
 
-bool mmAttachmentManage::CopyAttachment(const wxString& FileToImport, const wxString& ImportedFile)
-{
+bool mmAttachmentManage::CopyAttachment(
+    const wxString& FileToImport,
+    const wxString& ImportedFile
+) {
     wxString destinationFolder = wxPathOnly(ImportedFile);
 
     if (!wxDirExists(destinationFolder)) {
@@ -490,21 +501,19 @@ bool mmAttachmentManage::CopyAttachment(const wxString& FileToImport, const wxSt
 
 bool mmAttachmentManage::DeleteAttachment(const wxString& FileToDelete)
 {
-    if (wxFileExists(FileToDelete))
-    {
-        if (InfoModel::instance().getBool("ATTACHMENTSTRASH", false))
-        {
-            const wxString DeletedAttachmentFolder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting()) + m_PathSep + "Deleted";
+    if (wxFileExists(FileToDelete)) {
+        if (InfoModel::instance().getBool("ATTACHMENTSTRASH", false)) {
+            const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
+            const wxString folder_deleted = folder + m_PathSep + "Deleted";
 
-            if (!wxDirExists(DeletedAttachmentFolder))
-            {
-                if (wxMkdir(DeletedAttachmentFolder))
-                    mmAttachmentManage::CreateReadmeFile(DeletedAttachmentFolder);
+            if (!wxDirExists(folder_deleted)) {
+                if (wxMkdir(folder_deleted))
+                    mmAttachmentManage::CreateReadmeFile(folder_deleted);
                 else
                     return false;
             }
 
-            const wxString FileToTrash = DeletedAttachmentFolder + m_PathSep
+            const wxString FileToTrash = folder_deleted + m_PathSep
                 + wxDateTime::Now().FormatISODate() + "_" + wxFileNameFromPath(FileToDelete);
 
             if (!wxRenameFile(FileToDelete, FileToTrash))
@@ -519,7 +528,11 @@ bool mmAttachmentManage::DeleteAttachment(const wxString& FileToDelete)
             << "'" << FileToDelete << "'" << "\n"
             << "\n"
             << _t("Do you want to delete the attachment in the database?") << "\n";
-        int DeleteResponse = wxMessageBox(msgStr, _t("Delete attachment failed"), wxYES_NO | wxNO_DEFAULT | wxICON_ERROR);
+        int DeleteResponse = wxMessageBox(
+            msgStr,
+            _t("Delete attachment failed"),
+            wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
+        );
         if (DeleteResponse == wxYES)
             return true;
         else
@@ -530,8 +543,7 @@ bool mmAttachmentManage::DeleteAttachment(const wxString& FileToDelete)
 
 bool mmAttachmentManage::OpenAttachment(const wxString& FileToOpen)
 {
-    if (!wxFileExists(FileToOpen))
-    {
+    if (!wxFileExists(FileToOpen)) {
         wxString msgStr = wxString() << _t("Unable to open file:") << "\n"
             << "'" << FileToOpen << "'" << "\n"
             << "\n"
@@ -543,118 +555,118 @@ bool mmAttachmentManage::OpenAttachment(const wxString& FileToOpen)
     return wxLaunchDefaultApplication(FileToOpen);;
 }
 
-bool mmAttachmentManage::DeleteAllAttachments(const wxString& RefType, int64 RefId)
+bool mmAttachmentManage::DeleteAllAttachments(const wxString& ref_type, int64 ref_id)
 {
-    AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(RefType, RefId);
-    wxString AttachmentsFolder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting()) + m_PathSep + RefType;
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(ref_type), ref_id);
+    wxString folder = mmex::getPathAttachment(
+        mmAttachmentManage::InfotablePathSetting()
+    ) + m_PathSep + ref_type;
 
-    for (const auto &entry : attachments)
-    {
-        mmAttachmentManage::DeleteAttachment(AttachmentsFolder + m_PathSep + entry.FILENAME);
-        AttachmentModel::instance().purge_id(entry.ATTACHMENTID);
+    for (const auto& att_d : att_a) {
+        mmAttachmentManage::DeleteAttachment(folder + m_PathSep + att_d.m_filename);
+        AttachmentModel::instance().purge_id(att_d.m_id);
     }
 
-    if (RefType == TrxModel::refTypeName)
-        TrxModel::instance().save_timestamp(RefId);
+    if (RefTypeN(ref_type).id_n() == RefTypeN::e_trx)
+        TrxModel::instance().save_timestamp(ref_id);
 
     return true;
 }
 
 bool mmAttachmentManage::RelocateAllAttachments(
-        const wxString& OldRefType,
-        int64 OldRefId,
-        const wxString& NewRefType,
-        int64 NewRefId
+    const wxString& old_ref_type,
+    int64 old_ref_id,
+    const wxString& new_ref_type,
+    int64 new_ref_id
 ) {
-    auto attachment_a = AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(OldRefType),
-        AttachmentCol::REFID(OldRefId)
+    auto att_a = AttachmentModel::instance().find(
+        AttachmentCol::REFTYPE(old_ref_type),
+        AttachmentCol::REFID(old_ref_id)
     );
 
-    if (attachment_a.size() == 0)
+    if (att_a.size() == 0)
         return false;
 
-    const wxString OldAttachmentsFolder = mmex::getPathAttachment(
+    const wxString old_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + OldRefType + m_PathSep;
-    const wxString NewAttachmentsFolder = mmex::getPathAttachment(
+    ) + old_ref_type + m_PathSep;
+    const wxString new_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + NewRefType + m_PathSep;
+    ) + new_ref_type + m_PathSep;
 
-    for (auto& att_d : attachment_a) {
-        wxString newFileName = att_d.FILENAME;
+    for (auto& att_d : att_a) {
+        wxString newFileName = att_d.m_filename;
         newFileName.Replace(
-            att_d.REFTYPE + "_" + wxString::Format("%lld", att_d.REFID),
-            NewRefType + "_" + wxString::Format("%lld", NewRefId)
+            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
+            new_ref_type + "_" + wxString::Format("%lld", new_ref_id)
         );
         wxRenameFile(
-            OldAttachmentsFolder + att_d.FILENAME,
-            NewAttachmentsFolder + newFileName
+            old_folder + att_d.m_filename,
+            new_folder + newFileName
         );
-        att_d.REFTYPE  = NewRefType;
-        att_d.REFID    = NewRefId;
-        att_d.FILENAME = newFileName;
+        att_d.m_ref_type_n = RefTypeN(new_ref_type);
+        att_d.m_ref_id     = new_ref_id;
+        att_d.m_filename   = newFileName;
     }
-    AttachmentModel::instance().save_data_a(attachment_a);
+    AttachmentModel::instance().save_data_a(att_a);
 
-    if (OldRefType == TrxModel::refTypeName)
-        TrxModel::instance().save_timestamp(OldRefId);
-    if (NewRefType == TrxModel::refTypeName)
-        TrxModel::instance().save_timestamp(NewRefId);
+    if (RefTypeN(old_ref_type).id_n() == RefTypeN::e_trx)
+        TrxModel::instance().save_timestamp(old_ref_id);
+    if (RefTypeN(new_ref_type).id_n() == RefTypeN::e_trx)
+        TrxModel::instance().save_timestamp(new_ref_id);
 
     return true;
 }
 
 bool mmAttachmentManage::CloneAllAttachments(
-    const wxString& refType,
-    int64 srcRefId,
-    int64 dstRefId
+    const wxString& ref_type,
+    int64 ref_id,
+    int64 new_ref_id
 ) {
-    auto src_a = AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(refType),
-        AttachmentCol::REFID(srcRefId)
-    );
-    const wxString AttachmentsFolder = mmex::getPathAttachment(
+    const wxString folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + refType + m_PathSep;
+    ) + ref_type + m_PathSep;
 
-    for (auto& src_d : src_a) {
-        wxString dstFileName = src_d.FILENAME;
-        dstFileName.Replace(
-            src_d.REFTYPE + "_" + wxString::Format("%lld", src_d.REFID),
-            src_d.REFTYPE + "_" + wxString::Format("%lld", dstRefId)
+    for (auto& att_d : AttachmentModel::instance().find(
+        AttachmentCol::REFTYPE(ref_type),
+        AttachmentCol::REFID(ref_id)
+    )) {
+        wxString new_filename = att_d.m_filename;
+        new_filename.Replace(
+            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
+            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", new_ref_id)
         );
-        wxCopyFile(AttachmentsFolder + src_d.FILENAME, AttachmentsFolder + dstFileName);
-        AttachmentData dst_d = AttachmentData();
-        dst_d.REFTYPE     = refType;
-        dst_d.REFID       = dstRefId;
-        dst_d.FILENAME    = dstFileName;
-        dst_d.DESCRIPTION = src_d.DESCRIPTION;
-        AttachmentModel::instance().add_data_n(dst_d);
+        wxCopyFile(folder + att_d.m_filename, folder + new_filename);
+        AttachmentData new_att_d = AttachmentData();
+        new_att_d.m_ref_type_n  = RefTypeN(ref_type);
+        new_att_d.m_ref_id      = new_ref_id;
+        new_att_d.m_filename    = new_filename;
+        new_att_d.m_description = att_d.m_description;
+        AttachmentModel::instance().add_data_n(new_att_d);
     }
 
-    if (refType == TrxModel::refTypeName)
-        TrxModel::instance().save_timestamp(dstRefId);
+    if (RefTypeN(ref_type).id_n() == RefTypeN::e_trx)
+        TrxModel::instance().save_timestamp(new_ref_id);
 
     return true;
 }
 
 void mmAttachmentManage::OpenAttachmentFromPanelIcon(
     wxWindow* parent,
-    const wxString& refType,
-    int64 refId
+    const wxString& ref_type,
+    int64 ref_id
 ) {
-    int AttachmentsNr = AttachmentModel::instance().NrAttachments(refType, refId);
+    int att_c = AttachmentModel::instance().find_id_c(RefTypeN(ref_type), ref_id);
 
-    if (AttachmentsNr == 1) {
-        AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(refType, refId);
-        wxString attachmentFilePath = mmex::getPathAttachment(
+    if (att_c == 1) {
+        AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(ref_type), ref_id);
+        wxString file_path = mmex::getPathAttachment(
             mmAttachmentManage::InfotablePathSetting()
-        ) + attachments[0].REFTYPE + m_PathSep + attachments[0].FILENAME;
-        mmAttachmentManage::OpenAttachment(attachmentFilePath);
+        ) + att_a[0].m_ref_type_n.name_n() + m_PathSep + att_a[0].m_filename;
+        mmAttachmentManage::OpenAttachment(file_path);
     }
     else {
-        AttachmentDialog dlg(parent, refType, refId);
+        AttachmentDialog dlg(parent, ref_type, ref_id);
         dlg.ShowModal();
     }
 }

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -91,7 +91,7 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
         wxString ref_name;
         switch (m_ref_type.id_n()) {
         case RefTypeN::e_stock:
-            ref_name = StockModel::get_id_name(m_ref_id);
+            ref_name = StockModel::instance().get_id_name(m_ref_id);
             break;
         case RefTypeN::e_asset:
             ref_name = AssetModel::instance().get_id_name(m_ref_id);

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -50,12 +50,12 @@ wxEND_EVENT_TABLE()
 
 AttachmentDialog::AttachmentDialog(
     wxWindow* parent,
-    const wxString& RefType,
-    int64 RefId,
+    RefTypeN ref_type,
+    int64 ref_id,
     const wxString& name
 ) :
-    m_RefType(RefType),
-    m_RefId(RefId)
+    m_ref_type(ref_type),
+    m_ref_id(ref_id)
 {
     if (debug_)
         ColName_[ATTACHMENT_ID] = "#";
@@ -87,11 +87,11 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
     long style = wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER;
 
     wxString WindowTitle;
-    if (m_RefId > 0) {
+    if (m_ref_id > 0) {
         int refEnum = 0;
         for (int i = 0; i < ModelBase::REFTYPE_ID_size; ++i) {
             wxString reftype = ModelBase::reftype_name(i);
-            if (reftype == m_RefType)
+            if (reftype == m_ref_type.name_n())
                 break;
             refEnum++;
         }
@@ -99,16 +99,16 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
         switch (refEnum)
         {
         case ModelBase::REFTYPE_ID_STOCK:
-            RefName = StockModel::get_id_name(m_RefId);
+            RefName = StockModel::get_id_name(m_ref_id);
             break;
         case ModelBase::REFTYPE_ID_ASSET:
-            RefName = AssetModel::instance().get_id_name(m_RefId);
+            RefName = AssetModel::instance().get_id_name(m_ref_id);
             break;
         case ModelBase::REFTYPE_ID_BANKACCOUNT:
-            RefName = AccountModel::instance().get_id_name(m_RefId);
+            RefName = AccountModel::instance().get_id_name(m_ref_id);
             break;
         case ModelBase::REFTYPE_ID_PAYEE:
-            RefName = PayeeModel::instance().get_id_name(m_RefId);
+            RefName = PayeeModel::instance().get_id_name(m_ref_id);
             break;
         case ModelBase::REFTYPE_ID_TRANSACTION:
         case ModelBase::REFTYPE_ID_BILLSDEPOSIT:
@@ -117,15 +117,15 @@ void AttachmentDialog::Create(wxWindow* parent, const wxString& name)
         }       
         if (RefName.IsEmpty())
             WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$lld"),
-                wxGetTranslation(m_RefType), m_RefId
+                wxGetTranslation(m_ref_type.name_n()), m_ref_id
             );
         else
             WindowTitle = wxString::Format(_t("Attachment Manager | %1$s | %2$s"),
-                wxGetTranslation(m_RefType), RefName
+                wxGetTranslation(m_ref_type.name_n()), RefName
             );
     } else
         WindowTitle = wxString::Format(_t("Attachment Manager | New %s"),
-            wxGetTranslation(m_RefType)
+            wxGetTranslation(m_ref_type.name_n())
         );
 
     if (!wxDialog::Create(
@@ -183,7 +183,7 @@ void AttachmentDialog::fillControls()
     attachmentListBox_->DeleteAllItems();
 
     AttachmentModel::DataA att_a = AttachmentModel::instance().find_ref_data_a(
-        RefTypeN(m_RefType), m_RefId
+        m_ref_type, m_ref_id
     );
     if (att_a.empty())
         return;
@@ -233,27 +233,27 @@ void AttachmentDialog::AddAttachment(wxString file_path)
     const wxString desc = dlg.getText();
 
     const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
-    int last_num = AttachmentModel::instance().find_ref_last_num(RefTypeN(m_RefType), m_RefId);
+    int last_num = AttachmentModel::instance().find_ref_last_num(m_ref_type, m_ref_id);
 
-    wxString importedFileName = m_RefType + "_" + wxString::Format("%lld", m_RefId) + "_Attach"
+    wxString importedFileName = m_ref_type.name_n() + "_" + wxString::Format("%lld", m_ref_id) + "_Attach"
         + wxString::Format("%i", last_num + 1);
     if (!file_ext.empty())
         importedFileName += "." + file_ext;
 
     if (mmAttachmentManage::CopyAttachment(
         file_path,
-        folder + m_RefType + m_PathSep + importedFileName
+        folder + m_ref_type.name_n() + m_PathSep + importedFileName
     )) {
         AttachmentData new_att_d = AttachmentData();
-        new_att_d.m_ref_type_n  = RefTypeN(m_RefType);
-        new_att_d.m_ref_id      = m_RefId;
+        new_att_d.m_ref_type_n  = m_ref_type;
+        new_att_d.m_ref_id      = m_ref_id;
         new_att_d.m_description = desc;
         new_att_d.m_filename    = importedFileName;
         AttachmentModel::instance().add_data_n(new_att_d);
         m_attachment_id = new_att_d.id();
 
-        if (RefTypeN(m_RefType).id_n() == RefTypeN::e_trx)
-            TrxModel::instance().save_timestamp(m_RefId);
+        if (m_ref_type == TrxModel::s_ref_type)
+            TrxModel::instance().save_timestamp(m_ref_id);
     }
 
     fillControls();
@@ -291,7 +291,7 @@ void AttachmentDialog::EditAttachment()
     AttachmentModel::instance().unsafe_update_data_n(att_n);
     m_attachment_id = att_n->id();
 
-    if (att_n->m_ref_type_n.id_n() == RefTypeN::e_trx)
+    if (att_n->m_ref_type_n == TrxModel::s_ref_type)
         TrxModel::instance().save_timestamp(att_n->m_ref_id);
 
     fillControls();
@@ -315,7 +315,7 @@ void AttachmentDialog::DeleteAttachment()
         if (mmAttachmentManage::DeleteAttachment(
             AttachmentsFolder + m_PathSep + att_n->m_filename
         )) {
-            if (att_n->m_ref_type_n.id_n() == RefTypeN::e_trx)
+            if (att_n->m_ref_type_n == TrxModel::s_ref_type)
                 TrxModel::instance().save_timestamp(att_n->m_ref_id);
             AttachmentModel::instance().purge_id(m_attachment_id);
         }

--- a/src/dialog/AttachmentDialog.h
+++ b/src/dialog/AttachmentDialog.h
@@ -24,14 +24,12 @@
 #include <map>
 
 #include "util/_primitive.h"
+#include "data/_DataEnum.h"
 
 class AttachmentDialog : public wxDialog
 {
     wxDECLARE_DYNAMIC_CLASS(AttachmentDialog);
     wxDECLARE_EVENT_TABLE();
-
-public:
-    AttachmentDialog(wxWindow* parent, const wxString& RefType, int64 RefId, const wxString& name = "AttachmentDialog");
 
 private:
     enum cols
@@ -49,19 +47,33 @@ private:
         MENU_DELETE_ATTACHMENT,
     };
 
-    wxDataViewListCtrl* attachmentListBox_ = nullptr;
-
+private:
     int64 m_attachment_id = -1;
-    std::map<int, wxString> ColName_;
-    //wxButton* btnCancel_ = nullptr;
-    //wxButton* button_OK_ = nullptr;
-    wxString m_PathSep = wxFileName::GetPathSeparator();
-
     wxString m_RefType;
     int64 m_RefId = -1;
+    std::map<int, wxString> ColName_;
+    wxString m_PathSep = wxFileName::GetPathSeparator();
 
+    //wxButton* btnCancel_ = nullptr;
+    //wxButton* button_OK_ = nullptr;
+    wxDataViewListCtrl* attachmentListBox_ = nullptr;
+
+    #ifdef _DEBUG
+        bool debug_ = true;
+    #else
+        bool debug_ = false;
+    #endif
+
+public:
     AttachmentDialog() {}
+    AttachmentDialog(
+        wxWindow* parent,
+        const wxString& RefType,
+        int64 RefId,
+        const wxString& name = "AttachmentDialog"
+    );
 
+private:
     void Create(wxWindow* parent, const wxString& name);
     void CreateControls();
     void fillControls();
@@ -79,16 +91,14 @@ private:
     void OnItemRightClick(wxDataViewEvent& event);
     void OnListItemActivated(wxDataViewEvent& event);
     void OnMagicButton(wxCommandEvent& event);
-
-    #ifdef _DEBUG
-        bool debug_ = true;
-    #else
-        bool debug_ = false;
-    #endif
 };
 
+// TODO: move to AttachmentModel
 class mmAttachmentManage
 {
+private:
+    static wxString m_PathSep;
+
 public:
     static const wxString InfotablePathSetting();
     static const wxString GetAttachmentNoteSign();
@@ -96,11 +106,15 @@ public:
     static bool CopyAttachment(const wxString& FileToImport, const wxString& ImportedFile);
     static bool DeleteAttachment(const wxString& FileToDelete);
     static bool OpenAttachment(const wxString& FileToOpen);
-    static bool DeleteAllAttachments(const wxString& RefType, int64 RefId);
-    static bool RelocateAllAttachments(const wxString& OldRefType, int64 OldRefId, const wxString& NewRefType, int64 NewRefId);
-    static bool CloneAllAttachments(const wxString& RefType, int64 OldRefId, int64 NewRefId);
-    static void OpenAttachmentFromPanelIcon(wxWindow* parent, const wxString& RefType, int64 RefId);
-private:
-    static wxString m_PathSep;
-};
 
+    static bool DeleteAllAttachments(RefTypeN ref_type, int64 ref_id);
+    static bool RelocateAllAttachments(
+        RefTypeN old_ref_type, int64 old_ref_id,
+        RefTypeN new_ref_type, int64 new_ref_id
+    );
+    static bool CloneAllAttachments(RefTypeN ref_type, int64 src_ref_id, int64 dst_ref_id);
+    static void OpenAttachmentFromPanelIcon(
+        wxWindow* parent,
+        RefTypeN ref_type, int64 ref_id
+    );
+};

--- a/src/dialog/AttachmentDialog.h
+++ b/src/dialog/AttachmentDialog.h
@@ -49,8 +49,8 @@ private:
 
 private:
     int64 m_attachment_id = -1;
-    wxString m_RefType;
-    int64 m_RefId = -1;
+    RefTypeN m_ref_type;
+    int64 m_ref_id = -1;
     std::map<int, wxString> ColName_;
     wxString m_PathSep = wxFileName::GetPathSeparator();
 
@@ -68,8 +68,8 @@ public:
     AttachmentDialog() {}
     AttachmentDialog(
         wxWindow* parent,
-        const wxString& RefType,
-        int64 RefId,
+        RefTypeN ref_type,
+        int64 ref_id,
         const wxString& name = "AttachmentDialog"
     );
 

--- a/src/dialog/BudgetEntryDialog.cpp
+++ b/src/dialog/BudgetEntryDialog.cpp
@@ -116,7 +116,7 @@ void BudgetEntryDialog::CreateControls()
     wxStaticText* itemTextActCatAmt = new wxStaticText(itemPanel7, wxID_STATIC, catActualAmountStr_);
     
     itemGridSizer2->Add(new wxStaticText(itemPanel7, wxID_STATIC, _t("Category: ")), g_flagsH);
-    wxString categname = CategoryModel::full_name(category);
+    wxString categname = CategoryModel::instance().full_name(category);
     wxStaticText* categNameLabel = new wxStaticText(itemPanel7, wxID_STATIC,
         (categname.size() > 50 ? wxString::FromUTF8("\u2026") + categname.substr(categname.size() - 50) : categname));
     if (categname.size() > 50) categNameLabel->SetToolTip(categname);

--- a/src/dialog/BudgetYearDialog.cpp
+++ b/src/dialog/BudgetYearDialog.cpp
@@ -146,9 +146,11 @@ void BudgetYearDialog::OnAddMonth(wxCommandEvent& /*event*/)
 
 void BudgetYearDialog::OnDelete(wxCommandEvent& /*event*/)
 {
-    wxString budgetYearString = m_listBox->GetStringSelection();
-    int64 budgetYearID = BudgetPeriodModel::instance().get_name_id(budgetYearString);
-    BudgetPeriodModel::instance().purge_id(budgetYearID);
+    wxString bp_name = m_listBox->GetStringSelection();
+    int64 bp_id_n = BudgetPeriodModel::instance().get_name_id_n(bp_name);
+    if (bp_id_n > 0) {
+        BudgetPeriodModel::instance().purge_id(bp_id_n);
+    }
     m_listBox->Clear();
     fillControls();
 }

--- a/src/dialog/BudgetYearEntryDialog.cpp
+++ b/src/dialog/BudgetYearEntryDialog.cpp
@@ -148,16 +148,19 @@ void BudgetYearEntryDialog::OnOk(wxCommandEvent& /*event*/)
         currYearText << "-" << currMonthText;
     }
 
-    if (BudgetPeriodModel::instance().get_name_id(currYearText) != -1) {   
-        wxMessageBox(_t("Budget Year already exists")
-            , _t("Budget Entry Details"), wxICON_WARNING);
+    if (BudgetPeriodModel::instance().get_name_id_n(currYearText) > 0) {   
+        wxMessageBox(
+            _t("Budget Year already exists"),
+            _t("Budget Entry Details"),
+            wxICON_WARNING
+        );
         return;
     }
     else {
         BudgetPeriodModel::instance().ensure_name(currYearText);
         if (baseYear != "None" && !baseYear.empty()) {
-            int64 baseYearID = BudgetPeriodModel::instance().get_name_id(baseYear);
-            int64 newYearID  = BudgetPeriodModel::instance().get_name_id(currYearText);
+            int64 baseYearID = BudgetPeriodModel::instance().get_name_id_n(baseYear);
+            int64 newYearID  = BudgetPeriodModel::instance().get_name_id_n(currYearText);
             BudgetModel::instance().copyBudgetYear(newYearID, baseYearID);
         }
     }

--- a/src/dialog/FieldDialog.cpp
+++ b/src/dialog/FieldDialog.cpp
@@ -46,7 +46,7 @@ wxEND_EVENT_TABLE()
 
 FieldDialog::FieldDialog(wxWindow* parent, FieldData* field) :
     m_field_n(field),
-    m_fieldRefType(TrxModel::refTypeName)
+    m_ref_type(TrxModel::s_ref_type)
 {
     this->SetFont(parent->GetFont());
     Create(parent);
@@ -80,7 +80,7 @@ void FieldDialog::dataToControls()
     if (m_field_n) {
         m_itemDescription->SetValue(m_field_n->m_description);
         m_itemType->SetSelection(m_field_n->m_type_n.id_n());
-        m_itemReference->SetSelection(ModelBase::reftype_id(m_field_n->m_ref_type.name_n()));
+        m_itemReference->SetSelection(m_field_n->m_ref_type.id_n());
         m_itemTooltip->SetValue(FieldModel::getTooltip(m_field_n->m_properties));
         m_itemRegEx->SetValue(FieldModel::getRegEx(m_field_n->m_properties));
         m_itemAutocomplete->SetValue(FieldModel::getAutocomplete(m_field_n->m_properties));
@@ -96,7 +96,7 @@ void FieldDialog::dataToControls()
         m_itemChoices->ChangeValue(choices);
     }
     else {
-        m_itemReference->SetSelection(ModelBase::reftype_id(m_fieldRefType));
+        m_itemReference->SetSelection(m_ref_type.id_n());
         m_itemType->SetSelection(FieldTypeN::e_string);
         m_itemUDFC->SetSelection(0);
     }
@@ -125,11 +125,14 @@ void FieldDialog::CreateControls()
 
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _t("Attribute of")), g_flagsH);
     m_itemReference = new wxChoice(itemPanel5, wxID_HIGHEST);
-    for (int i = 0; i < ModelBase::REFTYPE_ID_size; ++i) {
-        if (i != ModelBase::REFTYPE_ID_BILLSDEPOSIT) {
-            wxString reftype = ModelBase::reftype_name(i);
-            m_itemReference->Append(wxGetTranslation(reftype), new wxStringClientData(reftype));
-        }
+    for (int type_id = 0; type_id < RefTypeN::size; ++type_id) {
+        if (RefTypeN::field_id_n(type_id) != type_id)
+            continue;
+        wxString type_name = RefTypeN(type_id).name_n();
+        m_itemReference->Append(
+            wxGetTranslation(type_name),
+            new wxStringClientData(type_name)
+        );
     }
     mmToolTip(m_itemReference, _t("Select the item that the custom field is associated with"));
     itemFlexGridSizer6->Add(m_itemReference, g_flagsExpand);
@@ -144,9 +147,12 @@ void FieldDialog::CreateControls()
 
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _t("Field Type")), g_flagsH);
     m_itemType = new wxChoice(itemPanel5, wxID_HIGHEST);
-    for (int i = 0; i < FieldTypeN::size; ++i) {
-        wxString type_name = FieldTypeN(i).name_n();
-        m_itemType->Append(wxGetTranslation(type_name), new wxStringClientData(type_name));
+    for (int type_id = 0; type_id < FieldTypeN::size; ++type_id) {
+        wxString type_name = FieldTypeN(type_id).name_n();
+        m_itemType->Append(
+            wxGetTranslation(type_name),
+            new wxStringClientData(type_name)
+        );
     }
     mmToolTip(m_itemType, _t("Select the custom field type"));
     itemFlexGridSizer6->Add(m_itemType, g_flagsExpand);
@@ -285,7 +291,7 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             return;
     }
 
-    m_field_n->m_ref_type = RefTypeN(m_fieldRefType);
+    m_field_n->m_ref_type = m_ref_type;
     m_field_n->m_description = name;
     m_field_n->m_type_n = FieldTypeN(m_itemType->GetSelection());
     m_field_n->m_properties = FieldModel::formatProperties(

--- a/src/dialog/FieldDialog.cpp
+++ b/src/dialog/FieldDialog.cpp
@@ -78,19 +78,19 @@ bool FieldDialog::Create(
 void FieldDialog::dataToControls()
 {
     if (m_field_n) {
-        m_itemDescription->SetValue(m_field_n->DESCRIPTION);
+        m_itemDescription->SetValue(m_field_n->m_description);
         m_itemType->SetSelection(FieldModel::type_id(m_field_n));
-        m_itemReference->SetSelection(ModelBase::reftype_id(m_field_n->REFTYPE));
-        m_itemTooltip->SetValue(FieldModel::getTooltip(m_field_n->PROPERTIES));
-        m_itemRegEx->SetValue(FieldModel::getRegEx(m_field_n->PROPERTIES));
-        m_itemAutocomplete->SetValue(FieldModel::getAutocomplete(m_field_n->PROPERTIES));
-        m_itemDefault->SetValue(FieldModel::getDefault(m_field_n->PROPERTIES));
-        m_itemDigitScale->SetValue(FieldModel::getDigitScale(m_field_n->PROPERTIES));
-        m_itemUDFC->SetStringSelection(FieldModel::getUDFC(m_field_n->PROPERTIES));
+        m_itemReference->SetSelection(ModelBase::reftype_id(m_field_n->m_ref_type.name_n()));
+        m_itemTooltip->SetValue(FieldModel::getTooltip(m_field_n->m_properties));
+        m_itemRegEx->SetValue(FieldModel::getRegEx(m_field_n->m_properties));
+        m_itemAutocomplete->SetValue(FieldModel::getAutocomplete(m_field_n->m_properties));
+        m_itemDefault->SetValue(FieldModel::getDefault(m_field_n->m_properties));
+        m_itemDigitScale->SetValue(FieldModel::getDigitScale(m_field_n->m_properties));
+        m_itemUDFC->SetStringSelection(FieldModel::getUDFC(m_field_n->m_properties));
 
 
         wxString choices = wxEmptyString;
-        for (const auto& arrChoices : FieldModel::getChoices(m_field_n->PROPERTIES)) {
+        for (const auto& arrChoices : FieldModel::getChoices(m_field_n->m_properties)) {
             choices += (choices.empty() ? "": ";") + arrChoices;
         }
         m_itemChoices->ChangeValue(choices);
@@ -230,9 +230,9 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         m_field_d = FieldData();
         m_field_n = &m_field_d;
     }
-    else if (m_field_n->TYPE != FieldModel::type_name(m_itemType->GetSelection())) {
+    else if (m_field_n->m_type_n.name_n() != FieldModel::type_name(m_itemType->GetSelection())) {
         auto fv_a = FieldValueModel::instance().find(
-            FieldValueCol::FIELDID(m_field_n->FIELDID)
+            FieldValueCol::FIELDID(m_field_n->m_id)
         );
         if (fv_a.size() > 0) {
             int DeleteResponse = wxMessageBox(
@@ -254,9 +254,9 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             FieldValueModel::instance().db_release_savepoint();
         }
     }
-    else if (FieldModel::getChoices(m_field_n->PROPERTIES) != ArrChoices) {
+    else if (FieldModel::getChoices(m_field_n->m_properties) != ArrChoices) {
         auto fv_a = FieldValueModel::instance().find(
-            FieldValueCol::FIELDID(m_field_n->FIELDID)
+            FieldValueCol::FIELDID(m_field_n->m_id)
         );
         if (fv_a.size() > 0) {
             int DeleteResponse = wxMessageBox(
@@ -285,10 +285,10 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             return;
     }
 
-    m_field_n->REFTYPE = m_fieldRefType;
-    m_field_n->DESCRIPTION = name;
-    m_field_n->TYPE = FieldModel::type_name(m_itemType->GetSelection());
-    m_field_n->PROPERTIES = FieldModel::formatProperties(
+    m_field_n->m_ref_type = RefTypeN(m_fieldRefType);
+    m_field_n->m_description = name;
+    m_field_n->m_type_n = FieldTypeN(FieldModel::type_name(m_itemType->GetSelection()));
+    m_field_n->m_properties = FieldModel::formatProperties(
         m_itemTooltip->GetValue(),
         regexp,
         m_itemAutocomplete->GetValue(),
@@ -297,7 +297,6 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         m_itemDigitScale->GetValue(),
         m_itemUDFC->GetString(m_itemUDFC->GetSelection())
     );
-
     FieldModel::instance().unsafe_save_data_n(m_field_n);
     EndModal(wxID_OK);
 }

--- a/src/dialog/FieldDialog.cpp
+++ b/src/dialog/FieldDialog.cpp
@@ -79,7 +79,7 @@ void FieldDialog::dataToControls()
 {
     if (m_field_n) {
         m_itemDescription->SetValue(m_field_n->m_description);
-        m_itemType->SetSelection(FieldModel::type_id(m_field_n));
+        m_itemType->SetSelection(m_field_n->m_type_n.id_n());
         m_itemReference->SetSelection(ModelBase::reftype_id(m_field_n->m_ref_type.name_n()));
         m_itemTooltip->SetValue(FieldModel::getTooltip(m_field_n->m_properties));
         m_itemRegEx->SetValue(FieldModel::getRegEx(m_field_n->m_properties));
@@ -97,7 +97,7 @@ void FieldDialog::dataToControls()
     }
     else {
         m_itemReference->SetSelection(ModelBase::reftype_id(m_fieldRefType));
-        m_itemType->SetSelection(FieldModel::TYPE_ID_STRING);
+        m_itemType->SetSelection(FieldTypeN::e_string);
         m_itemUDFC->SetSelection(0);
     }
     wxCommandEvent evt;
@@ -144,9 +144,9 @@ void FieldDialog::CreateControls()
 
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _t("Field Type")), g_flagsH);
     m_itemType = new wxChoice(itemPanel5, wxID_HIGHEST);
-    for (int i = 0; i < FieldModel::TYPE_ID_size; ++i) {
-        wxString type = FieldModel::type_name(i);
-        m_itemType->Append(wxGetTranslation(type), new wxStringClientData(type));
+    for (int i = 0; i < FieldTypeN::size; ++i) {
+        wxString type_name = FieldTypeN(i).name_n();
+        m_itemType->Append(wxGetTranslation(type_name), new wxStringClientData(type_name));
     }
     mmToolTip(m_itemType, _t("Select the custom field type"));
     itemFlexGridSizer6->Add(m_itemType, g_flagsExpand);
@@ -184,8 +184,8 @@ void FieldDialog::CreateControls()
 
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _t("Panel's column")), g_flagsH);
     m_itemUDFC = new wxChoice(itemPanel5, wxID_APPLY);
-    for (const auto& type : FieldModel::getUDFCList(m_field_n)) {
-        m_itemUDFC->Append(wxGetTranslation(type), new wxStringClientData(type));
+    for (const auto& udfc : FieldModel::instance().get_data_udfc_a(m_field_n)) {
+        m_itemUDFC->Append(wxGetTranslation(udfc), new wxStringClientData(udfc));
     }
     mmToolTip(m_itemUDFC, _t("Select a value to represent the item on a panel"));
     itemFlexGridSizer6->Add(m_itemUDFC, g_flagsExpand);
@@ -220,8 +220,8 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
     int itemType = m_itemType->GetSelection();
     if (ArrChoices.IsEmpty() && (
-        itemType == FieldModel::TYPE_ID_SINGLECHOICE ||
-        itemType == FieldModel::TYPE_ID_MULTICHOICE)
+        itemType == FieldTypeN::e_single_choice ||
+        itemType == FieldTypeN::e_multi_choice)
     ) {
         return mmErrorDialogs::ToolTip4Object(m_itemChoices, _t("Empty value"), _t("Choices"));
     }
@@ -230,7 +230,7 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         m_field_d = FieldData();
         m_field_n = &m_field_d;
     }
-    else if (m_field_n->m_type_n.name_n() != FieldModel::type_name(m_itemType->GetSelection())) {
+    else if (m_field_n->m_type_n.id_n() != m_itemType->GetSelection()) {
         auto fv_a = FieldValueModel::instance().find(
             FieldValueCol::FIELDID(m_field_n->m_id)
         );
@@ -287,7 +287,7 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
     m_field_n->m_ref_type = RefTypeN(m_fieldRefType);
     m_field_n->m_description = name;
-    m_field_n->m_type_n = FieldTypeN(FieldModel::type_name(m_itemType->GetSelection()));
+    m_field_n->m_type_n = FieldTypeN(m_itemType->GetSelection());
     m_field_n->m_properties = FieldModel::formatProperties(
         m_itemTooltip->GetValue(),
         regexp,
@@ -339,31 +339,31 @@ void FieldDialog::OnChangeType(wxCommandEvent& WXUNUSED(event), bool OnDataToCon
     //Enable specific fields
     switch (m_itemType->GetSelection())
     {
-    case FieldModel::TYPE_ID_STRING:
+    case FieldTypeN::e_string:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);
         m_itemAutocomplete->Enable(true);
         break;
     }
-    case FieldModel::TYPE_ID_SINGLECHOICE:
+    case FieldTypeN::e_single_choice:
     {
         m_itemChoices->Enable(true);
         m_itemDefault->Enable(true);
         break;
     }
-    case FieldModel::TYPE_ID_MULTICHOICE:
+    case FieldTypeN::e_multi_choice:
     {
         m_itemChoices->Enable(true);
         break;
     }
-    case FieldModel::TYPE_ID_INTEGER:
+    case FieldTypeN::e_integer:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);
         break;
     }
-    case FieldModel::TYPE_ID_DECIMAL:
+    case FieldTypeN::e_decimal:
     {
         m_itemDefault->Enable(true);
         m_itemRegEx->Enable(true);

--- a/src/dialog/FieldDialog.cpp
+++ b/src/dialog/FieldDialog.cpp
@@ -270,7 +270,7 @@ void FieldDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
             FieldValueModel::instance().db_savepoint();
             for (auto& fv_d : fv_a) {
-                if (ArrChoices.Index(fv_d.CONTENT) == wxNOT_FOUND)
+                if (ArrChoices.Index(fv_d.m_content) == wxNOT_FOUND)
                     FieldValueModel::instance().purge_id(fv_d.id());
             }
             FieldValueModel::instance().save_data_a(fv_a);

--- a/src/dialog/FieldDialog.h
+++ b/src/dialog/FieldDialog.h
@@ -44,7 +44,7 @@ private:
 private:
     FieldData* m_field_n = nullptr;
     FieldData m_field_d;
-    wxString m_fieldRefType;
+    RefTypeN m_ref_type;
 
     wxTextCtrl* m_itemDescription  = nullptr;
     wxChoice*   m_itemType         = nullptr;

--- a/src/dialog/FieldValueDialog.cpp
+++ b/src/dialog/FieldValueDialog.cpp
@@ -33,31 +33,38 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "FieldValueDialog.h"
 
-FieldValueDialog::~FieldValueDialog()
-{
-    wxLogDebug("~FieldValueDialog");
-}
-
-FieldValueDialog::FieldValueDialog()
-    : wxDialog()
+FieldValueDialog::FieldValueDialog() :
+    wxDialog()
 {
 }
 
-FieldValueDialog::FieldValueDialog(wxDialog* dialog, const wxString& ref_type, int64 ref_id) :
+FieldValueDialog::FieldValueDialog(
+    wxDialog* dialog,
+    RefTypeN ref_type,
+    int64 ref_id
+) :
     wxDialog(),
     m_ref_type(ref_type),
     m_ref_id(ref_id)
 {
     m_dialog = dialog;
-    m_field_a = FieldModel::instance().find(FieldCol::REFTYPE(m_ref_type));
+    m_field_a = FieldModel::instance().find(
+        FieldCol::REFTYPE(RefTypeN::field_ref_type_n(m_ref_type).name_n())
+    );
     std::sort(m_field_a.begin(), m_field_a.end(), FieldData::SorterByDESCRIPTION());
     m_data_changed.clear();
 }
 
+FieldValueDialog::~FieldValueDialog()
+{
+    wxLogDebug("~FieldValueDialog");
+}
+
+// TODO: refactor to FieldValueDialog()
 mmCustomDataTransaction::mmCustomDataTransaction(
-    wxDialog* dialog, int64 ref_id, wxWindowID base_id
+    wxDialog* dialog, RefTypeN ref_type, int64 ref_id, wxWindowID base_id
 ) :
-    FieldValueDialog(dialog, TrxModel::refTypeName, ref_id)
+    FieldValueDialog(dialog, ref_type, ref_id)
 {
     SetBaseID(base_id);
 }
@@ -80,16 +87,19 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
     int field_index = 0;
     for (const auto& field_d : m_field_a) {
         bool nonDefaultData = true;
-        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, m_ref_id);
-        FieldValueData fv_data;
+        const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(
+            field_d.m_id, m_ref_type, m_ref_id
+        );
+        FieldValueData fv_d;
         if (fv_n) {
-            fv_data = *fv_n;
+            fv_d = *fv_n;
         }
         else {
-            fv_data = FieldValueData();
-            fv_data.FIELDID = field_d.m_id;
-            fv_data.REFID = m_ref_id;
-            fv_data.CONTENT = FieldModel::getDefault(field_d.m_properties);
+            fv_d = FieldValueData();
+            fv_d.m_field_id = field_d.m_id;
+            fv_d.m_ref_type = m_ref_type;
+            fv_d.m_ref_id   = m_ref_id;
+            fv_d.m_content  = FieldModel::getDefault(field_d.m_properties);
             nonDefaultData = false;
         }
 
@@ -112,11 +122,11 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         {
         case FieldModel::TYPE_ID_STRING:
         {
-            const auto& data = fv_data.CONTENT;
+            const auto& data = fv_d.m_content;
             wxTextCtrl* CustomString = new wxTextCtrl(scrolled_window, controlID, data, wxDefaultPosition, wxDefaultSize);
             mmToolTip(CustomString, FieldModel::getTooltip(field_d.m_properties));
             if (FieldModel::getAutocomplete(field_d.m_properties)) {
-                const wxArrayString& values = FieldValueModel::instance().allValue(field_d.m_id);
+                const wxArrayString& values = FieldModel::instance().find_id_value_a(field_d.m_id);
                 CustomString->AutoComplete(values);
             }
             grid_sizer_custom->Add(CustomString, g_flagsExpand);
@@ -133,7 +143,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         case FieldModel::TYPE_ID_DECIMAL:
         {
             int digitScale = FieldModel::getDigitScale(field_d.m_properties);
-            wxString content = cleanseNumberString(fv_data.CONTENT, digitScale > 0);
+            wxString content = cleanseNumberString(fv_d.m_content, digitScale > 0);
 
             double value;
             if (!content.ToCDouble(&value)) {
@@ -144,13 +154,16 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
                     SetWidgetChanged(controlID, CurrencyModel::toString(value, nullptr, digitScale));
             }
             
-            mmTextCtrl* CustomDecimal = new mmTextCtrl(scrolled_window, controlID
-                , wxEmptyString, wxDefaultPosition, wxDefaultSize
-                , wxALIGN_RIGHT | wxTE_PROCESS_ENTER, mmCalcValidator());
+            mmTextCtrl* CustomDecimal = new mmTextCtrl(scrolled_window, controlID,
+                wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                wxALIGN_RIGHT | wxTE_PROCESS_ENTER,
+                mmCalcValidator()
+            );
             CustomDecimal->SetAltPrecision(digitScale);
             CustomDecimal->SetValue(value, digitScale);
-            CustomDecimal->Connect(wxID_ANY, wxEVT_TEXT
-                , wxCommandEventHandler(FieldValueDialog::OnStringChanged), nullptr, this);
+            CustomDecimal->Connect(wxID_ANY, wxEVT_TEXT,
+                wxCommandEventHandler(FieldValueDialog::OnStringChanged), nullptr, this
+            );
 
             mmToolTip(CustomDecimal, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(CustomDecimal, g_flagsExpand);
@@ -164,9 +177,8 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
             wxRadioButton* CustomBooleanT = new wxRadioButton(scrolled_window, controlID + 1
                 , _t("True"), wxDefaultPosition, wxDefaultSize);
 
-            const auto& data = fv_data.CONTENT;
-            if (!data.empty())
-            {
+            const auto& data = fv_d.m_content;
+            if (!data.empty()) {
                 data == "TRUE" ? CustomBooleanT->SetValue(true) : CustomBooleanF->SetValue(true);
                 if (nonDefaultData) 
                     SetWidgetChanged(controlID, data);
@@ -187,7 +199,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         case FieldModel::TYPE_ID_DATE:
         {
             wxDate value;
-            if (!value.ParseDate(fv_data.CONTENT)) {
+            if (!value.ParseDate(fv_d.m_content)) {
                 value = wxDate::Today();
             }
             else {
@@ -206,7 +218,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         case FieldModel::TYPE_ID_TIME:
         {
             wxDateTime value;
-            if (!value.ParseTime(fv_data.CONTENT)) {
+            if (!value.ParseTime(fv_d.m_content)) {
                 value.ParseTime("00:00:00");
             }
             else {
@@ -237,7 +249,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
                 CustomChoice->Enable(false);
             }
 
-            const auto& data = fv_data.CONTENT;
+            const auto& data = fv_d.m_content;
             if (!data.empty())
             {
                 CustomChoice->SetStringSelection(data);
@@ -250,7 +262,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         }
         case FieldModel::TYPE_ID_MULTICHOICE:
         {
-            const auto& content = fv_data.CONTENT;
+            const auto& content = fv_d.m_content;
             const auto& name = field_d.m_description;
 
             wxButton* multi_choice_button = new wxButton(scrolled_window, controlID, content
@@ -276,7 +288,8 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
     scrolled_window->SetScrollRate(6, 6);
     box_sizer_right->Add(scrolled_window, g_flagsExpand);
     const TrxData* ref_trx_n = TrxModel::instance().get_id_data_n(m_ref_id);
-    if (ref_trx_n && !ref_trx_n->DELETEDTIME.IsEmpty()) scrolled_window->Disable();
+    if (ref_trx_n && !ref_trx_n->DELETEDTIME.IsEmpty())
+        scrolled_window->Disable();
     m_static_box->Hide();
     mmThemeAutoColour(scrolled_window);
     return true;
@@ -295,7 +308,7 @@ void FieldValueDialog::OnMultiChoice(wxCommandEvent& event)
     const wxString& type = FieldModel::type_name(FieldModel::TYPE_ID_MULTICHOICE);
 
     FieldModel::DataA field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(m_ref_type),
+        FieldCol::REFTYPE(m_ref_type.name_n()),
         FieldCol::TYPE(type),
         FieldCol::DESCRIPTION(name)
     );
@@ -332,10 +345,9 @@ void FieldValueDialog::OnMultiChoice(wxCommandEvent& event)
 
 size_t FieldValueDialog::GetActiveCustomFieldsCount() const
 {
-    const auto& data_set = FieldValueModel::instance().find(
+    return FieldValueModel::instance().find(
         FieldValueCol::REFID(m_ref_id)
-    );
-    return data_set.size();
+    ).size();
 }
 
 std::map<int64, wxString> FieldValueDialog::GetActiveCustomFields() const
@@ -422,51 +434,41 @@ void FieldValueDialog::SetWidgetData(wxWindowID controlID, const wxString& value
 const wxString FieldValueDialog::GetWidgetData(wxWindowID controlID) const
 {
     wxString data;
-    if (m_data_changed.find(controlID) != m_data_changed.end())
-    {
+    if (m_data_changed.find(controlID) != m_data_changed.end()) {
         data = m_data_changed.at(controlID);
     }
-    else
-    {
+    else {
         wxWindow* w = FindWindowById(controlID, m_dialog);
-        if (w)
-        {
+        if (w) {
             wxString class_name = w->GetEventHandler()->GetClassInfo()->GetClassName();
 
-            if (class_name == "wxPanel")
-            {
+            if (class_name == "wxPanel") {
                 wxWindow* child = w->GetChildren()[0];
                 if (child)
                     class_name = child->GetEventHandler()->GetClassInfo()->GetClassName();
             }
 
-            if (class_name == "wxDatePickerCtrl")
-            {
+            if (class_name == "wxDatePickerCtrl") {
                 mmDatePickerCtrl* d = static_cast<mmDatePickerCtrl*>(w);
                 data = d->GetValue().FormatISODate();
             }
-            else if (class_name == "wxTimePickerCtrl")
-            {
+            else if (class_name == "wxTimePickerCtrl") {
                 wxTimePickerCtrl* d = static_cast<wxTimePickerCtrl*>(w);
                 data = d->GetValue().FormatISOTime();
             }
-            else if (class_name == "wxChoice")
-            {
+            else if (class_name == "wxChoice") {
                 wxChoice* d = static_cast<wxChoice*>(w);
                 data = d->GetStringSelection();
             }
-            else if (class_name == "wxButton")
-            {
+            else if (class_name == "wxButton") {
                 wxButton* d = static_cast<wxButton*>(w);
                 data = d->GetLabel();
             }
-            else if (class_name == "wxTextCtrl")
-            {
+            else if (class_name == "wxTextCtrl") {
                 wxTextCtrl* d = static_cast<wxTextCtrl*>(w);
                 data = d->GetValue();
             }
-            else if (class_name == "wxRadioButton")
-            {
+            else if (class_name == "wxRadioButton") {
                 wxRadioButton* d = static_cast<wxRadioButton*>(w);
                 data = (d->GetValue() ? "FALSE" : "TRUE");
             }
@@ -475,91 +477,86 @@ const wxString FieldValueDialog::GetWidgetData(wxWindowID controlID) const
     return data;
 }
 
-bool FieldValueDialog::SaveCustomValues(int64 ref_id)
+bool FieldValueDialog::SaveCustomValues(RefTypeN ref_type, int64 ref_id)
 {
-    bool save_timestamp = false;
+    bool changed = false;
     FieldValueModel::instance().db_savepoint();
     int field_index = 0;
     for (const auto& field_d : m_field_a) {
-        wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
-        const auto& data = IsWidgetChanged(controlID) ? GetWidgetData(controlID) : "";
+        wxWindowID controlID = GetBaseID() + (field_index++) * FIELDMULTIPLIER;
+        const wxString data = IsWidgetChanged(controlID) ? GetWidgetData(controlID) : "";
 
-        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
-        FieldValueData oldData;
-        if (fv_n)
-            oldData = *fv_n;
+        const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(
+            field_d.m_id, ref_type, ref_id
+        );
         if (!data.empty()) {
+            FieldValueData old_fv_d = fv_n ? *fv_n : FieldValueData();
             FieldValueData fv_d = fv_n ? *fv_n : FieldValueData();
-            fv_d.REFID   = ref_id;
-            fv_d.FIELDID = field_d.m_id;
-            fv_d.CONTENT = data;
+            fv_d.m_field_id = field_d.m_id;
+            fv_d.m_ref_type = ref_type;
+            fv_d.m_ref_id   = ref_id;
+            fv_d.m_content  = data;
             wxLogDebug("Control:%i Type:%s Value:%s",
                 controlID,
                 FieldModel::type_name(FieldModel::type_id(field_d)),
                 data
             );
 
-            if (!fv_d.equals(&oldData))
-                save_timestamp = true;
+            if (fv_n && !fv_d.equals(&old_fv_d))
+                changed = true;
 
             FieldValueModel::instance().save_data_n(fv_d);
         }
         else if (fv_n) {
-            FieldValueModel::instance().purge_id(fv_n->FIELDATADID);
-            save_timestamp = true;
+            FieldValueModel::instance().purge_id(fv_n->m_id);
+            changed = true;
         }
     }
-
     FieldValueModel::instance().db_release_savepoint();
 
-    if (save_timestamp && m_ref_type == TrxModel::refTypeName)
+    if (ref_type.id_n() == TrxModel::s_ref_type.id_n() && changed)
         TrxModel::instance().save_timestamp(ref_id);        
 
     return true;
 }
 
-void FieldValueDialog::UpdateCustomValues(int64 ref_id)
+void FieldValueDialog::UpdateCustomValues(RefTypeN ref_type, int64 ref_id)
 {
+    bool changed = false;
     FieldValueModel::instance().db_savepoint();
-    bool save_timestamp = false;
     int field_index = 0;
     for (const auto& field_d : m_field_a) {
-        bool is_changed = false;
-
-        wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
+        wxWindowID controlID = GetBaseID() + (field_index++) * FIELDMULTIPLIER;
         auto label_id = controlID + CONTROLOFFSET;
-        wxCheckBox* Description = static_cast<wxCheckBox*>(m_dialog->FindWindow(label_id));
-        if (Description) {
-            is_changed = Description->GetValue();
+        wxCheckBox* label_cb = static_cast<wxCheckBox*>(m_dialog->FindWindow(label_id));
+        if (!label_cb || !label_cb->GetValue())
+            continue;
+
+        const wxString data = GetWidgetData(controlID);
+        const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(
+            field_d.m_id, ref_type, ref_id
+        );
+        if (!data.empty()) {
+            FieldValueData old_fv_d = fv_n ? *fv_n : FieldValueData();
+            FieldValueData fv_d = fv_n ? *fv_n : FieldValueData();
+            fv_d.m_field_id = field_d.m_id;
+            fv_d.m_ref_type = ref_type;
+            fv_d.m_ref_id   = ref_id;
+            fv_d.m_content  = data;
+
+            if (!fv_d.equals(&old_fv_d))
+                changed = true;
+
+            FieldValueModel::instance().save_data_n(fv_d);
         }
-
-        if (is_changed) {
-            const auto& data = GetWidgetData(controlID);
-            const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
-            FieldValueData oldData;
-            if (fv_n)
-                oldData = *fv_n;
-            if (!data.empty()) {
-                FieldValueData fv_d = fv_n ? *fv_n : FieldValueData();
-                fv_d.REFID   = ref_id;
-                fv_d.FIELDID = field_d.m_id;
-                fv_d.CONTENT = data;
-
-                if (!fv_d.equals(&oldData))
-                    save_timestamp = true;
-
-                FieldValueModel::instance().save_data_n(fv_d);
-            }
-            else if (fv_n) {
-                FieldValueModel::instance().purge_id(fv_n->FIELDATADID);
-                save_timestamp = true;
-            }
+        else if (fv_n) {
+            FieldValueModel::instance().purge_id(fv_n->m_id);
+            changed = true;
         }
     }
-
     FieldValueModel::instance().db_release_savepoint();
 
-    if (save_timestamp && m_ref_type == TrxModel::refTypeName)
+    if (ref_type.id_n() == TrxModel::s_ref_type.id_n() && changed)
         TrxModel::instance().save_timestamp(ref_id);        
 }
 
@@ -633,7 +630,7 @@ int FieldValueDialog::GetWidgetType(wxWindowID controlID) const
 {
     int control_id = (controlID - GetBaseID()) / FIELDMULTIPLIER;
     for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(m_ref_type)
+        FieldCol::REFTYPE(m_ref_type.name_n())
     )) {
         if (field_d.m_id == m_field_a[control_id].m_id) {
             return field_d.m_type_n.id_n();
@@ -661,7 +658,7 @@ void FieldValueDialog::OnCheckBoxActivated(wxCommandEvent& event)
 
     if (checked) {
         //TODO:
-        const auto& data = GetWidgetData(widget_id);
+        const wxString data = GetWidgetData(widget_id);
         SetWidgetChanged(widget_id, data);
     }
     else {
@@ -717,7 +714,7 @@ bool FieldValueDialog::IsDataFound(const TrxModel::Full_Data& trx_xd)
     );
     for (const auto& filter : m_data_changed) {
         for (const auto& fv_d : fv_a) {
-            if (filter.second == fv_d.CONTENT) {
+            if (filter.second == fv_d.m_content) {
                 return true;
             }
         }
@@ -760,15 +757,15 @@ bool FieldValueDialog::ValidateCustomValues(int64)
     bool is_valid = true;
     int field_index = 0;
     for (const auto& field_d : m_field_a) {
-        wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
+        wxWindowID controlID = GetBaseID() + (field_index++) * FIELDMULTIPLIER;
         wxWindowID labelID = controlID + CONTROLOFFSET;
 
         wxCheckBox* cb = static_cast<wxCheckBox*>(FindWindowById(labelID, m_dialog));
         if (!cb || !cb->GetValue())
             continue;
 
-        if (GetWidgetType(controlID) == FieldModel::TYPE_ID_DECIMAL 
-                || GetWidgetType(controlID) == FieldModel::TYPE_ID_INTEGER
+        if (GetWidgetType(controlID) == FieldModel::TYPE_ID_DECIMAL ||
+            GetWidgetType(controlID) == FieldModel::TYPE_ID_INTEGER
         ) {
             wxWindow* w = FindWindowById(controlID, m_dialog);
             if (w) {
@@ -787,14 +784,19 @@ bool FieldValueDialog::ValidateCustomValues(int64)
 
         const wxString regExStr = FieldModel::getRegEx(field_d.m_properties);
         if (!regExStr.empty()) {
-            const auto& data = GetWidgetData(controlID);
+            const wxString data = GetWidgetData(controlID);
             wxRegEx regEx(regExStr, wxRE_EXTENDED);
 
             if (!regEx.Matches(data)) {
-                mmErrorDialogs::MessageError(this, wxString::Format(_t("Unable to save custom field \"%1$s\":\nvalue \"%2$s\" "
-                    "does not match RegEx validation \"%3$s\"")
-                    , field_d.m_description, data, regExStr)
-                    , _t("CustomField validation error"));
+                mmErrorDialogs::MessageError(this,
+                    wxString::Format(
+                        _t("Unable to save custom field \"%1$s\":\nvalue \"%2$s\" "
+                            "does not match RegEx validation \"%3$s\""
+                        ),
+                        field_d.m_description, data, regExStr
+                    ),
+                    _t("CustomField validation error")
+                );
                 is_valid = false;
                 continue;
             }

--- a/src/dialog/FieldValueDialog.cpp
+++ b/src/dialog/FieldValueDialog.cpp
@@ -43,21 +43,21 @@ FieldValueDialog::FieldValueDialog()
 {
 }
 
-FieldValueDialog::FieldValueDialog(wxDialog* dialog, const wxString& ref_type, int64 ref_id)
-    : wxDialog()
-    , m_ref_type(ref_type)
-    , m_ref_id(ref_id)
+FieldValueDialog::FieldValueDialog(wxDialog* dialog, const wxString& ref_type, int64 ref_id) :
+    wxDialog(),
+    m_ref_type(ref_type),
+    m_ref_id(ref_id)
 {
     m_dialog = dialog;
-    m_fields = FieldModel::instance().find(FieldCol::REFTYPE(m_ref_type));
-    std::sort(m_fields.begin(), m_fields.end(), FieldData::SorterByDESCRIPTION());
+    m_field_a = FieldModel::instance().find(FieldCol::REFTYPE(m_ref_type));
+    std::sort(m_field_a.begin(), m_field_a.end(), FieldData::SorterByDESCRIPTION());
     m_data_changed.clear();
 }
 
-mmCustomDataTransaction::mmCustomDataTransaction(wxDialog* dialog, int64 ref_id, wxWindowID base_id)
-    : FieldValueDialog(dialog
-        , TrxModel::refTypeName
-        , ref_id)
+mmCustomDataTransaction::mmCustomDataTransaction(
+    wxDialog* dialog, int64 ref_id, wxWindowID base_id
+) :
+    FieldValueDialog(dialog, TrxModel::refTypeName, ref_id)
 {
     SetBaseID(base_id);
 }
@@ -78,43 +78,45 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
     custom_sizer->Add(grid_sizer_custom, g_flagsExpand);
 
     int field_index = 0;
-    for (const auto &field : m_fields) {
+    for (const auto& field_d : m_field_a) {
         bool nonDefaultData = true;
-        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field.FIELDID, m_ref_id);
+        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, m_ref_id);
         FieldValueData fv_data;
         if (fv_n) {
             fv_data = *fv_n;
         }
         else {
             fv_data = FieldValueData();
-            fv_data.FIELDID = field.FIELDID;
+            fv_data.FIELDID = field_d.m_id;
             fv_data.REFID = m_ref_id;
-            fv_data.CONTENT = FieldModel::getDefault(field.PROPERTIES);
+            fv_data.CONTENT = FieldModel::getDefault(field_d.m_properties);
             nonDefaultData = false;
         }
 
         wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
         wxWindowID labelID = controlID + CONTROLOFFSET;
 
-        wxCheckBox* Description = new wxCheckBox(scrolled_window
-            , labelID, field.DESCRIPTION
-            , wxDefaultPosition, wxDefaultSize, wxCHK_2STATE
-            , wxDefaultValidator, field.TYPE);
-        Description->Connect(labelID, wxEVT_CHECKBOX
-            , wxCommandEventHandler(FieldValueDialog::OnCheckBoxActivated), nullptr, this);
+        wxCheckBox* Description = new wxCheckBox(
+            scrolled_window,
+            labelID, field_d.m_description,
+            wxDefaultPosition, wxDefaultSize, wxCHK_2STATE,
+            wxDefaultValidator, field_d.m_type_n.name_n()
+        );
+        Description->Connect(labelID, wxEVT_CHECKBOX,
+            wxCommandEventHandler(FieldValueDialog::OnCheckBoxActivated), nullptr, this
+        );
 
         grid_sizer_custom->Add(Description, g_flagsH);
 
-        switch (FieldModel::type_id(field))
+        switch (FieldModel::type_id(field_d))
         {
         case FieldModel::TYPE_ID_STRING:
         {
             const auto& data = fv_data.CONTENT;
             wxTextCtrl* CustomString = new wxTextCtrl(scrolled_window, controlID, data, wxDefaultPosition, wxDefaultSize);
-            mmToolTip(CustomString, FieldModel::getTooltip(field.PROPERTIES));
-            if (FieldModel::getAutocomplete(field.PROPERTIES))
-            {
-                const wxArrayString& values = FieldValueModel::instance().allValue(field.FIELDID);
+            mmToolTip(CustomString, FieldModel::getTooltip(field_d.m_properties));
+            if (FieldModel::getAutocomplete(field_d.m_properties)) {
+                const wxArrayString& values = FieldValueModel::instance().allValue(field_d.m_id);
                 CustomString->AutoComplete(values);
             }
             grid_sizer_custom->Add(CustomString, g_flagsExpand);
@@ -130,7 +132,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         case FieldModel::TYPE_ID_INTEGER:
         case FieldModel::TYPE_ID_DECIMAL:
         {
-            int digitScale = FieldModel::getDigitScale(field.PROPERTIES);
+            int digitScale = FieldModel::getDigitScale(field_d.m_properties);
             wxString content = cleanseNumberString(fv_data.CONTENT, digitScale > 0);
 
             double value;
@@ -150,7 +152,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
             CustomDecimal->Connect(wxID_ANY, wxEVT_TEXT
                 , wxCommandEventHandler(FieldValueDialog::OnStringChanged), nullptr, this);
 
-            mmToolTip(CustomDecimal, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(CustomDecimal, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(CustomDecimal, g_flagsExpand);
 
             break;
@@ -170,8 +172,8 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
                     SetWidgetChanged(controlID, data);
             }
 
-            mmToolTip(CustomBooleanF, FieldModel::getTooltip(field.PROPERTIES));
-            mmToolTip(CustomBooleanT, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(CustomBooleanF, FieldModel::getTooltip(field_d.m_properties));
+            mmToolTip(CustomBooleanT, FieldModel::getTooltip(field_d.m_properties));
             wxBoxSizer* boolsizer = new wxBoxSizer(wxHORIZONTAL);
             boolsizer->Add(CustomBooleanF);
             boolsizer->Add(CustomBooleanT);
@@ -194,7 +196,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
             }
 
             mmDatePickerCtrl* CustomDate = new mmDatePickerCtrl(scrolled_window, controlID, value);
-            mmToolTip(CustomDate, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(CustomDate, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(CustomDate->mmGetLayout(false));
 
             CustomDate->Connect(controlID, wxEVT_DATE_CHANGED, wxDateEventHandler(FieldValueDialog::OnDateChanged), nullptr, this);
@@ -214,7 +216,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
             wxTimePickerCtrl* CustomTime = new wxTimePickerCtrl(scrolled_window, controlID
                 , value, wxDefaultPosition, wxDefaultSize, wxDP_DROPDOWN);
-            mmToolTip(CustomTime, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(CustomTime, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(CustomTime, g_flagsExpand);
 
             CustomTime->Connect(controlID, wxEVT_TIME_CHANGED, wxDateEventHandler(FieldValueDialog::OnTimeChanged), nullptr, this);
@@ -223,12 +225,12 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         }
         case FieldModel::TYPE_ID_SINGLECHOICE:
         {
-            wxArrayString Choices = FieldModel::getChoices(field.PROPERTIES);
+            wxArrayString Choices = FieldModel::getChoices(field_d.m_properties);
             Choices.Sort();
 
             wxChoice* CustomChoice = new wxChoice(scrolled_window, controlID
                 , wxDefaultPosition, wxDefaultSize, Choices);
-            mmToolTip(CustomChoice, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(CustomChoice, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(CustomChoice, g_flagsExpand);
 
             if (Choices.empty()) {
@@ -249,11 +251,11 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         case FieldModel::TYPE_ID_MULTICHOICE:
         {
             const auto& content = fv_data.CONTENT;
-            const auto& name = field.DESCRIPTION;
+            const auto& name = field_d.m_description;
 
             wxButton* multi_choice_button = new wxButton(scrolled_window, controlID, content
                 , wxDefaultPosition, wxDefaultSize, 0L, wxDefaultValidator, name);
-            mmToolTip(multi_choice_button, FieldModel::getTooltip(field.PROPERTIES));
+            mmToolTip(multi_choice_button, FieldModel::getTooltip(field_d.m_properties));
             grid_sizer_custom->Add(multi_choice_button, g_flagsExpand);
 
             if (!content.empty()) {
@@ -292,12 +294,12 @@ void FieldValueDialog::OnMultiChoice(wxCommandEvent& event)
     const auto& name = button->GetName();
     const wxString& type = FieldModel::type_name(FieldModel::TYPE_ID_MULTICHOICE);
 
-    FieldModel::DataA fields = FieldModel::instance().find(
+    FieldModel::DataA field_a = FieldModel::instance().find(
         FieldCol::REFTYPE(m_ref_type),
         FieldCol::TYPE(type),
         FieldCol::DESCRIPTION(name)
     );
-    wxArrayString all_choices = FieldModel::getChoices(fields.begin()->PROPERTIES);
+    wxArrayString all_choices = FieldModel::getChoices(field_a.begin()->m_properties);
 
     const wxString& label = button->GetLabelText();
     wxArrayInt arr_selections;
@@ -341,9 +343,9 @@ std::map<int64, wxString> FieldValueDialog::GetActiveCustomFields() const
     std::map<int64, wxString> values;
     for (const auto& entry : m_data_changed) {
         int id = (entry.first - GetBaseID()) / FIELDMULTIPLIER;
-        const FieldData* data_n = FieldModel::instance().get_id_data_n(m_fields[id].FIELDID);
-        if (data_n) {
-            values[data_n->FIELDID] = entry.second;
+        const FieldData* field_n = FieldModel::instance().get_id_data_n(m_field_a[id].m_id);
+        if (field_n) {
+            values[field_n->m_id] = entry.second;
         }
     }
 
@@ -478,22 +480,22 @@ bool FieldValueDialog::SaveCustomValues(int64 ref_id)
     bool save_timestamp = false;
     FieldValueModel::instance().db_savepoint();
     int field_index = 0;
-    for (const auto &field : m_fields) {
+    for (const auto& field_d : m_field_a) {
         wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
         const auto& data = IsWidgetChanged(controlID) ? GetWidgetData(controlID) : "";
 
-        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field.FIELDID, ref_id);
+        const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
         FieldValueData oldData;
         if (fv_n)
             oldData = *fv_n;
         if (!data.empty()) {
             FieldValueData fv_d = fv_n ? *fv_n : FieldValueData();
             fv_d.REFID   = ref_id;
-            fv_d.FIELDID = field.FIELDID;
+            fv_d.FIELDID = field_d.m_id;
             fv_d.CONTENT = data;
             wxLogDebug("Control:%i Type:%s Value:%s",
                 controlID,
-                FieldModel::type_name(FieldModel::type_id(field)),
+                FieldModel::type_name(FieldModel::type_id(field_d)),
                 data
             );
 
@@ -521,7 +523,7 @@ void FieldValueDialog::UpdateCustomValues(int64 ref_id)
     FieldValueModel::instance().db_savepoint();
     bool save_timestamp = false;
     int field_index = 0;
-    for (const auto& field : m_fields) {
+    for (const auto& field_d : m_field_a) {
         bool is_changed = false;
 
         wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
@@ -533,14 +535,14 @@ void FieldValueDialog::UpdateCustomValues(int64 ref_id)
 
         if (is_changed) {
             const auto& data = GetWidgetData(controlID);
-            const FieldValueData* fv_n = FieldValueModel::instance().get_key(field.FIELDID, ref_id);
+            const FieldValueData* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
             FieldValueData oldData;
             if (fv_n)
                 oldData = *fv_n;
             if (!data.empty()) {
                 FieldValueData fv_d = fv_n ? *fv_n : FieldValueData();
                 fv_d.REFID   = ref_id;
-                fv_d.FIELDID = field.FIELDID;
+                fv_d.FIELDID = field_d.m_id;
                 fv_d.CONTENT = data;
 
                 if (!fv_d.equals(&oldData))
@@ -602,7 +604,7 @@ void FieldValueDialog::ResetWidgetsChanged()
 
 void FieldValueDialog::ClearSettings()
 {
-    for (unsigned int field_index = 0 ; field_index < m_fields.size() ; field_index++ )
+    for (unsigned int field_index = 0 ; field_index < m_field_a.size() ; field_index++ )
     {
         SetStringValue(field_index, "");
         wxWindowID labelID = GetBaseID() + field_index * FIELDMULTIPLIER + CONTROLOFFSET;
@@ -629,13 +631,12 @@ void FieldValueDialog::OnRadioButtonChanged(wxCommandEvent& event)
 
 int FieldValueDialog::GetWidgetType(wxWindowID controlID) const
 {
-    FieldModel::DataA fields = FieldModel::instance().find(
-        FieldCol::REFTYPE(m_ref_type)
-    );
     int control_id = (controlID - GetBaseID()) / FIELDMULTIPLIER;
-    for (const auto& entry : fields) {
-        if (entry.FIELDID == m_fields[control_id].FIELDID) {
-            return FieldModel::type_id(entry);
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(m_ref_type)
+    )) {
+        if (field_d.m_id == m_field_a[control_id].m_id) {
+            return field_d.m_type_n.id_n();
         }
     }
     wxFAIL_MSG("unknown custom field type");
@@ -645,9 +646,9 @@ int FieldValueDialog::GetWidgetType(wxWindowID controlID) const
 int FieldValueDialog::GetPrecision(wxWindowID controlID) const
 {
     int control_id = (controlID - GetBaseID()) / FIELDMULTIPLIER;
-    for (const auto &field : m_fields)
-    if (field.FIELDID == m_fields[control_id].FIELDID)
-            return (FieldModel::getDigitScale(field.PROPERTIES));
+    for (const auto& field_d : m_field_a)
+    if (field_d.m_id == m_field_a[control_id].m_id)
+            return (FieldModel::getDigitScale(field_d.m_properties));
     wxFAIL_MSG("No field found");
     return -1;
 }
@@ -736,7 +737,7 @@ void FieldValueDialog::ShowHideCustomPanel() const
         m_static_box->Hide();
     }
     else {
-        if (!m_fields.empty())
+        if (!m_field_a.empty())
             m_static_box->Show();
     }
 }
@@ -758,8 +759,7 @@ bool FieldValueDialog::ValidateCustomValues(int64)
 {
     bool is_valid = true;
     int field_index = 0;
-    for (const auto &field : m_fields)
-    {
+    for (const auto& field_d : m_field_a) {
         wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
         wxWindowID labelID = controlID + CONTROLOFFSET;
 
@@ -768,32 +768,32 @@ bool FieldValueDialog::ValidateCustomValues(int64)
             continue;
 
         if (GetWidgetType(controlID) == FieldModel::TYPE_ID_DECIMAL 
-                || GetWidgetType(controlID) == FieldModel::TYPE_ID_INTEGER)
-        {
+                || GetWidgetType(controlID) == FieldModel::TYPE_ID_INTEGER
+        ) {
             wxWindow* w = FindWindowById(controlID, m_dialog);
-            if (w)
-            {
+            if (w) {
                 mmTextCtrl* d = static_cast<mmTextCtrl*>(w);
                 double value;
                 if (d->checkValue(value, false))
-                    SetWidgetChanged(controlID, CurrencyModel::toString(value, nullptr
-                                                , FieldModel::getDigitScale(field.PROPERTIES)));
+                    SetWidgetChanged(controlID,
+                        CurrencyModel::toString(value, nullptr,
+                            FieldModel::getDigitScale(field_d.m_properties)
+                        )
+                    );
                 else
                     is_valid = false;
             }
         }
 
-        const wxString regExStr = FieldModel::getRegEx(field.PROPERTIES);
-        if (!regExStr.empty())
-        {
+        const wxString regExStr = FieldModel::getRegEx(field_d.m_properties);
+        if (!regExStr.empty()) {
             const auto& data = GetWidgetData(controlID);
             wxRegEx regEx(regExStr, wxRE_EXTENDED);
 
-            if (!regEx.Matches(data))
-            {
+            if (!regEx.Matches(data)) {
                 mmErrorDialogs::MessageError(this, wxString::Format(_t("Unable to save custom field \"%1$s\":\nvalue \"%2$s\" "
                     "does not match RegEx validation \"%3$s\"")
-                    , field.DESCRIPTION, data, regExStr)
+                    , field_d.m_description, data, regExStr)
                     , _t("CustomField validation error"));
                 is_valid = false;
                 continue;

--- a/src/dialog/FieldValueDialog.cpp
+++ b/src/dialog/FieldValueDialog.cpp
@@ -118,9 +118,8 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
         grid_sizer_custom->Add(Description, g_flagsH);
 
-        switch (FieldModel::type_id(field_d))
-        {
-        case FieldModel::TYPE_ID_STRING:
+        switch (field_d.m_type_n.id_n()) {
+        case FieldTypeN::e_string:
         {
             const auto& data = fv_d.m_content;
             wxTextCtrl* CustomString = new wxTextCtrl(scrolled_window, controlID, data, wxDefaultPosition, wxDefaultSize);
@@ -139,8 +138,8 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
             CustomString->Connect(controlID, wxEVT_TEXT, wxCommandEventHandler(FieldValueDialog::OnStringChanged), nullptr, this);
             break;
         }
-        case FieldModel::TYPE_ID_INTEGER:
-        case FieldModel::TYPE_ID_DECIMAL:
+        case FieldTypeN::e_integer:
+        case FieldTypeN::e_decimal:
         {
             int digitScale = FieldModel::getDigitScale(field_d.m_properties);
             wxString content = cleanseNumberString(fv_d.m_content, digitScale > 0);
@@ -170,7 +169,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case FieldModel::TYPE_ID_BOOLEAN:
+        case FieldTypeN::e_boolean:
         {
             wxRadioButton* CustomBooleanF = new wxRadioButton(scrolled_window, controlID
                 , _t("False"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
@@ -196,7 +195,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case FieldModel::TYPE_ID_DATE:
+        case FieldTypeN::e_date:
         {
             wxDate value;
             if (!value.ParseDate(fv_d.m_content)) {
@@ -215,7 +214,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case FieldModel::TYPE_ID_TIME:
+        case FieldTypeN::e_time:
         {
             wxDateTime value;
             if (!value.ParseTime(fv_d.m_content)) {
@@ -235,7 +234,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
 
             break;
         }
-        case FieldModel::TYPE_ID_SINGLECHOICE:
+        case FieldTypeN::e_single_choice:
         {
             wxArrayString Choices = FieldModel::getChoices(field_d.m_properties);
             Choices.Sort();
@@ -260,7 +259,7 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
             CustomChoice->Connect(controlID, wxEVT_CHOICE, wxCommandEventHandler(FieldValueDialog::OnSingleChoice), nullptr, this);
             break;
         }
-        case FieldModel::TYPE_ID_MULTICHOICE:
+        case FieldTypeN::e_multi_choice:
         {
             const auto& content = fv_d.m_content;
             const auto& name = field_d.m_description;
@@ -305,11 +304,10 @@ void FieldValueDialog::OnMultiChoice(wxCommandEvent& event)
     }
 
     const auto& name = button->GetName();
-    const wxString& type = FieldModel::type_name(FieldModel::TYPE_ID_MULTICHOICE);
 
     FieldModel::DataA field_a = FieldModel::instance().find(
         FieldCol::REFTYPE(m_ref_type.name_n()),
-        FieldCol::TYPE(type),
+        FieldCol::TYPE(FieldTypeN(FieldTypeN::e_multi_choice).name_n()),
         FieldCol::DESCRIPTION(name)
     );
     wxArrayString all_choices = FieldModel::getChoices(field_a.begin()->m_properties);
@@ -498,7 +496,7 @@ bool FieldValueDialog::SaveCustomValues(RefTypeN ref_type, int64 ref_id)
             fv_d.m_content  = data;
             wxLogDebug("Control:%i Type:%s Value:%s",
                 controlID,
-                FieldModel::type_name(FieldModel::type_id(field_d)),
+                field_d.m_type_n.name_n(),
                 data
             );
 
@@ -764,8 +762,8 @@ bool FieldValueDialog::ValidateCustomValues(int64)
         if (!cb || !cb->GetValue())
             continue;
 
-        if (GetWidgetType(controlID) == FieldModel::TYPE_ID_DECIMAL ||
-            GetWidgetType(controlID) == FieldModel::TYPE_ID_INTEGER
+        if (GetWidgetType(controlID) == FieldTypeN::e_decimal ||
+            GetWidgetType(controlID) == FieldTypeN::e_integer
         ) {
             wxWindow* w = FindWindowById(controlID, m_dialog);
             if (w) {

--- a/src/dialog/FieldValueDialog.h
+++ b/src/dialog/FieldValueDialog.h
@@ -30,12 +30,27 @@ class wxDialog;
 
 class FieldValueDialog : public wxDialog
 {
+private:
+    const int FIELDMULTIPLIER = 4;
+    const int CONTROLOFFSET = FIELDMULTIPLIER - 1;
+
+    const RefTypeN m_ref_type;
+    int64 m_ref_id = -1;
+    FieldModel::DataA m_field_a;
+    std::map<wxWindowID, wxString> m_data_changed;
+
+    wxDialog* m_dialog = nullptr;
+    wxStaticBox* m_static_box = nullptr;
+    wxWindowID m_init_control_id = wxID_ANY;
+
 public:
     FieldValueDialog();
+    FieldValueDialog(wxDialog* dialog, RefTypeN ref_type, int64 ref_id);
     ~FieldValueDialog();
+
     bool FillCustomFields(wxBoxSizer* box_sizer);
-    bool SaveCustomValues(int64 ref_id);
-    void UpdateCustomValues(int64 ref_id);
+    bool SaveCustomValues(RefTypeN ref_type, int64 ref_id);
+    void UpdateCustomValues(RefTypeN ref_type, int64 ref_id);
     void SetStringValue(int fieldIndex, const wxString& value, bool hasChanged = false);
     bool ValidateCustomValues(int64);
     const wxString GetWidgetData(wxWindowID controlID) const;
@@ -56,17 +71,7 @@ public:
     void ShowHideCustomPanel() const;
     void ShowCustomPanel() const;
 
-protected:
-    FieldValueDialog(wxDialog* dialog, const wxString& ref_type, int64 ref_id);
 private:
-    const int FIELDMULTIPLIER = 4;
-    const int CONTROLOFFSET = FIELDMULTIPLIER - 1;
-    wxDialog* m_dialog = nullptr;
-    wxStaticBox* m_static_box =nullptr;
-    const wxString m_ref_type;
-    int64 m_ref_id = -1;
-    FieldModel::DataA m_field_a;
-    std::map<wxWindowID, wxString> m_data_changed;
     void OnStringChanged(wxCommandEvent& event);
     void OnDateChanged(wxDateEvent& event);
     void OnTimeChanged(wxDateEvent& event);
@@ -77,17 +82,17 @@ private:
     bool IsWidgetChanged(wxWindowID id);
     void SetWidgetChanged(wxWindowID id, const wxString& data);
     void ResetWidgetChanged(wxWindowID id);
-    wxWindowID m_init_control_id = wxID_ANY;
-
 };
 
 class mmCustomDataTransaction : public FieldValueDialog
 {
 public:
-    mmCustomDataTransaction(wxDialog* dialog, int64 ref_id, wxWindowID base_id);
+    mmCustomDataTransaction(
+        wxDialog* dialog, RefTypeN ref_type, int64 ref_id, wxWindowID base_id
+    );
 };
 
-inline void       FieldValueDialog::ResetRefID() { m_ref_id = wxID_ANY; }
+inline void       FieldValueDialog::ResetRefID() { m_ref_id = -1; }
 inline void       FieldValueDialog::SetBaseID(wxWindowID id) { m_init_control_id = id; }
 inline size_t     FieldValueDialog::GetCustomFieldsCount() const { return m_field_a.size(); }
 inline wxWindowID FieldValueDialog::GetBaseID() const { return m_init_control_id; }

--- a/src/dialog/FieldValueDialog.h
+++ b/src/dialog/FieldValueDialog.h
@@ -65,7 +65,7 @@ private:
     wxStaticBox* m_static_box =nullptr;
     const wxString m_ref_type;
     int64 m_ref_id = -1;
-    FieldModel::DataA m_fields;
+    FieldModel::DataA m_field_a;
     std::map<wxWindowID, wxString> m_data_changed;
     void OnStringChanged(wxCommandEvent& event);
     void OnDateChanged(wxDateEvent& event);
@@ -89,6 +89,6 @@ public:
 
 inline void       FieldValueDialog::ResetRefID() { m_ref_id = wxID_ANY; }
 inline void       FieldValueDialog::SetBaseID(wxWindowID id) { m_init_control_id = id; }
-inline size_t     FieldValueDialog::GetCustomFieldsCount() const { return m_fields.size(); }
+inline size_t     FieldValueDialog::GetCustomFieldsCount() const { return m_field_a.size(); }
 inline wxWindowID FieldValueDialog::GetBaseID() const { return m_init_control_id; }
 

--- a/src/dialog/MergeCategoryDialog.cpp
+++ b/src/dialog/MergeCategoryDialog.cpp
@@ -96,7 +96,7 @@ void MergeCategoryDialog::CreateControls()
     cbSourceCategory_->SetMinSize(wxSize(200, -1));
     const CategoryData* category_n = CategoryModel::instance().get_id_data_n(m_sourceCatID);
     if (category_n)
-        cbSourceCategory_->SetValue(CategoryModel::full_name(m_sourceCatID));
+        cbSourceCategory_->SetValue(CategoryModel::instance().full_name(m_sourceCatID));
 
     cbDestCategory_ = new mmComboBoxCategory(this, wxID_NEW, wxDefaultSize, -1, true);
     cbDestCategory_->SetMinSize(wxSize(200, -1));
@@ -213,7 +213,8 @@ void MergeCategoryDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
         if (cbDeleteSourceCategory_->IsChecked()) {
             if (m_sourceSubCatID == -1) {
-                if (CategoryModel::sub_category(CategoryModel::instance().get_id_data_n(m_sourceCatID)).empty())
+                const CategoryData* src_category_n = CategoryModel::instance().get_id_data_n(m_sourceCatID);
+                if (CategoryModel::instance().find_data_sub_a(*src_category_n).empty())
                     CategoryModel::instance().purge_id(m_sourceCatID);
             }
 
@@ -290,7 +291,7 @@ void MergeCategoryDialog::OnComboKey(wxKeyEvent& event)
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     cbSourceCategory_->mmDoReInitialize();
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 cbSourceCategory_->ChangeValue(category);
                 return;
             }
@@ -306,7 +307,7 @@ void MergeCategoryDialog::OnComboKey(wxKeyEvent& event)
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     cbDestCategory_->mmDoReInitialize();
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 cbDestCategory_->ChangeValue(category);
                 return;
             }

--- a/src/dialog/MergePayeeDialog.cpp
+++ b/src/dialog/MergePayeeDialog.cpp
@@ -184,7 +184,7 @@ void MergePayeeDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
         if (cbDeleteSourcePayee_->IsChecked()) {
             if (PayeeModel::instance().purge_id(sourcePayeeID_)) {
-                mmAttachmentManage::DeleteAllAttachments(PayeeModel::refTypeName, sourcePayeeID_);
+                mmAttachmentManage::DeleteAllAttachments(PayeeModel::s_ref_type, sourcePayeeID_);
                 mmWebApp::MMEX_WebApp_UpdatePayee();
             }
             cbSourcePayee_->mmDoReInitialize();

--- a/src/dialog/MergeTagDialog.cpp
+++ b/src/dialog/MergeTagDialog.cpp
@@ -189,27 +189,27 @@ void MergeTagDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void MergeTagDialog::IsOkOk()
 {
     bool e = true;
-    const TagData* src_tag_n = TagModel::instance().get_key(cbSourceTag_->GetValue());
-    const TagData* dst_tag_n = TagModel::instance().get_key(cbDestTag_->GetValue());
+    const TagData* src_tag_n = TagModel::instance().get_name_data_n(cbSourceTag_->GetValue());
+    const TagData* dst_tag_n = TagModel::instance().get_name_data_n(cbDestTag_->GetValue());
     if (src_tag_n)
         sourceTagID_ = src_tag_n->m_id;
     if (dst_tag_n)
         destTagID_ = dst_tag_n->m_id;
 
     int trxs_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxModel::refTypeName),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int split_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
+        TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int bills_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedModel::refTypeName),
+        TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int bill_split_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedSplitModel::refTypeName),
+        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
 

--- a/src/dialog/MergeTagDialog.cpp
+++ b/src/dialog/MergeTagDialog.cpp
@@ -169,8 +169,8 @@ void MergeTagDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     TagLinkModel::DataA gl_a = TagLinkModel::instance().find(
         TagLinkCol::TAGID(sourceTagID_)
     );
-    for (auto &gl_d : gl_a) {
-        gl_d.TAGID = destTagID_;
+    for (auto& gl_d : gl_a) {
+        gl_d.m_tag_id = destTagID_;
     }
     TagLinkModel::instance().save_data_a(gl_a);
     m_changed_records += gl_a.size();

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -725,11 +725,11 @@ void SchedDialog::OnPayee(wxCommandEvent& WXUNUSED(event))
     if (m_sched_xd.local_splits.empty()
         && (PrefModel::instance().getTransCategoryNone() == PrefModel::LASTUSED ||
             PrefModel::instance().getTransCategoryNone() == PrefModel::DEFAULT)
-        && (!CategoryModel::is_hidden(payee_n->m_category_id_n) && !CategoryModel::is_hidden(payee_n->m_category_id_n)))
+        && (!CategoryModel::instance().is_hidden(payee_n->m_category_id_n) && !CategoryModel::instance().is_hidden(payee_n->m_category_id_n)))
     {
         m_sched_xd.m_category_id_n = payee_n->m_category_id_n;
 
-        cbCategory_->ChangeValue(CategoryModel::full_name(m_sched_xd.m_category_id_n));
+        cbCategory_->ChangeValue(CategoryModel::instance().full_name(m_sched_xd.m_category_id_n));
     }
 }
 
@@ -785,7 +785,7 @@ void SchedDialog::OnComboKey(wxKeyEvent& event)
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     cbCategory_->mmDoReInitialize();
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 cbCategory_->ChangeValue(category);
                 cbCategory_->SelectAll();
                 return;
@@ -1463,11 +1463,11 @@ void SchedDialog::setCategoryLabel()
 
         if (!transactions.empty()) {
             const int64 cat = transactions.back().m_category_id_n;
-            cbCategory_->ChangeValue(CategoryModel::full_name(cat));
+            cbCategory_->ChangeValue(CategoryModel::instance().full_name(cat));
         }
     }
     else {
-        const auto fullCategoryName = CategoryModel::full_name(m_sched_xd.m_category_id_n);
+        const auto fullCategoryName = CategoryModel::instance().full_name(m_sched_xd.m_category_id_n);
         cbCategory_->ChangeValue(fullCategoryName);
     }
 

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -141,7 +141,7 @@ SchedDialog::SchedDialog(
 
         wxArrayInt64 tag_id_a;
         for (const auto& gl_d : TagLinkModel::instance().find(
-            TagLinkCol::REFTYPE(SchedModel::refTypeName),
+            TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
             TagLinkCol::REFID(sched_n->m_id)
         ))
             tag_id_a.push_back(gl_d.m_tag_id);
@@ -816,8 +816,7 @@ void SchedDialog::OnComboKey(wxKeyEvent& event)
 
 void SchedDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = SchedModel::refTypeName;
-    AttachmentDialog dlg(this, RefType, m_sched_xd.m_id);
+    AttachmentDialog dlg(this, SchedModel::s_ref_type, m_sched_xd.m_id);
     dlg.ShowModal();
 }
 

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -346,12 +346,12 @@ void SchedDialog::SetDialogHeader(const wxString& header)
 void SchedDialog::SetDialogParameters(int64 trx_id)
 {
     const auto split = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+    const auto schedId_glA_m = TagLinkModel::instance().find_refType_mRefId(
         SchedModel::s_ref_type
     );
     //const auto trx = TrxModel::instance().find(TrxCol::TRANSID(trx_id)).at(0);
     const TrxData* trx_n = TrxModel::instance().get_id_data_n(trx_id);
-    TrxModel::Full_Data trx_xd(*trx_n, split, tags);
+    TrxModel::Full_Data trx_xd(*trx_n, split, schedId_glA_m);
     m_sched_xd.m_account_id = trx_xd.m_account_id;
     cbAccount_->SetValue(trx_xd.ACCOUNTNAME);
 
@@ -756,16 +756,12 @@ void SchedDialog::OnTypeChanged(wxCommandEvent& WXUNUSED(event))
 
 void SchedDialog::OnComboKey(wxKeyEvent& event)
 {
-    if (event.GetKeyCode() == WXK_RETURN)
-    {
+    if (event.GetKeyCode() == WXK_RETURN) {
         auto id = event.GetId();
-        switch (id)
-        {
-        case mmID_PAYEE:
-        {
+        switch (id) {
+        case mmID_PAYEE: {
             const auto payeeName = cbPayee_->GetValue();
-            if (payeeName.empty())
-            {
+            if (payeeName.empty()) {
                 mmPayeeDialog dlg(this, true);
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
@@ -780,13 +776,11 @@ void SchedDialog::OnComboKey(wxKeyEvent& event)
                 }
                 return;
             }
+            break;
         }
-        break;
-        case mmID_CATEGORY:
-        {
+        case mmID_CATEGORY: {
             auto category = cbCategory_->GetValue();
-            if (category.empty())
-            {
+            if (category.empty()) {
                 CategoryManager dlg(this, true, -1);
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
@@ -796,8 +790,8 @@ void SchedDialog::OnComboKey(wxKeyEvent& event)
                 cbCategory_->SelectAll();
                 return;
             }
+            break;
         }
-        break;
         default:
             break;
         }
@@ -805,8 +799,7 @@ void SchedDialog::OnComboKey(wxKeyEvent& event)
 
     // The first time the ALT key is pressed accelerator hints are drawn, but custom painting on the tags button
     // is not applied. We need to refresh the tag ctrl to redraw the drop button with the correct image.
-    if (event.AltDown() && !altRefreshDone)
-    {
+    if (event.AltDown() && !altRefreshDone) {
         tagTextCtrl_->Refresh();
         altRefreshDone = true;
     }
@@ -828,8 +821,7 @@ void SchedDialog::updateControlsForTransType()
     m_transfer = false;
     switch (m_choice_transaction_type->GetSelection())
     {
-    case TrxModel::TYPE_ID_TRANSFER:
-    {
+    case TrxModel::TYPE_ID_TRANSFER: {
         m_transfer = true;
         mmToolTip(textAmount_, amountTransferTip_);
         accountLabel->SetLabelText(_t("From"));
@@ -838,8 +830,7 @@ void SchedDialog::updateControlsForTransType()
         m_sched_xd.m_payee_id_n = -1;
         break;
     }
-    case TrxModel::TYPE_ID_WITHDRAWAL:
-    {
+    case TrxModel::TYPE_ID_WITHDRAWAL: {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_t("Account"));
         stp->SetLabelText(_t("Payee"));
@@ -851,8 +842,7 @@ void SchedDialog::updateControlsForTransType()
         OnPayee(evt);
         break;
     }
-    case TrxModel::TYPE_ID_DEPOSIT:
-    {
+    case TrxModel::TYPE_ID_DEPOSIT: {
         mmToolTip(textAmount_, amountNormalTip_);
         accountLabel->SetLabelText(_t("Account"));
         stp->SetLabelText(_t("From"));
@@ -1083,7 +1073,7 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             new_qp_d.m_notes       = split_d.NOTES;
             new_qp_a.push_back(new_qp_d);
         }
-        SchedSplitModel::instance().update(new_qp_a, m_trans_id);
+        SchedSplitModel::instance().update(m_trans_id, new_qp_a);
 
         // Save split tags
         for (size_t i = 0; i < m_sched_xd.local_splits.size(); i++) {

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -161,17 +161,21 @@ SchedDialog::SchedDialog(
         }
 
         // If duplicate then we may need to copy the attachments
-        if (m_dup_bill && InfoModel::instance().getBool("ATTACHMENTSDUPLICATE", false))
-        {
-            const wxString& RefType = SchedModel::refTypeName;
-            mmAttachmentManage::CloneAllAttachments(RefType, sched_id, 0);
+        if (m_dup_bill && InfoModel::instance().getBool("ATTACHMENTSDUPLICATE", false)) {
+            // FIXME: id 0 does not exist in database
+            mmAttachmentManage::CloneAllAttachments(
+                SchedModel::s_ref_type, sched_id, 0
+            );
         }
     }
 
     m_transfer = (m_sched_xd.TRANSCODE == TrxModel::TYPE_NAME_TRANSFER);
 
-    int64 ref_id = m_dup_bill ? -sched_id : (m_new_bill ? 0 : -m_sched_xd.m_id);
-    m_custom_fields = new mmCustomDataTransaction(this, ref_id, ID_CUSTOMFIELDS);
+    m_custom_fields = new mmCustomDataTransaction(this,
+        SchedModel::s_ref_type,
+        (m_dup_bill ? sched_id : !m_new_bill ? m_sched_xd.m_id : 0),
+        ID_CUSTOMFIELDS
+    );
 
     this->SetFont(parent->GetFont());
     Create(parent);
@@ -685,9 +689,8 @@ void SchedDialog::CreateControls()
 
 void SchedDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& RefType = SchedModel::refTypeName;
     if (m_enter_occur && m_sched_xd.m_id != 0) {
-        mmAttachmentManage::DeleteAllAttachments(RefType, m_sched_xd.m_id);
+        mmAttachmentManage::DeleteAllAttachments(SchedModel::s_ref_type, m_sched_xd.m_id);
     }
     EndModal(wxID_CANCEL);
 }
@@ -704,9 +707,8 @@ void SchedDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
     }
 #endif
 
-    const wxString RefType = SchedModel::refTypeName;
     if (m_enter_occur && m_sched_xd.m_id != 0) {
-        mmAttachmentManage::DeleteAllAttachments(RefType, m_sched_xd.m_id);
+        mmAttachmentManage::DeleteAllAttachments(SchedModel::s_ref_type, m_sched_xd.m_id);
     }
     EndModal(wxID_CANCEL);
 }
@@ -1085,7 +1087,6 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
         // Save split tags
         const wxString& splitRefType = SchedSplitModel::refTypeName;
-
         for (size_t i = 0; i < m_sched_xd.local_splits.size(); i++) {
             TagLinkModel::DataA splitTaglinks;
             for (const auto& tag_id : m_sched_xd.local_splits.at(i).TAGS) {
@@ -1098,23 +1099,25 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             TagLinkModel::instance().update(splitTaglinks, splitRefType, qp_a.at(i).m_id);
         }
 
-        const wxString& RefType = SchedModel::refTypeName;
-        mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, m_trans_id);
+        // FIXME: ref_id 0 does not exists in database
+        mmAttachmentManage::RelocateAllAttachments(
+            SchedModel::s_ref_type, 0,
+            SchedModel::s_ref_type, m_trans_id
+        );
 
         // Save base transaction tags
         TagLinkModel::DataA taglinks;
         for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
             TagLinkData gl_d = TagLinkData();
-            gl_d.REFTYPE = RefType;
+            gl_d.REFTYPE = SchedModel::refTypeName;
             gl_d.REFID   = m_trans_id;
             gl_d.TAGID   = tag_id;
             taglinks.push_back(gl_d);
         }
-        TagLinkModel::instance().update(taglinks, RefType, m_trans_id);
+        TagLinkModel::instance().update(taglinks, SchedModel::refTypeName, m_trans_id);
 
         //Custom Data
-        m_custom_fields->SaveCustomValues(-m_trans_id);
-
+        m_custom_fields->SaveCustomValues(SchedModel::s_ref_type, m_trans_id);
     }
     else {
         // the following condition is always true, since old inactive entries of type
@@ -1123,6 +1126,7 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             rn.freq > SchedModel::REPEAT_FREQ_EVERY_X_MONTHS ||
             rn.x > 0
         ) {
+            // FIXME: use m_sched_xd directly
             SchedData sched_d;
             sched_d.m_account_id = m_sched_xd.m_account_id;
             sched_d.TRANSCODE    = m_sched_xd.TRANSCODE;
@@ -1159,37 +1163,36 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             TrxSplitModel::instance().update(tp_a, trx_id);
 
             // Save split tags
-            const wxString& splitRefType = TrxSplitModel::refTypeName;
-
             for (size_t i = 0; i < m_sched_xd.local_splits.size(); i++) {
                 TagLinkModel::DataA gl_a;
                 for (const auto& tag_id : m_sched_xd.local_splits.at(i).TAGS) {
                     TagLinkData gl_d = TagLinkData();
-                    gl_d.REFTYPE = splitRefType;
+                    gl_d.REFTYPE = TrxSplitModel::refTypeName;
                     gl_d.REFID   = tp_a.at(i).m_id;
                     gl_d.TAGID   = tag_id;
                     gl_a.push_back(gl_d);
                 }
-                TagLinkModel::instance().update(gl_a, splitRefType, tp_a.at(i).m_id);
+                TagLinkModel::instance().update(gl_a, TrxSplitModel::refTypeName, tp_a.at(i).m_id);
             }
 
             // Custom Data
-            m_custom_fields->SaveCustomValues(trx_id);
+            m_custom_fields->SaveCustomValues(TrxModel::s_ref_type, trx_id);
 
-            const wxString& oldRefType = SchedModel::refTypeName;
-            const wxString& newRefType = TrxModel::refTypeName;
-            mmAttachmentManage::RelocateAllAttachments(oldRefType, m_sched_xd.m_id, newRefType, trx_id);
+            mmAttachmentManage::RelocateAllAttachments(
+                SchedModel::s_ref_type, m_sched_xd.m_id,
+                TrxModel::s_ref_type, trx_id
+            );
 
             // Save base transaction tags
             TagLinkModel::DataA gl_a;
             for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
                 TagLinkData gl_d = TagLinkData();
-                gl_d.REFTYPE = newRefType;
+                gl_d.REFTYPE = TrxModel::refTypeName;
                 gl_d.REFID   = trx_id;
                 gl_d.TAGID   = tag_id;
                 gl_a.push_back(gl_d);
             }
-            TagLinkModel::instance().update(gl_a, newRefType, trx_id);
+            TagLinkModel::instance().update(gl_a, TrxModel::refTypeName, trx_id);
         }
         SchedModel::instance().completeBDInSeries(m_sched_xd.m_id);
     }
@@ -1201,13 +1204,11 @@ void SchedDialog::SetSplitControls(bool split)
 {
     textAmount_->Enable(!split);
     bCalc_->Enable(!split);
-    if (split)
-    {
+    if (split) {
         m_sched_xd.m_amount = TrxSplitModel::get_total(m_sched_xd.local_splits);
         m_sched_xd.m_category_id_n = -1;
     }
-    else
-    {
+    else {
         m_sched_xd.local_splits.clear();
     }
     setCategoryLabel();
@@ -1216,14 +1217,12 @@ void SchedDialog::SetSplitControls(bool split)
 void SchedDialog::OnAutoExecutionUserAckChecked(wxCommandEvent& WXUNUSED(event))
 {
     autoExecuteUserAck_ = !autoExecuteUserAck_;
-    if (autoExecuteUserAck_)
-    {
+    if (autoExecuteUserAck_) {
         itemCheckBoxAutoExeSilent_->SetValue(false);
         itemCheckBoxAutoExeSilent_->Enable(false);
         autoExecuteSilent_ = false;
     }
-    else
-    {
+    else {
         itemCheckBoxAutoExeSilent_->Enable(true);
     }
 }
@@ -1231,14 +1230,12 @@ void SchedDialog::OnAutoExecutionUserAckChecked(wxCommandEvent& WXUNUSED(event))
 void SchedDialog::OnAutoExecutionSilentChecked(wxCommandEvent& WXUNUSED(event))
 {
     autoExecuteSilent_ = !autoExecuteSilent_;
-    if (autoExecuteSilent_)
-    {
+    if (autoExecuteSilent_) {
         itemCheckBoxAutoExeUserAck_->SetValue(false);
         itemCheckBoxAutoExeUserAck_->Enable(false);
         autoExecuteUserAck_ = false;
     }
-    else
-    {
+    else {
         itemCheckBoxAutoExeUserAck_->Enable(true);
     }
 }
@@ -1254,12 +1251,10 @@ void SchedDialog::SetTransferControls(bool transfers)
     wxStaticText* stta = static_cast<wxStaticText*>(FindWindow(ID_DIALOG_TRANS_STATIC_TOACCOUNT));
 
     cAdvanced_->Enable(transfers);
-    if (transfers)
-    {
+    if (transfers) {
         SetSplitControls();
     }
-    else
-    {
+    else {
         SetAdvancedTransferControls();
         toTextAmount_->ChangeValue("");
         cAdvanced_->SetValue(false);
@@ -1277,7 +1272,10 @@ void SchedDialog::SetAdvancedTransferControls(bool advanced)
 {
     m_advanced = advanced;
     toTextAmount_->Enable(m_advanced);
-    mmToolTip(textAmount_, m_advanced ? amountTransferTip_ : _t("Specify the transfer amount in the From Account"));
+    mmToolTip(textAmount_, m_advanced
+        ? amountTransferTip_
+        : _t("Specify the transfer amount in the From Account")
+    );
     if (m_advanced)
         toTextAmount_->SetValue(m_sched_xd.m_to_amount);
     else
@@ -1289,12 +1287,16 @@ void SchedDialog::setRepeatDetails()
     staticTextRepeats_->SetLabelText(_t("Repeats"));
 
     int repeats = getRepeatType();
-    if (repeats == SchedModel::REPEAT_FREQ_IN_X_DAYS || repeats == SchedModel::REPEAT_FREQ_EVERY_X_DAYS) {
+    if (repeats == SchedModel::REPEAT_FREQ_IN_X_DAYS ||
+        repeats == SchedModel::REPEAT_FREQ_EVERY_X_DAYS
+    ) {
         staticTimesRepeat_->SetLabelText(_t("Period: Days"));
         const auto toolTipsStr = _t("Specify period in Days.");
         mmToolTip(textNumRepeats_, toolTipsStr);
     }
-    else if (repeats == SchedModel::REPEAT_FREQ_IN_X_MONTHS || repeats == SchedModel::REPEAT_FREQ_EVERY_X_MONTHS) {
+    else if (repeats == SchedModel::REPEAT_FREQ_IN_X_MONTHS ||
+        repeats == SchedModel::REPEAT_FREQ_EVERY_X_MONTHS
+    ) {
         staticTimesRepeat_->SetLabelText(_t("Period: Months"));
         const auto toolTipsStr = _t("Specify period in Months.");
         mmToolTip(textNumRepeats_, toolTipsStr);
@@ -1325,24 +1327,21 @@ int SchedDialog::getRepeatType()
 
 void SchedDialog::setRepeatType(int repeatType)
 {
-    if (repeatType < 0)
-    {
+    if (repeatType < 0) {
         wxFAIL;
         return;
     }
 
     // fast path
     int repeatIndex = repeatType;
-    if (BILLSDEPOSITS_REPEATS.at(repeatIndex).first != repeatType)
-    {
+    if (BILLSDEPOSITS_REPEATS.at(repeatIndex).first != repeatType) {
         // slow path: BILLSDEPOSITS_REPEATS is not sorted by REPEAT_FREQ
         // cache the mapping from type to index
         static std::vector<int> index;
         if (index.size() == 0) {
             wxLogDebug("SchedDialog::setRepeatType : cache index");
             index.resize(BILLSDEPOSITS_REPEATS.size(), -1);
-            for (size_t i = 0; i < BILLSDEPOSITS_REPEATS.size(); i++)
-            {
+            for (size_t i = 0; i < BILLSDEPOSITS_REPEATS.size(); i++) {
                 unsigned int j = BILLSDEPOSITS_REPEATS.at(i).first;
                 if (j < BILLSDEPOSITS_REPEATS.size() && index.at(j) == -1)
                     index.at(j) = i;
@@ -1353,8 +1352,7 @@ void SchedDialog::setRepeatType(int repeatType)
         }
 
         repeatIndex = index.at(repeatType);
-        if (repeatIndex == -1)
-        {
+        if (repeatIndex == -1) {
             wxFAIL;
             repeatIndex = 0;
         }
@@ -1462,8 +1460,7 @@ void SchedDialog::setCategoryLabel()
             TrxModel::TRANSDATE(OP_LE, mmDate::today())
         );
 
-        if (!transactions.empty())
-        {
+        if (!transactions.empty()) {
             const int64 cat = transactions.back().m_category_id_n;
             cbCategory_->ChangeValue(CategoryModel::full_name(cat));
         }

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -139,24 +139,23 @@ SchedDialog::SchedDialog(
         m_sched_xd.m_followup_id      = sched_n->m_followup_id;
         m_sched_xd.m_color            = sched_n->m_color;
 
-        wxArrayInt64 billtags;
-        for (const auto& tag : TagLinkModel::instance().find(
+        wxArrayInt64 tag_id_a;
+        for (const auto& gl_d : TagLinkModel::instance().find(
             TagLinkCol::REFTYPE(SchedModel::refTypeName),
             TagLinkCol::REFID(sched_n->m_id)
         ))
-            billtags.push_back(tag.TAGID);
-        m_sched_xd.TAGS = billtags;
-        //
-        const wxString& splitRefType = SchedSplitModel::refTypeName;
+            tag_id_a.push_back(gl_d.m_tag_id);
+        m_sched_xd.TAGS = tag_id_a;
+
         for (const auto& qp_d : SchedModel::split(*sched_n)) {
-            wxArrayInt64 splittags;
-            for (const auto& tag : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(splitRefType),
+            wxArrayInt64 split_tag_id_a;
+            for (const auto& gl_d : TagLinkModel::instance().find(
+                TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
                 TagLinkCol::REFID(qp_d.m_id)
             ))
-                splittags.push_back(tag.TAGID);
+                split_tag_id_a.push_back(gl_d.m_tag_id);
             m_sched_xd.local_splits.push_back(
-                { qp_d.m_category_id, qp_d.m_amount, splittags, qp_d.m_notes }
+                { qp_d.m_category_id, qp_d.m_amount, split_tag_id_a, qp_d.m_notes }
             );
         }
 
@@ -347,7 +346,9 @@ void SchedDialog::SetDialogHeader(const wxString& header)
 void SchedDialog::SetDialogParameters(int64 trx_id)
 {
     const auto split = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().get_all_id(SchedModel::refTypeName);
+    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        SchedModel::s_ref_type
+    );
     //const auto trx = TrxModel::instance().find(TrxCol::TRANSID(trx_id)).at(0);
     const TrxData* trx_n = TrxModel::instance().get_id_data_n(trx_id);
     TrxModel::Full_Data trx_xd(*trx_n, split, tags);
@@ -1075,28 +1076,30 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         SchedModel::instance().save_data_n(sched_d);
         m_trans_id = sched_d.id();
 
-        SchedSplitModel::DataA qp_a;
+        SchedSplitModel::DataA new_qp_a;
         for (const auto& split_d : m_sched_xd.local_splits) {
-            SchedSplitData qp_d = SchedSplitData();
-            qp_d.m_category_id = split_d.CATEGID;
-            qp_d.m_amount      = split_d.SPLITTRANSAMOUNT;
-            qp_d.m_notes       = split_d.NOTES;
-            qp_a.push_back(qp_d);
+            SchedSplitData new_qp_d = SchedSplitData();
+            new_qp_d.m_category_id = split_d.CATEGID;
+            new_qp_d.m_amount      = split_d.SPLITTRANSAMOUNT;
+            new_qp_d.m_notes       = split_d.NOTES;
+            new_qp_a.push_back(new_qp_d);
         }
-        SchedSplitModel::instance().update(qp_a, m_trans_id);
+        SchedSplitModel::instance().update(new_qp_a, m_trans_id);
 
         // Save split tags
-        const wxString& splitRefType = SchedSplitModel::refTypeName;
         for (size_t i = 0; i < m_sched_xd.local_splits.size(); i++) {
-            TagLinkModel::DataA splitTaglinks;
+            TagLinkModel::DataA new_qp_gl_a;
             for (const auto& tag_id : m_sched_xd.local_splits.at(i).TAGS) {
-                TagLinkData gl_d = TagLinkData();
-                gl_d.REFTYPE = splitRefType;
-                gl_d.REFID   = qp_a.at(i).m_id;
-                gl_d.TAGID   = tag_id;
-                splitTaglinks.push_back(gl_d);
+                TagLinkData new_gl_d = TagLinkData();
+                new_gl_d.m_tag_id   = tag_id;
+                new_gl_d.m_ref_type = SchedSplitModel::s_ref_type;
+                new_gl_d.m_ref_id   = new_qp_a.at(i).m_id;
+                new_qp_gl_a.push_back(new_gl_d);
             }
-            TagLinkModel::instance().update(splitTaglinks, splitRefType, qp_a.at(i).m_id);
+            TagLinkModel::instance().update(
+                SchedSplitModel::s_ref_type, new_qp_a.at(i).m_id,
+                new_qp_gl_a
+            );
         }
 
         // FIXME: ref_id 0 does not exists in database
@@ -1106,15 +1109,18 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         );
 
         // Save base transaction tags
-        TagLinkModel::DataA taglinks;
+        TagLinkModel::DataA new_gl_a;
         for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
-            TagLinkData gl_d = TagLinkData();
-            gl_d.REFTYPE = SchedModel::refTypeName;
-            gl_d.REFID   = m_trans_id;
-            gl_d.TAGID   = tag_id;
-            taglinks.push_back(gl_d);
+            TagLinkData new_gl_d = TagLinkData();
+            new_gl_d.m_tag_id   = tag_id;
+            new_gl_d.m_ref_type = SchedModel::s_ref_type;
+            new_gl_d.m_ref_id   = m_trans_id;
+            new_gl_a.push_back(new_gl_d);
         }
-        TagLinkModel::instance().update(taglinks, SchedModel::refTypeName, m_trans_id);
+        TagLinkModel::instance().update(
+            SchedModel::s_ref_type, m_trans_id,
+            new_gl_a
+        );
 
         //Custom Data
         m_custom_fields->SaveCustomValues(SchedModel::s_ref_type, m_trans_id);
@@ -1149,50 +1155,56 @@ void SchedDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             new_trx_d.m_followup_id     = m_sched_xd.m_followup_id;
             new_trx_d.m_color           = m_sched_xd.m_color;
             TrxModel::instance().save_trx_n(new_trx_d);
-            int64 trx_id = new_trx_d.id();
+            int64 new_trx_id = new_trx_d.id();
 
-            TrxSplitModel::DataA tp_a;
+            TrxSplitModel::DataA new_tp_a;
             for (auto& split_d : m_sched_xd.local_splits) {
-                TrxSplitData tp_d = TrxSplitData();
-                tp_d.m_trx_id      = trx_id;
-                tp_d.m_category_id = split_d.CATEGID;
-                tp_d.m_amount      = split_d.SPLITTRANSAMOUNT;
-                tp_d.m_notes       = split_d.NOTES;
-                tp_a.push_back(tp_d);
+                TrxSplitData new_tp_d = TrxSplitData();
+                new_tp_d.m_trx_id      = new_trx_id;
+                new_tp_d.m_category_id = split_d.CATEGID;
+                new_tp_d.m_amount      = split_d.SPLITTRANSAMOUNT;
+                new_tp_d.m_notes       = split_d.NOTES;
+                new_tp_a.push_back(new_tp_d);
             }
-            TrxSplitModel::instance().update(tp_a, trx_id);
+            TrxSplitModel::instance().update(new_tp_a, new_trx_id);
 
             // Save split tags
             for (size_t i = 0; i < m_sched_xd.local_splits.size(); i++) {
-                TagLinkModel::DataA gl_a;
+                TagLinkModel::DataA new_tp_gl_a;
                 for (const auto& tag_id : m_sched_xd.local_splits.at(i).TAGS) {
-                    TagLinkData gl_d = TagLinkData();
-                    gl_d.REFTYPE = TrxSplitModel::refTypeName;
-                    gl_d.REFID   = tp_a.at(i).m_id;
-                    gl_d.TAGID   = tag_id;
-                    gl_a.push_back(gl_d);
+                    TagLinkData new_gl_d = TagLinkData();
+                    new_gl_d.m_tag_id   = tag_id;
+                    new_gl_d.m_ref_type = TrxSplitModel::s_ref_type;
+                    new_gl_d.m_ref_id   = new_tp_a.at(i).m_id;
+                    new_tp_gl_a.push_back(new_gl_d);
                 }
-                TagLinkModel::instance().update(gl_a, TrxSplitModel::refTypeName, tp_a.at(i).m_id);
+                TagLinkModel::instance().update(
+                    TrxSplitModel::s_ref_type, new_tp_a.at(i).m_id,
+                    new_tp_gl_a
+                );
             }
 
             // Custom Data
-            m_custom_fields->SaveCustomValues(TrxModel::s_ref_type, trx_id);
+            m_custom_fields->SaveCustomValues(TrxModel::s_ref_type, new_trx_id);
 
             mmAttachmentManage::RelocateAllAttachments(
                 SchedModel::s_ref_type, m_sched_xd.m_id,
-                TrxModel::s_ref_type, trx_id
+                TrxModel::s_ref_type, new_trx_id
             );
 
             // Save base transaction tags
-            TagLinkModel::DataA gl_a;
+            TagLinkModel::DataA new_gl_a;
             for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
-                TagLinkData gl_d = TagLinkData();
-                gl_d.REFTYPE = TrxModel::refTypeName;
-                gl_d.REFID   = trx_id;
-                gl_d.TAGID   = tag_id;
-                gl_a.push_back(gl_d);
+                TagLinkData new_gl_d = TagLinkData();
+                new_gl_d.m_tag_id   = tag_id;
+                new_gl_d.m_ref_type = TrxModel::s_ref_type;
+                new_gl_d.m_ref_id   = new_trx_id;
+                new_gl_a.push_back(new_gl_d);
             }
-            TagLinkModel::instance().update(gl_a, TrxModel::refTypeName, trx_id);
+            TagLinkModel::instance().update(
+                TrxModel::s_ref_type, new_trx_id,
+                new_gl_a
+            );
         }
         SchedModel::instance().completeBDInSeries(m_sched_xd.m_id);
     }

--- a/src/dialog/SplitDialog.cpp
+++ b/src/dialog/SplitDialog.cpp
@@ -86,7 +86,7 @@ void mmEditSplitOther::CreateControls()
 
     // Split Category
     fgSizer1->Add(new wxStaticText(this, wxID_STATIC, _t("Category")), g_flagsH);
-    wxString catName = CategoryModel::full_name(m_split->CATEGID);
+    wxString catName = CategoryModel::instance().full_name(m_split->CATEGID);
     wxTextCtrl* category = new wxTextCtrl(this, wxID_ANY, catName);
     category->Disable();
     fgSizer1->Add(category, g_flagsExpand);
@@ -310,7 +310,7 @@ void SplitDialog::FillControls(const int focusRow)
         if (row < static_cast<int>(m_splits.size()))
         {
             m_splits_widgets.at(row).category->ChangeValue(
-                    CategoryModel::full_name(m_splits.at(row).CATEGID));
+                    CategoryModel::instance().full_name(m_splits.at(row).CATEGID));
             if (m_splits.at(row).CATEGID == -1)
                 m_splits_widgets.at(row).amount->SetValue("");
             else
@@ -531,13 +531,13 @@ void SplitDialog::OnComboKey(wxKeyEvent& event)
                         auto cbcUpdate = m_splits_widgets.at(i).category;
                         if (cbc != cbcUpdate)
                         {
-                            category = CategoryModel::full_name(cbcUpdate->mmGetCategoryId());
+                            category = CategoryModel::instance().full_name(cbcUpdate->mmGetCategoryId());
                             cbcUpdate->mmDoReInitialize();
                             cbcUpdate->ChangeValue(category);
                         }
                     }
                 }
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 if (dlg.getRefreshRequested())
                     cbc->mmDoReInitialize();
                 cbc->ChangeValue(category);

--- a/src/dialog/StockDialog.cpp
+++ b/src/dialog/StockDialog.cpp
@@ -395,7 +395,7 @@ void StockDialog::OnCancel(wxCommandEvent& /*event*/)
 void StockDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
     int64 ref_id = (m_stock_id > 0) ? m_stock_id : 0;
-    AttachmentDialog dlg(this, StockModel::refTypeName, ref_id);
+    AttachmentDialog dlg(this, StockModel::s_ref_type, ref_id);
     dlg.ShowModal();
 }
 

--- a/src/dialog/StockDialog.cpp
+++ b/src/dialog/StockDialog.cpp
@@ -378,29 +378,22 @@ void StockDialog::CreateControls()
 
 void StockDialog::OnQuit(wxCloseEvent& /*event*/)
 {
-    const wxString& RefType = StockModel::refTypeName;
     if (!m_edit)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 
 void StockDialog::OnCancel(wxCommandEvent& /*event*/)
 {
-    const wxString& RefType = StockModel::refTypeName;
     if (m_stock_id <= 0)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 
 void StockDialog::OnAttachments(wxCommandEvent& /*event*/)
 {
-    const wxString RefType = StockModel::refTypeName;
-    int64 RefId = m_stock_id;
-
-    if (RefId < 0)
-        RefId = 0;
-
-    AttachmentDialog dlg(this, RefType, RefId);
+    int64 ref_id = (m_stock_id > 0) ? m_stock_id : 0;
+    AttachmentDialog dlg(this, StockModel::refTypeName, ref_id);
     dlg.ShowModal();
 }
 
@@ -501,8 +494,11 @@ void StockDialog::OnSave(wxCommandEvent & /*event*/)
     m_stock_id = m_stock_n->id();
 
     if (!m_edit) {
-        const wxString RefType = StockModel::refTypeName;
-        mmAttachmentManage::RelocateAllAttachments(RefType, 0, RefType, m_stock_n->m_id);
+        // FIXME
+        mmAttachmentManage::RelocateAllAttachments(
+            StockModel::s_ref_type, 0,
+            StockModel::s_ref_type, m_stock_n->m_id
+        );
         TrxShareDialog share_dialog(this, m_stock_n);
         share_dialog.ShowModal();
     }

--- a/src/dialog/StockDialog.cpp
+++ b/src/dialog/StockDialog.cpp
@@ -112,7 +112,7 @@ void StockDialog::DataToControls()
     m_stock_name_ctrl->SetValue(m_stock_n->m_name);
     m_stock_symbol_ctrl->SetValue(m_stock_n->m_symbol);
     m_notes_ctrl->SetValue(m_stock_n->m_notes);
-    m_purchase_date_ctrl->SetValue(StockModel::PURCHASEDATE(*m_stock_n));
+    m_purchase_date_ctrl->SetValue(m_stock_n->m_purchase_date.getDateTime());
 
     int precision = m_stock_n->m_num_shares == floor(m_stock_n->m_num_shares)
         ? 0
@@ -141,7 +141,7 @@ void StockDialog::UpdateControls()
         if (m_stock_n) {
             m_value_investment->SetLabelText(AccountModel::instance().value_number_currency(
                 *account_n,
-                StockModel::instance().CurrentValue(*m_stock_n)
+                m_stock_n->current_value()
             ));
         }
     }
@@ -920,7 +920,7 @@ void StockDialog::OnHistoryAddButton(wxCommandEvent& /*event*/)
         ));
         m_value_investment->SetLabelText(AccountModel::instance().value_number_currency(
             *account,
-            StockModel::instance().CurrentValue(*m_stock_n)
+            m_stock_n->current_value()
         ));
     }
 }
@@ -985,11 +985,13 @@ void StockDialog::ShowStockHistory()
         m_current_price_ctrl->SetValue(disp_price);
         // if the latest share price is not the current stock price, update it.
         if (m_stock_n->m_current_price != sh_d.m_price) {
-            StockModel::UpdateCurrentPrice(m_stock_n->m_symbol, sh_d.m_price);
+            StockModel::instance().update_symbol_current_price(
+                m_stock_n->m_symbol, sh_d.m_price
+            );
             m_stock_n = StockModel::instance().unsafe_get_id_data_n(m_stock_n->m_id);
             m_value_investment->SetLabelText(AccountModel::instance().value_number_currency(
                 *(AccountModel::instance().get_id_data_n(m_stock_n->m_account_id_n)),
-                StockModel::instance().CurrentValue(*m_stock_n)
+                m_stock_n->current_value()
             ));
         }
     }

--- a/src/dialog/StockDialog.cpp
+++ b/src/dialog/StockDialog.cpp
@@ -162,7 +162,7 @@ void StockDialog::UpdateControls()
     wxBitmapButton* buttonAdd = static_cast<wxBitmapButton*>(FindWindow(wxID_ADD));
     buttonAdd->Enable(m_edit);
 
-    bool initial_shares = !TrxLinkModel::HasShares(m_stock_id);
+    bool initial_shares = (TrxLinkModel::instance().find_stock_id_c(m_stock_id) == 0);
     m_num_shares_ctrl->Enable(!m_edit || initial_shares);
     m_purchase_date_ctrl->Enable(!m_edit || initial_shares);
     m_purchase_price_ctrl->Enable(!m_edit || initial_shares);
@@ -187,7 +187,9 @@ void StockDialog::CreateControls()
 {
     bool initial_stock_transaction = true;
     if (m_stock_n) {
-        if (!TrxLinkModel::TranslinkList<StockModel>(m_stock_n->m_id).empty()) {
+        if (!TrxLinkModel::instance().find_ref_data_a(
+            StockModel::s_ref_type, m_stock_n->m_id
+        ).empty()) {
             initial_stock_transaction = false;
         }
     }

--- a/src/dialog/TrxDialog.cpp
+++ b/src/dialog/TrxDialog.cpp
@@ -389,14 +389,14 @@ void TrxDialog::dataToControls()
             );
 
             if (!transactions.empty() &&
-                !CategoryModel::is_hidden(transactions.back().m_category_id_n)
+                !CategoryModel::instance().is_hidden(transactions.back().m_category_id_n)
             ) {
                 const int64 cat = transactions.back().m_category_id_n;
-                cbCategory_->ChangeValue(CategoryModel::full_name(cat));
+                cbCategory_->ChangeValue(CategoryModel::instance().full_name(cat));
             }
         }
         else {
-            auto fullCategoryName = CategoryModel::full_name(m_journal_data.m_category_id_n);
+            auto fullCategoryName = CategoryModel::instance().full_name(m_journal_data.m_category_id_n);
             cbCategory_->ChangeValue(fullCategoryName);
         }
         skip_category_init_ = true;
@@ -771,7 +771,7 @@ bool TrxDialog::ValidateData()
         }
 
         if (PrefModel::instance().getTransCategoryNone() == PrefModel::LASTUSED
-            && !CategoryModel::is_hidden(m_journal_data.m_category_id_n)
+            && !CategoryModel::instance().is_hidden(m_journal_data.m_category_id_n)
         ) {
             PayeeData payee_d = *payee_n;
             payee_d.m_category_id_n = m_journal_data.m_category_id_n;
@@ -1010,7 +1010,7 @@ void TrxDialog::OnComboKey(wxKeyEvent& event)
                 int rc = dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     cbCategory_->mmDoReInitialize();
-                if (rc != wxID_CANCEL) cbCategory_->ChangeValue(CategoryModel::full_name(dlg.getCategId()));
+                if (rc != wxID_CANCEL) cbCategory_->ChangeValue(CategoryModel::instance().full_name(dlg.getCategId()));
                 return;
             }
         }
@@ -1039,7 +1039,9 @@ void TrxDialog::SetCategoryForPayee(const PayeeData *payee_n)
         && PrefModel::instance().getTransCategoryNone() == PrefModel::UNUSED
         && m_local_splits.empty()
     ) {
-        const CategoryData* category_n = CategoryModel::instance().get_key(_t("Unknown"), int64(-1));
+        const CategoryData* category_n = CategoryModel::instance().get_key_data_n(
+            _t("Unknown"), int64(-1)
+        );
         if (!category_n) {
             CategoryData new_category_d = CategoryData();
             new_category_d.m_name = _t("Unknown");
@@ -1064,13 +1066,13 @@ void TrxDialog::SetCategoryForPayee(const PayeeData *payee_n)
     if ((PrefModel::instance().getTransCategoryNone() == PrefModel::LASTUSED ||
             PrefModel::instance().getTransCategoryNone() == PrefModel::DEFAULT)
         && m_mode == MODE_NEW && m_local_splits.empty()
-        && (!CategoryModel::is_hidden(payee_n->m_category_id_n))
+        && (!CategoryModel::instance().is_hidden(payee_n->m_category_id_n))
     ) {
         // if payee has memory of last category used then display last category for payee
         const CategoryData* category_n = CategoryModel::instance().get_id_data_n(payee_n->m_category_id_n);
         if (category_n) {
             m_journal_data.m_category_id_n = payee_n->m_category_id_n;
-            cbCategory_->ChangeValue(CategoryModel::full_name(payee_n->m_category_id_n));
+            cbCategory_->ChangeValue(CategoryModel::instance().full_name(payee_n->m_category_id_n));
             wxLogDebug("Category: %s = %.2f", cbCategory_->GetLabel(), m_journal_data.m_amount);
         }
         else {

--- a/src/dialog/TrxDialog.cpp
+++ b/src/dialog/TrxDialog.cpp
@@ -152,15 +152,24 @@ TrxDialog::TrxDialog(
     m_transfer = TrxModel::type_id(m_journal_data.TRANSCODE) == TrxModel::TYPE_ID_TRANSFER;
     m_advanced = m_mode != MODE_NEW && m_transfer && (m_journal_data.m_amount != m_journal_data.m_to_amount);
 
-    int64 ref_id = (m_mode == MODE_NEW) ? 0 : (m_journal_data.m_repeat_num == 0) ?
-        m_journal_data.m_id : -(m_journal_data.m_bdid);
-    m_custom_fields = new mmCustomDataTransaction(this, ref_id, ID_CUSTOMFIELDS);
+    m_custom_fields = new mmCustomDataTransaction(this,
+        (m_mode == MODE_NEW ? TrxModel::s_ref_type :
+            m_journal_data.m_repeat_num == 0 ? TrxModel::s_ref_type :
+            SchedModel::s_ref_type
+        ),
+        (m_mode == MODE_NEW ? 0 :
+            m_journal_data.m_repeat_num == 0 ? m_journal_data.m_id :
+            m_journal_data.m_bdid
+        ),
+        ID_CUSTOMFIELDS
+    );
 
     // If duplicate then we may need to copy the attachments
-    if (m_mode == MODE_DUP && InfoModel::instance().getBool("ATTACHMENTSDUPLICATE", false))
-    {
-        const wxString& refType = TrxModel::refTypeName;
-        mmAttachmentManage::CloneAllAttachments(refType, journal_id.first, -1);
+    if (m_mode == MODE_DUP && InfoModel::instance().getBool("ATTACHMENTSDUPLICATE", false)) {
+        // FIXME: id -1 does not exist in database
+        mmAttachmentManage::CloneAllAttachments(
+            TrxModel::s_ref_type, journal_id.first, -1
+        );
     }
 
     this->SetFont(parent->GetFont());
@@ -1290,23 +1299,26 @@ void TrxDialog::OnOk(wxCommandEvent& event)
         }
         TagLinkModel::instance().update(splitTaglinks, splitRefType, tp_a.at(i).m_id);
     }
-    const wxString& ref_type = TrxModel::refTypeName;
     if (m_mode != MODE_EDIT) {
-        mmAttachmentManage::RelocateAllAttachments(ref_type, -1, ref_type, m_journal_data.m_id);
+        // FIXME
+        mmAttachmentManage::RelocateAllAttachments(
+            TrxModel::s_ref_type, -1,
+            TrxModel::s_ref_type, m_journal_data.m_id
+        );
     }
 
-    m_custom_fields->SaveCustomValues(m_journal_data.m_id);
+    m_custom_fields->SaveCustomValues(TrxModel::s_ref_type, m_journal_data.m_id);
 
     // Save base transaction tags
     TagLinkModel::DataA taglinks;
     for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
         TagLinkData gl_d = TagLinkData();
-        gl_d.REFTYPE = ref_type;
+        gl_d.REFTYPE = TrxModel::refTypeName;
         gl_d.REFID   = m_journal_data.m_id;
         gl_d.TAGID   = tag_id;
         taglinks.push_back(gl_d);
     }
-    TagLinkModel::instance().update(taglinks, ref_type, m_journal_data.m_id);
+    TagLinkModel::instance().update(taglinks, TrxModel::refTypeName, m_journal_data.m_id);
 
     //TrxModel::Full_Data trx(trx_d);
     //wxLogDebug("%s", trx.to_json());
@@ -1333,9 +1345,9 @@ void TrxDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 #endif
 
     if (m_mode != MODE_EDIT) {
-        const wxString& ref_type = TrxModel::refTypeName;
-        mmAttachmentManage::DeleteAllAttachments(ref_type, -1);
-        FieldValueModel::instance().DeleteAllData(ref_type, -1);
+        // FIXME: temporary records (with id -1) are not stored in database
+        mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, -1);
+        FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, -1);
     }
     previousDate = wxDateTime(); // invalidate!
     EndModal(wxID_CANCEL);
@@ -1390,10 +1402,10 @@ void TrxDialog::SetTooltips()
 
 void TrxDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& ref_type = TrxModel::refTypeName;
     if (m_mode != MODE_EDIT) {
-        mmAttachmentManage::DeleteAllAttachments(ref_type, -1);
-        FieldValueModel::instance().DeleteAllData(ref_type, -1);
+        // FIXME: temporary records (with id -1) are not stored in database
+        mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, -1);
+        FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, -1);
     }
     EndModal(wxID_CANCEL);
 }

--- a/src/dialog/TrxDialog.cpp
+++ b/src/dialog/TrxDialog.cpp
@@ -119,13 +119,13 @@ TrxDialog::TrxDialog(
     if (found) {
         // a bill can only be duplicated
         m_mode = (duplicate || journal_id.second) ? MODE_DUP : MODE_EDIT;
-        const wxString& splitRefType = (m_journal_data.m_repeat_num == 0) ?
-            TrxSplitModel::refTypeName :
-            SchedSplitModel::refTypeName;
+        RefTypeN split_ref_type = (m_journal_data.m_repeat_num == 0) ?
+            TrxSplitModel::s_ref_type :
+            SchedSplitModel::s_ref_type;
         for (const auto& tp_d : Journal::split(m_journal_data)) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(splitRefType),
+                TagLinkCol::REFTYPE(split_ref_type.name_n()),
                 TagLinkCol::REFID(tp_d.m_id))
             )
                 tag_id_a.push_back(gl_d.m_tag_id);
@@ -1171,11 +1171,11 @@ void TrxDialog::OnCategs(wxCommandEvent& WXUNUSED(event))
 
 void TrxDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& refType = (m_journal_data.m_repeat_num == 0) ?
-        TrxModel::refTypeName :
-        SchedModel::refTypeName;
+    RefTypeN ref_type = (m_journal_data.m_repeat_num == 0) ?
+        TrxModel::s_ref_type :
+        SchedModel::s_ref_type;
     int64 transID = (m_mode == MODE_DUP) ? -1 : m_journal_data.m_id;
-    AttachmentDialog dlg(this, refType, transID);
+    AttachmentDialog dlg(this, ref_type, transID);
     dlg.ShowModal();
 }
 

--- a/src/dialog/TrxDialog.cpp
+++ b/src/dialog/TrxDialog.cpp
@@ -128,7 +128,7 @@ TrxDialog::TrxDialog(
                 TagLinkCol::REFTYPE(splitRefType),
                 TagLinkCol::REFID(tp_d.m_id))
             )
-                tag_id_a.push_back(gl_d.TAGID);
+                tag_id_a.push_back(gl_d.m_tag_id);
             m_local_splits.push_back(
                 {tp_d.m_category_id, tp_d.m_amount, tag_id_a, tp_d.m_notes}
             );
@@ -409,17 +409,19 @@ void TrxDialog::dataToControls()
 
     // Tags
     if (!skip_tag_init_) {
-        wxArrayInt64 tagIds;
-        for (const auto& tag : GL.find(
-            TagLinkCol::REFTYPE((m_journal_data.m_repeat_num == 0) ?
-                TrxModel::refTypeName :
-                SchedModel::refTypeName),
-            TagLinkCol::REFID((m_journal_data.m_repeat_num == 0) ?
-                m_journal_data.m_id :
-                m_journal_data.m_bdid))
-        )
-            tagIds.push_back(tag.TAGID);
-        tagTextCtrl_->SetTags(tagIds);
+        wxArrayInt64 tag_id_a;
+        for (const auto& gl_d : GL.find(
+            TagLinkCol::REFTYPE((m_journal_data.m_repeat_num == 0)
+                ? TrxModel::s_ref_type.name_n()
+                : SchedModel::s_ref_type.name_n()
+            ),
+            TagLinkCol::REFID((m_journal_data.m_repeat_num == 0)
+                ? m_journal_data.m_id
+                : m_journal_data.m_bdid
+            )
+        ))
+            tag_id_a.push_back(gl_d.m_tag_id);
+        tagTextCtrl_->SetTags(tag_id_a);
         skip_tag_init_ = true;
     }
 
@@ -1286,18 +1288,19 @@ void TrxDialog::OnOk(wxCommandEvent& event)
     TrxSplitModel::instance().update(tp_a, m_journal_data.m_id);
 
     // Save split tags
-    const wxString& splitRefType = TrxSplitModel::refTypeName;
-
     for (unsigned int i = 0; i < m_local_splits.size(); i++) {
-        TagLinkModel::DataA splitTaglinks;
+        TagLinkModel::DataA new_tp_gl_a;
         for (const auto& tag_id : m_local_splits.at(i).TAGS) {
-            TagLinkData gl_d = TagLinkData();
-            gl_d.REFTYPE = splitRefType;
-            gl_d.REFID   = tp_a.at(i).m_id;
-            gl_d.TAGID   = tag_id;
-            splitTaglinks.push_back(gl_d);
+            TagLinkData new_gl_d = TagLinkData();
+            new_gl_d.m_tag_id   = tag_id;
+            new_gl_d.m_ref_type = TrxSplitModel::s_ref_type;
+            new_gl_d.m_ref_id   = tp_a.at(i).m_id;
+            new_tp_gl_a.push_back(new_gl_d);
         }
-        TagLinkModel::instance().update(splitTaglinks, splitRefType, tp_a.at(i).m_id);
+        TagLinkModel::instance().update(
+            TrxSplitModel::s_ref_type, tp_a.at(i).m_id,
+            new_tp_gl_a
+        );
     }
     if (m_mode != MODE_EDIT) {
         // FIXME
@@ -1310,15 +1313,18 @@ void TrxDialog::OnOk(wxCommandEvent& event)
     m_custom_fields->SaveCustomValues(TrxModel::s_ref_type, m_journal_data.m_id);
 
     // Save base transaction tags
-    TagLinkModel::DataA taglinks;
+    TagLinkModel::DataA new_gl_a;
     for (const auto& tag_id : tagTextCtrl_->GetTagIDs()) {
-        TagLinkData gl_d = TagLinkData();
-        gl_d.REFTYPE = TrxModel::refTypeName;
-        gl_d.REFID   = m_journal_data.m_id;
-        gl_d.TAGID   = tag_id;
-        taglinks.push_back(gl_d);
+        TagLinkData new_gl_d = TagLinkData();
+        new_gl_d.m_tag_id   = tag_id;
+        new_gl_d.m_ref_type = TrxModel::s_ref_type;
+        new_gl_d.m_ref_id   = m_journal_data.m_id;
+        new_gl_a.push_back(new_gl_d);
     }
-    TagLinkModel::instance().update(taglinks, TrxModel::refTypeName, m_journal_data.m_id);
+    TagLinkModel::instance().update(
+        TrxModel::s_ref_type.name_n(), m_journal_data.m_id,
+        new_gl_a
+    );
 
     //TrxModel::Full_Data trx(trx_d);
     //wxLogDebug("%s", trx.to_json());

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -419,10 +419,10 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
     bool is_custom_found = false;
     const wxString ref_type = TrxModel::refTypeName;
     int field_index = 0;
-    for (const auto& i : FieldModel::instance().find(
+    for (const auto& field_d : FieldModel::instance().find(
         FieldCol::REFTYPE(ref_type)
     )) {
-        const auto entry = wxString::Format("CUSTOM%lld", i.FIELDID);
+        const auto entry = wxString::Format("CUSTOM%lld", field_d.m_id);
         if (j_doc.HasMember(entry.c_str())) {
             const auto value = j_doc[const_cast<char*>(static_cast<const char*>(entry.mb_str()))].GetString();
             m_custom_fields->SetStringValue(field_index, value, true);
@@ -441,10 +441,8 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
     // Hide Columns
     Value& j_columns = GetValueByPointerWithDefault(j_doc, "/COLUMN", "");
     m_selected_columns_id.Clear();
-    if (j_columns.IsArray())
-    {
-        for (rapidjson::SizeType i = 0; i < j_columns.Size(); i++)
-        {
+    if (j_columns.IsArray()) {
+        for (rapidjson::SizeType i = 0; i < j_columns.Size(); i++) {
             wxASSERT(j_columns[i].IsInt());
             const int colID = j_columns[i].GetInt();
 
@@ -453,8 +451,7 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
         showColumnsCheckBox_->SetValue(true);
         bHideColumns_->SetLabelText("...");
     }
-    else
-    {
+    else {
         showColumnsCheckBox_->SetValue(false);
         bHideColumns_->SetLabelText("");
     }
@@ -1944,8 +1941,8 @@ const wxString TrxFilterDialog::mmGetJsonSettings(bool i18n) const
     if (cf.size() > 0) {
         for (const auto& i : cf) {
             if (!i.second.empty()) {
-                const auto field = FieldModel::instance().get_id_data_n(i.first);
-                json_writer.Key(wxString::Format("CUSTOM%lld", field->FIELDID).utf8_str());
+                const auto field_n = FieldModel::instance().get_id_data_n(i.first);
+                json_writer.Key(wxString::Format("CUSTOM%lld", field_n->m_id).utf8_str());
                 json_writer.String(i.second.utf8_str());
             }
         }

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -117,8 +117,11 @@ TrxFilterDialog::TrxFilterDialog(wxWindow* parent, int64 accountID, bool isRepor
     mmDoDataToControls(m_settings_json);
 }
 
-TrxFilterDialog::TrxFilterDialog(wxWindow* parent, const wxString& json)
-    : isMultiAccount_(true), accountID_(-1), isReportMode_(true), m_filter_key("TRANSACTIONS_FILTER")
+TrxFilterDialog::TrxFilterDialog(wxWindow* parent, const wxString& json) :
+    isMultiAccount_(true),
+    accountID_(-1),
+    isReportMode_(true),
+    m_filter_key("TRANSACTIONS_FILTER")
 {
     this->SetFont(parent->GetFont());
     mmDoInitVariables();
@@ -130,7 +133,11 @@ void TrxFilterDialog::mmDoInitVariables()
 {
     m_use_date_filter = isReportMode_; //|| PrefModel::instance().getUsePerAccountFilter();
 
-    m_custom_fields = new mmCustomDataTransaction(this, 0, ID_CUSTOMFIELDS + (isReportMode_ ? 100 : 0));
+    m_custom_fields = new mmCustomDataTransaction(this,
+        TrxModel::s_ref_type,
+        0,
+        ID_CUSTOMFIELDS + (isReportMode_ ? 100 : 0)
+    );
 
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmToday()));
     m_all_date_ranges.push_back(wxSharedPtr<mmDateRange>(new mmCurrentMonth()));
@@ -2045,17 +2052,16 @@ bool TrxFilterDialog::mmIsCustomFieldChecked() const
     return (cf.size() > 0);
 }
 
-bool TrxFilterDialog::mmIsCustomFieldMatches(int64 transid) const
+bool TrxFilterDialog::mmIsCustomFieldMatches(int64 trx_id) const
 {
     const auto cf = m_custom_fields->GetActiveCustomFields();
     int matched = 0;
     for (const auto& i : cf) {
-        auto DataSet = FieldValueModel::instance().find(
-            FieldValueCol::REFID(transid)
-        );
-        for (const auto& j : DataSet) {
-            if (i.first == j.FIELDID) {
-                if (j.CONTENT.Matches(i.second))
+        for (const auto& fv_d : FieldValueModel::instance().find(
+            FieldValueModel::REFTYPEID(TrxModel::s_ref_type, trx_id)
+        )) {
+            if (i.first == fv_d.m_field_id) {
+                if (fv_d.m_content.Matches(i.second))
                     matched += 1;
                 else
                     return false;

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -1379,64 +1379,64 @@ bool TrxFilterDialog::mmIsCategoryMatches(int64 categid)
     return std::find(m_selected_categories_id.begin(), m_selected_categories_id.end(), categid) != m_selected_categories_id.end();
 }
 
-bool TrxFilterDialog::mmIsTagMatches(const wxString& refType, int64 refId, bool mergeSplitTags)
+bool TrxFilterDialog::mmIsTagMatches(RefTypeN ref_type, int64 ref_id, bool mergeSplitTags)
 {
-    std::map<wxString, int64> tagnames = TagLinkModel::instance().get_ref(refType, refId);
+    std::map<wxString, int64> tagnames = TagLinkModel::instance().find_ref_tag_m(
+        ref_type, ref_id
+    );
 
     // If we have a split, merge the transaciton tags so that an AND condition captures cases
     // where one tag is on the base txn and the other is on the split
-    std::map<wxString, int64> txnTagnames;
-    if (refType == TrxSplitModel::refTypeName)
-        txnTagnames = TagLinkModel::instance().get_ref(
+    std::map<wxString, int64> tag_name_id_m;
+    if (ref_type == TrxSplitModel::s_ref_type)
+        tag_name_id_m = TagLinkModel::instance().find_ref_tag_m(
             TrxModel::refTypeName,
-            TrxSplitModel::instance().get_id_data_n(refId)->m_trx_id
+            TrxSplitModel::instance().get_id_data_n(ref_id)->m_trx_id
         );
-    else if (refType == SchedSplitModel::refTypeName)
-        txnTagnames = TagLinkModel::instance().get_ref(
+    else if (ref_type == SchedSplitModel::s_ref_type)
+        tag_name_id_m = TagLinkModel::instance().find_ref_tag_m(
             SchedModel::refTypeName,
-            SchedSplitModel::instance().get_id_data_n(refId)->m_sched_id
+            SchedSplitModel::instance().get_id_data_n(ref_id)->m_sched_id
         );
 
-    if (mergeSplitTags)
-    {
+    if (mergeSplitTags) {
         // Merge transaction tags and split tags. This is necessary when checking
         // if a split record matches the filter since we are using mmIsRecordMatches
-        // to validate the split which gives it the wrong refType & refId
-        if (refType == TrxModel::refTypeName) {
+        // to validate the split which gives it the wrong ref_type & ref_id
+        if (ref_type == TrxModel::s_ref_type) {
             // Loop through checking splits and merge tags for each SPLITTRANSID
             for (const auto& tp_d : TrxSplitModel::instance().find(
-                TrxSplitCol::TRANSID(refId)
+                TrxSplitCol::TRANSID(ref_id)
             )) {
                 std::map<wxString, int64> splitTagnames =
-                    TagLinkModel::instance().get_ref(
-                        TrxSplitModel::refTypeName, tp_d.m_id
+                    TagLinkModel::instance().find_ref_tag_m(
+                        TrxSplitModel::s_ref_type, tp_d.m_id
                     );
-                txnTagnames.insert(splitTagnames.begin(), splitTagnames.end());
+                tag_name_id_m.insert(splitTagnames.begin(), splitTagnames.end());
             }
         }
-        else if (refType == SchedModel::refTypeName) {
+        else if (ref_type == SchedModel::s_ref_type) {
             // Loop through scheduled txn splits and merge tags for each SPLITTRANSID
             for (const auto& qp_d : SchedSplitModel::instance().find(
-                SchedSplitCol::TRANSID(refId)
+                SchedSplitCol::TRANSID(ref_id)
             )) {
                 std::map<wxString, int64> splitTagnames =
-                    TagLinkModel::instance().get_ref(
-                        SchedSplitModel::refTypeName, qp_d.m_id
+                    TagLinkModel::instance().find_ref_tag_m(
+                        SchedSplitModel::s_ref_type, qp_d.m_id
                     );
-                txnTagnames.insert(splitTagnames.begin(), splitTagnames.end());
+                tag_name_id_m.insert(splitTagnames.begin(), splitTagnames.end());
             }
         }
     }
 
-    tagnames.insert(txnTagnames.begin(), txnTagnames.end());
+    tagnames.insert(tag_name_id_m.begin(), tag_name_id_m.end());
     if (tagnames.empty())
         return false;
 
     bool match = true;
 
     wxArrayString tags = tagTextCtrl_->GetTagStrings();
-    for (int i = 0; i < static_cast<int>(tags.GetCount()); i++)
-    {
+    for (int i = 0; i < static_cast<int>(tags.GetCount()); i++) {
         // if the tag is the "OR" operator, fetch the next tag and compare with OR
         if (tags.Item(i) == "|" && i++ < static_cast<int>(tags.GetCount()) - 1)
             match |= tagnames.find(tags.Item(i)) != tagnames.end();
@@ -1482,14 +1482,13 @@ bool TrxFilterDialog::mmIsRecordMatches(const DATA& tran, bool mergeSplitTags)
         ok = false;
     else if (mmIsCustomFieldChecked() && !mmIsCustomFieldMatches(tran.id()))
         ok = false;
-    else if (mmIsTagsChecked())
-    {
-        wxString refType;
+    else if (mmIsTagsChecked()) {
+        RefTypeN refType;
         // Check the Data type to determine the tag RefType
         if (typeid(tran).hash_code() == typeid(TrxData).hash_code())
-            refType = TrxModel::refTypeName;
+            refType = TrxModel::s_ref_type;
         else if (typeid(tran).hash_code() == typeid(SchedData).hash_code())
-            refType = SchedModel::refTypeName;
+            refType = SchedModel::s_ref_type;
         if (!mmIsTagMatches(refType, tran.id(), mergeSplitTags))
             ok = false;
     }
@@ -1499,13 +1498,13 @@ bool TrxFilterDialog::mmIsRecordMatches(const DATA& tran, bool mergeSplitTags)
 template <class MODEL, class DATA>
 bool TrxFilterDialog::mmIsSplitRecordMatches(const DATA& split_d)
 {
-    wxString refType;
+    RefTypeN refType;
 
     if (typeid(split_d).hash_code() == typeid(TrxSplitData).hash_code()) {
-        refType = TrxSplitModel::refTypeName;
+        refType = TrxSplitModel::s_ref_type;
     }
     else if (typeid(split_d).hash_code() == typeid(SchedSplitData).hash_code()) {
-        refType = SchedSplitModel::refTypeName;
+        refType = SchedSplitModel::s_ref_type;
     }
 
     if (mmIsTagsChecked() && !mmIsTagMatches(refType, split_d.m_id))

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -291,7 +291,7 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
 
     const wxString& delimiter = InfoModel::instance().getString("CATEG_DELIMITER", ":");
     if (delimiter != ":" && s_category.Contains(":")) {
-        for (const auto& category : CategoryModel::all_categories()) {
+        for (const auto& category : CategoryModel::instance().all_categories()) {
             wxString full_name = category.first;
             wxRegEx regex(delimiter);
             regex.Replace(&full_name, ":");
@@ -1852,7 +1852,7 @@ const wxString TrxFilterDialog::mmGetJsonSettings(bool i18n) const
         json_writer.Key((i18n ? _t("Category") : "CATEGORY").utf8_str());
         if (categoryComboBox_->mmIsValid()) {
             int64 categ = categoryComboBox_->mmGetCategoryId();
-            const auto& full_name = CategoryModel::full_name(categ, ":");
+            const auto& full_name = CategoryModel::instance().full_name(categ, ":");
             json_writer.String(full_name.utf8_str());
         }
         else {
@@ -2001,14 +2001,18 @@ void TrxFilterDialog::OnCategoryChange(wxEvent& event)
     m_selected_categories_id.clear();
     if (!categoryComboBox_->GetValue().IsEmpty()) {
         wxRegEx pattern("^(" + categoryComboBox_->mmGetPattern() + ")$", wxRE_ICASE | wxRE_ADVANCED);
-        if (pattern.IsValid())
-            for (const auto& category : CategoryModel::instance().all_categories())
-                if (pattern.Matches(category.first)) {
-                    m_selected_categories_id.push_back(category.second);
-                    if (mmIsCategorySubCatChecked())
-                        for (const auto& subcat : CategoryModel::instance().sub_tree(CategoryModel::instance().get_id_data_n(category.second)))
-                            m_selected_categories_id.push_back(subcat.m_id);
-                }
+        if (pattern.IsValid()) {
+            for (const auto& category : CategoryModel::instance().all_categories()) {
+                if (!pattern.Matches(category.first))
+                    continue;
+                m_selected_categories_id.push_back(category.second);
+                if (!mmIsCategorySubCatChecked())
+                    continue;
+                const CategoryData* cat_n = CategoryModel::instance().get_id_data_n(category.second);
+                for (const auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n))
+                    m_selected_categories_id.push_back(sub_d.m_id);
+            }
+        }
     }
     event.Skip();
 }
@@ -2363,7 +2367,7 @@ void TrxFilterDialog::OnComboKey(wxKeyEvent& event)
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     categoryComboBox_->mmDoReInitialize();
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 categoryComboBox_->ChangeValue(category);
                 categoryComboBox_->SelectAll();
                 return;

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -424,10 +424,9 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
 
     // Custom Fields
     bool is_custom_found = false;
-    const wxString ref_type = TrxModel::refTypeName;
     int field_index = 0;
     for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
+        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
     )) {
         const auto entry = wxString::Format("CUSTOM%lld", field_d.m_id);
         if (j_doc.HasMember(entry.c_str())) {
@@ -1390,12 +1389,12 @@ bool TrxFilterDialog::mmIsTagMatches(RefTypeN ref_type, int64 ref_id, bool merge
     std::map<wxString, int64> tag_name_id_m;
     if (ref_type == TrxSplitModel::s_ref_type)
         tag_name_id_m = TagLinkModel::instance().find_ref_tag_m(
-            TrxModel::refTypeName,
+            TrxModel::s_ref_type,
             TrxSplitModel::instance().get_id_data_n(ref_id)->m_trx_id
         );
     else if (ref_type == SchedSplitModel::s_ref_type)
         tag_name_id_m = TagLinkModel::instance().find_ref_tag_m(
-            SchedModel::refTypeName,
+            SchedModel::s_ref_type,
             SchedSplitModel::instance().get_id_data_n(ref_id)->m_sched_id
         );
 
@@ -1919,11 +1918,11 @@ const wxString TrxFilterDialog::mmGetJsonSettings(bool i18n) const
         json_writer.Key((i18n ? _t("Tags") : "TAGS").utf8_str());
         json_writer.StartArray();
 
-        for (const auto& tag : tagTextCtrl_->GetTagStrings()) {
-            if (tag == "&" || tag == "|")
-                json_writer.String(tag.utf8_str());
+        for (const auto& tag_name : tagTextCtrl_->GetTagStrings()) {
+            if (tag_name == "&" || tag_name == "|")
+                json_writer.String(tag_name.utf8_str());
             else
-                json_writer.Int64(TagModel::instance().get_key(tag)->m_id.GetValue());
+                json_writer.Int64(TagModel::instance().get_name_data_n(tag_name)->m_id.GetValue());
         }
 
         json_writer.EndArray();

--- a/src/dialog/TrxFilterDialog.h
+++ b/src/dialog/TrxFilterDialog.h
@@ -133,7 +133,7 @@ private:
     bool mmIsPayeeMatches(int64 payeeid);
     bool mmIsCategoryMatches(int64 categid);
     bool mmIsNoteMatches(const wxString& note);
-    bool mmIsTagMatches(const wxString& refType, int64 refId, bool mergeSplitTags = false);
+    bool mmIsTagMatches(RefTypeN ref_type, int64 ref_id, bool mergeSplitTags = false);
 
     void setTransferTypeCheckBoxes();
 

--- a/src/dialog/TrxLinkDialog.cpp
+++ b/src/dialog/TrxLinkDialog.cpp
@@ -273,7 +273,7 @@ void TrxLinkDialog::DataToControls()
     m_payee->SetLabelText(PayeeModel::instance().get_id_name(m_payee_id));
 
     m_category_id = m_transaction_n->m_category_id_n;
-    m_category->SetValue(CategoryModel::full_name(m_category_id));
+    m_category->SetValue(CategoryModel::instance().full_name(m_category_id));
 
     m_entered_number->SetValue(m_transaction_n->m_number);
     m_entered_notes->SetValue(m_transaction_n->m_notes);
@@ -336,10 +336,10 @@ void TrxLinkDialog::SetLastPayeeAndCategory(const int64 account_id)
                 m_payee->SetLabelText(last_payee_n->m_name);
                 m_payee_id = last_payee_n->m_id;
                 if ((PrefModel::instance().getTransCategoryNone() == PrefModel::LASTUSED)
-                    && !CategoryModel::is_hidden(last_payee_n->m_category_id_n)
+                    && !CategoryModel::instance().is_hidden(last_payee_n->m_category_id_n)
                 ) {
                     m_category_id = last_payee_n->m_category_id_n;
-                    m_category->SetLabelText(CategoryModel::full_name(last_payee_n->m_category_id_n));
+                    m_category->SetLabelText(CategoryModel::instance().full_name(last_payee_n->m_category_id_n));
                 }
             }
         }
@@ -374,11 +374,11 @@ void TrxLinkDialog::OnTransPayeeButton(wxCommandEvent& WXUNUSED(event))
             if (PrefModel::instance().getTransCategoryNone() == PrefModel::LASTUSED
                 && m_category_id < 0
                 && m_subcategory_id < 0
-                && !CategoryModel::is_hidden(payee_n->m_category_id_n)
+                && !CategoryModel::instance().is_hidden(payee_n->m_category_id_n)
             ) {
                 if (payee_n->m_category_id_n > 0) {
                     m_category_id = payee_n->m_category_id_n;
-                    m_category->SetLabelText(CategoryModel::full_name(m_category_id));
+                    m_category->SetLabelText(CategoryModel::instance().full_name(m_category_id));
                 }
             }
         }
@@ -396,7 +396,7 @@ void TrxLinkDialog::OnTransCategoryCombobox(wxCommandEvent& WXUNUSED(event))
     if (dlg.ShowModal() == wxID_OK)
     {
         m_category_id = dlg.getCategId();
-        m_category->SetLabelText(CategoryModel::full_name(m_category_id));
+        m_category->SetLabelText(CategoryModel::instance().full_name(m_category_id));
     }
 }
 
@@ -478,7 +478,7 @@ void TrxLinkDialog::SetTransactionPayee(const int64 payeeid)
 void TrxLinkDialog::SetTransactionCategory(const int64 categid)
 {
     m_category_id = categid;
-    m_category->SetLabelText(CategoryModel::full_name(m_category_id));
+    m_category->SetLabelText(CategoryModel::instance().full_name(m_category_id));
 }
 
 void TrxLinkDialog::SetTransactionAccount(const wxString& trans_account)
@@ -577,7 +577,7 @@ void TrxLinkDialog::OnCategs(wxCommandEvent& WXUNUSED(event))
         m_local_splits = dlg.mmGetResult();
 
         if (m_local_splits.size() == 1) {
-            m_category->SetLabelText(CategoryModel::full_name(m_local_splits[0].CATEGID));
+            m_category->SetLabelText(CategoryModel::instance().full_name(m_local_splits[0].CATEGID));
             m_entered_amount->SetValue(m_local_splits[0].SPLITTRANSAMOUNT);
             m_entered_notes->SetValue(m_local_splits[0].NOTES);
 

--- a/src/dialog/TrxLinkDialog.cpp
+++ b/src/dialog/TrxLinkDialog.cpp
@@ -69,7 +69,7 @@ TrxLinkDialog::TrxLinkDialog(
                 TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
-                tag_id_a.push_back(gl_d.TAGID);
+                tag_id_a.push_back(gl_d.m_tag_id);
             }
             m_local_splits.push_back(
                 {tp_d.m_category_id, tp_d.m_amount, tag_id_a, tp_d.m_notes}

--- a/src/dialog/TrxLinkDialog.cpp
+++ b/src/dialog/TrxLinkDialog.cpp
@@ -66,7 +66,7 @@ TrxLinkDialog::TrxLinkDialog(
         )) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
+                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
                 tag_id_a.push_back(gl_d.m_tag_id);
@@ -424,13 +424,12 @@ void TrxLinkDialog::OnFrequentNotes(wxCommandEvent& WXUNUSED(event))
 
 void TrxLinkDialog::OnAttachments(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = TrxModel::refTypeName;
     int64 RefId = m_transaction_id;
 
     if (RefId < 0)
         RefId = 0;
 
-    AttachmentDialog dlg(this, RefType, RefId);
+    AttachmentDialog dlg(this, TrxModel::s_ref_type, RefId);
     dlg.ShowModal();
 }
 

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -98,7 +98,7 @@ TrxShareDialog::TrxShareDialog(
                     TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
                     TagLinkCol::REFID(tp_d.m_id)
                 )) {
-                    tag_id_a.push_back(gl_d.TAGID);
+                    tag_id_a.push_back(gl_d.m_tag_id);
                 }
                 m_local_deductible_splits.push_back(
                     {tp_d.m_category_id, tp_d.m_amount, tag_id_a, tp_d.m_notes}
@@ -116,7 +116,7 @@ TrxShareDialog::TrxShareDialog(
                 TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
-                tag_id_a.push_back(gl_d.TAGID);
+                tag_id_a.push_back(gl_d.m_tag_id);
             }
             m_local_non_deductible_splits.push_back(
                 {tp_d.m_category_id, tp_d.m_amount, tag_id_a, tp_d.m_notes}

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -71,20 +71,20 @@ TrxShareDialog::TrxShareDialog(wxWindow* parent, StockData* stock)
 
 TrxShareDialog::TrxShareDialog(
     wxWindow* parent,
-    const TrxLinkData* translink_entry,
+    const TrxLinkData* tl_n,
     TrxData* checking_entry
 ) :
     m_dialog_heading(_t("Edit Share Transaction")),
     m_checking_entry(checking_entry),
-    m_translink_entry(translink_entry)
+    m_translink_entry(tl_n)
 {
     if (m_translink_entry) {
         m_stock_n = StockModel::instance().unsafe_get_id_data_n(
-            m_translink_entry->LINKRECORDID
+            m_translink_entry->m_ref_id
         );
-        if (m_translink_entry->LINKTYPE == StockModel::refTypeName) {
+        if (m_translink_entry->m_ref_type == StockModel::s_ref_type) {
             m_share_entry = TrxShareModel::instance().unsafe_get_trx_share_n(
-                m_translink_entry->CHECKINGACCOUNTID
+                m_translink_entry->m_trx_id
             );
             if (m_share_entry->m_lot.IsEmpty())
                 // FIXME: m_share_entry is changed but not saved
@@ -163,9 +163,11 @@ void TrxShareDialog::DataToControls()
     m_share_lot_ctrl->Enable(false);
     m_notes_ctrl->Enable(false);
 
-    TrxLinkModel::DataA translink_list = TrxLinkModel::TranslinkList<StockModel>(m_stock_n->m_id);
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        StockModel::s_ref_type, m_stock_n->m_id
+    );
 
-    if (translink_list.empty()) {
+    if (tl_a.empty()) {
         // Set up the transaction as the first entry.
         int precision = m_stock_n->m_num_shares == floor(m_stock_n->m_num_shares) ? 0 : PrefModel::instance().getSharePrecision();
         m_share_num_ctrl->SetValue(m_stock_n->m_num_shares, precision);
@@ -185,7 +187,7 @@ void TrxShareDialog::DataToControls()
             m_share_lot_ctrl->SetValue(m_share_entry->m_lot);
 
             if (m_translink_entry) {
-                const TrxData* trx_n = TrxModel::instance().get_id_data_n(m_translink_entry->CHECKINGACCOUNTID);
+                const TrxData* trx_n = TrxModel::instance().get_id_data_n(m_translink_entry->m_trx_id);
                 if (trx_n) {
                     m_transaction_panel->TransactionDate(TrxModel::getTransDateTime(*trx_n));
                     m_transaction_panel->SetTransactionValue(GetAmount(std::abs(m_share_entry->m_number)
@@ -454,8 +456,9 @@ void TrxShareDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         // date of purchase, together with a record in the checking account table.
         */
         if (!m_translink_entry) {
-             TrxLinkModel::SetStockTranslink(
-                m_stock_n->m_id, trx_id, m_transaction_panel->CheckingType()
+             TrxLinkModel::instance().SetStockTranslink(
+                trx_id, m_stock_n->m_id,
+                m_transaction_panel->CheckingType()
             );
         }
         TrxShareModel::ShareEntry(

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -387,17 +387,17 @@ void TrxShareDialog::CreateControls()
 
 void TrxShareDialog::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
-    const wxString& RefType = StockModel::refTypeName;
+    // FIXME
     if (!this->m_stock_n)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 
 void TrxShareDialog::OnCancel(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString& RefType = StockModel::refTypeName;
+    // FIXME
     if (m_stock_id <= 0)
-        mmAttachmentManage::DeleteAllAttachments(RefType, 0);
+        mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, 0);
     EndModal(wxID_CANCEL);
 }
 

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -95,7 +95,7 @@ TrxShareDialog::TrxShareDialog(
             )) {
                 wxArrayInt64 tag_id_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
+                    TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
                     TagLinkCol::REFID(tp_d.m_id)
                 )) {
                     tag_id_a.push_back(gl_d.m_tag_id);
@@ -113,7 +113,7 @@ TrxShareDialog::TrxShareDialog(
         )) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(TrxSplitModel::refTypeName),
+                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
                 tag_id_a.push_back(gl_d.m_tag_id);

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -527,7 +527,9 @@ void TrxShareDialog::OnDeductibleSplit(wxCommandEvent&)
         double commission = 0;
         m_share_commission_ctrl->GetDouble(commission);
 
-        const CategoryData* category_n = CategoryModel::instance().get_key(_("Investment"), int64(-1L));
+        const CategoryData* category_n = CategoryModel::instance().get_key_data_n(
+            _("Investment"), int64(-1L)
+        );
         if (!category_n) {
             CategoryData new_category_d = CategoryData();
             new_category_d.m_name = _("Investment");

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -61,9 +61,9 @@ TrxShareDialog::TrxShareDialog()
 {
 }
 
-TrxShareDialog::TrxShareDialog(wxWindow* parent, StockData* stock)
-    : m_stock_n(stock)
-    , m_dialog_heading(_t("Add Share Transaction"))
+TrxShareDialog::TrxShareDialog(wxWindow* parent, StockData* stock_n) :
+    m_stock_n(stock_n),
+    m_dialog_heading(_t("Add Share Transaction"))
 {
     long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX;
     Create(parent, wxID_ANY, m_dialog_heading, wxDefaultPosition, wxSize(400, 300), style);
@@ -72,26 +72,26 @@ TrxShareDialog::TrxShareDialog(wxWindow* parent, StockData* stock)
 TrxShareDialog::TrxShareDialog(
     wxWindow* parent,
     const TrxLinkData* tl_n,
-    TrxData* checking_entry
+    TrxData* trx_n
 ) :
     m_dialog_heading(_t("Edit Share Transaction")),
-    m_checking_entry(checking_entry),
-    m_translink_entry(tl_n)
+    m_trx_n(trx_n),
+    m_tl_n(tl_n)
 {
-    if (m_translink_entry) {
+    if (m_tl_n) {
         m_stock_n = StockModel::instance().unsafe_get_id_data_n(
-            m_translink_entry->m_ref_id
+            m_tl_n->m_ref_id
         );
-        if (m_translink_entry->m_ref_type == StockModel::s_ref_type) {
-            m_share_entry = TrxShareModel::instance().unsafe_get_trx_share_n(
-                m_translink_entry->m_trx_id
+        if (m_tl_n->m_ref_type == StockModel::s_ref_type) {
+            m_ts_n = TrxShareModel::instance().unsafe_get_trxId_data_n(
+                m_tl_n->m_trx_id
             );
-            if (m_share_entry->m_lot.IsEmpty())
-                // FIXME: m_share_entry is changed but not saved
-                m_share_entry->m_lot = m_stock_n->m_id.ToString();
+            if (m_ts_n->m_lot.IsEmpty())
+                // FIXME: m_ts_n is changed but not saved
+                m_ts_n->m_lot = m_stock_n->m_id.ToString();
 
             for (const auto& tp_d: TrxSplitModel::instance().find(
-                TrxSplitCol::TRANSID(m_share_entry->m_id)
+                TrxSplitCol::TRANSID(m_ts_n->m_id)
             )) {
                 wxArrayInt64 tag_id_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
@@ -107,9 +107,9 @@ TrxShareDialog::TrxShareDialog(
         }
     }
 
-    if (m_checking_entry) {
+    if (m_trx_n) {
         for (const auto& tp_d: TrxSplitModel::instance().find(
-            TrxSplitCol::TRANSID(m_checking_entry->m_id)
+            TrxSplitCol::TRANSID(m_trx_n->m_id)
         )) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
@@ -129,9 +129,11 @@ TrxShareDialog::TrxShareDialog(
     this->SetMinSize(wxSize(400, 300));
 }
 
-bool TrxShareDialog::Create(wxWindow* parent, wxWindowID id, const wxString& caption
-    , const wxPoint& pos, const wxSize& size, long style)
-{
+bool TrxShareDialog::Create(
+    wxWindow* parent, wxWindowID id,
+    const wxString& caption,
+    const wxPoint& pos, const wxSize& size, long style
+) {
     SetExtraStyle(GetExtraStyle()|wxWS_EX_BLOCK_EVENTS);
     wxDialog::Create(parent, id, caption, pos, size, style);
 
@@ -169,29 +171,49 @@ void TrxShareDialog::DataToControls()
 
     if (tl_a.empty()) {
         // Set up the transaction as the first entry.
-        int precision = m_stock_n->m_num_shares == floor(m_stock_n->m_num_shares) ? 0 : PrefModel::instance().getSharePrecision();
+        int precision = m_stock_n->m_num_shares == floor(m_stock_n->m_num_shares)
+            ? 0
+            : PrefModel::instance().getSharePrecision();
         m_share_num_ctrl->SetValue(m_stock_n->m_num_shares, precision);
-        m_share_price_ctrl->SetValue(m_stock_n->m_purchase_price, PrefModel::instance().getSharePrecision());
-        m_share_commission_ctrl->SetValue(m_stock_n->m_commission, PrefModel::instance().getSharePrecision());
+        m_share_price_ctrl->SetValue(
+            m_stock_n->m_purchase_price,
+            PrefModel::instance().getSharePrecision()
+        );
+        m_share_commission_ctrl->SetValue(
+            m_stock_n->m_commission,
+            PrefModel::instance().getSharePrecision()
+        );
         m_share_lot_ctrl->SetValue(m_stock_n->m_id.ToString());
-        m_transaction_panel->TransactionDate(StockModel::PURCHASEDATE(*m_stock_n));
-        m_transaction_panel->SetTransactionValue(GetAmount(m_stock_n->m_num_shares, m_stock_n->m_purchase_price
-                , m_stock_n->m_commission), true);
+        m_transaction_panel->TransactionDate(m_stock_n->m_purchase_date.getDateTime());
+        m_transaction_panel->SetTransactionValue(
+            GetAmount(m_stock_n->m_num_shares, m_stock_n->m_purchase_price, m_stock_n->m_commission),
+            true
+        );
     }
     else {
-        if (m_share_entry) {
-            int precision = m_share_entry->m_number == floor(m_share_entry->m_number) ? 0 : PrefModel::instance().getSharePrecision();
-            m_share_num_ctrl->SetValue(std::abs(m_share_entry->m_number), precision);
-            m_share_price_ctrl->SetValue(m_share_entry->m_price, PrefModel::instance().getSharePrecision());
-            m_share_commission_ctrl->SetValue(m_share_entry->m_commission, PrefModel::instance().getSharePrecision());
-            m_share_lot_ctrl->SetValue(m_share_entry->m_lot);
+        if (m_ts_n) {
+            int precision = m_ts_n->m_number == floor(m_ts_n->m_number)
+                ? 0
+                : PrefModel::instance().getSharePrecision();
+            m_share_num_ctrl->SetValue(std::abs(m_ts_n->m_number), precision);
+            m_share_price_ctrl->SetValue(
+                m_ts_n->m_price,
+                PrefModel::instance().getSharePrecision()
+            );
+            m_share_commission_ctrl->SetValue(
+                m_ts_n->m_commission,
+                PrefModel::instance().getSharePrecision()
+            );
+            m_share_lot_ctrl->SetValue(m_ts_n->m_lot);
 
-            if (m_translink_entry) {
-                const TrxData* trx_n = TrxModel::instance().get_id_data_n(m_translink_entry->m_trx_id);
+            if (m_tl_n) {
+                const TrxData* trx_n = TrxModel::instance().get_id_data_n(m_tl_n->m_trx_id);
                 if (trx_n) {
                     m_transaction_panel->TransactionDate(TrxModel::getTransDateTime(*trx_n));
-                    m_transaction_panel->SetTransactionValue(GetAmount(std::abs(m_share_entry->m_number)
-                        , m_share_entry->m_price, m_share_entry->m_commission), true);
+                    m_transaction_panel->SetTransactionValue(
+                        GetAmount(std::abs(m_ts_n->m_number), m_ts_n->m_price, m_ts_n->m_commission),
+                        true
+                    );
                     m_transaction_panel->SetTransactionAccount(AccountModel::instance().get_id_name(trx_n->m_account_id));
                     m_transaction_panel->SetTransactionStatus(TrxModel::status_id(*trx_n));
                     m_transaction_panel->SetTransactionPayee(trx_n->m_payee_id_n);
@@ -205,8 +227,7 @@ void TrxShareDialog::DataToControls()
                 }
             }
         }
-        else
-        {
+        else {
             m_share_num_ctrl->SetValue(0, 0);
             m_share_price_ctrl->SetValue(0, PrefModel::instance().getSharePrecision());
             m_share_lot_ctrl->SetValue(m_stock_n->m_id.ToString());
@@ -215,8 +236,7 @@ void TrxShareDialog::DataToControls()
     }
 
     bool has_split = !(m_local_deductible_splits.size() <= 1);
-    if (has_split)
-    {
+    if (has_split) {
         m_share_commission_ctrl->Enable(!has_split);
         m_share_commission_ctrl->SetValue(TrxSplitModel::get_total(m_local_deductible_splits), PrefModel::instance().getSharePrecision());
         mmToolTip(m_deductible_comm_split, TrxSplitModel::get_tooltip(m_local_deductible_splits, nullptr /* currency */));
@@ -348,16 +368,16 @@ void TrxShareDialog::CreateControls()
     Transaction Panel
     *********************************************************************/
 
-    wxStaticBox* transaction_frame = new wxStaticBox(this, wxID_ANY, m_checking_entry ? _t("Edit Transaction Details") : _t("Add Transaction Details"));
+    wxStaticBox* transaction_frame = new wxStaticBox(this, wxID_ANY, m_trx_n ? _t("Edit Transaction Details") : _t("Add Transaction Details"));
     wxStaticBoxSizer* transaction_frame_sizer = new wxStaticBoxSizer(transaction_frame, wxVERTICAL);
     right_sizer->Add(transaction_frame_sizer, g_flagsV);
 
-    m_transaction_panel = new TrxLinkDialog(transaction_frame, m_checking_entry, false, wxID_STATIC);
+    m_transaction_panel = new TrxLinkDialog(transaction_frame, m_trx_n, false, wxID_STATIC);
     m_transaction_panel->Bind(wxEVT_CHOICE, &TrxShareDialog::CalculateAmount, this, wxID_VIEW_DETAILS);
     transaction_frame_sizer->Add(m_transaction_panel, g_flagsV);
-    if (m_translink_entry && m_checking_entry) {
+    if (m_tl_n && m_trx_n) {
         m_transaction_panel->CheckingType(
-            TrxLinkModel::type_checking(m_checking_entry->m_to_account_id_n)
+            TrxLinkModel::type_checking(m_trx_n->m_to_account_id_n)
         );
     }
     else {
@@ -407,8 +427,7 @@ void TrxShareDialog::OnStockPriceButton(wxCommandEvent& WXUNUSED(event))
 {
     const wxString stockSymbol = m_stock_symbol_ctrl->GetValue().Trim();
 
-    if (!stockSymbol.IsEmpty())
-    {
+    if (!stockSymbol.IsEmpty()) {
         const wxString& stockURL = InfoModel::instance().getString("STOCKURL", mmex::weblink::DefStockUrl);
         const wxString& httpString = wxString::Format(stockURL, stockSymbol);
         wxLaunchDefaultBrowser(httpString);
@@ -419,15 +438,11 @@ void TrxShareDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 {
     double num_shares = 0;
     if (!m_share_num_ctrl->checkValue(num_shares))
-    {
         return;
-    }
 
     double share_price = 0;
     if (!m_share_price_ctrl->checkValue(share_price))
-    {
         return;
-    }
 
     double commission = 0;
     m_share_commission_ctrl->GetDouble(commission);
@@ -455,18 +470,18 @@ void TrxShareDialog::OnOk(wxCommandEvent& WXUNUSED(event))
         // The Shares table now maintains share_num, share_price, and commission on the
         // date of purchase, together with a record in the checking account table.
         */
-        if (!m_translink_entry) {
+        if (!m_tl_n) {
              TrxLinkModel::instance().SetStockTranslink(
                 trx_id, m_stock_n->m_id,
                 m_transaction_panel->CheckingType()
             );
         }
-        TrxShareModel::ShareEntry(
-            trx_id, num_shares, share_price, commission,
-            m_local_deductible_splits,  m_share_lot_ctrl->GetValue()
+        TrxShareModel::instance().update_trxID(trx_id,
+            num_shares, share_price, commission, m_share_lot_ctrl->GetValue(),
+            m_local_deductible_splits
         );
 
-        StockModel::UpdatePosition(m_stock_n);
+        StockModel::instance().update_data_position(m_stock_n);
         if (!loyalty_shares) {
             StockHistoryModel::instance().addUpdate(
                 m_stock_n->m_symbol,
@@ -487,25 +502,21 @@ void TrxShareDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 void TrxShareDialog::CalculateAmount(wxCommandEvent& WXUNUSED(event))
 {
     double share_num = 0;
-    if (!m_share_num_ctrl->GetValue().empty())
-    {
+    if (!m_share_num_ctrl->GetValue().empty()) {
         m_share_num_ctrl->GetDouble(share_num);
     }
 
     double share_price = 0;
-    if (!m_share_price_ctrl->GetValue().empty())
-    {
+    if (!m_share_price_ctrl->GetValue().empty()) {
         m_share_price_ctrl->GetDouble(share_price);
     }
 
     double share_commission = 0;
-    if (m_share_commission_ctrl && !m_share_commission_ctrl->GetValue().empty())
-    {
+    if (m_share_commission_ctrl && !m_share_commission_ctrl->GetValue().empty()) {
         m_share_commission_ctrl->GetDouble(share_commission);
     }
 
-    if (share_num > 0)
-    {
+    if (share_num > 0) {
         m_transaction_panel->SetTransactionValue(GetAmount(share_num, share_price, share_commission));
     }
 }
@@ -528,26 +539,28 @@ void TrxShareDialog::OnDeductibleSplit(wxCommandEvent&)
 
     SplitDialog dlg(this, m_local_deductible_splits, m_stock_n->m_account_id_n);
 
-    if (dlg.ShowModal() == wxID_OK)
-    {
+    if (dlg.ShowModal() == wxID_OK) {
         m_local_deductible_splits = dlg.mmGetResult();
 
-        if (m_local_deductible_splits.size() == 1)
-        {
+        if (m_local_deductible_splits.size() == 1) {
             // TODO other informations
-            m_share_commission_ctrl->SetValue(m_local_deductible_splits[0].SPLITTRANSAMOUNT, PrefModel::instance().getSharePrecision());
+            m_share_commission_ctrl->SetValue(
+                m_local_deductible_splits[0].SPLITTRANSAMOUNT,
+                PrefModel::instance().getSharePrecision()
+            );
 
             m_local_deductible_splits.clear();
         }
 
-        if (m_local_deductible_splits.empty())
-        {
+        if (m_local_deductible_splits.empty()) {
             m_share_commission_ctrl->Enable(true);
             mmToolTip(m_deductible_comm_split, _t("Use Deductible Comm. split Categories"));
         }
-        else
-        {
-            m_share_commission_ctrl->SetValue(TrxSplitModel::get_total(m_local_deductible_splits), PrefModel::instance().getSharePrecision());
+        else {
+            m_share_commission_ctrl->SetValue(
+                TrxSplitModel::get_total(m_local_deductible_splits),
+                PrefModel::instance().getSharePrecision()
+            );
             m_share_commission_ctrl->Enable(false);
             mmToolTip(m_deductible_comm_split, TrxSplitModel::get_tooltip(m_local_deductible_splits, nullptr /* currency */));
         }

--- a/src/dialog/TrxShareDialog.h
+++ b/src/dialog/TrxShareDialog.h
@@ -31,60 +31,7 @@ class TrxShareDialog : public wxDialog
     wxDECLARE_DYNAMIC_CLASS(TrxShareDialog);
     wxDECLARE_EVENT_TABLE();
 
-public:
-    TrxShareDialog();
-    TrxShareDialog(
-        wxWindow* parent,
-        StockData* stock_n
-    );
-    TrxShareDialog(
-        wxWindow* parent,
-        const TrxLinkData* transfer_entry,
-        TrxData* checking_entry
-    );
-
-    int64 m_stock_id = -1;
-
 private:
-    bool Create(wxWindow* parent, wxWindowID id = wxID_ANY
-        , const wxString& caption = _t("Edit Share Transaction")
-        , const wxPoint& pos = wxDefaultPosition
-        , const wxSize& size = wxDefaultSize
-        , long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX);
-
-    void CreateControls();
-    void DataToControls();
-
-    double GetAmount(double shares, double price, double commission);
-    void OnQuit(wxCloseEvent& WXUNUSED(event));
-    void OnOk(wxCommandEvent& WXUNUSED(event));
-    void OnCancel(wxCommandEvent& WXUNUSED(event));
-    void OnStockPriceButton(wxCommandEvent& event);
-    void CalculateAmount(wxCommandEvent& event);
-    void OnDeductibleSplit(wxCommandEvent& event);
-
-private:
-    StockData* m_stock_n = nullptr;
-    wxTextCtrl* m_stock_name_ctrl = nullptr;
-    mmTextCtrl* m_share_num_ctrl = nullptr;
-    wxTextCtrl* m_stock_symbol_ctrl = nullptr;
-    mmTextCtrl* m_share_price_ctrl = nullptr;
-    wxTextCtrl* m_share_lot_ctrl = nullptr;
-    mmTextCtrl* m_share_commission_ctrl = nullptr;
-    wxBitmapButton* m_deductible_comm_split = nullptr;
-    wxTextCtrl* m_notes_ctrl = nullptr;
-    wxBitmapButton* m_attachments_btn = nullptr;
-    wxBitmapButton* web_button = nullptr;
-
-    TrxLinkDialog* m_transaction_panel = nullptr;
-    wxString m_dialog_heading;
-
-    TrxData* m_checking_entry = nullptr;
-    const TrxLinkData* m_translink_entry = nullptr;
-    TrxShareData* m_share_entry = nullptr;
-
-    std::vector<Split> m_local_deductible_splits, m_local_non_deductible_splits;
-
     enum
     {
         ID_STOCKTRANS_DATEPICKER_CHANGE = wxID_HIGHEST + 820,
@@ -96,4 +43,59 @@ private:
         ID_STOCKTRANS_SHARE_COMMISSION,
         mmID_COMM_SPLIT,
     };
+
+public:
+    int64 m_stock_id = -1;
+
+private:
+    TrxData* m_trx_n = nullptr;
+    const TrxLinkData* m_tl_n = nullptr;
+    TrxShareData* m_ts_n = nullptr;
+    StockData* m_stock_n = nullptr;
+    wxString m_dialog_heading;
+    std::vector<Split> m_local_deductible_splits, m_local_non_deductible_splits;
+
+    TrxLinkDialog*  m_transaction_panel     = nullptr;
+    wxTextCtrl*     m_stock_name_ctrl       = nullptr;
+    mmTextCtrl*     m_share_num_ctrl        = nullptr;
+    wxTextCtrl*     m_stock_symbol_ctrl     = nullptr;
+    mmTextCtrl*     m_share_price_ctrl      = nullptr;
+    wxTextCtrl*     m_share_lot_ctrl        = nullptr;
+    mmTextCtrl*     m_share_commission_ctrl = nullptr;
+    wxBitmapButton* m_deductible_comm_split = nullptr;
+    wxTextCtrl*     m_notes_ctrl            = nullptr;
+    wxBitmapButton* m_attachments_btn       = nullptr;
+    wxBitmapButton* web_button              = nullptr;
+
+public:
+    TrxShareDialog();
+    TrxShareDialog(
+        wxWindow* parent,
+        StockData* stock_n
+    );
+    TrxShareDialog(
+        wxWindow* parent,
+        const TrxLinkData* tl_n,
+        TrxData* trx_n
+    );
+
+private:
+    bool Create(
+        wxWindow* parent,
+        wxWindowID id = wxID_ANY,
+        const wxString& caption = _t("Edit Share Transaction"),
+        const wxPoint& pos = wxDefaultPosition,
+        const wxSize& size = wxDefaultSize,
+        long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX
+    );
+    void CreateControls();
+    void DataToControls();
+
+    double GetAmount(double shares, double price, double commission);
+    void OnQuit(wxCloseEvent& WXUNUSED(event));
+    void OnOk(wxCommandEvent& WXUNUSED(event));
+    void OnCancel(wxCommandEvent& WXUNUSED(event));
+    void OnStockPriceButton(wxCommandEvent& event);
+    void CalculateAmount(wxCommandEvent& event);
+    void OnDeductibleSplit(wxCommandEvent& event);
 };

--- a/src/dialog/TrxUpdateDialog.cpp
+++ b/src/dialog/TrxUpdateDialog.cpp
@@ -458,34 +458,35 @@ void TrxUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
         // Update tags
         if (tag_checkbox_->IsChecked()) {
-            TagLinkModel::DataA taglinks;
-            const wxString& refType = TrxModel::refTypeName;
-            wxArrayInt64 tagIds = tagTextCtrl_->GetTagIDs();
+            TagLinkModel::DataA gl_a;
+            wxArrayInt64 tag_id_a = tagTextCtrl_->GetTagIDs();
 
             if (tag_append_checkbox_->IsChecked()) {
                 // Since we are appending, start with the existing tags
-                taglinks = TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(refType),
+                gl_a = TagLinkModel::instance().find(
+                    TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
                     TagLinkCol::REFID(trx_n->m_id)
                 );
                 // Remove existing tags from the new list to avoid duplicates
-                for (const auto& link : taglinks)
-                {
-                    auto index = std::find(tagIds.begin(), tagIds.end(), link.TAGID);
-                    if (index != tagIds.end())
-                        tagIds.erase(index);
+                for (const auto& gl_d : gl_a) {
+                    auto index = std::find(tag_id_a.begin(), tag_id_a.end(), gl_d.m_tag_id);
+                    if (index != tag_id_a.end())
+                        tag_id_a.erase(index);
                 }
             }
             // Create new taglinks for each tag ID
-            for (const auto& tagId : tagIds) {
+            for (const auto& tag_id : tag_id_a) {
                 TagLinkData new_gl_d = TagLinkData();
-                new_gl_d.REFTYPE = refType;
-                new_gl_d.REFID   = trx_n->m_id;
-                new_gl_d.TAGID   = tagId;
-                taglinks.push_back(new_gl_d);
+                new_gl_d.m_tag_id   = tag_id;
+                new_gl_d.m_ref_type = TrxModel::s_ref_type;
+                new_gl_d.m_ref_id   = trx_n->m_id;
+                gl_a.push_back(new_gl_d);
             }
             // Update the links for the transaction
-            TagLinkModel::instance().update(taglinks, refType, trx_n->m_id);
+            TagLinkModel::instance().update(
+                TrxModel::s_ref_type, trx_n->m_id,
+                gl_a
+            );
         }
 
         if (m_amount_checkbox->IsChecked()) {

--- a/src/dialog/TrxUpdateDialog.cpp
+++ b/src/dialog/TrxUpdateDialog.cpp
@@ -60,20 +60,22 @@ TrxUpdateDialog::~TrxUpdateDialog()
 // accelerator hints are shown which only occurs once.
 static bool altRefreshDone;
 
-TrxUpdateDialog::TrxUpdateDialog(wxWindow* parent
-    , std::vector<int64>& transaction_id)
-    : m_transaction_id(transaction_id)
+TrxUpdateDialog::TrxUpdateDialog(
+    wxWindow* parent,
+    std::vector<int64>& trx_id_a
+) :
+    m_trx_id_a(trx_id_a)
 {
-    m_currency = CurrencyModel::GetBaseCurrency(); // base currency if we need it
+    m_currency_n = CurrencyModel::GetBaseCurrency(); // base currency if we need it
 
     // Determine the mix of transaction that have been selected
-    for (const auto& id : m_transaction_id) {
-        const TrxData *trx = TrxModel::instance().get_id_data_n(id);
+    for (const auto& trx_id : m_trx_id_a) {
+        const TrxData *trx = TrxModel::instance().get_id_data_n(trx_id);
         const bool isTransfer = TrxModel::is_transfer(*trx);
 
         if (!m_hasSplits) {
             TrxSplitModel::DataA split = TrxSplitModel::instance().find(
-                TrxSplitCol::TRANSID(id)
+                TrxSplitCol::TRANSID(trx_id)
             );
             if (!split.empty())
                 m_hasSplits = true;
@@ -86,18 +88,19 @@ TrxUpdateDialog::TrxUpdateDialog(wxWindow* parent
             m_hasNonTransfers = true;
     }
 
-    m_custom_fields = new mmCustomDataTransaction(this, 0, ID_CUSTOMFIELDS);
+    m_custom_fields = new mmCustomDataTransaction(this, TrxModel::s_ref_type, 0, ID_CUSTOMFIELDS);
 
     this->SetFont(parent->GetFont());
     Create(parent);
 }
 
-bool TrxUpdateDialog::Create(wxWindow* parent
-    , wxWindowID id
-    , const wxString& caption
-    , const wxPoint& pos
-    , const wxSize& size, long style)
-{
+bool TrxUpdateDialog::Create(
+    wxWindow* parent,
+    wxWindowID id,
+    const wxString& caption,
+    const wxPoint& pos,
+    const wxSize& size, long style
+) {
     altRefreshDone = false; // reset the ALT refresh indicator on new dialog creation
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
     wxDialog::Create(parent, id, wxGetTranslation(caption), pos, size, style);
@@ -387,8 +390,8 @@ void TrxUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
     std::vector<int64> skip_trx;
     TrxModel::instance().db_savepoint();
     TagLinkModel::instance().db_savepoint();
-    for (const auto& id : m_transaction_id) {
-        TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(id);
+    for (const auto& trx_id : m_trx_id_a) {
+        TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(trx_id);
         bool is_locked = TrxModel::is_locked(*trx_n);
 
         if (is_locked) {
@@ -522,20 +525,23 @@ void TrxUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             }
         }
 
-        m_custom_fields->UpdateCustomValues(id);
+        m_custom_fields->UpdateCustomValues(TrxModel::s_ref_type, trx_id);
 
         TrxModel::instance().unsafe_save_trx_n(trx_n);
     }
     TagLinkModel::instance().db_release_savepoint();
     TrxModel::instance().db_release_savepoint();
     if (!skip_trx.empty()) {
-        const wxString detail = wxString::Format("%s\n%s: %zu\n%s: %zu"
-                        , _t("This is due to some elements of the transaction or account detail not allowing the update")
-                        , _t("Updated"), m_transaction_id.size() - skip_trx.size()
-                        , _t("Not updated"), skip_trx.size());
-        mmErrorDialogs::MessageWarning(this
-            , detail
-            , _t("Unable to update some transactions."));
+        const wxString detail = wxString::Format("%s\n%s: %zu\n%s: %zu",
+            _t("This is due to some elements of the transaction or account detail not allowing the update"),
+            _t("Updated"),
+            m_trx_id_a.size() - skip_trx.size(),
+            _t("Not updated"), skip_trx.size()
+        );
+        mmErrorDialogs::MessageWarning(this,
+            detail,
+            _t("Unable to update some transactions.")
+        );
     }
     //TODO: enable report to detail transactions that are unable to be updated
 
@@ -544,17 +550,18 @@ void TrxUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
 
 void TrxUpdateDialog::SetPayeeTransferControls()
 {
-    wxStringClientData* trans_obj = static_cast<wxStringClientData*>(m_type_choice->GetClientObject(m_type_choice->GetSelection()));
+    wxStringClientData* trans_obj = static_cast<wxStringClientData*>(
+        m_type_choice->GetClientObject(m_type_choice->GetSelection())
+    );
     bool transfer = (TrxModel::TYPE_NAME_TRANSFER == trans_obj->GetData());
 
     m_payee_checkbox->Enable(!transfer);
     m_transferAcc_checkbox->Enable(transfer);
-    if (transfer)
-    {
+    if (transfer) {
         m_payee_checkbox->SetValue(false);
         cbPayee_->Enable(false);
-    } else
-    {
+    }
+    else {
         m_transferAcc_checkbox->SetValue(false);
         cbAccount_->Enable(false);
     }
@@ -600,17 +607,14 @@ void TrxUpdateDialog::onFocusChange(wxChildFocusEvent& event)
 
     int object_in_focus = -1;
     wxWindow *w = event.GetWindow();
-    if (w)
-    {
+    if (w) {
         object_in_focus = w->GetId();
     }
 
-    if (object_in_focus == m_amount_ctrl->GetId())
-    {
+    if (object_in_focus == m_amount_ctrl->GetId()) {
         m_amount_ctrl->SelectAll();
     }
-    else
-    {
+    else {
         m_amount_ctrl->Calculate();
     }
 
@@ -622,7 +626,12 @@ void TrxUpdateDialog::OnMoreFields(wxCommandEvent& WXUNUSED(event))
     wxBitmapButton* button = static_cast<wxBitmapButton*>(FindWindow(ID_BTN_CUSTOMFIELDS));
 
     if (button)
-        button->SetBitmap(mmBitmapBundle(m_custom_fields->IsCustomPanelShown() ? png::RIGHTARROW : png::LEFTARROW, mmBitmapButtonSize));
+        button->SetBitmap(mmBitmapBundle(
+            m_custom_fields->IsCustomPanelShown()
+                ? png::RIGHTARROW
+                : png::LEFTARROW,
+            mmBitmapButtonSize
+        ));
 
     m_custom_fields->ShowHideCustomPanel();
 
@@ -632,16 +641,13 @@ void TrxUpdateDialog::OnMoreFields(wxCommandEvent& WXUNUSED(event))
 
 void TrxUpdateDialog::OnComboKey(wxKeyEvent& event)
 {
-    if (event.GetKeyCode() == WXK_RETURN)
-    {
+    if (event.GetKeyCode() == WXK_RETURN) {
         auto id = event.GetId();
-        switch (id)
-        {
+        switch (id) {
         case mmID_PAYEE:
         {
             const auto payeeName = cbPayee_->GetValue();
-            if (payeeName.empty())
-            {
+            if (payeeName.empty()) {
                 mmPayeeDialog dlg(this, true);
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
@@ -659,8 +665,7 @@ void TrxUpdateDialog::OnComboKey(wxKeyEvent& event)
         case mmID_CATEGORY:
         {
             auto category = cbCategory_->GetValue();
-            if (category.empty())
-            {
+            if (category.empty()) {
                 CategoryManager dlg(this, true, -1);
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
@@ -679,8 +684,7 @@ void TrxUpdateDialog::OnComboKey(wxKeyEvent& event)
 
     // The first time the ALT key is pressed accelerator hints are drawn, but custom painting on the tags button
     // is not applied. We need to refresh the tag ctrl to redraw the drop button with the correct image.
-    if (event.AltDown() && !altRefreshDone)
-    {
+    if (event.AltDown() && !altRefreshDone) {
         tagTextCtrl_->Refresh();
         altRefreshDone = true;
     }

--- a/src/dialog/TrxUpdateDialog.cpp
+++ b/src/dialog/TrxUpdateDialog.cpp
@@ -671,7 +671,7 @@ void TrxUpdateDialog::OnComboKey(wxKeyEvent& event)
                 dlg.ShowModal();
                 if (dlg.getRefreshRequested())
                     cbCategory_->mmDoReInitialize();
-                category = CategoryModel::full_name(dlg.getCategId());
+                category = CategoryModel::instance().full_name(dlg.getCategId());
                 cbCategory_->ChangeValue(category);
                 cbCategory_->SelectAll();
                 return;

--- a/src/dialog/TrxUpdateDialog.h
+++ b/src/dialog/TrxUpdateDialog.h
@@ -31,58 +31,7 @@ class TrxUpdateDialog : public wxDialog
     wxDECLARE_DYNAMIC_CLASS(TrxUpdateDialog);
     wxDECLARE_EVENT_TABLE();
 
-public:
-    TrxUpdateDialog();
-    ~TrxUpdateDialog();
-    TrxUpdateDialog(wxWindow* parent, std::vector<int64>& transaction_id);
-
 private:
-    bool Create(wxWindow* parent
-        , wxWindowID id = wxID_ANY
-        , const wxString& caption = _n("Multi Transactions Update")
-        , const wxPoint& pos = wxDefaultPosition
-        , const wxSize& size = wxSize(500, 300)
-        , long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX);
-
-    void CreateControls();
-    void OnOk(wxCommandEvent& event);
-    void OnCheckboxClick(wxCommandEvent& event);
-    void OnComboKey(wxKeyEvent& event);
-    void onFocusChange(wxChildFocusEvent& event);
-    void SetPayeeTransferControls();
-    void OnTransTypeChanged(wxCommandEvent&);
-    void OnMoreFields(wxCommandEvent& event);
-
-private:
-    wxCheckBox* m_payee_checkbox = nullptr;
-    mmComboBoxPayee* cbPayee_ = nullptr;
-    wxCheckBox* m_transferAcc_checkbox = nullptr;
-    mmComboBoxAccount* cbAccount_ = nullptr;
-    wxCheckBox* m_date_checkbox = nullptr;
-    mmDatePickerCtrl* m_dpc = nullptr;
-    wxCheckBox* m_time_checkbox = nullptr;
-    wxTimePickerCtrl* m_time_ctrl = nullptr;
-    wxCheckBox* m_status_checkbox = nullptr;
-    wxChoice* m_status_choice = nullptr;
-    wxCheckBox* m_categ_checkbox = nullptr;
-    mmComboBoxCategory* cbCategory_ = nullptr;
-    mmColorButton* bColours_ = nullptr;
-    wxCheckBox* m_color_checkbox = nullptr;
-    wxCheckBox* m_type_checkbox = nullptr;
-    wxCheckBox* tag_checkbox_ = nullptr;
-    wxCheckBox* tag_append_checkbox_ = nullptr;
-    mmTagTextCtrl* tagTextCtrl_ = nullptr;
-    wxChoice* m_type_choice = nullptr;
-    wxCheckBox* m_amount_checkbox = nullptr;
-    mmTextCtrl* m_amount_ctrl = nullptr;
-    wxCheckBox* m_notes_checkbox = nullptr;
-    wxCheckBox* m_append_checkbox = nullptr;
-    wxTextCtrl* m_notes_ctrl = nullptr;
-    std::vector<int64> m_transaction_id;
-    const CurrencyData* m_currency = nullptr;
-    bool m_hasTransfers = false, m_hasNonTransfers = false, m_hasSplits = false;
-    wxSharedPtr<FieldValueDialog> m_custom_fields;
-
     enum
     {
         /* Transaction Dialog */
@@ -92,5 +41,58 @@ private:
         ID_BTN_CUSTOMFIELDS,
         ID_CUSTOMFIELDS,
     };
+
+private:
+    std::vector<int64> m_trx_id_a;
+    const CurrencyData* m_currency_n = nullptr;
+    bool m_hasTransfers = false, m_hasNonTransfers = false, m_hasSplits = false;
+
+    wxSharedPtr<FieldValueDialog> m_custom_fields;
+    wxCheckBox*         m_payee_checkbox       = nullptr;
+    mmComboBoxPayee*    cbPayee_               = nullptr;
+    wxCheckBox*         m_transferAcc_checkbox = nullptr;
+    mmComboBoxAccount*  cbAccount_             = nullptr;
+    wxCheckBox*         m_date_checkbox        = nullptr;
+    mmDatePickerCtrl*   m_dpc                  = nullptr;
+    wxCheckBox*         m_time_checkbox        = nullptr;
+    wxTimePickerCtrl*   m_time_ctrl            = nullptr;
+    wxCheckBox*         m_status_checkbox      = nullptr;
+    wxChoice*           m_status_choice        = nullptr;
+    wxCheckBox*         m_categ_checkbox       = nullptr;
+    mmComboBoxCategory* cbCategory_            = nullptr;
+    mmColorButton*      bColours_              = nullptr;
+    wxCheckBox*         m_color_checkbox       = nullptr;
+    wxCheckBox*         m_type_checkbox        = nullptr;
+    wxCheckBox*         tag_checkbox_          = nullptr;
+    wxCheckBox*         tag_append_checkbox_   = nullptr;
+    mmTagTextCtrl*      tagTextCtrl_           = nullptr;
+    wxChoice*           m_type_choice          = nullptr;
+    wxCheckBox*         m_amount_checkbox      = nullptr;
+    mmTextCtrl*         m_amount_ctrl          = nullptr;
+    wxCheckBox*         m_notes_checkbox       = nullptr;
+    wxCheckBox*         m_append_checkbox      = nullptr;
+    wxTextCtrl*         m_notes_ctrl           = nullptr;
+
+public:
+    TrxUpdateDialog();
+    TrxUpdateDialog(wxWindow* parent, std::vector<int64>& trx_id_a);
+    ~TrxUpdateDialog();
+
+private:
+    bool Create(wxWindow* parent,
+        wxWindowID id = wxID_ANY,
+        const wxString& caption = _n("Multi Transactions Update"),
+        const wxPoint& pos = wxDefaultPosition,
+        const wxSize& size = wxSize(500, 300),
+        long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX
+    );
+    void CreateControls();
+    void OnOk(wxCommandEvent& event);
+    void OnCheckboxClick(wxCommandEvent& event);
+    void OnComboKey(wxKeyEvent& event);
+    void onFocusChange(wxChildFocusEvent& event);
+    void SetPayeeTransferControls();
+    void OnTransTypeChanged(wxCommandEvent&);
+    void OnMoreFields(wxCommandEvent& event);
 };
 

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -47,7 +47,7 @@ const wxString mmExportTransaction::getTransactionCSV(const TrxModel::Full_Data&
     bool is_transfer = TrxModel::is_transfer(full_tran.TRANSCODE);
     const wxString delimiter = InfoModel::instance().getString("DELIMITER", mmex::DEFDELIMTER);
 
-    wxString categ = full_tran.m_splits.empty() ? CategoryModel::full_name(full_tran.m_category_id_n, ":") : "";
+    wxString categ = full_tran.m_splits.empty() ? CategoryModel::instance().full_name(full_tran.m_category_id_n, ":") : "";
     wxString transNum = full_tran.m_number;
     wxString notes = full_tran.m_notes;
     wxString payee = full_tran.PAYEENAME;
@@ -79,7 +79,7 @@ const wxString mmExportTransaction::getTransactionCSV(const TrxModel::Full_Data&
             if (TrxModel::type_id(full_tran) == TrxModel::TYPE_ID_WITHDRAWAL)
                 valueSplit = -valueSplit;
             const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
-            const wxString split_categ = CategoryModel::full_name(tp_d.m_category_id, ":");
+            const wxString split_categ = CategoryModel::instance().full_name(tp_d.m_category_id, ":");
 
             buffer << inQuotes(wxString::Format("%lld", full_tran.m_id), delimiter) << delimiter;
             buffer << inQuotes(mmGetDateTimeForDisplay(full_tran.TRANSDATE, dateMask), delimiter) << delimiter;
@@ -128,7 +128,7 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
     bool transfer = TrxModel::is_transfer(full_tran.TRANSCODE);
 
     wxString buffer = "";
-    wxString categ = full_tran.m_splits.empty() ? CategoryModel::full_name(full_tran.m_category_id_n, ":") : "";
+    wxString categ = full_tran.m_splits.empty() ? CategoryModel::instance().full_name(full_tran.m_category_id_n, ":") : "";
     // Replace square brackets which are used to denote transfers in QIF
     categ.Replace("[", "(");
     categ.Replace("]", ")");
@@ -188,7 +188,7 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
         if (TrxModel::type_id(full_tran) == TrxModel::TYPE_ID_WITHDRAWAL)
             valueSplit = -valueSplit;
         const wxString split_amount = wxString::FromCDouble(valueSplit, 2);
-        wxString split_categ = CategoryModel::full_name(tp_d.m_category_id, ":");
+        wxString split_categ = CategoryModel::instance().full_name(tp_d.m_category_id, ":");
         split_categ.Replace("/", "-");
         TagLinkModel::DataA splitTags = TagLinkModel::instance().find(
             TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
@@ -248,11 +248,10 @@ const wxString mmExportTransaction::getCategoriesQIF()
     wxString buffer_qif = "";
 
     buffer_qif << "!Type:Cat" << "\n";
-    for (const auto& category : CategoryModel::instance().find_all())
-    {
-        const wxString& categ_name = CategoryModel::full_name(category.m_id, ":");
-        bool bIncome = CategoryModel::has_income(category.m_id);
-        buffer_qif << "N" << categ_name << "\n"
+    for (const auto& cat_d : CategoryModel::instance().find_all()) {
+        const wxString& full_name = CategoryModel::instance().full_name(cat_d.m_id, ":");
+        bool bIncome = CategoryModel::instance().has_income(cat_d.m_id);
+        buffer_qif << "N" << full_name << "\n"
             << (bIncome ? "I" : "E") << "\n"
             << "^" << "\n";
     }
@@ -359,7 +358,7 @@ void mmExportTransaction::getCategoriesJSON(PrettyWriter<StringBuffer>& json_wri
         json_writer.Key("ID");
         json_writer.Int64(category.m_id.GetValue());
         json_writer.Key("NAME");
-        json_writer.String(CategoryModel::full_name(category.m_id, ":").utf8_str());
+        json_writer.String(CategoryModel::instance().full_name(category.m_id, ":").utf8_str());
         json_writer.EndObject();
     }
     json_writer.EndArray();
@@ -396,7 +395,7 @@ void mmExportTransaction::getUsedCategoriesJSON(PrettyWriter<StringBuffer>& json
         json_writer.Key("ID");
         json_writer.Int64(category.m_id.GetValue());
         json_writer.Key("NAME");
-        json_writer.String(CategoryModel::full_name(category.m_id, ":").utf8_str());
+        json_writer.String(CategoryModel::instance().full_name(category.m_id, ":").utf8_str());
         json_writer.EndObject();
     }
     json_writer.EndArray();

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -465,7 +465,7 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
                 FieldCol::FIELDID(fv_d.FIELDID)
             );
             for (const auto& field_d : field_a) {
-                json_writer.Int64(field_d.FIELDID.GetValue());
+                json_writer.Int64(field_d.m_id.GetValue());
             }
         }
         json_writer.EndArray();
@@ -547,30 +547,29 @@ void mmExportTransaction::getCustomFieldsJSON(
         }
 
         //Settings
-        FieldModel::DataA custom_fields = FieldModel::instance().find(
+        FieldModel::DataA field_a = FieldModel::instance().find(
             FieldCol::REFTYPE(RefType)
         );
 
-        if (!custom_fields.empty()) {
+        if (!field_a.empty()) {
             json_writer.Key("CUSTOM_FIELDS_SETTINGS");
             json_writer.StartArray();
 
-            for (const auto& entry : custom_fields)
-            {
-                if (std::find(cd.begin(), cd.end(), entry.FIELDID) == cd.end())
+            for (const auto& field_d : field_a) {
+                if (std::find(cd.begin(), cd.end(), field_d.m_id) == cd.end())
                     continue;
 
                 json_writer.StartObject();
                 json_writer.Key("ID");
-                json_writer.Int64(entry.FIELDID.GetValue());
+                json_writer.Int64(field_d.m_id.GetValue());
                 json_writer.Key("REFTYPE");
-                json_writer.String(entry.REFTYPE.utf8_str());
+                json_writer.String(field_d.m_ref_type.name_n().utf8_str());
                 json_writer.Key("DESCRIPTION");
-                json_writer.String(entry.DESCRIPTION.utf8_str());
+                json_writer.String(field_d.m_description.utf8_str());
                 json_writer.Key("TYPE");
-                json_writer.String(entry.TYPE.utf8_str());
+                json_writer.String(field_d.m_type_n.name_n().utf8_str());
                 json_writer.Key("PROPERTIES");
-                json_writer.RawValue(entry.PROPERTIES.utf8_str(), entry.PROPERTIES.utf8_str().length(), rapidjson::Type::kObjectType);
+                json_writer.RawValue(field_d.m_properties.utf8_str(), field_d.m_properties.utf8_str().length(), rapidjson::Type::kObjectType);
                 json_writer.EndObject();
             }
             json_writer.EndArray();

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -440,34 +440,32 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
     }
 
     const wxString RefType = TrxModel::refTypeName;
-    AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(RefType, full_tran.id());
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(RefType), full_tran.id());
 
-    if (!attachments.empty()) {
+    if (!att_a.empty()) {
         //const wxString folder = InfoModel::instance().getString("ATTACHMENTSFOLDER:" + mmPlatformType(), "");
         json_writer.Key("ATTACHMENTS");
         json_writer.StartArray();
-        for (const auto &entry : attachments) {
-            json_writer.Int64(entry.ATTACHMENTID.GetValue());
+        for (const auto& att_d : att_a) {
+            json_writer.Int64(att_d.m_id.GetValue());
         }
         json_writer.EndArray();
     }
 
-    auto data = FieldValueModel::instance().find(
+    auto fv_a = FieldValueModel::instance().find(
         FieldValueCol::REFID(full_tran.id())
     );
     auto f = FieldModel::instance().find(FieldCol::REFTYPE(RefType));
-    if (!data.empty()) {
+    if (!fv_a.empty()) {
         json_writer.Key("CUSTOM_FIELDS");
         json_writer.StartArray();
-        for (const auto &entry : data) {
-
-            auto customFields = FieldModel::instance().find(
+        for (const auto& fv_d : fv_a) {
+            auto field_a = FieldModel::instance().find(
                 FieldCol::REFTYPE(RefType),
-                FieldCol::FIELDID(entry.FIELDID)
+                FieldCol::FIELDID(fv_d.FIELDID)
             );
-
-            for (const auto& i : customFields) {
-                json_writer.Int64(i.FIELDID.GetValue());
+            for (const auto& field_d : field_a) {
+                json_writer.Int64(field_d.FIELDID.GetValue());
             }
         }
         json_writer.EndArray();
@@ -476,48 +474,49 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
     json_writer.EndObject();
 }
 
-void mmExportTransaction::getAttachmentsJSON(PrettyWriter<StringBuffer>& json_writer, wxArrayInt64& allAttachment4Export)
-{
+void mmExportTransaction::getAttachmentsJSON(
+    PrettyWriter<StringBuffer>& json_writer,
+    wxArrayInt64& ref_id_a
+) {
+    if (ref_id_a.empty())
+        return;
 
-    if (!allAttachment4Export.empty())
-    {
-        const wxString RefType = TrxModel::refTypeName;
-        const wxString folder = InfoModel::instance().getString("ATTACHMENTSFOLDER:" + mmPlatformType(), "");
-        const wxString AttachmentsFolder = mmex::getPathAttachment(folder);
+    RefTypeN ref_type = RefTypeN(RefTypeN::e_trx);
+    const wxString folder = InfoModel::instance().getString("ATTACHMENTSFOLDER:" + mmPlatformType(), "");
+    const wxString AttachmentsFolder = mmex::getPathAttachment(folder);
 
-        json_writer.Key("ATTACHMENTS");
+    json_writer.Key("ATTACHMENTS");
+    json_writer.StartObject();
+
+    json_writer.Key("FOLDER");
+    json_writer.String(folder.utf8_str());
+    json_writer.Key("FULL_PATH");
+    json_writer.String(AttachmentsFolder.utf8_str());
+    json_writer.Key("REFTYPE");
+    json_writer.String(ref_type.name_n().utf8_str());
+
+    json_writer.Key("ATTACHMENTS_DATA");
+    json_writer.StartArray();
+
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_all();
+    for (const auto& att_d : att_a) {
+        if (att_d.m_ref_type_n.id_n() != ref_type.id_n())
+            continue;
+        if (std::find(ref_id_a.begin(), ref_id_a.end(), att_d.m_ref_id) == ref_id_a.end())
+            continue;
         json_writer.StartObject();
-
-        json_writer.Key("FOLDER");
-        json_writer.String(folder.utf8_str());
-        json_writer.Key("FULL_PATH");
-        json_writer.String(AttachmentsFolder.utf8_str());
-        json_writer.Key("REFTYPE");
-        json_writer.String(RefType.utf8_str());
-
-        json_writer.Key("ATTACHMENTS_DATA");
-        json_writer.StartArray();
-
-        AttachmentModel::DataA attachments = AttachmentModel::instance().find_all();
-        for (const auto& entry : attachments)
-        {
-            if (entry.REFTYPE != RefType) continue;
-            if (std::find(allAttachment4Export.begin(), allAttachment4Export.end(), entry.REFID) == allAttachment4Export.end()) continue;
-
-            json_writer.StartObject();
-            entry.as_json(json_writer);
-            json_writer.EndObject();
-        }
-        json_writer.EndArray();
+        att_d.as_json(json_writer);
         json_writer.EndObject();
     }
+    json_writer.EndArray();
+    json_writer.EndObject();
 }
 
-void mmExportTransaction::getCustomFieldsJSON(PrettyWriter<StringBuffer>& json_writer, wxArrayInt64& allCustomFields4Export)
-{
-
-    if (!allCustomFields4Export.empty())
-    {
+void mmExportTransaction::getCustomFieldsJSON(
+    PrettyWriter<StringBuffer>& json_writer,
+    wxArrayInt64& allCustomFields4Export
+) {
+    if (!allCustomFields4Export.empty()) {
         const wxString RefType = TrxModel::refTypeName;
 
         json_writer.Key("CUSTOM_FIELDS");

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -183,7 +183,6 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
         buffer << "M" << notes << "\n";
     }
 
-    wxString reftype = TrxSplitModel::refTypeName;
     for (const auto& tp_d : full_tran.m_splits) {
         double valueSplit = tp_d.m_amount;
         if (TrxModel::type_id(full_tran) == TrxModel::TYPE_ID_WITHDRAWAL)
@@ -192,7 +191,7 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
         wxString split_categ = CategoryModel::full_name(tp_d.m_category_id, ":");
         split_categ.Replace("/", "-");
         TagLinkModel::DataA splitTags = TagLinkModel::instance().find(
-            TagLinkCol::REFTYPE(reftype),
+            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
             TagLinkCol::REFID(tp_d.m_id)
         );
         if (!splitTags.empty()) {

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -401,23 +401,25 @@ void mmExportTransaction::getUsedCategoriesJSON(PrettyWriter<StringBuffer>& json
     json_writer.EndArray();
 }
 
-void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_writer, const TrxModel::Full_Data& full_tran)
-{
+void mmExportTransaction::getTransactionJSON(
+    PrettyWriter<StringBuffer>& json_writer,
+    const TrxModel::Full_Data& trx_xd
+) {
     json_writer.StartObject();
-    full_tran.as_json(json_writer);
+    trx_xd.as_json(json_writer);
 
     json_writer.Key("TAGS");
     json_writer.StartArray();
-    for (const auto& tag : full_tran.m_tags)
+    for (const auto& tag : trx_xd.m_tags)
         json_writer.Int64(tag.TAGID.GetValue());
     json_writer.EndArray();
 
-    if (!full_tran.m_splits.empty()) {
+    if (!trx_xd.m_splits.empty()) {
         json_writer.Key("DIVISION");
         json_writer.StartArray();
-        for (const auto& tp_d : full_tran.m_splits) {
+        for (const auto& tp_d : trx_xd.m_splits) {
             double valueSplit = tp_d.m_amount;
-            if (TrxModel::type_id(full_tran) == TrxModel::TYPE_ID_WITHDRAWAL) {
+            if (TrxModel::type_id(trx_xd) == TrxModel::TYPE_ID_WITHDRAWAL) {
                 valueSplit = -valueSplit;
             }
 
@@ -439,8 +441,9 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
         json_writer.EndArray();
     }
 
-    const wxString RefType = TrxModel::refTypeName;
-    AttachmentModel::DataA att_a = AttachmentModel::instance().find_id_data_a(RefTypeN(RefType), full_tran.id());
+    AttachmentModel::DataA att_a = AttachmentModel::instance().find_ref_data_a(
+        TrxModel::s_ref_type, trx_xd.id()
+    );
 
     if (!att_a.empty()) {
         //const wxString folder = InfoModel::instance().getString("ATTACHMENTSFOLDER:" + mmPlatformType(), "");
@@ -453,16 +456,19 @@ void mmExportTransaction::getTransactionJSON(PrettyWriter<StringBuffer>& json_wr
     }
 
     auto fv_a = FieldValueModel::instance().find(
-        FieldValueCol::REFID(full_tran.id())
+        FieldValueModel::REFTYPEID(TrxModel::s_ref_type, trx_xd.id())
     );
-    auto f = FieldModel::instance().find(FieldCol::REFTYPE(RefType));
+    auto f = FieldModel::instance().find(
+        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+    );
     if (!fv_a.empty()) {
         json_writer.Key("CUSTOM_FIELDS");
         json_writer.StartArray();
         for (const auto& fv_d : fv_a) {
+            // TODO: field_d.m_id is equal to fv_d.m_field_id
             auto field_a = FieldModel::instance().find(
-                FieldCol::REFTYPE(RefType),
-                FieldCol::FIELDID(fv_d.FIELDID)
+                FieldCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+                FieldCol::FIELDID(fv_d.m_field_id)
             );
             for (const auto& field_d : field_a) {
                 json_writer.Int64(field_d.m_id.GetValue());
@@ -514,66 +520,66 @@ void mmExportTransaction::getAttachmentsJSON(
 
 void mmExportTransaction::getCustomFieldsJSON(
     PrettyWriter<StringBuffer>& json_writer,
-    wxArrayInt64& allCustomFields4Export
+    wxArrayInt64& fv_id_a
 ) {
-    if (!allCustomFields4Export.empty()) {
-        const wxString RefType = TrxModel::refTypeName;
+    if (fv_id_a.empty())
+        return;
 
-        json_writer.Key("CUSTOM_FIELDS");
-        json_writer.StartObject();
+    json_writer.Key("CUSTOM_FIELDS");
+    json_writer.StartObject();
 
-        // Data
-        wxArrayInt64 cd;
-        FieldValueModel::DataA cds = FieldValueModel::instance().find_all();
+    // Data
+    wxArrayInt64 field_id_a;
+    FieldValueModel::DataA fv_a = FieldValueModel::instance().find_all();
+    if (!fv_a.empty()) {
+        json_writer.Key("CUSTOM_FIELDS_DATA");
+        json_writer.StartArray();
+        for (const auto& fv_d : fv_a) {
+            if (std::find(fv_id_a.begin(), fv_id_a.end(), fv_d.m_id) == fv_id_a.end())
+                continue;
 
-        if (!cds.empty()) {
-            json_writer.Key("CUSTOM_FIELDS_DATA");
-            json_writer.StartArray();
-
-            for (const auto& entry : cds)
-            {
-                if (std::find(allCustomFields4Export.begin(), allCustomFields4Export.end(), entry.FIELDATADID) != allCustomFields4Export.end())
-                {
-                    if (std::find(cd.begin(), cd.end(), entry.FIELDID) == cd.end())
-                    {
-                        cd.push_back(entry.FIELDID);
-                    }
-                    json_writer.StartObject();
-                    entry.as_json(json_writer);
-                    json_writer.EndObject();
-                }
+            if (std::find(
+                field_id_a.begin(), field_id_a.end(), fv_d.m_field_id
+            ) == field_id_a.end()) {
+                field_id_a.push_back(fv_d.m_field_id);
             }
-            json_writer.EndArray();
-        }
-
-        //Settings
-        FieldModel::DataA field_a = FieldModel::instance().find(
-            FieldCol::REFTYPE(RefType)
-        );
-
-        if (!field_a.empty()) {
-            json_writer.Key("CUSTOM_FIELDS_SETTINGS");
-            json_writer.StartArray();
-
-            for (const auto& field_d : field_a) {
-                if (std::find(cd.begin(), cd.end(), field_d.m_id) == cd.end())
-                    continue;
-
-                json_writer.StartObject();
-                json_writer.Key("ID");
-                json_writer.Int64(field_d.m_id.GetValue());
-                json_writer.Key("REFTYPE");
-                json_writer.String(field_d.m_ref_type.name_n().utf8_str());
-                json_writer.Key("DESCRIPTION");
-                json_writer.String(field_d.m_description.utf8_str());
-                json_writer.Key("TYPE");
-                json_writer.String(field_d.m_type_n.name_n().utf8_str());
-                json_writer.Key("PROPERTIES");
-                json_writer.RawValue(field_d.m_properties.utf8_str(), field_d.m_properties.utf8_str().length(), rapidjson::Type::kObjectType);
-                json_writer.EndObject();
-            }
-            json_writer.EndArray();
+            json_writer.StartObject();
+            fv_d.as_json(json_writer);
             json_writer.EndObject();
         }
+        json_writer.EndArray();
+    }
+
+    //Settings
+    FieldModel::DataA field_a = FieldModel::instance().find(
+        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+    );
+
+    if (!field_a.empty()) {
+        json_writer.Key("CUSTOM_FIELDS_SETTINGS");
+        json_writer.StartArray();
+
+        for (const auto& field_d : field_a) {
+            if (std::find(
+                field_id_a.begin(), field_id_a.end(), field_d.m_id
+            ) == field_id_a.end()) {
+                continue;
+            }
+
+            json_writer.StartObject();
+            json_writer.Key("ID");
+            json_writer.Int64(field_d.m_id.GetValue());
+            json_writer.Key("REFTYPE");
+            json_writer.String(field_d.m_ref_type.name_n().utf8_str());
+            json_writer.Key("DESCRIPTION");
+            json_writer.String(field_d.m_description.utf8_str());
+            json_writer.Key("TYPE");
+            json_writer.String(field_d.m_type_n.name_n().utf8_str());
+            json_writer.Key("PROPERTIES");
+            json_writer.RawValue(field_d.m_properties.utf8_str(), field_d.m_properties.utf8_str().length(), rapidjson::Type::kObjectType);
+            json_writer.EndObject();
+        }
+        json_writer.EndArray();
+        json_writer.EndObject();
     }
 }

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -155,12 +155,13 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
 
     // don't allow '/' in category name as it is reserved for the class/tag separator
     categ.Replace("/", "-");
-    if (!full_tran.m_tags.empty())
-    {
+    if (!full_tran.m_tags.empty()) {
         categ.Append("/");
         auto numTags = full_tran.m_tags.size();
-        for (decltype(numTags) i = 0; i < numTags; i++)
-            categ.Append((i > 0 ? ":" : "") + TagModel::instance().get_id_data_n(full_tran.m_tags[i].TAGID)->m_name);
+        for (decltype(numTags) i = 0; i < numTags; i++) {
+            const TagData* tag_n = TagModel::instance().get_id_data_n(full_tran.m_tags[i].m_tag_id);
+            categ.Append((i > 0 ? ":" : "") + tag_n->m_name);
+        }
     }
 
     buffer << "D" << mmGetDateTimeForDisplay(full_tran.TRANSDATE, dateMask) << "\n";
@@ -198,7 +199,8 @@ const wxString mmExportTransaction::getTransactionQIF(const TrxModel::Full_Data&
             split_categ.Append("/");
             auto numTags = splitTags.size();
             for (decltype(numTags) i = 0; i < numTags; i++) {
-                split_categ.Append((i > 0 ? ":" : "") + TagModel::instance().get_id_data_n(splitTags[i].TAGID)->m_name);
+                const TagData* tag_n = TagModel::instance().get_id_data_n(splitTags[i].m_tag_id);
+                split_categ.Append((i > 0 ? ":" : "") + tag_n->m_name);
             }
         }
         buffer << "S" << split_categ << "\n"
@@ -410,8 +412,8 @@ void mmExportTransaction::getTransactionJSON(
 
     json_writer.Key("TAGS");
     json_writer.StartArray();
-    for (const auto& tag : trx_xd.m_tags)
-        json_writer.Int64(tag.TAGID.GetValue());
+    for (const auto& gl_d : trx_xd.m_tags)
+        json_writer.Int64(gl_d.m_tag_id.GetValue());
     json_writer.EndArray();
 
     if (!trx_xd.m_splits.empty()) {
@@ -430,8 +432,8 @@ void mmExportTransaction::getTransactionJSON(
             json_writer.Double(valueSplit);
             json_writer.Key("TAGS");
             json_writer.StartArray();
-            for (const auto& tag : TagLinkModel::instance().get_ref(
-                TrxSplitModel::refTypeName, tp_d.m_id)
+            for (const auto& tag : TagLinkModel::instance().find_ref_tag_m(
+                TrxSplitModel::s_ref_type, tp_d.m_id)
             )
                 json_writer.Int64(tag.second.GetValue());
             json_writer.EndArray();

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -487,7 +487,7 @@ void mmQIFExportDialog::mmExportQIF()
             , 100, this, wxPD_APP_MODAL | wxPD_CAN_ABORT);
 
         const auto splits = TrxSplitModel::instance().get_all_id();
-        const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(
             TrxModel::s_ref_type
         );
 
@@ -518,7 +518,7 @@ void mmQIFExportDialog::mmExportQIF()
 
             bool is_reverce = false;
             wxString trx_str;
-            TrxModel::Full_Data full_tran(trx_d, splits, tags);
+            TrxModel::Full_Data full_tran(trx_d, splits, trxId_glA_m);
             int64 account_id = trx_d.m_account_id;
 
             switch (m_type)

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -438,7 +438,9 @@ void mmQIFExportDialog::mmExportQIF()
     wxString sErrorMsg;
     size_t numRecords = 0, numCategories = 0;
 
-    wxStringClientData* data_obj = static_cast<wxStringClientData*>(m_choiceDateFormat->GetClientObject(m_choiceDateFormat->GetSelection()));
+    wxStringClientData* data_obj = static_cast<wxStringClientData*>(
+        m_choiceDateFormat->GetClientObject(m_choiceDateFormat->GetSelection())
+    );
     const wxString dateMask = data_obj->GetData();
 
     wxString buffer;
@@ -467,15 +469,14 @@ void mmQIFExportDialog::mmExportQIF()
 
     std::map<int64 /*account ID*/, wxString> allAccounts4Export;
     wxArrayInt64 allPayees4Export;
-    const wxString RefType = TrxModel::refTypeName;
     wxArrayInt64 allAttachments4Export;
     wxArrayInt64 allCustomFields4Export;
     wxArrayInt64 allTags4Export;
-    const auto transactions = TrxModel::instance().find(
-        TrxModel::STATUS(OP_NE, TrxModel::STATUS_ID_VOID));
+    const auto trx_a = TrxModel::instance().find(
+        TrxModel::STATUS(OP_NE, TrxModel::STATUS_ID_VOID)
+    );
 
-    if (exp_transactions && !transactions.empty())
-    {
+    if (exp_transactions && !trx_a.empty()) {
         json_writer.Key("transactions");
         json_writer.StartArray();
 
@@ -491,21 +492,21 @@ void mmQIFExportDialog::mmExportQIF()
         const wxString begin_date = fromDateCtrl_->GetValue().FormatISODate();
         const wxString end_date = toDateCtrl_->GetValue().FormatISODate();
 
-        for (const auto& transaction : transactions)
-        {
-            if (!transaction.DELETEDTIME.IsEmpty()) continue;
-            wxString strDate = TrxModel::getTransDateTime(transaction).FormatISODate();
+        for (const auto& trx_d : trx_a) {
+            if (!trx_d.DELETEDTIME.IsEmpty())
+                continue;
+            wxString strDate = TrxModel::getTransDateTime(trx_d).FormatISODate();
             //Filtering
             if (dateFromCheckBox_->IsChecked() && strDate < begin_date)
                 continue;
             if (dateToCheckBox_->IsChecked() && strDate > end_date)
                 continue;
-            if (!TrxModel::is_transfer(transaction.TRANSCODE)
-                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), transaction.m_account_id) == selected_accounts_id_.end()))
+            if (!TrxModel::is_transfer(trx_d.TRANSCODE)
+                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), trx_d.m_account_id) == selected_accounts_id_.end()))
                 continue;
-            if (TrxModel::is_transfer(transaction.TRANSCODE)
-                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), transaction.m_account_id) == selected_accounts_id_.end())
-                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), transaction.m_to_account_id_n) == selected_accounts_id_.end()))
+            if (TrxModel::is_transfer(trx_d.TRANSCODE)
+                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), trx_d.m_account_id) == selected_accounts_id_.end())
+                && (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), trx_d.m_to_account_id_n) == selected_accounts_id_.end()))
                 continue;
             //
 
@@ -515,8 +516,8 @@ void mmQIFExportDialog::mmExportQIF()
 
             bool is_reverce = false;
             wxString trx_str;
-            TrxModel::Full_Data full_tran(transaction, splits, tags);
-            int64 account_id = transaction.m_account_id;
+            TrxModel::Full_Data full_tran(trx_d, splits, tags);
+            int64 account_id = trx_d.m_account_id;
 
             switch (m_type)
             {
@@ -528,23 +529,31 @@ void mmQIFExportDialog::mmExportQIF()
                     allPayees4Export.push_back(full_tran.m_payee_id_n);
                 }
 
-                if (!AttachmentModel::instance().find_id_data_a(RefTypeN(RefType), full_tran.id()).empty()
-                    && std::find(allAttachments4Export.begin(), allAttachments4Export.end(), full_tran.m_id) == allAttachments4Export.end()) {
+                if (
+                    !AttachmentModel::instance().find_ref_data_a(
+                        TrxModel::s_ref_type, full_tran.id()
+                    ).empty() &&
+                    std::find(
+                        allAttachments4Export.begin(), allAttachments4Export.end(), full_tran.m_id
+                    ) == allAttachments4Export.end()
+                ) {
                     allAttachments4Export.push_back(full_tran.m_id);
                 }
 
-                for (const auto & entry : FieldValueModel::instance().find(
-                    FieldValueCol::REFID(full_tran.id())
+                for (const auto & fv_d : FieldValueModel::instance().find(
+                    FieldValueModel::REFTYPEID(TrxModel::s_ref_type, full_tran.id())
                 )) {
-                    if (std::find(allCustomFields4Export.begin(), allCustomFields4Export.end(), entry.FIELDATADID) == allCustomFields4Export.end()) {
-                        allCustomFields4Export.push_back(entry.FIELDATADID);
+                    if (std::find(allCustomFields4Export.begin(), allCustomFields4Export.end(),
+                        fv_d.m_id) == allCustomFields4Export.end()
+                    ) {
+                        allCustomFields4Export.push_back(fv_d.m_id);
                     }
                 }
 
                 // store tags from the transaction
-                for (const auto& tag : full_tran.m_tags) {
-                    if (std::find(allTags4Export.begin(), allTags4Export.end(), tag.TAGID) == allTags4Export.end())
-                        allTags4Export.push_back(tag.TAGID);
+                for (const auto& tag_d : full_tran.m_tags) {
+                    if (std::find(allTags4Export.begin(), allTags4Export.end(), tag_d.TAGID) == allTags4Export.end())
+                        allTags4Export.push_back(tag_d.TAGID);
                 }
                 // store tags from the splits
                 for (const auto& tp_d : full_tran.m_splits) {
@@ -560,16 +569,17 @@ void mmQIFExportDialog::mmExportQIF()
 
             case QIF:
 
-                if (TrxModel::is_transfer(transaction.TRANSCODE))
-                {
-                    if (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), transaction.m_account_id) == selected_accounts_id_.end()) {
+                if (TrxModel::is_transfer(trx_d.TRANSCODE)) {
+                    if (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(),
+                        trx_d.m_account_id) == selected_accounts_id_.end()
+                    ) {
                         is_reverce = true;
-                        account_id = transaction.m_to_account_id_n;
+                        account_id = trx_d.m_to_account_id_n;
                     }
 
-                    if (transaction.m_amount != transaction.m_to_amount) {
+                    if (trx_d.m_amount != trx_d.m_to_amount) {
                         const auto trx2_str = mmExportTransaction::getTransactionQIF(full_tran, dateMask, !is_reverce);
-                        extraTransfers[is_reverce ? transaction.m_account_id : transaction.m_to_account_id_n] += trx2_str;
+                        extraTransfers[is_reverce ? trx_d.m_account_id : trx_d.m_to_account_id_n] += trx2_str;
                     }
                 }
 
@@ -579,14 +589,13 @@ void mmQIFExportDialog::mmExportQIF()
 
             case CSV:
 
-                if (TrxModel::is_transfer(transaction.TRANSCODE))
-                {
-                    if (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), transaction.m_account_id) == selected_accounts_id_.end()) {
+                if (TrxModel::is_transfer(trx_d.TRANSCODE)) {
+                    if (std::find(selected_accounts_id_.begin(), selected_accounts_id_.end(), trx_d.m_account_id) == selected_accounts_id_.end()) {
                         is_reverce = true;
-                        account_id = transaction.m_to_account_id_n;
+                        account_id = trx_d.m_to_account_id_n;
                     }
                     const auto trx2_str = mmExportTransaction::getTransactionCSV(full_tran, dateMask, !is_reverce);
-                    extraTransfers[is_reverce ? transaction.m_account_id : transaction.m_to_account_id_n] += trx2_str;
+                    extraTransfers[is_reverce ? trx_d.m_account_id : trx_d.m_to_account_id_n] += trx2_str;
                 }
 
                 trx_str = mmExportTransaction::getTransactionCSV(full_tran, dateMask, is_reverce);
@@ -657,8 +666,7 @@ void mmQIFExportDialog::mmExportQIF()
         break;
     }
 
-    if (write_to_file)
-    {
+    if (write_to_file) {
         wxFileOutputStream output(fileName);
         wxTextOutputStream text(output);
         text << buffer;
@@ -672,12 +680,21 @@ void mmQIFExportDialog::mmExportQIF()
 
     wxString msg = "";
     if (numCategories > 0) {
-        msg += wxString::Format(_t("Number of categories exported: %zu \n"), numCategories);
+        msg += wxString::Format(_t("Number of categories exported: %zu \n"),
+            numCategories
+        );
     }
-    msg += wxString::Format(_t("Number of transactions exported: %zu \n"), numRecords);
-    msg += wxString::Format(_t("Number of accounts exported: %zu"), allAccounts4Export.size());
+    msg += wxString::Format(_t("Number of transactions exported: %zu \n"),
+        numRecords
+    );
+    msg += wxString::Format(_t("Number of accounts exported: %zu"),
+        allAccounts4Export.size()
+    );
 
-    wxMessageDialog msgDlg(this, msg, _t("Export as QIF file"), wxOK | wxICON_INFORMATION);
+    wxMessageDialog msgDlg(this, msg,
+        _t("Export as QIF file"),
+        wxOK | wxICON_INFORMATION
+    );
 
     msgDlg.ShowModal();
 }

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -528,7 +528,7 @@ void mmQIFExportDialog::mmExportQIF()
                     allPayees4Export.push_back(full_tran.m_payee_id_n);
                 }
 
-                if (!AttachmentModel::instance().FilterAttachments(RefType, full_tran.id()).empty()
+                if (!AttachmentModel::instance().find_id_data_a(RefTypeN(RefType), full_tran.id()).empty()
                     && std::find(allAttachments4Export.begin(), allAttachments4Export.end(), full_tran.m_id) == allAttachments4Export.end()) {
                     allAttachments4Export.push_back(full_tran.m_id);
                 }

--- a/src/import_export/qif_export.cpp
+++ b/src/import_export/qif_export.cpp
@@ -487,7 +487,9 @@ void mmQIFExportDialog::mmExportQIF()
             , 100, this, wxPD_APP_MODAL | wxPD_CAN_ABORT);
 
         const auto splits = TrxSplitModel::instance().get_all_id();
-        const auto tags = TagLinkModel::instance().get_all_id(TrxModel::refTypeName);
+        const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+            TrxModel::s_ref_type
+        );
 
         const wxString begin_date = fromDateCtrl_->GetValue().FormatISODate();
         const wxString end_date = toDateCtrl_->GetValue().FormatISODate();
@@ -551,14 +553,14 @@ void mmQIFExportDialog::mmExportQIF()
                 }
 
                 // store tags from the transaction
-                for (const auto& tag_d : full_tran.m_tags) {
-                    if (std::find(allTags4Export.begin(), allTags4Export.end(), tag_d.TAGID) == allTags4Export.end())
-                        allTags4Export.push_back(tag_d.TAGID);
+                for (const auto& gl_d : full_tran.m_tags) {
+                    if (std::find(allTags4Export.begin(), allTags4Export.end(), gl_d.m_tag_id) == allTags4Export.end())
+                        allTags4Export.push_back(gl_d.m_tag_id);
                 }
                 // store tags from the splits
                 for (const auto& tp_d : full_tran.m_splits) {
-                    for (const auto& gl_d : TagLinkModel::instance().get_ref(
-                        TrxSplitModel::refTypeName, tp_d.m_id
+                    for (const auto& gl_d : TagLinkModel::instance().find_ref_tag_m(
+                        TrxSplitModel::s_ref_type, tp_d.m_id
                     )) {
                         if (std::find(allTags4Export.begin(), allTags4Export.end(), gl_d.second) == allTags4Export.end())
                             allTags4Export.push_back(gl_d.second);

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -855,7 +855,7 @@ void mmQIFImportDialog::refreshTabs(int tabs)
 
     if (tabs & CAT_TAB) {
         num = 0;
-        const auto& c(CategoryModel::all_categories());
+        const auto& c(CategoryModel::instance().all_categories());
         categoryListBox_->DeleteAllItems();
         for (const auto& categ : m_QIFcategoryNames) {
             wxVector<wxVariant> data;
@@ -899,7 +899,7 @@ void mmQIFImportDialog::OnShowCategDialog(wxMouseEvent&)
         wxString selectedCategname = value.GetString();
         id = m_QIFcategoryNames[selectedCategname];
         if (id == -1) {
-            std::map<wxString, int64 > categories = CategoryModel::all_categories();
+            std::map<wxString, int64 > categories = CategoryModel::instance().all_categories();
             for (const auto& category : categories)
             {
                 if (category.first.CmpNoCase(selectedCategname) <= 0) id = category.second;
@@ -1561,7 +1561,7 @@ bool mmQIFImportDialog::completeTransaction(
             if (payee_n) {
                 trx_n->m_category_id_n = payee_n->m_category_id_n;
             }
-            categStr = CategoryModel::full_name(trx_n->m_category_id_n, ":");
+            categStr = CategoryModel::instance().full_name(trx_n->m_category_id_n, ":");
 
             if (categStr.empty()) {
                 trx_n->m_category_id_n = (m_QIFcategoryNames[_t("Unknown")]);
@@ -1731,24 +1731,26 @@ void mmQIFImportDialog::getOrCreatePayees()
 void mmQIFImportDialog::getOrCreateCategories()
 {
     wxArrayString temp;
-    for (const auto &item : m_QIFcategoryNames) {
+    for (const auto& item : m_QIFcategoryNames) {
         wxString categStr;
         wxStringTokenizer token(item.first, ":");
         int64 parentID = -1;
         while(token.HasMoreTokens()){
             categStr = token.GetNextToken().Trim(false).Trim();
-            const CategoryData* category_n = CategoryModel::instance().get_key(categStr, parentID);
+            const CategoryData* cat_n = CategoryModel::instance().get_key_data_n(
+                categStr, parentID
+            );
             if (temp.Index(categStr + wxString::Format(":%lld", parentID)) == wxNOT_FOUND) {
-                if (!category_n) {
-                    CategoryData new_category_d = CategoryData();
-                    new_category_d.m_name        = categStr;
-                    new_category_d.m_parent_id_n = parentID;
-                    CategoryModel::instance().add_data_n(new_category_d);
-                    category_n = CategoryModel::instance().get_id_data_n(new_category_d.id());
+                if (!cat_n) {
+                    CategoryData new_cat_d = CategoryData();
+                    new_cat_d.m_name        = categStr;
+                    new_cat_d.m_parent_id_n = parentID;
+                    CategoryModel::instance().add_data_n(new_cat_d);
+                    cat_n = CategoryModel::instance().get_id_data_n(new_cat_d.id());
                 }
                 temp.Add(categStr + wxString::Format(":%lld", parentID));
             }
-            parentID = category_n->m_id;
+            parentID = cat_n->m_id;
         }
         m_QIFcategoryNames[item.first] = parentID;
     }
@@ -1756,17 +1758,16 @@ void mmQIFImportDialog::getOrCreateCategories()
 
 int64 mmQIFImportDialog::get_last_imported_acc()
 {
-    int64 accID = -1;
-    const AccountData* acc = AccountModel::instance().get_name_data_n(m_accountNameStr);
-    if (acc)
-        accID = acc->m_id;
-    return accID;
+    const AccountData* account_n = AccountModel::instance().get_name_data_n(m_accountNameStr);
+    return account_n ? account_n->m_id : -1;
 }
 
 void mmQIFImportDialog::OnDecimalChange(wxCommandEvent& event)
 {
     int i = m_choiceDecimalSeparator->GetSelection();
-    wxStringClientData* type_obj = static_cast<wxStringClientData*>(m_choiceDecimalSeparator->GetClientObject(i));
+    wxStringClientData* type_obj = static_cast<wxStringClientData*>(
+        m_choiceDecimalSeparator->GetClientObject(i)
+    );
     if (type_obj) {
         decimal_ = type_obj->GetData();
     }

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1167,7 +1167,6 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
                 wxString tagStr = (entry.find(QIF_ID_Category) != entry.end() ? entry.at(QIF_ID_Category).AfterFirst('/') : "");
                 TagLinkModel::DataA gl_a;
                 if (!tagStr.IsEmpty()) {
-                    wxString reftype = TrxModel::refTypeName;
                     wxStringTokenizer tagTokens = wxStringTokenizer(tagStr, ":");
                     while (tagTokens.HasMoreTokens()) {
                         wxString tagname = tagTokens.GetNextToken().Trim(false).Trim();
@@ -1181,8 +1180,8 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
                             tag_n = TagModel::instance().get_id_data_n(new_tag_d.id());
                         }
                         TagLinkData gl_d = TagLinkData();
-                        gl_d.REFTYPE = reftype;
-                        gl_d.TAGID = tag_n->m_id;
+                        gl_d.m_tag_id   = tag_n->m_id;
+                        gl_d.m_ref_type = TrxModel::s_ref_type;
                         // Just cache the new taglink since we don't know the m_id yet
                         gl_a.push_back(gl_d);
                     }
@@ -1246,10 +1245,9 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             if (!m_txnTaglinks[std::make_pair(0, i)].empty()) {
                 // we need to know the transid for the taglink, so save the transaction first
                 TrxModel::instance().save_trx_n(trx_a[i]);
-                int64 transid = trx_a[i].id();
                 // apply that transid to all associated tags
-                for (auto& taglink : m_txnTaglinks[std::make_pair(0, i)])
-                    taglink.REFID = transid;
+                for (auto& gl_d : m_txnTaglinks[std::make_pair(0, i)])
+                    gl_d.m_ref_id = trx_a[i].m_id;
                 // save the block of taglinks
                 TagLinkModel::instance().save_data_a(m_txnTaglinks[std::make_pair(0, i)]);
             }
@@ -1296,8 +1294,8 @@ void mmQIFImportDialog::saveSplit()
             // check if there are any taglinks for this split index in this group
             if (!m_splitTaglinks[i][j].empty()) {
                 // apply the SPLITTRANSID as the REFID for all the cached taglinks
-                for (auto& taglink : m_splitTaglinks[i][j])
-                    taglink.REFID = splitTransID;
+                for (auto& gl_d : m_splitTaglinks[i][j])
+                    gl_d.m_ref_id = splitTransID;
                 // save cached taglinks
                 TagLinkModel::instance().save_data_a(m_splitTaglinks[i][j]);
             }
@@ -1526,7 +1524,6 @@ bool mmQIFImportDialog::completeTransaction(
             // Save split tags
             if (!tagStr.IsEmpty()) {
                 TagLinkModel::DataA splitTaglinks;
-                wxString reftype = TrxSplitModel::refTypeName;
                 wxStringTokenizer tagTokens = wxStringTokenizer(tagStr, ":");
                 while (tagTokens.HasMoreTokens()) {
                     wxString tagname = tagTokens.GetNextToken().Trim(false).Trim();
@@ -1540,8 +1537,8 @@ bool mmQIFImportDialog::completeTransaction(
                         tag_n = TagModel::instance().get_id_data_n(new_tag_d.id());
                     }
                     TagLinkData gl_d = TagLinkData();
-                    gl_d.REFTYPE = reftype;
-                    gl_d.TAGID   = tag_n->m_id;
+                    gl_d.m_tag_id   = tag_n->m_id;
+                    gl_d.m_ref_type = TrxSplitModel::s_ref_type;
                     splitTaglinks.push_back(gl_d);
                 }
                 // Here we keep track of which block of splits and which split in the block

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -1172,7 +1172,7 @@ void mmQIFImportDialog::OnOk(wxCommandEvent& WXUNUSED(event))
                         wxString tagname = tagTokens.GetNextToken().Trim(false).Trim();
                         // make tag names single-word
                         tagname.Replace(" ", "_");
-                        const TagData* tag_n = TagModel::instance().get_key(tagname);
+                        const TagData* tag_n = TagModel::instance().get_name_data_n(tagname);
                         if (!tag_n) {
                             TagData new_tag_d = TagData();
                             new_tag_d.m_name = tagname;
@@ -1529,7 +1529,7 @@ bool mmQIFImportDialog::completeTransaction(
                     wxString tagname = tagTokens.GetNextToken().Trim(false).Trim();
                     // make tag names single-word
                     tagname.Replace(" ", "_");
-                    const TagData* tag_n = TagModel::instance().get_key(tagname);
+                    const TagData* tag_n = TagModel::instance().get_name_data_n(tagname);
                     if (!tag_n) {
                         TagData new_tag_d = TagData();
                         new_tag_d.m_name = tagname;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -304,7 +304,7 @@ void mmUnivCSVDialog::CreateControls()
 
     //Custom Fields
     FieldModel::DataA field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::refTypeName)
+        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
     );
     if (!field_a.empty()) {
         std::sort(field_a.begin(), field_a.end(), FieldData::SorterByDESCRIPTION());
@@ -2854,15 +2854,14 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
     {
         // split the tag string at space characters
         wxStringTokenizer tokenizer = wxStringTokenizer(token, " ");
-        while (tokenizer.HasMoreTokens())
-        {
-            wxString tagname = tokenizer.GetNextToken();
+        while (tokenizer.HasMoreTokens()) {
+            wxString tag_name = tokenizer.GetNextToken();
             // check for an existing tag
-            const TagData* tag_n = TagModel::instance().get_key(tagname);
+            const TagData* tag_n = TagModel::instance().get_name_data_n(tag_name);
             if (!tag_n) {
                 // create a new tag if we didn't find one
                 TagData new_tag_d = TagData();
-                new_tag_d.m_name = tagname;
+                new_tag_d.m_name = tag_name;
                 TagModel::instance().save_data_n(new_tag_d);
                 tag_n = TagModel::instance().get_id_data_n(new_tag_d.id());
             }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -303,19 +303,19 @@ void mmUnivCSVDialog::CreateControls()
         csvFieldCandicate_->Append(wxGetTranslation(it.second.first), new mmListBoxItem(it.first, it.second.first));
 
     //Custom Fields
-    FieldModel::DataA fields = FieldModel::instance().find(
+    FieldModel::DataA field_a = FieldModel::instance().find(
         FieldCol::REFTYPE(TrxModel::refTypeName)
     );
-    if (!fields.empty()) {
-        std::sort(fields.begin(), fields.end(), FieldData::SorterByDESCRIPTION());
+    if (!field_a.empty()) {
+        std::sort(field_a.begin(), field_a.end(), FieldData::SorterByDESCRIPTION());
         int customField = 1;    // Start of custom fields numbering
-        for (const FieldData& entry : fields) {
+        for (const FieldData& field_d : field_a) {
             // Can't use an enum for the field index since there can be infinite custom fields
             // Instead we offset the last enum by a custom field offset and store the custom field id
             int csvField = UNIV_CSV_LAST + customField;
-            CSVFieldName_[csvField].first = entry.DESCRIPTION;
-            CSVFieldName_[csvField].second = entry.FIELDID.GetValue();
-            csvFieldCandicate_->Append(entry.DESCRIPTION, new mmListBoxItem(csvField, entry.DESCRIPTION));
+            CSVFieldName_[csvField].first = field_d.m_description;
+            CSVFieldName_[csvField].second = field_d.m_id.GetValue();
+            csvFieldCandicate_->Append(field_d.m_description, new mmListBoxItem(csvField, field_d.m_description));
             customField++;
         }
     }
@@ -3134,16 +3134,15 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
     const wxArrayString bool_false_array(4, bool_false);
 
     if (!value.IsEmpty()) {
-        const FieldData* data = FieldModel::instance().get_id_data_n(fieldId);
-        wxString type_string = FieldModel::type_name(FieldModel::type_id(data));
-        switch (FieldModel::type_id(data))
+        const FieldData* field_n = FieldModel::instance().get_id_data_n(fieldId);
+        wxString type_string = FieldModel::type_name(FieldModel::type_id(field_n));
+        switch (FieldModel::type_id(field_n))
         {
             // Check if string can be read as an integer. Will fail if passed a double.
         case FieldModel::TYPE_ID_INTEGER:
             value = cleanseNumberString(value, true);
-            if (!value.ToCLong(&int_val))
-            {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string);
+            if (!value.ToCLong(&int_val)) {
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
                 is_valid = false;
             }
             else value = wxString::Format("%i", int_val);
@@ -3154,13 +3153,13 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
             value = cleanseNumberString(value, true);
             if (!value.ToCDouble(&double_val))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string);
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
                 is_valid = false;
             }
             else
             {
                 // round to required precision
-                int precision = FieldModel::getDigitScale(data->PROPERTIES);
+                int precision = FieldModel::getDigitScale(field_n->m_properties);
                 value = wxString::Format("%.*f", precision, double_val);
             }
             break;
@@ -3170,7 +3169,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
             if (bool_true_array.Index(value, false) == wxNOT_FOUND)
                 if (bool_false_array.Index(value, false) == wxNOT_FOUND)
                 {
-                    message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string);
+                    message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
                     is_valid = false;
                 }
                 else value = "FALSE";
@@ -3179,11 +3178,11 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
 
             // Check if string is a valid choice (case insensitive)
         case FieldModel::TYPE_ID_SINGLECHOICE:
-            choices = FieldModel::getChoices(data->PROPERTIES);
+            choices = FieldModel::getChoices(field_n->m_properties);
             index = choices.Index(value, false);
             if (index == wxNOT_FOUND)
             {
-                message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), value, type_string, data->DESCRIPTION);
+                message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), value, type_string, field_n->m_description);
                 is_valid = false;
             }
             else value = choices[index];
@@ -3191,7 +3190,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
 
             // Check if all of the ';' delimited strings are valid choices (case insensitive)
         case FieldModel::TYPE_ID_MULTICHOICE:
-            choices = FieldModel::getChoices(data->PROPERTIES);
+            choices = FieldModel::getChoices(field_n->m_properties);
             tokenizer = wxStringTokenizer(value, ";");
             value.Clear();
             while (tokenizer.HasMoreTokens())
@@ -3204,7 +3203,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
                     if (tokenizer.HasMoreTokens()) value.Append(";");
                 }
                 else {
-                    message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), token, type_string, data->DESCRIPTION);
+                    message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), token, type_string, field_n->m_description);
                     is_valid = false;
                 }
             }
@@ -3214,7 +3213,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
         case FieldModel::TYPE_ID_DATE:
             if (!mmParseDisplayStringToDate(date, value, date_format_))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string) <<
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string) <<
                     " " << wxString::Format(_t("Confirm format matches selection %s."), date_format_);
                 is_valid = false;
             }
@@ -3225,7 +3224,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
         case FieldModel::TYPE_ID_TIME:
             if (!time.ParseTime(value))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, data->DESCRIPTION, type_string);
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
                 is_valid = false;
             }
             else value = time.FormatISOTime();
@@ -3235,14 +3234,14 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
         }
 
         // if regex check is enabled, perform regex validation
-        const wxString regExStr = FieldModel::getRegEx(data->PROPERTIES);
+        const wxString regExStr = FieldModel::getRegEx(field_n->m_properties);
         if (!regExStr.empty())
         {
             wxRegEx regEx(regExStr, wxRE_EXTENDED);
 
             if (!regEx.Matches(value))
             {
-                message << " " << wxString::Format(_t("Value %1$s does not match regex %2$s for custom field '%3$s'."), value, regExStr, data->DESCRIPTION);
+                message << " " << wxString::Format(_t("Value %1$s does not match regex %2$s for custom field '%3$s'."), value, regExStr, field_n->m_description);
                 is_valid = false;
             }
         }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1458,9 +1458,7 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& WXUNUSED(event))
     m_reverce_sign = m_choiceAmountFieldSign->GetCurrentSelection() == PositiveIsWithdrawal;
     // A place to store all rejected rows to display after import
     wxString rejectedRows;
-    wxString reftype = TrxModel::refTypeName;
-    for (long nLines = firstRow; nLines < lastRow; nLines++)
-    {
+    for (long nLines = firstRow; nLines < lastRow; nLines++) {
         const wxString& progressMsg = wxString::Format(_t("Transactions imported to account %s: %ld")
             , "'" + acctName + "'", nImportedLines);
         if (!progressDlg.Update(nLines - firstRow, progressMsg))
@@ -1559,11 +1557,11 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& WXUNUSED(event))
 
         // save tags
         if (!holder.tagIDs.empty()) {
-            for (const auto& tag : holder.tagIDs) {
+            for (const auto& tag_id : holder.tagIDs) {
                 TagLinkData new_gl_d = TagLinkData();
-                new_gl_d.REFTYPE = reftype;
-                new_gl_d.REFID   = new_trx_d.m_id;
-                new_gl_d.TAGID   = tag;
+                new_gl_d.m_tag_id   = tag_id;
+                new_gl_d.m_ref_type = TrxModel::s_ref_type;
+                new_gl_d.m_ref_id   = new_trx_d.m_id;
                 TagLinkModel::instance().add_data_n(new_gl_d);
             }
         }
@@ -1693,7 +1691,9 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
         );
 
     const auto split = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().get_all_id(TrxModel::refTypeName);
+    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        TrxModel::s_ref_type
+    );
     int64 fromAccountID = from_account->m_id;
 
     long numRecords = 0;
@@ -1796,7 +1796,9 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                         case UNIV_CSV_TAGS:
                         {
                             wxString splitTags;
-                            for (const auto& tag : TagLinkModel::instance().get_ref(TrxSplitModel::refTypeName, tp_d.m_id))
+                            for (const auto& tag : TagLinkModel::instance().find_ref_tag_m(
+                                TrxSplitModel::s_ref_type, tp_d.m_id
+                            ))
                                 splitTags.Append((splitTags.IsEmpty() ? "" : " ") + tag.first);
                             entry = tran.TAGNAMES;
                             if (!splitTags.IsEmpty())
@@ -2093,7 +2095,9 @@ void mmUnivCSVDialog::update_preview()
 
         if (from_account) {
             const auto split = TrxSplitModel::instance().get_all_id();
-            const auto tags = TagLinkModel::instance().get_all_id(TrxModel::refTypeName);
+            const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+                TrxModel::s_ref_type
+            );
             int64 fromAccountID = from_account->m_id;
             size_t count = 0;
             int row = 0;
@@ -2193,8 +2197,9 @@ void mmUnivCSVDialog::update_preview()
                                 case UNIV_CSV_TAGS:
                                 {
                                     wxString splitTags;
-                                    for (const auto& tag :
-                                         TagLinkModel::instance().get_ref(TrxSplitModel::refTypeName, tp_d.m_id))
+                                    for (const auto& tag : TagLinkModel::instance().find_ref_tag_m(
+                                            TrxSplitModel::s_ref_type, tp_d.m_id
+                                    ))
                                         splitTags.Append((splitTags.IsEmpty() ? "" : " ") + tag.first);
                                     text << inQuotes(tran.TAGNAMES + (tran.TAGNAMES.IsEmpty() ? "" : " ") + splitTags, delimit);
                                     break;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -740,7 +740,7 @@ void mmUnivCSVDialog::OnShowCategDialog(wxMouseEvent&)
         wxString selectedCategname = value.GetString();
         id = m_CSVcategoryNames[selectedCategname];
         if (id == -1) {
-            std::map<wxString, int64 > categories = CategoryModel::all_categories();
+            std::map<wxString, int64 > categories = CategoryModel::instance().all_categories();
             for (const auto& category : categories)
             {
                 if (category.first.CmpNoCase(selectedCategname) <= 0) id = category.second;
@@ -1372,17 +1372,19 @@ bool mmUnivCSVDialog::validateData(tran_holder & holder, wxString& message)
         }
     }
 
-    if (holder.CategoryID == -1) //The category name is missing in SCV file and not assigned for the payee
-    {
-        const CategoryData* categ = CategoryModel::instance().get_key(_t("Unknown"), int64(-1));
-        if (categ) {
-            holder.CategoryID = categ->m_id;
+    //The category name is missing in SCV file and not assigned for the payee
+    if (holder.CategoryID == -1) {
+        const CategoryData* cat_n = CategoryModel::instance().get_key_data_n(
+            _t("Unknown"), int64(-1)
+        );
+        if (cat_n) {
+            holder.CategoryID = cat_n->m_id;
         }
         else {
-            CategoryData new_category_d = CategoryData();
-            new_category_d.m_name = _t("Unknown");
-            CategoryModel::instance().add_data_n(new_category_d);
-            holder.CategoryID = new_category_d.id();
+            CategoryData new_cat_d = CategoryData();
+            new_cat_d.m_name = _t("Unknown");
+            CategoryModel::instance().add_data_n(new_cat_d);
+            holder.CategoryID = new_cat_d.id();
         }
     }
 
@@ -1784,9 +1786,9 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                             if (category)
                             {
                                 if (isIndexPresent(UNIV_CSV_SUBCATEGORY) && category->m_parent_id_n != -1)
-                                    entry = wxGetTranslation(CategoryModel::full_name(category->m_parent_id_n, ":"));
+                                    entry = wxGetTranslation(CategoryModel::instance().full_name(category->m_parent_id_n, ":"));
                                 else
-                                    entry = wxGetTranslation(CategoryModel::full_name(category->m_id, ":"));
+                                    entry = wxGetTranslation(CategoryModel::instance().full_name(category->m_id, ":"));
                             }
                             break;
                         case UNIV_CSV_SUBCATEGORY:
@@ -2184,9 +2186,9 @@ void mmUnivCSVDialog::update_preview()
                                 case UNIV_CSV_CATEGORY:
                                     if (category) {
                                         if (isIndexPresent(UNIV_CSV_SUBCATEGORY) && category->m_parent_id_n != -1)
-                                            text << inQuotes(CategoryModel::full_name(category->m_parent_id_n, ":"), delimit);
+                                            text << inQuotes(CategoryModel::instance().full_name(category->m_parent_id_n, ":"), delimit);
                                         else
-                                            text << inQuotes(CategoryModel::full_name(category->m_id, ":"), delimit);
+                                            text << inQuotes(CategoryModel::instance().full_name(category->m_id, ":"), delimit);
                                     }
                                     else text << inQuotes("", delimit);
                                     break;
@@ -2738,24 +2740,25 @@ void mmUnivCSVDialog::validatePayees() {
     }
 }
 
-void mmUnivCSVDialog::validateCategories() {
-    for(const auto& catname : m_CSVcategoryNames) {
+void mmUnivCSVDialog::validateCategories()
+{
+    for (const auto& catname : m_CSVcategoryNames) {
         wxString search_name = catname.first;
-        int64 parentID = -1;
+        int64 parent_id = -1;
         // delimit string by ":"
         wxStringTokenizer categs = wxStringTokenizer(search_name, ":");
         // check each level of category exists
-        const CategoryData* category_n = nullptr;
+        const CategoryData* cat_n = nullptr;
         while (categs.HasMoreTokens()) {
-            wxString categname = categs.GetNextToken();
-            category_n = CategoryModel::instance().get_key(categname, parentID);
-            if (!category_n)
+            wxString cat_name = categs.GetNextToken();
+            cat_n = CategoryModel::instance().get_key_data_n(cat_name, parent_id);
+            if (!cat_n)
                 break;
-            parentID = category_n->m_id;
+            parent_id = cat_n->m_id;
         }
 
-        if (category_n)
-            m_CSVcategoryNames[search_name] = category_n->m_id;
+        if (cat_n)
+            m_CSVcategoryNames[search_name] = cat_n->m_id;
     }
 }
 
@@ -2778,12 +2781,16 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         break;
     }
     case UNIV_CSV_PAYEE:
-        if (m_CSVpayeeNames.find(token) != m_CSVpayeeNames.end() && std::get<0>(m_CSVpayeeNames[token]) != -1)
-        {
+        if (m_CSVpayeeNames.find(token) != m_CSVpayeeNames.end() &&
+            std::get<0>(m_CSVpayeeNames[token]) != -1
+        ) {
             holder.PayeeID = std::get<0>(m_CSVpayeeNames[token]);
-            if (payeeMatchAddNotes_->IsChecked() && !std::get<2>(m_CSVpayeeNames[token]).IsEmpty())
-            {
-                holder.PayeeMatchNotes = wxString::Format(_t("%1$s matched by %2$s"), token, std::get<2>(m_CSVpayeeNames[token]));
+            if (payeeMatchAddNotes_->IsChecked() &&
+                !std::get<2>(m_CSVpayeeNames[token]).IsEmpty()
+            ) {
+                holder.PayeeMatchNotes = wxString::Format(_t("%1$s matched by %2$s"),
+                    token, std::get<2>(m_CSVpayeeNames[token])
+                );
             }
         }
         else {
@@ -2798,7 +2805,11 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
     case UNIV_CSV_AMOUNT:
         mmTrimAmount(token, decimal_, ".").ToCDouble(&amount);
 
-        if (find_if(csvFieldOrder_.begin(), csvFieldOrder_.end(), [](const std::pair<int, int>& element) {return element.first == UNIV_CSV_TYPE; }) == csvFieldOrder_.end()) {
+        if (find_if(csvFieldOrder_.begin(), csvFieldOrder_.end(),
+            [](const std::pair<int, int>& element) {
+                return element.first == UNIV_CSV_TYPE;
+            }
+        ) == csvFieldOrder_.end()) {
             if ((amount > 0.0 && !m_reverce_sign) || (amount <= 0.0 && m_reverce_sign)) {
                 holder.Type = TrxModel::TYPE_NAME_DEPOSIT;
             }
@@ -2813,29 +2824,31 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
         wxRegEx categDelimiterRegex(" ?: ?");
         categDelimiterRegex.Replace(&token, ":");
         // check if we already have this category
-        if (m_CSVcategoryNames.find(token) != m_CSVcategoryNames.end() && m_CSVcategoryNames[token] != -1)
+        if (m_CSVcategoryNames.find(token) != m_CSVcategoryNames.end() &&
+            m_CSVcategoryNames[token] != -1
+        )
             holder.CategoryID = m_CSVcategoryNames[token];
-        else // create category and any missing parent categories
-        {
-            const CategoryData* category_n = nullptr;
+        // create category and any missing parent categories
+        else {
+            const CategoryData* cat_n = nullptr;
             int64 parentID = -1;
             wxStringTokenizer tokenizer = wxStringTokenizer(token, ":");
             while (tokenizer.HasMoreTokens()) {
-                wxString categname = tokenizer.GetNextToken().Trim().Trim(false);
-                category_n = CategoryModel::instance().get_key(categname, parentID);
-                if (!category_n) {
-                    CategoryData new_category_d = CategoryData();
-                    new_category_d.m_name        = categname;
-                    new_category_d.m_parent_id_n = parentID;
-                    CategoryModel::instance().add_data_n(new_category_d);
-                    category_n = CategoryModel::instance().get_id_data_n(new_category_d.id());
+                wxString cat_name = tokenizer.GetNextToken().Trim().Trim(false);
+                cat_n = CategoryModel::instance().get_key_data_n(cat_name, parentID);
+                if (!cat_n) {
+                    CategoryData new_cat_d = CategoryData();
+                    new_cat_d.m_name        = cat_name;
+                    new_cat_d.m_parent_id_n = parentID;
+                    CategoryModel::instance().add_data_n(new_cat_d);
+                    cat_n = CategoryModel::instance().get_id_data_n(new_cat_d.id());
                 }
-                parentID = category_n->m_id;
+                parentID = cat_n->m_id;
             }
 
-            if (category_n) {
-                holder.CategoryID = category_n->m_id;
-                m_CSVcategoryNames[token] = category_n->m_id;
+            if (cat_n) {
+                holder.CategoryID = cat_n->m_id;
+                m_CSVcategoryNames[token] = cat_n->m_id;
             }
         }
         break;
@@ -2846,18 +2859,20 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             return;
 
         token.Replace(":", "|");
-        wxString categname = CategoryModel::full_name(holder.CategoryID);
+        wxString categname = CategoryModel::instance().full_name(holder.CategoryID);
         categname.Append(":" + token);
-        if (m_CSVcategoryNames.find(categname) != m_CSVcategoryNames.end() && m_CSVcategoryNames[categname] != -1)
+        if (m_CSVcategoryNames.find(categname) != m_CSVcategoryNames.end() &&
+            m_CSVcategoryNames[categname] != -1
+        )
             holder.CategoryID = m_CSVcategoryNames[categname];
         else {
-            CategoryData new_category_d = CategoryData();
-            new_category_d.m_name        = token;
-            new_category_d.m_parent_id_n = holder.CategoryID;
-            CategoryModel::instance().add_data_n(new_category_d);
+            CategoryData new_cat_d = CategoryData();
+            new_cat_d.m_name        = token;
+            new_cat_d.m_parent_id_n = holder.CategoryID;
+            CategoryModel::instance().add_data_n(new_cat_d);
 
-            holder.CategoryID = new_category_d.m_id;
-            m_CSVcategoryNames[categname] = new_category_d.m_id;
+            holder.CategoryID = new_cat_d.m_id;
+            m_CSVcategoryNames[categname] = new_cat_d.m_id;
         }
         break;
     }

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1839,7 +1839,8 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                                 );
                                 if (fv_n) {
                                     // format date fields
-                                    if (FieldModel::type_id(FieldModel::instance().get_id_data_n(fv_n->m_field_id)) == FieldModel::TYPE_ID_DATE)
+                                    const FieldData* field_n = FieldModel::instance().get_id_data_n(fv_n->m_field_id);
+                                    if (field_n->m_type_n.id_n() == FieldTypeN::e_date)
                                         entry = mmGetDateTimeForDisplay(fv_n->m_content, date_format_);
                                     else
                                         entry = fv_n->m_content;
@@ -2228,7 +2229,8 @@ void mmUnivCSVDialog::update_preview()
                                         const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(CSVFieldName_[it].second, TrxModel::s_ref_type, trx_d.m_id);
                                         if (fv_n) {
                                             // Format date fields
-                                            if (FieldModel::type_id(FieldModel::instance().get_id_data_n(fv_n->m_field_id)) == FieldModel::TYPE_ID_DATE)
+                                            const FieldData* field_n = FieldModel::instance().get_id_data_n(fv_n->m_field_id);
+                                            if (field_n->m_type_n.id_n() == FieldTypeN::e_date)
                                                 text << inQuotes(mmGetDateTimeForDisplay(fv_n->m_content, date_format_), delimit);
                                             else
                                                 text << inQuotes(fv_n->m_content, delimit);
@@ -3141,25 +3143,24 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
 
     if (!value.IsEmpty()) {
         const FieldData* field_n = FieldModel::instance().get_id_data_n(fieldId);
-        wxString type_string = FieldModel::type_name(FieldModel::type_id(field_n));
-        switch (FieldModel::type_id(field_n))
-        {
+        wxString type_name = field_n->m_type_n.name_n();
+        switch (field_n->m_type_n.id_n()) {
             // Check if string can be read as an integer. Will fail if passed a double.
-        case FieldModel::TYPE_ID_INTEGER:
+        case FieldTypeN::e_integer:
             value = cleanseNumberString(value, true);
             if (!value.ToCLong(&int_val)) {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_name);
                 is_valid = false;
             }
             else value = wxString::Format("%i", int_val);
             break;
 
             // Check if string can be read as a double
-        case FieldModel::TYPE_ID_DECIMAL:
+        case FieldTypeN::e_decimal:
             value = cleanseNumberString(value, true);
             if (!value.ToCDouble(&double_val))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_name);
                 is_valid = false;
             }
             else
@@ -3171,11 +3172,11 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
             break;
 
             // Check if string can be interpreted as "True" or "False" (case insensitive)    
-        case FieldModel::TYPE_ID_BOOLEAN:
+        case FieldTypeN::e_boolean:
             if (bool_true_array.Index(value, false) == wxNOT_FOUND)
                 if (bool_false_array.Index(value, false) == wxNOT_FOUND)
                 {
-                    message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
+                    message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_name);
                     is_valid = false;
                 }
                 else value = "FALSE";
@@ -3183,19 +3184,19 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
             break;
 
             // Check if string is a valid choice (case insensitive)
-        case FieldModel::TYPE_ID_SINGLECHOICE:
+        case FieldTypeN::e_single_choice:
             choices = FieldModel::getChoices(field_n->m_properties);
             index = choices.Index(value, false);
             if (index == wxNOT_FOUND)
             {
-                message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), value, type_string, field_n->m_description);
+                message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), value, type_name, field_n->m_description);
                 is_valid = false;
             }
             else value = choices[index];
             break;
 
             // Check if all of the ';' delimited strings are valid choices (case insensitive)
-        case FieldModel::TYPE_ID_MULTICHOICE:
+        case FieldTypeN::e_multi_choice:
             choices = FieldModel::getChoices(field_n->m_properties);
             tokenizer = wxStringTokenizer(value, ";");
             value.Clear();
@@ -3209,17 +3210,17 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
                     if (tokenizer.HasMoreTokens()) value.Append(";");
                 }
                 else {
-                    message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), token, type_string, field_n->m_description);
+                    message << " " << wxString::Format(_t("Value %1$s for %2$s custom field '%3$s' is not a valid selection."), token, type_name, field_n->m_description);
                     is_valid = false;
                 }
             }
             break;
 
             // Parse the date using the user specified format. Convert to ISO date
-        case FieldModel::TYPE_ID_DATE:
+        case FieldTypeN::e_date:
             if (!mmParseDisplayStringToDate(date, value, date_format_))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string) <<
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_name) <<
                     " " << wxString::Format(_t("Confirm format matches selection %s."), date_format_);
                 is_valid = false;
             }
@@ -3227,10 +3228,10 @@ bool mmUnivCSVDialog::validateCustomFieldData(int64 fieldId, wxString& value, wx
             break;
 
             // Parse the time. Convert to ISO Format
-        case FieldModel::TYPE_ID_TIME:
+        case FieldTypeN::e_time:
             if (!time.ParseTime(value))
             {
-                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_string);
+                message << " " << wxString::Format(_t("Value %1$s for custom field '%2$s' is not type %3$s."), value, field_n->m_description, type_name);
                 is_valid = false;
             }
             else value = time.FormatISOTime();

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1549,9 +1549,10 @@ void mmUnivCSVDialog::OnImport(wxCommandEvent& WXUNUSED(event))
         if (!holder.customFieldData.empty()) {
             for (const auto& field : holder.customFieldData) {
                 FieldValueData new_fv_d = FieldValueData();
-                new_fv_d.FIELDID = field.first;
-                new_fv_d.REFID   = new_trx_d.m_id;
-                new_fv_d.CONTENT = field.second;
+                new_fv_d.m_field_id = field.first;
+                new_fv_d.m_ref_type = TrxModel::s_ref_type;
+                new_fv_d.m_ref_id   = new_trx_d.m_id;
+                new_fv_d.m_content  = field.second;
                 FieldValueModel::instance().add_data_n(new_fv_d);
             }
         }
@@ -1828,17 +1829,18 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                             entry = wxString::Format("%lld", tran.m_id);
                             break;
                         default:
-                            if (it.first > UNIV_CSV_LAST) // Custom Fields
-                            {
+                            // Custom Fields
+                            if (it.first > UNIV_CSV_LAST) {
                                 // Get field content
-                                const FieldValueData* data = FieldValueModel::instance().get_key(CSVFieldName_[it.first].second, trx_d.m_id);
-                                if (data)
-                                {
+                                const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(
+                                    CSVFieldName_[it.first].second, TrxModel::s_ref_type, trx_d.m_id
+                                );
+                                if (fv_n) {
                                     // format date fields
-                                    if (FieldModel::type_id(FieldModel::instance().get_id_data_n(data->FIELDID)) == FieldModel::TYPE_ID_DATE)
-                                        entry = mmGetDateTimeForDisplay(data->CONTENT, date_format_);
+                                    if (FieldModel::type_id(FieldModel::instance().get_id_data_n(fv_n->m_field_id)) == FieldModel::TYPE_ID_DATE)
+                                        entry = mmGetDateTimeForDisplay(fv_n->m_content, date_format_);
                                     else
-                                        entry = data->CONTENT;
+                                        entry = fv_n->m_content;
                                 }
                             }
                             break;
@@ -2216,16 +2218,15 @@ void mmUnivCSVDialog::update_preview()
                                     text << trx_d.TRANSCODE;
                                     break;
                                 default:
-                                    if (it > UNIV_CSV_LAST) // Custom Fields
-                                    {
-                                        const FieldValueData* data = FieldValueModel::instance().get_key(CSVFieldName_[it].second, trx_d.m_id);
-                                        if (data)
-                                        {
+                                    // Custom Fields
+                                    if (it > UNIV_CSV_LAST) {
+                                        const FieldValueData* fv_n = FieldValueModel::instance().get_key_data_n(CSVFieldName_[it].second, TrxModel::s_ref_type, trx_d.m_id);
+                                        if (fv_n) {
                                             // Format date fields
-                                            if (FieldModel::type_id(FieldModel::instance().get_id_data_n(data->FIELDID)) == FieldModel::TYPE_ID_DATE)
-                                                text << inQuotes(mmGetDateTimeForDisplay(data->CONTENT, date_format_), delimit);
+                                            if (FieldModel::type_id(FieldModel::instance().get_id_data_n(fv_n->m_field_id)) == FieldModel::TYPE_ID_DATE)
+                                                text << inQuotes(mmGetDateTimeForDisplay(fv_n->m_content, date_format_), delimit);
                                             else
-                                                text << inQuotes(data->CONTENT, delimit);
+                                                text << inQuotes(fv_n->m_content, delimit);
                                         }
                                     }
                                     break;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -1691,7 +1691,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
         );
 
     const auto split = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+    const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(
         TrxModel::s_ref_type
     );
     int64 fromAccountID = from_account->m_id;
@@ -1728,7 +1728,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
             if (TrxModel::status_id(trx_d) == TrxModel::STATUS_ID_VOID || !trx_d.DELETEDTIME.IsEmpty())
                 continue;
 
-            TrxModel::Full_Data tran(trx_d, split, tags);
+            TrxModel::Full_Data tran(trx_d, split, trxId_glA_m);
             bool has_split = tran.has_split();
             double value = TrxModel::account_flow(trx_d, fromAccountID);
             account_balance += value;
@@ -1867,7 +1867,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
         const AccountData* account = AccountModel::instance().get_id_data_n(fromAccountID);
         for (const auto& stock_d : stock_a) {
             //If the transaction happened between the dates that the user selected or if the user selected to export all the transactions regardless of date then the row is added to the preview
-            if (StockModel::PURCHASEDATE(stock_d).IsBetween(
+            if (stock_d.m_purchase_date.getDateTime().IsBetween(
                 m_date_picker_start->GetValue(),
                 m_date_picker_end->GetValue()
             ) || m_haveDatesCheckBox->GetValue()==false) {
@@ -1882,10 +1882,10 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                         entry = wxString::Format("%lld", stock_d.m_id);
                         break;
                     case UNIV_CSV_DATE:
-                        entry = mmGetDateTimeForDisplay(StockModel::PURCHASEDATE(stock_d).FormatISODate(), date_format_);
+                        entry = mmGetDateTimeForDisplay(stock_d.m_purchase_date.isoDate(), date_format_);
                         break;
                     case UNIV_CSV_COMPANY_NAME:
-                        entry = StockModel::get_id_name(stock_d.m_id);
+                        entry = StockModel::instance().get_id_name(stock_d.m_id);
                         break;
                     case UNIV_CSV_SYMBOL:
                         entry = stock_d.m_symbol;
@@ -1897,19 +1897,19 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                         entry = std::to_wstring(stock_d.m_purchase_price);
                         break;
                     case UNIV_CSV_TOTAL_COST:
-                        entry = std::to_wstring(StockModel::InvestmentValue(stock_d));
+                        entry = std::to_wstring(stock_d.m_purchase_value);
                         break;
                     case UNIV_CSV_REAL_GAIN:
-                        entry = std::to_wstring(StockModel::RealGainLoss(stock_d));
+                        entry = std::to_wstring(StockModel::instance().calculate_realized_gain(stock_d));
                         break;
                     case UNIV_CSV_UNREAL_GAIN:
-                        entry = std::to_wstring(StockModel::UnrealGainLoss(stock_d));
+                        entry = std::to_wstring(StockModel::instance().calculate_unrealiazed_gain(stock_d));
                         break;
                     case UNIV_CSV_CURRENT_PRICE:
-                        entry = std::to_wstring(StockModel::CurrentValue(stock_d)/stock_d.m_num_shares);
+                        entry = std::to_wstring(stock_d.current_value()/stock_d.m_num_shares);
                         break;
                     case UNIV_CSV_CURRENT_TOTAL_VALUE:
-                        entry = std::to_wstring(StockModel::CurrentValue(stock_d));
+                        entry = std::to_wstring(stock_d.current_value());
                         break;
                     case UNIV_CSV_NOTES:
                         entry = wxString(stock_d.m_notes).Trim();
@@ -2096,7 +2096,7 @@ void mmUnivCSVDialog::update_preview()
 
         if (from_account) {
             const auto split = TrxSplitModel::instance().get_all_id();
-            const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+            const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(
                 TrxModel::s_ref_type
             );
             int64 fromAccountID = from_account->m_id;
@@ -2124,7 +2124,7 @@ void mmUnivCSVDialog::update_preview()
                     if (TrxModel::getTransDateTime(trx_d).IsBetween(m_date_picker_start->GetValue(),m_date_picker_end->GetValue()) ||
                         m_haveDatesCheckBox->GetValue() == false
                     ) {
-                        TrxModel::Full_Data tran(trx_d, split, tags);
+                        TrxModel::Full_Data tran(trx_d, split, trxId_glA_m);
                         bool has_split = tran.has_split();
                         double value = TrxModel::account_flow(trx_d, fromAccountID);
                         account_balance += value;
@@ -2273,7 +2273,7 @@ void mmUnivCSVDialog::update_preview()
                 const AccountData* account = AccountModel::instance().get_id_data_n(fromAccountID);
                 for (const auto& stock_d : stock_a) {
                     // If the transaction happened between the dates that the user selected or if the user selected to export all the transactions regardless of date then the row is added to the preview
-                    if (StockModel::PURCHASEDATE(stock_d).IsBetween(m_date_picker_start->GetValue(),m_date_picker_end->GetValue()) ||
+                    if (stock_d.m_purchase_date.getDateTime().IsBetween(m_date_picker_start->GetValue(),m_date_picker_end->GetValue()) ||
                         m_haveDatesCheckBox->GetValue() == false
                     ) {
                         int col = 0;
@@ -2284,24 +2284,35 @@ void mmUnivCSVDialog::update_preview()
                         m_list_ctrl_->SetItem(itemIndex, col, buf);
                         m_list_ctrl_->SetItemData(itemIndex, row);
 
-                        const CurrencyData* currency = AccountModel::instance().get_data_currency_p(*from_account);
-                        const wxString shareTotal = CurrencyModel::toStringNoFormatting(stock_d.m_num_shares, currency);
-                        const wxString avgSharePrice = CurrencyModel::toStringNoFormatting(stock_d.m_purchase_price, currency);
-                        const wxString totalCost = CurrencyModel::toStringNoFormatting(StockModel::InvestmentValue(stock_d), currency);
-                        const wxString realGain = CurrencyModel::toStringNoFormatting(StockModel::RealGainLoss(stock_d), currency);
+                        const CurrencyData* currency_n = AccountModel::instance().get_data_currency_p(*from_account);
+                        const wxString shareTotal = CurrencyModel::toStringNoFormatting(
+                            stock_d.m_num_shares,
+                            currency_n
+                        );
+                        const wxString avgSharePrice = CurrencyModel::toStringNoFormatting(
+                            stock_d.m_purchase_price,
+                            currency_n
+                        );
+                        const wxString totalCost = CurrencyModel::toStringNoFormatting(
+                            stock_d.m_purchase_value,
+                            currency_n
+                        );
+                        const wxString realGain = CurrencyModel::toStringNoFormatting(
+                            StockModel::instance().calculate_realized_gain(stock_d),
+                             currency_n
+                        );
                         const wxString unrealGain = CurrencyModel::toStringNoFormatting(
-                            StockModel::UnrealGainLoss(stock_d), currency
+                            StockModel::instance().calculate_unrealiazed_gain(stock_d), currency_n
                         );
                         const wxString currentPrice = CurrencyModel::toStringNoFormatting(
-                            StockModel::CurrentValue(stock_d)/stock_d.m_num_shares, currency
+                            stock_d.current_value()/stock_d.m_num_shares, currency_n
                         );
                         const wxString currentTotalValue = CurrencyModel::toStringNoFormatting(
-                            StockModel::CurrentValue(stock_d), currency
+                            stock_d.current_value(), currency_n
                         );
-                        const wxString commission = CurrencyModel::toStringNoFormatting(stock_d.m_commission, currency);
+                        const wxString commission = CurrencyModel::toStringNoFormatting(stock_d.m_commission, currency_n);
 
-                        for (const auto& field : csvFieldOrder_)
-                        {
+                        for (const auto& field : csvFieldOrder_) {
                             int it = field.first;
                             wxString text;
                             switch (it)
@@ -2310,10 +2321,10 @@ void mmUnivCSVDialog::update_preview()
                                 text << wxString::Format("%lld", stock_d.m_id);
                                 break;
                             case UNIV_CSV_DATE:
-                                text << inQuotes(mmGetDateTimeForDisplay(StockModel::PURCHASEDATE(stock_d).FormatISODate(), date_format_), delimit);
+                                text << inQuotes(mmGetDateTimeForDisplay(stock_d.m_purchase_date.isoDate(), date_format_), delimit);
                                 break;
                             case UNIV_CSV_COMPANY_NAME:
-                                text << inQuotes(StockModel::get_id_name(stock_d.m_id), delimit);
+                                text << inQuotes(StockModel::instance().get_id_name(stock_d.m_id), delimit);
                                 break;
                             case UNIV_CSV_SYMBOL:
                                 text << inQuotes(stock_d.m_symbol, delimit);

--- a/src/import_export/webapp.cpp
+++ b/src/import_export/webapp.cpp
@@ -292,35 +292,32 @@ bool mmWebApp::WebApp_UpdateCategory()
     json_writer.Key("Categories");
 
     json_writer.StartArray();
-    const auto &categories = CategoryModel::instance().find(CategoryCol::PARENTID(-1));
-    for (const CategoryData& category : categories)
-    {
+    for (const CategoryData& category_d : CategoryModel::instance().find(
+        CategoryCol::PARENTID(-1)
+    )) {
         bool first_category_run = true;
         bool sub_category_found = false;
 
         json_writer.StartObject();
         json_writer.Key("CategoryName");
-        json_writer.String(category.m_name.utf8_str());
+        json_writer.String(category_d.m_name.utf8_str());
 
-        for (const auto &sub_category : CategoryModel::sub_category(category))
-        {
+        for (const auto& subcategory_d : CategoryModel::instance().find_data_sub_a(category_d)) {
             sub_category_found = true;
-            if (first_category_run == true)
-            {
+            if (first_category_run == true) {
                 json_writer.Key("SubCategoryName");
-                json_writer.String(sub_category.m_name.utf8_str());
+                json_writer.String(subcategory_d.m_name.utf8_str());
                 json_writer.EndObject();
 
                 first_category_run = false;
             }
-            else
-            {
+            else {
                 json_writer.StartObject();
                 json_writer.Key("CategoryName");
-                json_writer.String(category.m_name.utf8_str());
+                json_writer.String(category_d.m_name.utf8_str());
 
                 json_writer.Key("SubCategoryName");
-                json_writer.String(sub_category.m_name.utf8_str());
+                json_writer.String(subcategory_d.m_name.utf8_str());
                 json_writer.EndObject();
 
                 first_category_run = false;
@@ -461,7 +458,7 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     int64 AccountID = -1;
     int64 ToAccountID = -1;
     int64 payeeID = -1;
-    int64 categoryID = -1;
+    int64 category_id = -1;
     wxString TrStatus;
 
     //Search Account
@@ -508,28 +505,32 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     }
 
     //Search or insert Category
-    const CategoryData* category_n = CategoryModel::instance().get_key(WebAppTrans.Category, int64(-1));
+    const CategoryData* category_n = CategoryModel::instance().get_key_data_n(
+        WebAppTrans.Category, int64(-1)
+    );
     if (category_n != nullptr)
-        categoryID = category_n->m_id;
+        category_id = category_n->m_id;
     else {
         CategoryData new_category_d = CategoryData();
         new_category_d.m_name = WebAppTrans.Category;
         CategoryModel::instance().add_data_n(new_category_d);
-        categoryID = new_category_d.id();
+        category_id = new_category_d.id();
     }
 
     // Search or insert SubCategory
     if (!WebAppTrans.SubCategory.IsEmpty()) {
-        const CategoryData* subcategory_n = CategoryModel::instance().get_key(WebAppTrans.SubCategory, categoryID);
+        const CategoryData* subcategory_n = CategoryModel::instance().get_key_data_n(
+            WebAppTrans.SubCategory, category_id
+        );
         if (subcategory_n) {
-            categoryID = subcategory_n->m_id;
+            category_id = subcategory_n->m_id;
         }
-        else if (categoryID != -1) {
+        else if (category_id != -1) {
             CategoryData new_subcategory_d = CategoryData();
             new_subcategory_d.m_name        = WebAppTrans.SubCategory;
-            new_subcategory_d.m_parent_id_n = categoryID;
+            new_subcategory_d.m_parent_id_n = category_id;
             CategoryModel::instance().add_data_n(new_subcategory_d);
-            categoryID = new_subcategory_d.id();
+            category_id = new_subcategory_d.id();
         }
     }
 
@@ -541,7 +542,7 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     else {
         PayeeData new_payee_d = PayeeData();
         new_payee_d.m_name          = WebAppTrans.Payee;
-        new_payee_d.m_category_id_n = categoryID;
+        new_payee_d.m_category_id_n = category_id;
         PayeeModel::instance().add_data_n(new_payee_d);
         payeeID = new_payee_d.id();
     }
@@ -569,7 +570,7 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
     new_trx_d.m_account_id      = AccountID;
     new_trx_d.m_to_account_id_n = ToAccountID;
     new_trx_d.m_payee_id_n      = payeeID;
-    new_trx_d.m_category_id_n   = categoryID;
+    new_trx_d.m_category_id_n   = category_id;
     new_trx_d.m_number          = "";
     new_trx_d.m_notes           = WebAppTrans.Notes;
     new_trx_d.m_followup_id     = -1;
@@ -631,8 +632,8 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
                 bDeleteTrWebApp = true;
             }
         }
-        else //Transaction without attachments
-        {
+        //Transaction without attachments
+        else {
             bDeleteTrWebApp = true;
         }
     }

--- a/src/import_export/webapp.cpp
+++ b/src/import_export/webapp.cpp
@@ -657,10 +657,10 @@ bool mmWebApp::WebApp_DeleteOneTransaction(int64 WebAppTransactionId)
 wxString mmWebApp::WebApp_DownloadOneAttachment(const wxString& AttachmentName, int64 DesktopTransactionID, int AttachmentNr, wxString& Error)
 {
     wxString FileExtension = wxFileName(AttachmentName).GetExt().MakeLower();
-    wxString FileName = TrxModel::refTypeName + "_" + wxString::Format("%lld", DesktopTransactionID)
+    wxString FileName = TrxModel::s_ref_type.name_n() + "_" + wxString::Format("%lld", DesktopTransactionID)
         + "_Attach" + wxString::Format("%i", AttachmentNr) + "." + FileExtension;
     const wxString FilePath = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting())
-        + TrxModel::refTypeName + wxFileName::GetPathSeparator() + FileName;
+        + TrxModel::s_ref_type.name_n() + wxFileName::GetPathSeparator() + FileName;
     wxString URL = mmWebApp::getServicesPageURL() + "&" + WebAppParam::DownloadAttachments + "=" + AttachmentName;
     CURLcode CurlStatus = http_download_file(URL, FilePath);
     if (CurlStatus == CURLE_OK)

--- a/src/import_export/webapp.cpp
+++ b/src/import_export/webapp.cpp
@@ -608,10 +608,10 @@ int64 mmWebApp::MMEX_InsertNewTransaction(webtran_holder& WebAppTrans)
                     DesktopAttachmentName = WebApp_DownloadOneAttachment(WebAppAttachmentName, DeskNewTrID, AttachmentNr, CurlError);
                     if (DesktopAttachmentName != wxEmptyString) {
                         AttachmentData new_att_d = AttachmentData();
-                        new_att_d.REFTYPE     = TrxModel::refTypeName;
-                        new_att_d.REFID       = DeskNewTrID;
-                        new_att_d.DESCRIPTION = _t("Attachment") + "_" << AttachmentNr;
-                        new_att_d.FILENAME    = DesktopAttachmentName;
+                        new_att_d.m_ref_type_n  = RefTypeN(RefTypeN::e_trx);
+                        new_att_d.m_ref_id      = DeskNewTrID;
+                        new_att_d.m_description = _t("Attachment") + "_" << AttachmentNr;
+                        new_att_d.m_filename    = DesktopAttachmentName;
                         AttachmentModel::instance().add_data_n(new_att_d);
                     }
                     else {

--- a/src/manager/CategoryManager.cpp
+++ b/src/manager/CategoryManager.cpp
@@ -19,6 +19,7 @@
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ********************************************************/
 
+#include <set>
 #include "base/constants.h"
 #include "base/paths.h"
 #include "base/images_list.h"
@@ -510,27 +511,26 @@ void CategoryManager::mmDoDeleteSelectedCategory()
     if (CategoryModel::is_used(m_categ_id) || m_categ_id == m_init_selected_categ_id)
         return showCategDialogDeleteError();
 
-    // TODO: only the deleted trx ids are needed; define a single set of int64
-    TrxModel::DataA deleted_trx_a;
-    TrxSplitModel::DataA deleted_tp_a;
-
-    deleted_trx_a = TrxModel::instance().find(
-        TrxCol::CATEGID(m_categ_id)
-    );
-    deleted_tp_a = TrxSplitModel::instance().find(
-        TrxSplitCol::CATEGID(m_categ_id)
-    );
+    std::set<int64> category_id_m;
+    category_id_m.insert(m_categ_id);
     for (const auto& subcat_d : CategoryModel::sub_tree(
         CategoryModel::instance().get_id_data_n(m_categ_id)
     )) {
-        TrxModel::DataA trx_a = TrxModel::instance().find(
-            TrxCol::CATEGID(subcat_d.m_id)
-        );
-        deleted_trx_a.insert(deleted_trx_a.end(), trx_a.begin(), trx_a.end());
-        TrxSplitModel::DataA tp_a = TrxSplitModel::instance().find(
-            TrxSplitCol::CATEGID(subcat_d.m_id)
-        );
-        deleted_tp_a.insert(deleted_tp_a.end(), tp_a.begin(), tp_a.end());
+        category_id_m.insert(subcat_d.m_id);
+    }
+
+    std::set<int64> trx_id_m;
+    for (int64 category_id : category_id_m) {
+        for (const TrxData& trx_d : TrxModel::instance().find(
+            TrxCol::CATEGID(category_id)
+        )) {
+            trx_id_m.insert(trx_d.m_id);
+        }
+        for (const TrxSplitData& tp_d : TrxSplitModel::instance().find(
+            TrxSplitCol::CATEGID(category_id)
+        )) {
+            trx_id_m.insert(tp_d.m_trx_id);
+        }
     }
 
     wxMessageDialog msgDlg(this,
@@ -540,40 +540,33 @@ void CategoryManager::mmDoDeleteSelectedCategory()
         _t("Confirm Category Deletion"),
         wxYES_NO | wxNO_DEFAULT | wxICON_WARNING
     );
+    if (!trx_id_m.empty() && msgDlg.ShowModal() != wxID_YES)
+        return;
 
-    if ((deleted_trx_a.empty() && deleted_tp_a.empty()) || msgDlg.ShowModal() == wxID_YES) {
-        if (!deleted_trx_a.empty() || !deleted_tp_a.empty()) {
-            TrxModel::instance().db_savepoint();
-            TrxSplitModel::instance().db_savepoint();
-            AttachmentModel::instance().db_savepoint();
-            FieldValueModel::instance().db_savepoint();
-            const wxString& RefType = TrxModel::refTypeName;
+    if (!trx_id_m.empty()) {
+        TrxModel::instance().db_savepoint();
+        TrxSplitModel::instance().db_savepoint();
+        AttachmentModel::instance().db_savepoint();
+        FieldValueModel::instance().db_savepoint();
 
-            // TODO: do not delete the same trx id multiple times
-            for (auto& tp_d : deleted_tp_a) {
-                TrxModel::instance().purge_id(tp_d.m_trx_id);
-                mmAttachmentManage::DeleteAllAttachments(RefType, tp_d.m_trx_id);
-                FieldValueModel::DeleteAllData(RefType, tp_d.m_trx_id);
-            }
-
-            for (auto& trx_d : deleted_trx_a) {
-                TrxModel::instance().purge_id(trx_d.m_id);
-                mmAttachmentManage::DeleteAllAttachments(RefType, trx_d.m_id);
-                FieldValueModel::DeleteAllData(RefType, trx_d.m_id);
-            }
-
-            TrxModel::instance().db_release_savepoint();
-            TrxSplitModel::instance().db_release_savepoint();
-            AttachmentModel::instance().db_release_savepoint();
-            FieldValueModel::instance().db_release_savepoint();
+        for (int64 trx_id : trx_id_m) {
+            FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, trx_id);
+            mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_id);
+            TrxModel::instance().purge_id(trx_id);
         }
 
-        for (auto& subcat : CategoryModel::sub_tree(CategoryModel::instance().get_id_data_n(m_categ_id)))
-            CategoryModel::instance().purge_id(subcat.m_id);
-
-        CategoryModel::instance().purge_id(m_categ_id);
+        FieldValueModel::instance().db_release_savepoint();
+        AttachmentModel::instance().db_release_savepoint();
+        TrxSplitModel::instance().db_release_savepoint();
+        TrxModel::instance().db_release_savepoint();
     }
-    else return;
+
+    for (auto& subcat_d : CategoryModel::sub_tree(
+        CategoryModel::instance().get_id_data_n(m_categ_id)
+    )) {
+        CategoryModel::instance().purge_id(subcat_d.m_id);
+    }
+    CategoryModel::instance().purge_id(m_categ_id);
 
     m_refresh_requested = true;
     m_treeCtrl->Delete(m_selectedItemId);

--- a/src/manager/CategoryManager.cpp
+++ b/src/manager/CategoryManager.cpp
@@ -171,7 +171,7 @@ bool CategoryManager::AppendSubcategoryItems(wxTreeItemId parent, const Category
     bool catDisplayed = false;
     for (auto& subcat : m_categ_children[category->m_id]) {
         // Check if the subcategory should be shown
-        bool subcatDisplayed = (show_hidden_categs || subcat.m_active || subcat.m_id == m_init_selected_categ_id) && CategoryModel::full_name(subcat.m_id).Lower().Matches(m_maskStr + "*");
+        bool subcatDisplayed = (show_hidden_categs || subcat.m_active || subcat.m_id == m_init_selected_categ_id) && CategoryModel::instance().full_name(subcat.m_id).Lower().Matches(m_maskStr + "*");
         // Append it to get the item ID
         wxTreeItemId newId = m_treeCtrl->AppendItem(parent, subcat.m_name);
         // Check if any subcategories are not filtered out
@@ -210,7 +210,7 @@ void CategoryManager::fillControls()
     for (auto& category : m_categ_children[-1])
     {
         bool cat_bShow = categShowStatus(category.m_id);
-        bool catDisplayed = (show_hidden_categs || cat_bShow || category.m_id == m_init_selected_categ_id) && CategoryModel::full_name(category.m_id).Lower().Matches(match);
+        bool catDisplayed = (show_hidden_categs || cat_bShow || category.m_id == m_init_selected_categ_id) && CategoryModel::instance().full_name(category.m_id).Lower().Matches(match);
 
         // Append top level category to root_ to get the item ID
         maincat = m_treeCtrl->AppendItem(root_, category.m_name);
@@ -432,58 +432,71 @@ void CategoryManager::OnBeginDrag(wxTreeEvent& event)
 void CategoryManager::OnEndDrag(wxTreeEvent& event)
 {
     wxTreeItemId destItem = event.GetItem();
-    int64 categID = -1;
+    int64 cat_id = -1;
 
     if (destItem.IsOk() && destItem != root_) {
-        CategoryData* newParent = dynamic_cast<mmTreeItemCateg*>(m_treeCtrl->GetItemData(destItem))->getCategData();
-        if (newParent) {
-            categID = newParent->m_id;
+        CategoryData* new_parent_n = dynamic_cast<mmTreeItemCateg*>(
+            m_treeCtrl->GetItemData(destItem)
+        )->getCategData();
+        if (new_parent_n) {
+            cat_id = new_parent_n->m_id;
         }
     }
 
-    if (categID == -1 || categID == m_dragSourceCATEGID) return;
+    if (cat_id == -1 || cat_id == m_dragSourceCATEGID)
+        return;
 
-    CategoryData* sourceCat = CategoryModel::instance().unsafe_get_id_data_n(m_dragSourceCATEGID);
+    CategoryData* src_cat_n = CategoryModel::instance().unsafe_get_id_data_n(m_dragSourceCATEGID);
 
-    if (categID == sourceCat->m_parent_id_n)
+    if (cat_id == src_cat_n->m_parent_id_n)
         return;
 
     if (!CategoryModel::instance().find(
-        CategoryCol::CATEGNAME(sourceCat->m_name),
-        CategoryCol::PARENTID(categID)
-    ).empty() && sourceCat->m_parent_id_n != categID) {
-        wxMessageBox(_t("Unable to move a subcategory to a category that already has a subcategory with that name. Consider renaming before moving.")
-            , _t("A subcategory with this name already exists")
-            , wxOK | wxICON_ERROR);
+        CategoryCol::CATEGNAME(src_cat_n->m_name),
+        CategoryCol::PARENTID(cat_id)
+    ).empty() && src_cat_n->m_parent_id_n != cat_id) {
+        wxMessageBox(
+            _t("Unable to move a subcategory to a category that already has a subcategory with that name. Consider renaming before moving."),
+            _t("A subcategory with this name already exists"),
+            wxOK | wxICON_ERROR
+        );
         return;
     }
 
     wxString subtree_root;
-    for (const auto& subcat : CategoryModel::sub_tree(sourceCat)) {
-        if (subcat.m_parent_id_n == sourceCat->m_id) subtree_root = subcat.m_name;
-        if (subcat.m_id == categID) {
-            wxMessageBox(wxString::Format("Unable to move a category to one of its own descendants.\n\nConsider first relocating subcategory %s to move the subtree.", subtree_root)
-                , _t("Target category is a descendant")
-                , wxOK | wxICON_ERROR);
+    for (const auto& sub_d : CategoryModel::instance().find_data_subtree_a(*src_cat_n)) {
+        if (sub_d.m_parent_id_n == src_cat_n->m_id) subtree_root = sub_d.m_name;
+        if (sub_d.m_id == cat_id) {
+            wxMessageBox(
+                wxString::Format(
+                    "Unable to move a category to one of its own descendants.\n\nConsider first relocating subcategory %s to move the subtree.",
+                    subtree_root
+                ),
+                _t("Target category is a descendant"),
+                wxOK | wxICON_ERROR
+            );
             return;
         }
     }
 
     wxString moveMessage = wxString::Format(
-        _tu("Do you want to move\n“%1$s”\nto:\n“%2$s”?")
-        , CategoryModel::full_name(m_dragSourceCATEGID)
-        , categID != -1 ? CategoryModel::full_name(categID) : _t("Top level"));
-    wxMessageDialog msgDlg(this, moveMessage, _t("Confirm Move"),
-        wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION);
+        _tu("Do you want to move\n“%1$s”\nto:\n“%2$s”?"),
+        CategoryModel::instance().full_name(m_dragSourceCATEGID),
+        cat_id != -1 ? CategoryModel::instance().full_name(cat_id) : _t("Top level")
+    );
+    wxMessageDialog msgDlg(this,
+        moveMessage, _t("Confirm Move"),
+        wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION
+    );
 
     if (msgDlg.ShowModal() != wxID_YES)
         return;
 
-    sourceCat->m_parent_id_n = categID;
-    CategoryModel::instance().unsafe_update_data_n(sourceCat);
+    src_cat_n->m_parent_id_n = cat_id;
+    CategoryModel::instance().unsafe_update_data_n(src_cat_n);
 
     m_refresh_requested = true;
-    m_categ_id = categID;
+    m_categ_id = cat_id;
     fillControls();
 }
 
@@ -508,26 +521,27 @@ void CategoryManager::mmDoDeleteSelectedCategory()
 {
     wxTreeItemId PreviousItem = m_treeCtrl->GetPrevVisible(m_selectedItemId);
 
-    if (CategoryModel::is_used(m_categ_id) || m_categ_id == m_init_selected_categ_id)
+    if (CategoryModel::instance().is_used(m_categ_id) ||
+        m_categ_id == m_init_selected_categ_id
+    )
         return showCategDialogDeleteError();
 
-    std::set<int64> category_id_m;
-    category_id_m.insert(m_categ_id);
-    for (const auto& subcat_d : CategoryModel::sub_tree(
-        CategoryModel::instance().get_id_data_n(m_categ_id)
-    )) {
-        category_id_m.insert(subcat_d.m_id);
+    std::set<int64> cat_id_m;
+    cat_id_m.insert(m_categ_id);
+    const CategoryData* cat_n = CategoryModel::instance().get_id_data_n(m_categ_id);
+    for (const auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
+        cat_id_m.insert(sub_d.m_id);
     }
 
     std::set<int64> trx_id_m;
-    for (int64 category_id : category_id_m) {
+    for (int64 cat_id : cat_id_m) {
         for (const TrxData& trx_d : TrxModel::instance().find(
-            TrxCol::CATEGID(category_id)
+            TrxCol::CATEGID(cat_id)
         )) {
             trx_id_m.insert(trx_d.m_id);
         }
         for (const TrxSplitData& tp_d : TrxSplitModel::instance().find(
-            TrxSplitCol::CATEGID(category_id)
+            TrxSplitCol::CATEGID(cat_id)
         )) {
             trx_id_m.insert(tp_d.m_trx_id);
         }
@@ -561,10 +575,8 @@ void CategoryManager::mmDoDeleteSelectedCategory()
         TrxModel::instance().db_release_savepoint();
     }
 
-    for (auto& subcat_d : CategoryModel::sub_tree(
-        CategoryModel::instance().get_id_data_n(m_categ_id)
-    )) {
-        CategoryModel::instance().purge_id(subcat_d.m_id);
+    for (auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
+        CategoryModel::instance().purge_id(sub_d.m_id);
     }
     CategoryModel::instance().purge_id(m_categ_id);
 
@@ -629,7 +641,7 @@ void CategoryManager::OnSelChanged(wxTreeEvent& event)
         m_categ_id = iData->getCategData()->m_id;
 
         m_buttonDelete->Enable(!mmIsUsed());
-        m_buttonSelect->Enable(m_IsSelection && !bRootSelected && !CategoryModel::is_hidden(m_categ_id));
+        m_buttonSelect->Enable(m_IsSelection && !bRootSelected && !CategoryModel::instance().is_hidden(m_categ_id));
     }
 
     m_buttonAdd->Enable(true);
@@ -763,48 +775,43 @@ void CategoryManager::OnMenuSelected(wxCommandEvent& event)
 {
     int id = event.GetId();
 
-    CategoryData* cat = CategoryModel::instance().unsafe_get_id_data_n(m_categ_id);
+    CategoryData* cat_n = CategoryModel::instance().unsafe_get_id_data_n(m_categ_id);
     switch (id)
     {
-        case MENU_ITEM_EDIT:
-        {
-            wxCommandEvent noop = wxEVT_NULL;
-            OnEdit(noop);
-            break;
+    case MENU_ITEM_EDIT: {
+        wxCommandEvent noop = wxEVT_NULL;
+        OnEdit(noop);
+        break;
+    }
+    case MENU_ITEM_HIDE: {
+        m_treeCtrl->SetItemTextColour(m_selectedItemId, m_hiddenColor);
+        cat_n->m_active = false;
+        CategoryModel::instance().unsafe_update_data_n(cat_n);
+        for (auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
+            sub_d.m_active = false;
+            CategoryModel::instance().save_data_n(sub_d);
         }
-        case MENU_ITEM_HIDE:
-        {
-            m_treeCtrl->SetItemTextColour(m_selectedItemId, m_hiddenColor);
-            cat->m_active = false;
-            CategoryModel::instance().unsafe_update_data_n(cat);
-            for (auto& subcat_d : CategoryModel::sub_tree(cat)) {
-                subcat_d.m_active = false;
-                CategoryModel::instance().save_data_n(subcat_d);
-            }
-            break;
+        break;
+    }
+    case MENU_ITEM_UNHIDE: {
+        m_treeCtrl->SetItemTextColour(m_selectedItemId, NormalColor_);
+        cat_n->m_active = true;
+        CategoryModel::instance().unsafe_update_data_n(cat_n);
+        for (auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
+            sub_d.m_active = true;
+            CategoryModel::instance().save_data_n(sub_d);
         }
-        case MENU_ITEM_UNHIDE:
-        {
-            m_treeCtrl->SetItemTextColour(m_selectedItemId, NormalColor_);
-            cat->m_active = true;
-            CategoryModel::instance().unsafe_update_data_n(cat);
-            for (auto& subcat_d : CategoryModel::sub_tree(cat)) {
-                subcat_d.m_active = true;
-                CategoryModel::instance().save_data_n(subcat_d);
-            }
-            break;
-        }
-        case MENU_ITEM_DELETE:
-        {
-            mmDoDeleteSelectedCategory();
-            break;
-        }
-        case MENU_ITEM_ADD:
-        {
-            wxCommandEvent noop = wxEVT_NULL;
-            OnAdd(noop);
-            break;
-        }
+        break;
+    }
+    case MENU_ITEM_DELETE: {
+        mmDoDeleteSelectedCategory();
+        break;
+    }
+    case MENU_ITEM_ADD: {
+        wxCommandEvent noop = wxEVT_NULL;
+        OnAdd(noop);
+        break;
+    }
     }
 
     fillControls();
@@ -860,7 +867,7 @@ void CategoryManager::OnItemCollapseOrExpand(wxTreeEvent& event)
 
 bool CategoryManager::categShowStatus(int64 categId)
 {
-    if (CategoryModel::is_hidden(categId))
+    if (CategoryModel::instance().is_hidden(categId))
         return false;
 
     return true;
@@ -868,10 +875,10 @@ bool CategoryManager::categShowStatus(int64 categId)
 
 wxString CategoryManager::getFullCategName()
 {
-    return CategoryModel::full_name(m_categ_id);
+    return CategoryModel::instance().full_name(m_categ_id);
 }
 
 bool CategoryManager::mmIsUsed() const
 {
-    return (CategoryModel::is_used(m_categ_id) || m_categ_id == m_init_selected_categ_id);
+    return (CategoryModel::instance().is_used(m_categ_id) || m_categ_id == m_init_selected_categ_id);
 }

--- a/src/manager/FieldManager.cpp
+++ b/src/manager/FieldManager.cpp
@@ -229,7 +229,7 @@ void FieldManager::UpdateField()
         FieldValueCol::CONTENT(txtSearch)
     );
     for (auto& fv_d : fv_a) {
-        fv_d.CONTENT = txtReplace;
+        fv_d.m_content = txtReplace;
     }
     FieldValueModel::instance().save_data_a(fv_a);
 

--- a/src/manager/FieldManager.cpp
+++ b/src/manager/FieldManager.cpp
@@ -173,7 +173,7 @@ void FieldManager::DeleteField()
         wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
     );
     if (DeleteResponse == wxYES) {
-        FieldModel::instance().Delete(m_field_id);
+        FieldModel::instance().purge_id(m_field_id);
         m_field_id = -1;
         fillControls();
     }

--- a/src/manager/FieldManager.cpp
+++ b/src/manager/FieldManager.cpp
@@ -104,25 +104,27 @@ void FieldManager::fillControls()
 {
     fieldListBox_->DeleteAllItems();
 
-    FieldModel::DataA fields = FieldModel::instance().find_all();
-    if (fields.empty()) return;
+    FieldModel::DataA field_a = FieldModel::instance().find_all();
+    if (field_a.empty())
+        return;
 
-    std::sort(fields.begin(), fields.end(), FieldData::SorterByDESCRIPTION());
+    std::sort(field_a.begin(), field_a.end(), FieldData::SorterByDESCRIPTION());
     int64 firstInTheListID = -1;
-    for (const auto& entry : fields)
-    {
-        if (firstInTheListID == -1) firstInTheListID = entry.FIELDID;
+    for (const auto& field_d : field_a) {
+        if (firstInTheListID == -1)
+            firstInTheListID = field_d.m_id;
         wxVector<wxVariant> data;
-        if (debug_) data.push_back(wxVariant(wxString::Format("%lld", entry.FIELDID)));
-        data.push_back(wxVariant(wxGetTranslation(entry.REFTYPE)));
-        data.push_back(wxVariant(entry.DESCRIPTION));
-        data.push_back(wxVariant(wxGetTranslation(entry.TYPE)));
+        if (debug_)
+            data.push_back(wxVariant(wxString::Format("%lld", field_d.m_id)));
+        data.push_back(wxVariant(wxGetTranslation(field_d.m_ref_type.name_n())));
+        data.push_back(wxVariant(field_d.m_description));
+        data.push_back(wxVariant(wxGetTranslation(field_d.m_type_n.name_n())));
 
-        wxString Properties = entry.PROPERTIES;
+        wxString Properties = field_d.m_properties;
         Properties.Replace("\n", "", true);
         data.push_back(wxVariant(Properties));
 
-        fieldListBox_->AppendItem(data, static_cast<wxUIntPtr>(entry.FIELDID.GetValue()));
+        fieldListBox_->AppendItem(data, static_cast<wxUIntPtr>(field_d.m_id.GetValue()));
     }
 
     m_field_id = firstInTheListID;
@@ -179,14 +181,14 @@ void FieldManager::DeleteField()
 
 void FieldManager::UpdateField()
 {
-    const FieldData *field = FieldModel::instance().get_id_data_n(m_field_id);
-    if (!field)
+    const FieldData* field_n = FieldModel::instance().get_id_data_n(m_field_id);
+    if (!field_n)
         return;
 
     int UpdateResponse = wxMessageBox(
         wxString::Format(_t("This function will bulk search & replace for \"%s\" custom field values\n"
             "It will match & replace only complete field value, no partial or middle-value replaces allowed\n"
-            "Please consider that there isn't any validation!"),field->DESCRIPTION)
+            "Please consider that there isn't any validation!"), field_n->m_description)
         , _t("Confirm Custom Field Content Update")
         , wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
     if (UpdateResponse != wxYES)
@@ -268,7 +270,7 @@ void FieldManager::OnItemRightClick(wxDataViewEvent& event)
 
     wxMenu* mainMenu = new wxMenu;
     if (field_n)
-        mainMenu->SetTitle(field_n->DESCRIPTION);
+        mainMenu->SetTitle(field_n->m_description);
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_NEW_FIELD, _t("&Add ")));
     mainMenu->AppendSeparator();
     mainMenu->Append(new wxMenuItem(mainMenu, MENU_EDIT_FIELD, _t("&Edit ")));

--- a/src/manager/PayeeManager.cpp
+++ b/src/manager/PayeeManager.cpp
@@ -189,7 +189,7 @@ void PayeeManager::fillControls()
             m_patternTable->SetCellValue(row++, 0, wxString::FromUTF8(member.value.GetString()));
         }
     }
-    const wxString category = CategoryModel::full_name(m_payee_n->m_category_id_n);
+    const wxString category = CategoryModel::instance().full_name(m_payee_n->m_category_id_n);
     m_category->ChangeValue(category);
     ResizeDialog();
 }
@@ -378,7 +378,7 @@ void PayeeManager::OnComboKey(wxKeyEvent& event)
             dlg.ShowModal();
             if (dlg.getRefreshRequested())
                 m_category->mmDoReInitialize();
-            category = CategoryModel::full_name(dlg.getCategId());
+            category = CategoryModel::instance().full_name(dlg.getCategId());
             m_category->ChangeValue(category);
             return;
         }

--- a/src/manager/PayeeManager.cpp
+++ b/src/manager/PayeeManager.cpp
@@ -755,7 +755,7 @@ void mmPayeeDialog::DeletePayee()
     FindSelectedPayees();
     for (RowData* rdata : m_selectedItems) {
         const PayeeData* payee_n = PayeeModel::instance().get_id_data_n(rdata->payeeId);
-        if (PayeeModel::instance().find_id_dep_cnt(rdata->payeeId) > 0) {
+        if (PayeeModel::instance().find_id_dep_c(rdata->payeeId) > 0) {
             wxString deletePayeeErrMsg = _t("Payee in use.");
             deletePayeeErrMsg
                 << "\n"

--- a/src/manager/PayeeManager.cpp
+++ b/src/manager/PayeeManager.cpp
@@ -772,35 +772,34 @@ void mmPayeeDialog::DeletePayee()
         TrxModel::DataA trx_a = TrxModel::instance().find(
             TrxCol::PAYEEID(rdata->payeeId)
         );
-        wxMessageDialog msgDlg(this
-            , _t("Deleted transactions exist which use this payee.")
-                + "\n\n" + _t("Deleting the payee will also automatically purge the associated deleted transactions.")
-                + "\n\n" + _t("Do you want to continue?")
-            , _t("Confirm Payee Deletion")
-            , wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
-        if (trx_a.empty() || msgDlg.ShowModal() == wxID_YES)
-        {
+        wxMessageDialog msgDlg(this,
+            _t("Deleted transactions exist which use this payee.") + "\n\n" +
+                _t("Deleting the payee will also automatically purge the associated deleted transactions.") + "\n\n" +
+                _t("Do you want to continue?"),
+            _t("Confirm Payee Deletion"),
+            wxYES_NO | wxNO_DEFAULT | wxICON_WARNING
+        );
+        if (trx_a.empty() || msgDlg.ShowModal() == wxID_YES) {
             if (!trx_a.empty()) {
                 TrxModel::instance().db_savepoint();
                 TrxSplitModel::instance().db_savepoint();
                 AttachmentModel::instance().db_savepoint();
                 FieldValueModel::instance().db_savepoint();
-                const wxString& RefType = TrxModel::refTypeName;
 
                 for (auto& trx_d : trx_a) {
+                    FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, trx_d.m_id);
+                    mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_d.m_id);
                     TrxModel::instance().purge_id(trx_d.m_id);
-                    mmAttachmentManage::DeleteAllAttachments(RefType, trx_d.m_id);
-                    FieldValueModel::DeleteAllData(RefType, trx_d.m_id);
                 }
 
-                TrxModel::instance().db_release_savepoint();
-                TrxSplitModel::instance().db_release_savepoint();
-                AttachmentModel::instance().db_release_savepoint();
                 FieldValueModel::instance().db_release_savepoint();
+                AttachmentModel::instance().db_release_savepoint();
+                TrxSplitModel::instance().db_release_savepoint();
+                TrxModel::instance().db_release_savepoint();
             }
 
             PayeeModel::instance().purge_id(payee_n->m_id);
-            mmAttachmentManage::DeleteAllAttachments(PayeeModel::refTypeName, payee_n->m_id);
+            mmAttachmentManage::DeleteAllAttachments(PayeeModel::s_ref_type, payee_n->m_id);
             refreshRequested_ = true;
             fillControls();
         }

--- a/src/manager/PayeeManager.cpp
+++ b/src/manager/PayeeManager.cpp
@@ -843,11 +843,10 @@ void mmPayeeDialog::RemoveDefaultCategory()
 
 void mmPayeeDialog::OnOrganizeAttachments()
 {
-    wxString RefType = PayeeModel::refTypeName;
     long sel = payeeListBox_->GetFocusedItem();
     if (sel > -1) {
         RowData* rdata = reinterpret_cast<RowData*>(payeeListBox_->GetItemData(sel));
-        AttachmentDialog dlg(this, RefType, rdata->payeeId);
+        AttachmentDialog dlg(this, PayeeModel::s_ref_type, rdata->payeeId);
         dlg.ShowModal();
         refreshRequested_ = true;
     }

--- a/src/manager/TagManager.cpp
+++ b/src/manager/TagManager.cpp
@@ -308,16 +308,20 @@ void TagManager::OnDelete(wxCommandEvent& WXUNUSED(event))
                 , _t("Confirm Tag Deletion"), wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
         
         if (tag_used == 0 || (tag_used == -1 && msgDlg.ShowModal() == wxID_YES)) {
-            TagLinkModel::DataA taglinks = TagLinkModel::instance().find(
+            TagLinkModel::DataA gl_a = TagLinkModel::instance().find(
                 TagLinkCol::TAGID(tag_d->m_id)
             );
-            for (const auto& link : taglinks)
+            for (const auto& gl_d : gl_a)
                 // Taglinks for deleted transactions are either TRANSACTION or TRANSACTIONSPLIT type.
                 // Remove the transactions which will delete all associated tags.
-                if (link.REFTYPE == TrxModel::refTypeName)
-                    TrxModel::instance().purge_id(link.REFID);
-                else if (link.REFTYPE == TrxSplitModel::refTypeName)
-                    TrxModel::instance().purge_id(TrxSplitModel::instance().get_id_data_n(link.REFID)->m_trx_id);
+                if (gl_d.m_ref_type == TrxModel::s_ref_type)
+                    TrxModel::instance().purge_id(gl_d.m_ref_id);
+                else if (gl_d.m_ref_type == TrxSplitModel::s_ref_type) {
+                    const TrxSplitData* tp_n = TrxSplitModel::instance().get_id_data_n(
+                        gl_d.m_ref_id
+                    );
+                    TrxModel::instance().purge_id(tp_n->m_trx_id);
+                }
             TagModel::instance().purge_id(tag_d->m_id);
             tagList_.Remove(selection);
             int index = selectedTags_.Index(selection);

--- a/src/manager/TagManager.cpp
+++ b/src/manager/TagManager.cpp
@@ -256,14 +256,14 @@ void TagManager::OnEdit(wxCommandEvent& WXUNUSED(event))
     if (text.IsEmpty() || old_name == text)
         return;
 
-    const TagData* tag_n = TagModel::instance().get_key(text);
+    const TagData* tag_n = TagModel::instance().get_name_data_n(text);
     if (tag_n) {
         wxString errMsg = _t("A tag with this name already exists");
         wxMessageBox(errMsg, _t("Tag Manager: Editing Error"), wxOK | wxICON_ERROR);
         return;
     }
 
-    tag_n = TagModel::instance().get_key(old_name);
+    tag_n = TagModel::instance().get_name_data_n(old_name);
     TagData tag_d = *tag_n;
     tag_d.m_name = text;
     TagModel::instance().save_data_n(tag_d);
@@ -296,20 +296,30 @@ void TagManager::OnDelete(wxCommandEvent& WXUNUSED(event))
     TrxModel::instance().db_savepoint();
     TrxSplitModel::instance().db_savepoint();
     for (const auto& selection : stringSelections) {
-        const TagData* tag_d = TagModel::instance().get_key(selection);
-        int tag_used = TagModel::instance().is_used(tag_d->m_id);
+        const TagData* tag_n = TagModel::instance().get_name_data_n(selection);
+        int tag_used = TagModel::instance().is_used(tag_n->m_id);
         if (tag_used == 1) {
-            wxMessageBox(wxString::Format(_t("Tag '%s' in use"), tag_d->m_name), _t("Tag Manager: Delete Error"), wxOK | wxICON_ERROR);
+            wxMessageBox(
+                wxString::Format(_t("Tag '%s' in use"), tag_n->m_name),
+                _t("Tag Manager: Delete Error"),
+                wxOK | wxICON_ERROR
+            );
             continue;
         }
-        wxMessageDialog msgDlg(this, wxString::Format(_t("Deleted transactions exist which use tag '%s'."), tag_d->m_name)
-                + "\n\n" + _t("Deleting the tag will also automatically purge the associated deleted transactions.")
-                + "\n\n" + _t("Do you want to continue?")
-                , _t("Confirm Tag Deletion"), wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
+        wxMessageDialog msgDlg(this,
+            wxString::Format(
+                _t("Deleted transactions exist which use tag '%s'."),
+                tag_n->m_name
+            ) + "\n\n" +
+                _t("Deleting the tag will also automatically purge the associated deleted transactions.") + "\n\n" +
+                _t("Do you want to continue?"),
+            _t("Confirm Tag Deletion"),
+            wxYES_NO | wxNO_DEFAULT | wxICON_WARNING
+        );
         
         if (tag_used == 0 || (tag_used == -1 && msgDlg.ShowModal() == wxID_YES)) {
             TagLinkModel::DataA gl_a = TagLinkModel::instance().find(
-                TagLinkCol::TAGID(tag_d->m_id)
+                TagLinkCol::TAGID(tag_n->m_id)
             );
             for (const auto& gl_d : gl_a)
                 // Taglinks for deleted transactions are either TRANSACTION or TRANSACTIONSPLIT type.
@@ -322,7 +332,7 @@ void TagManager::OnDelete(wxCommandEvent& WXUNUSED(event))
                     );
                     TrxModel::instance().purge_id(tp_n->m_trx_id);
                 }
-            TagModel::instance().purge_id(tag_d->m_id);
+            TagModel::instance().purge_id(tag_n->m_id);
             tagList_.Remove(selection);
             int index = selectedTags_.Index(selection);
             if (index != wxNOT_FOUND)
@@ -355,28 +365,25 @@ void TagManager::OnListSelChanged(wxCommandEvent& WXUNUSED(event))
     buttonEdit_->Enable(false);
     buttonDelete_->Enable(false);
 
-    wxArrayInt selections;
-    wxArrayString stringSelections;
+    wxArrayInt tag_i_a;
+    wxArrayString tag_name_a;
 
-    tagListBox_->GetSelections(selections);
-    for (const auto& selection : selections)
-        stringSelections.Add(tagListBox_->GetString(selection));
+    tagListBox_->GetSelections(tag_i_a);
+    for (const auto& tag_i : tag_i_a)
+        tag_name_a.Add(tagListBox_->GetString(tag_i));
 
-    int count = selections.GetCount();
+    int count = tag_i_a.GetCount();
 
     // Can only edit one tag at a time
-    if (count == 1)
-    {
+    if (count == 1) {
         buttonEdit_->Enable();
     }
     // Can delete multiple tags at once as long as all are unused
-    if (count > 0)
-    {
+    if (count > 0) {
         bool is_used = false;
-        for (const auto& selection : stringSelections)
-        {
-            const TagData* tag = TagModel::instance().get_key(selection);
-            is_used |= TagModel::instance().is_used(tag->m_id) == 1;
+        for (const auto& tag_name : tag_name_a) {
+            const TagData* tag_n = TagModel::instance().get_name_data_n(tag_name);
+            is_used |= TagModel::instance().is_used(tag_n->m_id) == 1;
         }
         buttonDelete_->Enable(!is_used);
     }    

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -655,7 +655,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
 
                     wxArrayInt64 tags;
                     for (const auto& gl_d : TagLinkModel::instance().find(
-                        TagLinkCol::REFTYPE(SchedSplitModel::refTypeName),
+                        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
                         TagLinkCol::REFID(qp_d.m_id)
                     )) {
                         tags.push_back(gl_d.m_tag_id);
@@ -698,7 +698,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 // Save base transaction tags
                 TagLinkModel::DataA new_gl_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(SchedModel::refTypeName),
+                    TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
                     TagLinkCol::REFID(q1.m_id)
                 )) {
                     TagLinkData new_gl_d = TagLinkData();
@@ -1429,9 +1429,8 @@ void mmGUIFrame::OnAccountAttachments(wxCommandEvent& /*event*/)
     if (!selectedItemData_)
         return;
 
-    wxString refType = AccountModel::refTypeName;
-    int64 refId = selectedItemData_->getId();
-    AttachmentDialog dlg(this, refType, refId);
+    int64 ref_id = selectedItemData_->getId();
+    AttachmentDialog dlg(this, AccountModel::s_ref_type, ref_id);
     dlg.ShowModal();
 }
 //----------------------------------------------------------------------------

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -681,14 +681,15 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
 
                 // Copy the custom fields to the newly created transaction
                 const auto& fv_a = FieldValueModel::instance().find(
-                    FieldValueCol::REFID(-q1.m_id)
+                    FieldValueModel::REFTYPEID(SchedModel::s_ref_type, q1.m_id)
                 );
                 FieldValueModel::instance().db_savepoint();
                 for (const auto& fv_d : fv_a) {
                     FieldValueData new_fv_d = FieldValueData();
-                    new_fv_d.FIELDID = fv_d.FIELDID;
-                    new_fv_d.REFID   = transID;
-                    new_fv_d.CONTENT = fv_d.CONTENT;
+                    new_fv_d.m_field_id = fv_d.m_field_id;
+                    new_fv_d.m_ref_type = RefTypeN(RefTypeN::e_trx);
+                    new_fv_d.m_ref_id   = transID;
+                    new_fv_d.m_content = fv_d.m_content;
                     FieldValueModel::instance().add_data_n(new_fv_d);
                 }
                 FieldValueModel::instance().db_release_savepoint();
@@ -1598,7 +1599,7 @@ void mmGUIFrame::OnPopupDeleteAccount(wxCommandEvent& /*event*/)
     if (msgDlg.ShowModal() == wxID_YES) {
         AccountModel::instance().purge_id(account_n->m_id);
         mmAttachmentManage::DeleteAllAttachments(
-            AccountModel::refTypeName, account_n->m_id
+            AccountModel::s_ref_type, account_n->m_id
         );
         DoRecreateNavTreeControl(true);
     }
@@ -3973,7 +3974,7 @@ void mmGUIFrame::OnDeleteAccount(wxCommandEvent& /*event*/)
         wxMessageDialog msgDlg(this, deletingAccountName, _t("Confirm Account Deletion"),
             wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION);
         if (msgDlg.ShowModal() == wxID_YES) {
-            mmAttachmentManage::DeleteAllAttachments(AccountModel::refTypeName, account->id());
+            mmAttachmentManage::DeleteAllAttachments(AccountModel::s_ref_type, account->id());
             AccountModel::instance().purge_id(account->id());
         }
     }
@@ -4213,31 +4214,28 @@ wxSizer* mmGUIFrame::cleanupHomePanel(bool new_sizer)
 void mmGUIFrame::autocleanDeletedTransactions() {
     wxDateSpan days = wxDateSpan::Days(SettingModel::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30));
     wxDateTime earliestDate = wxDateTime().Now().ToUTC().Subtract(days);
-    TrxModel::DataA deletedTransactions = TrxModel::instance().find(
+    TrxModel::DataA deleted_trx_a = TrxModel::instance().find(
         TrxCol::DELETEDTIME(OP_LE, earliestDate.FormatISOCombined()),
         TrxCol::DELETEDTIME(OP_NE, wxEmptyString)
     );
-    if (!deletedTransactions.empty()) {
-        TrxModel::instance().db_savepoint();
-        AttachmentModel::instance().db_savepoint();
-        TrxSplitModel::instance().db_savepoint();
-        FieldValueModel::instance().db_savepoint();
-        for (const auto& transaction : deletedTransactions) {
-            // removing the checking transaction also removes split, translink, and share entries
-            TrxModel::instance().purge_id(transaction.m_id);
+    if (deleted_trx_a.empty())
+        return;
 
-            // remove also any attachments for the transaction
-            const wxString& RefType = TrxModel::refTypeName;
-            mmAttachmentManage::DeleteAllAttachments(RefType, transaction.m_id);
+    TrxModel::instance().db_savepoint();
+    TrxSplitModel::instance().db_savepoint();
+    AttachmentModel::instance().db_savepoint();
+    FieldValueModel::instance().db_savepoint();
 
-            // remove also any custom fields for the transaction
-            FieldValueModel::DeleteAllData(RefType, transaction.m_id);
-        }
-        FieldValueModel::instance().db_release_savepoint();
-        TrxSplitModel::instance().db_release_savepoint();
-        AttachmentModel::instance().db_release_savepoint();
-        TrxModel::instance().db_release_savepoint();
+    for (const auto& trx_d : deleted_trx_a) {
+        FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, trx_d.m_id);
+        mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_d.m_id);
+        TrxModel::instance().purge_id(trx_d.m_id);
     }
+
+    FieldValueModel::instance().db_release_savepoint();
+    AttachmentModel::instance().db_release_savepoint();
+    TrxSplitModel::instance().db_release_savepoint();
+    TrxModel::instance().db_release_savepoint();
 }
 
 void mmGUIFrame::SetDatabaseFile(const wxString& dbFileName, bool newDatabase)

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -641,42 +641,43 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 new_trx_d.TRANSDATE         = payment_date.FormatISOCombined();
                 new_trx_d.m_color           = q1.m_color;
                 TrxModel::instance().save_trx_n(new_trx_d);
-                int64 transID = new_trx_d.id();
+                int64 new_trx_id = new_trx_d.id();
 
                 TrxSplitModel::DataA tp_a;
                 std::vector<wxArrayInt64> splitTags;
                 for (const auto& qp_d : SchedModel::split(q1)) {
                     TrxSplitData tp_d = TrxSplitData();
-                    tp_d.m_trx_id      = transID;
+                    tp_d.m_trx_id      = new_trx_id;
                     tp_d.m_category_id = qp_d.m_category_id;
                     tp_d.m_amount      = qp_d.m_amount;
                     tp_d.m_notes       = qp_d.m_notes;
                     tp_a.push_back(tp_d);
 
                     wxArrayInt64 tags;
-                    for (const auto& tag_d : TagLinkModel::instance().find(
+                    for (const auto& gl_d : TagLinkModel::instance().find(
                         TagLinkCol::REFTYPE(SchedSplitModel::refTypeName),
                         TagLinkCol::REFID(qp_d.m_id)
                     )) {
-                        tags.push_back(tag_d.TAGID);
+                        tags.push_back(gl_d.m_tag_id);
                     }
                     splitTags.push_back(tags);
                 }
                 TrxSplitModel::instance().save_data_a(tp_a);
 
                 // Save split tags
-                const wxString& splitRefType = TrxSplitModel::refTypeName;
-
                 for (size_t i = 0; i < tp_a.size(); i++) {
-                    TagLinkModel::DataA splitTaglinks;
+                    TagLinkModel::DataA new_gl_a;
                     for (const auto& tagId : splitTags.at(i)) {
                         TagLinkData new_gl_d = TagLinkData();
-                        new_gl_d.REFTYPE = splitRefType;
-                        new_gl_d.REFID   = tp_a[i].m_id;
-                        new_gl_d.TAGID   = tagId;
-                        splitTaglinks.push_back(new_gl_d);
+                        new_gl_d.m_tag_id   = tagId;
+                        new_gl_d.m_ref_type = TrxSplitModel::s_ref_type;
+                        new_gl_d.m_ref_id   = tp_a[i].m_id;
+                        new_gl_a.push_back(new_gl_d);
                     }
-                    TagLinkModel::instance().update(splitTaglinks, splitRefType, tp_a.at(i).m_id);
+                    TagLinkModel::instance().update(
+                        TrxSplitModel::s_ref_type, tp_a.at(i).m_id,
+                        new_gl_a
+                    );
                 }
 
                 // Copy the custom fields to the newly created transaction
@@ -688,26 +689,28 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                     FieldValueData new_fv_d = FieldValueData();
                     new_fv_d.m_field_id = fv_d.m_field_id;
                     new_fv_d.m_ref_type = RefTypeN(RefTypeN::e_trx);
-                    new_fv_d.m_ref_id   = transID;
+                    new_fv_d.m_ref_id   = new_trx_id;
                     new_fv_d.m_content = fv_d.m_content;
                     FieldValueModel::instance().add_data_n(new_fv_d);
                 }
                 FieldValueModel::instance().db_release_savepoint();
 
                 // Save base transaction tags
-                TagLinkModel::DataA taglinks;
-                const wxString& txnRefType = TrxModel::refTypeName;
+                TagLinkModel::DataA new_gl_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
                     TagLinkCol::REFTYPE(SchedModel::refTypeName),
                     TagLinkCol::REFID(q1.m_id)
                 )) {
                     TagLinkData new_gl_d = TagLinkData();
-                    new_gl_d.REFTYPE = txnRefType;
-                    new_gl_d.REFID   = transID;
-                    new_gl_d.TAGID   = gl_d.TAGID;
-                    taglinks.push_back(new_gl_d);
+                    new_gl_d.m_tag_id   = gl_d.m_tag_id;
+                    new_gl_d.m_ref_type = TrxModel::s_ref_type;
+                    new_gl_d.m_ref_id   = new_trx_id;
+                    new_gl_a.push_back(new_gl_d);
                 }
-                TagLinkModel::instance().update(taglinks, txnRefType, transID);
+                TagLinkModel::instance().update(
+                    TrxModel::s_ref_type, new_trx_id,
+                    new_gl_a
+                );
             }
             SchedModel::instance().completeBDInSeries(q1.m_id);
         }

--- a/src/model/AccountModel.cpp
+++ b/src/model/AccountModel.cpp
@@ -26,6 +26,8 @@
 #include "TrxLinkModel.h"
 #include "TrxShareModel.h"
 
+const RefTypeN AccountModel::s_ref_type = RefTypeN(RefTypeN::e_account);
+
 AccountModel::AccountModel() :
     TableFactory<AccountTable, AccountData>()
 {
@@ -284,7 +286,7 @@ const wxArrayString AccountModel::find_all_type_a(bool only_open)
     return usedTypes;
 }
 
-int AccountModel::find_money_type_cnt()
+int AccountModel::find_money_type_c()
 {
     return
         find(

--- a/src/model/AccountModel.cpp
+++ b/src/model/AccountModel.cpp
@@ -73,7 +73,7 @@ bool AccountModel::purge_id(int64 account_id)
         TrxCol::TOACCOUNTID(account_id)
     )) {
         if (TrxModel::is_foreign(trx_d)) {
-            TrxShareModel::instance().remove_trx_share(trx_d.m_id);
+            TrxShareModel::instance().purge_trxId(trx_d.m_id);
             const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_d.m_id);
             if (tl_n) {
                 TrxLinkModel::instance().purge_id(tl_n->m_id);
@@ -130,8 +130,8 @@ std::pair<double, double> AccountModel::get_data_investment_balance(const Data& 
     for (const auto& stock_d : StockModel::instance().find(
         StockCol::HELDAT(account_d.m_id)
     )) {
-        sum.first  += StockModel::CurrentValue(stock_d);
-        sum.second += StockModel::InvestmentValue(stock_d);
+        sum.first  += stock_d.current_value();
+        sum.second += stock_d.m_purchase_value;
     }
 
     for (const auto& asset_d : AssetModel::instance().find_or(

--- a/src/model/AccountModel.cpp
+++ b/src/model/AccountModel.cpp
@@ -74,8 +74,10 @@ bool AccountModel::purge_id(int64 account_id)
     )) {
         if (TrxModel::is_foreign(trx_d)) {
             TrxShareModel::instance().remove_trx_share(trx_d.m_id);
-            TrxLinkData tr = TrxLinkModel::TranslinkRecord(trx_d.m_id);
-            TrxLinkModel::instance().purge_id(tr.TRANSLINKID);
+            const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_d.m_id);
+            if (tl_n) {
+                TrxLinkModel::instance().purge_id(tl_n->m_id);
+            }
         }
         TrxModel::instance().purge_id(trx_d.m_id);
     }
@@ -87,7 +89,7 @@ bool AccountModel::purge_id(int64 account_id)
         SchedModel::instance().purge_id(sched_d.m_id);
 
     for (const auto& stock_d : StockModel::instance().find(StockCol::HELDAT(account_id))) {
-        TrxLinkModel::RemoveTransLinkRecords<StockModel>(stock_d.m_id);
+        TrxLinkModel::instance().purge_ref(StockModel::s_ref_type, stock_d.m_id);
         StockModel::instance().purge_id(stock_d.m_id);
     }
 

--- a/src/model/AccountModel.h
+++ b/src/model/AccountModel.h
@@ -37,6 +37,7 @@ class AccountModel : public TableFactory<AccountTable, AccountData>
 {
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     AccountModel();
@@ -76,7 +77,7 @@ public:
     auto find_all_name_a(bool only_open = false) -> const wxArrayString;
     auto find_all_name_id_m(bool only_open = false) -> const std::map<wxString, int64>;
     auto find_all_type_a(bool only_open = false) -> const wxArrayString;
-    int  find_money_type_cnt();
+    int  find_money_type_c();
 
     // wrapper for value format
     auto value_number(const Data& account_d, double value, int precision = 2) -> const wxString;

--- a/src/model/AccountModel.h
+++ b/src/model/AccountModel.h
@@ -36,7 +36,6 @@
 class AccountModel : public TableFactory<AccountTable, AccountData>
 {
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/AssetModel.cpp
+++ b/src/model/AssetModel.cpp
@@ -21,6 +21,8 @@
 #include "TrxLinkModel.h"
 #include "CurrencyHistoryModel.h"
 
+const RefTypeN AssetModel::s_ref_type = RefTypeN(RefTypeN::e_asset);
+
 AssetModel::AssetModel() :
     TableFactory<AssetTable, AssetData>()
 {

--- a/src/model/AssetModel.cpp
+++ b/src/model/AssetModel.cpp
@@ -108,7 +108,7 @@ const std::pair<double, double> AssetModel::get_data_value_date(const Data& asse
 
     TrxModel::DataA trx_a;
     for (const auto& tl_d : tl_a) {
-        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.CHECKINGACCOUNTID);
+        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
         if (trx_n &&
             trx_n->DELETEDTIME.IsEmpty() &&
             // FIXME: ignore Void transactions

--- a/src/model/AssetModel.cpp
+++ b/src/model/AssetModel.cpp
@@ -103,7 +103,7 @@ const std::pair<double, double> AssetModel::get_data_value_date(const Data& asse
 
     TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find(
         TrxLinkCol::LINKRECORDID(asset_d.m_id),
-        TrxLinkCol::LINKTYPE(this->refTypeName)
+        TrxLinkCol::LINKTYPE(s_ref_type.name_n())
     );
 
     TrxModel::DataA trx_a;

--- a/src/model/AssetModel.h
+++ b/src/model/AssetModel.h
@@ -22,6 +22,7 @@
 #include "base/defs.h"
 
 #include "table/AssetTable.h"
+#include "data/_DataEnum.h"
 #include "data/AssetData.h"
 
 #include "_ModelBase.h"
@@ -31,6 +32,7 @@ class AssetModel : public TableFactory<AssetTable, AssetData>
 {
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     AssetModel();

--- a/src/model/AssetModel.h
+++ b/src/model/AssetModel.h
@@ -31,7 +31,6 @@
 class AssetModel : public TableFactory<AssetTable, AssetData>
 {
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/AttachmentModel.cpp
+++ b/src/model/AttachmentModel.cpp
@@ -49,7 +49,7 @@ AttachmentModel& AttachmentModel::instance()
 }
 
 // Return the number of attachments linked to a specific object
-int AttachmentModel::find_id_c(RefTypeN ref_type, const int64 ref_id)
+int AttachmentModel::find_ref_c(RefTypeN ref_type, const int64 ref_id)
 {
     return AttachmentModel::instance().find(
         AttachmentCol::REFTYPE(ref_type.name_n()),
@@ -58,7 +58,7 @@ int AttachmentModel::find_id_c(RefTypeN ref_type, const int64 ref_id)
 }
 
 // Return a dataset with attachments linked to a specific object
-const AttachmentModel::DataA AttachmentModel::find_id_data_a(
+const AttachmentModel::DataA AttachmentModel::find_ref_data_a(
     RefTypeN ref_type,
     const int64 ref_id
 ) {
@@ -73,10 +73,10 @@ const AttachmentModel::DataA AttachmentModel::find_id_data_a(
 }
 
 // Return the last attachment number linked to a specific object
-int AttachmentModel::find_id_last_num(RefTypeN ref_type, const int64 ref_id)
+int AttachmentModel::find_ref_last_num(RefTypeN ref_type, const int64 ref_id)
 {
     int max_num = 0;
-    for (const auto& att_d : AttachmentModel::instance().find_id_data_a(ref_type, ref_id)) {
+    for (const auto& att_d : find_ref_data_a(ref_type, ref_id)) {
         wxString att_filename = att_d.m_filename;
         int num = wxAtoi(att_filename.SubString(
             att_filename.Find("Attach") + 6,

--- a/src/model/AttachmentModel.cpp
+++ b/src/model/AttachmentModel.cpp
@@ -89,17 +89,17 @@ int AttachmentModel::find_ref_last_num(RefTypeN ref_type, const int64 ref_id)
 }
 
 // Return a dataset with attachments linked to a specific type
-std::map<int64, AttachmentModel::DataA> AttachmentModel::find_reftype_refid_data_m(
+std::map<int64, AttachmentModel::DataA> AttachmentModel::find_refType_mRefId(
     RefTypeN ref_type
 ) {
-    std::map<int64, AttachmentModel::DataA> refid_data_m;
+    std::map<int64, AttachmentModel::DataA> refId_dataA_m;
     for (const auto& att_d : find(
         AttachmentCol::REFTYPE(ref_type.name_n())
     )) {
-        refid_data_m[att_d.m_ref_id].push_back(att_d);
+        refId_dataA_m[att_d.m_ref_id].push_back(att_d);
     }
 
-    return refid_data_m;
+    return refId_dataA_m;
 }
 
 // Return all attachments descriptions

--- a/src/model/AttachmentModel.cpp
+++ b/src/model/AttachmentModel.cpp
@@ -30,10 +30,8 @@ AttachmentModel::~AttachmentModel()
 {
 }
 
-/**
-* Initialize the global AttachmentModel table.
-* Reset the AttachmentModel table or create the table if it does not exist.
-*/
+// Initialize the global AttachmentModel table.
+// Reset the AttachmentModel table or create the table if it does not exist.
 AttachmentModel& AttachmentModel::instance(wxSQLite3Database* db)
 {
     AttachmentModel& ins = Singleton<AttachmentModel>::instance();
@@ -44,74 +42,75 @@ AttachmentModel& AttachmentModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of AttachmentModel table */
+// Return the static instance of AttachmentModel table
 AttachmentModel& AttachmentModel::instance()
 {
     return Singleton<AttachmentModel>::instance();
 }
 
-/** Return a dataset with attachments linked to a specific object */
-const AttachmentModel::DataA AttachmentModel::FilterAttachments(const wxString& RefType, const int64 RefId)
-{
-    DataA attachments;
-    for (const Data& attachment : find_all(Col::COL_ID_DESCRIPTION)) {
-        if (attachment.REFTYPE.Lower().Matches(RefType.Lower().Append("*")) && attachment.REFID == RefId)
-            attachments.push_back(attachment);
-    }
-    return attachments;
-}
-
-/** Return the number of attachments linked to a specific object */
-int AttachmentModel::NrAttachments(const wxString& RefType, const int64 RefId)
+// Return the number of attachments linked to a specific object
+int AttachmentModel::find_id_c(RefTypeN ref_type, const int64 ref_id)
 {
     return AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(RefType),
-        AttachmentCol::REFID(RefId)
+        AttachmentCol::REFTYPE(ref_type.name_n()),
+        AttachmentCol::REFID(ref_id)
     ).size();
 }
 
-/** Return the last attachment number linked to a specific object */
-int AttachmentModel::LastAttachmentNumber(const wxString& RefType, const int64 RefId)
-{
-    int LastAttachmentNumber = 0;
-    AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(RefType, RefId);
-
-    for (auto &attachment : attachments)
-    {
-        wxString FileName = attachment.FILENAME;
-        int AttachNumb = wxAtoi(FileName.SubString(FileName.Find("Attach") + 6, FileName.Find(".") - 1));
-        if (AttachNumb > LastAttachmentNumber)
-            LastAttachmentNumber = AttachNumb;
+// Return a dataset with attachments linked to a specific object
+const AttachmentModel::DataA AttachmentModel::find_id_data_a(
+    RefTypeN ref_type,
+    const int64 ref_id
+) {
+    DataA att_a;
+    for (const Data& att_d : find_all(Col::COL_ID_DESCRIPTION)) {
+        if (att_d.m_ref_type_n.name_n().Lower().Matches(
+            ref_type.name_n().Lower().Append("*")
+        ) && att_d.m_ref_id == ref_id)
+            att_a.push_back(att_d);
     }
-
-    return LastAttachmentNumber;
+    return att_a;
 }
 
-/** Return a dataset with attachments linked to a specific type*/
-std::map<int64, AttachmentModel::DataA> AttachmentModel::get_reftype(const wxString& reftype)
+// Return the last attachment number linked to a specific object
+int AttachmentModel::find_id_last_num(RefTypeN ref_type, const int64 ref_id)
 {
-    std::map<int64, AttachmentModel::DataA> data;
-    for (const auto & attachment : this->find(
-        AttachmentCol::REFTYPE(reftype)
+    int max_num = 0;
+    for (const auto& att_d : AttachmentModel::instance().find_id_data_a(ref_type, ref_id)) {
+        wxString att_filename = att_d.m_filename;
+        int num = wxAtoi(att_filename.SubString(
+            att_filename.Find("Attach") + 6,
+            att_filename.Find(".") - 1
+        ));
+        if (max_num < num)
+            max_num = num;
+    }
+    return max_num;
+}
+
+// Return a dataset with attachments linked to a specific type
+std::map<int64, AttachmentModel::DataA> AttachmentModel::find_type_id_data_a_m(RefTypeN ref_type)
+{
+    std::map<int64, AttachmentModel::DataA> id_a_m;
+    for (const auto& att_d : find(
+        AttachmentCol::REFTYPE(ref_type.name_n())
     )) {
-        data[attachment.REFID].push_back(attachment);
+        id_a_m[att_d.m_ref_id].push_back(att_d);
     }
 
-    return data;
+    return id_a_m;
 }
 
-/** Return all attachments descriptions*/
-wxArrayString AttachmentModel::allDescriptions()
+// Return all attachments descriptions
+wxArrayString AttachmentModel::find_all_desc_a()
 {
-    wxArrayString descriptions;
-    wxString PreviousDescription;
-    for (const auto &attachment : this->find_all(Col::COL_ID_DESCRIPTION))
-    {
-        if (attachment.DESCRIPTION != PreviousDescription)
-        {
-            descriptions.Add(attachment.DESCRIPTION);
-            PreviousDescription = attachment.DESCRIPTION;
+    wxArrayString desc_a;
+    wxString prev_desc;
+    for (const auto& att_d : find_all(Col::COL_ID_DESCRIPTION)) {
+        if (att_d.m_description != prev_desc) {
+            desc_a.Add(att_d.m_description);
+            prev_desc = att_d.m_description;
         }
     }
-    return descriptions;
+    return desc_a;
 }

--- a/src/model/AttachmentModel.cpp
+++ b/src/model/AttachmentModel.cpp
@@ -89,16 +89,17 @@ int AttachmentModel::find_ref_last_num(RefTypeN ref_type, const int64 ref_id)
 }
 
 // Return a dataset with attachments linked to a specific type
-std::map<int64, AttachmentModel::DataA> AttachmentModel::find_type_id_data_a_m(RefTypeN ref_type)
-{
-    std::map<int64, AttachmentModel::DataA> id_a_m;
+std::map<int64, AttachmentModel::DataA> AttachmentModel::find_reftype_refid_data_m(
+    RefTypeN ref_type
+) {
+    std::map<int64, AttachmentModel::DataA> refid_data_m;
     for (const auto& att_d : find(
         AttachmentCol::REFTYPE(ref_type.name_n())
     )) {
-        id_a_m[att_d.m_ref_id].push_back(att_d);
+        refid_data_m[att_d.m_ref_id].push_back(att_d);
     }
 
-    return id_a_m;
+    return refid_data_m;
 }
 
 // Return all attachments descriptions

--- a/src/model/AttachmentModel.h
+++ b/src/model/AttachmentModel.h
@@ -42,4 +42,3 @@ public:
     auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
     auto find_all_desc_a() -> wxArrayString;
 };
-

--- a/src/model/AttachmentModel.h
+++ b/src/model/AttachmentModel.h
@@ -39,6 +39,6 @@ public:
     int  find_ref_c(RefTypeN ref_type, const int64 ref_id);
     auto find_ref_data_a(RefTypeN ref_type, const int64 ref_id) -> const DataA;
     int  find_ref_last_num(RefTypeN ref_type, const int64 ref_id);
-    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
+    auto find_refType_mRefId(RefTypeN ref_type) -> std::map<int64, DataA>;
     auto find_all_desc_a() -> wxArrayString;
 };

--- a/src/model/AttachmentModel.h
+++ b/src/model/AttachmentModel.h
@@ -36,9 +36,9 @@ public:
     static AttachmentModel& instance();
 
 public:
-    int  find_id_c(RefTypeN ref_type, const int64 ref_id);
-    auto find_id_data_a(RefTypeN ref_type, const int64 ref_id) -> const DataA;
-    int  find_id_last_num(RefTypeN ref_type, const int64 ref_id);
+    int  find_ref_c(RefTypeN ref_type, const int64 ref_id);
+    auto find_ref_data_a(RefTypeN ref_type, const int64 ref_id) -> const DataA;
+    int  find_ref_last_num(RefTypeN ref_type, const int64 ref_id);
     auto find_type_id_data_a_m(RefTypeN ref_type) -> std::map<int64, DataA>;
     auto find_all_desc_a() -> wxArrayString;
 };

--- a/src/model/AttachmentModel.h
+++ b/src/model/AttachmentModel.h
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2014 Gabriele-V
+ Copyright (C) 2026 George Ef (george.a.ef@gmail.com)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -19,8 +20,6 @@
 #pragma once
 
 #include "base/defs.h"
-#include "util/mmChoice.h"
-
 #include "table/AttachmentTable.h"
 #include "data/AttachmentData.h"
 
@@ -33,34 +32,14 @@ public:
     ~AttachmentModel();
 
 public:
-    /**
-    Initialize the global AttachmentModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for AttachmentModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static AttachmentModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for AttachmentModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static AttachmentModel& instance();
 
 public:
-    /** Return a dataset with attachments linked to a specific object */
-    const DataA FilterAttachments(const wxString& RefType, const int64 RefId);
-
-    /** Return the number of attachments linked to a specific object */
-    static int NrAttachments(const wxString& RefType, const int64 RefId);
-
-    /** Return the last attachment number linked to a specific object */
-    static int LastAttachmentNumber(const wxString& RefType, const int64 RefId);
-
-    /** Return a dataset with attachments linked to a specific type*/
-    std::map<int64, DataA> get_reftype(const wxString& reftype);
-
-    /** Return all attachments descriptions*/
-    wxArrayString allDescriptions();
+    int  find_id_c(RefTypeN ref_type, const int64 ref_id);
+    auto find_id_data_a(RefTypeN ref_type, const int64 ref_id) -> const DataA;
+    int  find_id_last_num(RefTypeN ref_type, const int64 ref_id);
+    auto find_type_id_data_a_m(RefTypeN ref_type) -> std::map<int64, DataA>;
+    auto find_all_desc_a() -> wxArrayString;
 };
 

--- a/src/model/AttachmentModel.h
+++ b/src/model/AttachmentModel.h
@@ -39,7 +39,7 @@ public:
     int  find_ref_c(RefTypeN ref_type, const int64 ref_id);
     auto find_ref_data_a(RefTypeN ref_type, const int64 ref_id) -> const DataA;
     int  find_ref_last_num(RefTypeN ref_type, const int64 ref_id);
-    auto find_type_id_data_a_m(RefTypeN ref_type) -> std::map<int64, DataA>;
+    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
     auto find_all_desc_a() -> wxArrayString;
 };
 

--- a/src/model/BudgetModel.cpp
+++ b/src/model/BudgetModel.cpp
@@ -36,10 +36,8 @@ BudgetModel::~BudgetModel()
 {
 }
 
-/**
-* Initialize the global BudgetModel table.
-* Reset the BudgetModel table or create the table if it does not exist.
-*/
+// Initialize the global BudgetModel table.
+// Reset the BudgetModel table or create the table if it does not exist.
 BudgetModel& BudgetModel::instance(wxSQLite3Database* db)
 {
     BudgetModel& ins = Singleton<BudgetModel>::instance();
@@ -50,7 +48,7 @@ BudgetModel& BudgetModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of BudgetModel table */
+// Return the static instance of BudgetModel table
 BudgetModel& BudgetModel::instance()
 {
     return Singleton<BudgetModel>::instance();
@@ -61,19 +59,8 @@ BudgetCol::PERIOD BudgetModel::FREQUENCY(OP op, BudgetFrequency freq)
     return BudgetCol::PERIOD(op, freq.name());
 }
 
-double BudgetModel::getEstimate(
-    bool is_monthly,
-    const BudgetFrequency freq,
-    double amount
-) {
-    double estimated = amount * freq.times_per_year();
-    if (is_monthly)
-        estimated = estimated / 12;
-    return estimated;
-}
-
 void BudgetModel::getBudgetEntry(
-    int64 budgetYearID,
+    int64 bp_id,
     std::map<int64, BudgetFrequency>& budgetFreq,
     std::map<int64, double>& budgetAmt,
     std::map<int64, wxString>& budgetNotes
@@ -85,11 +72,12 @@ void BudgetModel::getBudgetEntry(
     }
 
     for (const auto& budget_d : find(
-        BudgetCol::BUDGETYEARID(budgetYearID)
+        BudgetCol::BUDGETYEARID(bp_id)
     )) {
-        budgetFreq[budget_d.m_category_id]  = budget_d.m_frequency;
-        budgetAmt[budget_d.m_category_id]   = budget_d.m_amount;
-        budgetNotes[budget_d.m_category_id] = budget_d.m_notes;
+        int64 category_id = budget_d.m_category_id;
+        budgetFreq[category_id]  = budget_d.m_frequency;
+        budgetAmt[category_id]   = budget_d.m_amount;
+        budgetNotes[category_id] = budget_d.m_notes;
     }
 }
 
@@ -113,27 +101,27 @@ void BudgetModel::getBudgetStats(
     std::map<std::pair<int, int64>, bool> isBudgeted;
     std::map<int64, int> budgetedMonths;
     const wxString year = wxString::Format("%i", start_date.GetYear());
-    int64 budgetYearID = BudgetPeriodModel::instance().get_name_id(year);
+    int64 bp_id_n = BudgetPeriodModel::instance().get_name_id_n(year);
     for (const Data& budget_d : find(
-        BudgetCol::BUDGETYEARID(budgetYearID)
+        BudgetCol::BUDGETYEARID(bp_id_n)
     )) {
         int64 category_id = budget_d.m_category_id;
         // Determine the monhly budgeted amounts
-        monthlyBudgetValue[category_id] = getEstimate(true, budget_d.m_frequency, budget_d.m_amount);
+        monthlyBudgetValue[category_id] = budget_d.amount_per_month();
         // Determine the yearly budgeted amounts
-        yearlyBudgetValue[category_id] = getEstimate(false, budget_d.m_frequency, budget_d.m_amount);
+        yearlyBudgetValue[category_id] = budget_d.amount_per_year();
         // Store the yearly budget to use in reporting. Monthly budgets are stored in index 0-11, so use index 12 for year
         budgetStats[category_id][12] = yearlyBudgetValue[category_id];
     }
     bool budgetOverride = PrefModel::instance().getBudgetOverride();
     bool budgetDeductMonthly = PrefModel::instance().getBudgetDeductMonthly();
     for (int month = 0; month < 12; month++) {
-        const wxString budgetYearMonth = wxString::Format("%s-%02d", year, month + 1);
-        budgetYearID = BudgetPeriodModel::instance().get_name_id(budgetYearMonth);
+        const wxString month_name = wxString::Format("%s-%02d", year, month + 1);
+        bp_id_n = BudgetPeriodModel::instance().get_name_id_n(month_name);
 
         //fill with amount from monthly budgets first
         for (const Data& budget_d : find(
-            BudgetCol::BUDGETYEARID(budgetYearID)
+            BudgetCol::BUDGETYEARID(bp_id_n)
         )) {
             int64 category_id = budget_d.m_category_id;
             std::pair<int, int64> month_categ = std::make_pair(month, category_id);
@@ -141,7 +129,7 @@ void BudgetModel::getBudgetStats(
                 isBudgeted[month_categ] = true;
                 budgetedMonths[category_id]++;
             }
-            budgetStats[category_id][month] = getEstimate(true, budget_d.m_frequency, budget_d.m_amount);
+            budgetStats[category_id][month] = budget_d.amount_per_month();
             yearDeduction[category_id] += budgetStats[category_id][month];
         }
     }
@@ -185,43 +173,49 @@ void BudgetModel::getBudgetStats(
     }
 }
 
-void BudgetModel::copyBudgetYear(int64 newYearID, int64 baseYearID)
+void BudgetModel::copyBudgetYear(int64 dst_bp_id, int64 src_bp_id)
 {
     std::map<int64, double> yearDeduction;
     int budgetedMonths = 0;
     bool optionDeductMonthly = PrefModel::instance().getBudgetDeductMonthly();
-    const wxString baseBudgetYearName = BudgetPeriodModel::instance().get_id_data_n(baseYearID)->m_name;
-    const wxString newBudgetYearName = BudgetPeriodModel::instance().get_id_data_n(newYearID)->m_name;
+    const wxString src_bp_name = BudgetPeriodModel::instance().get_id_name_n(src_bp_id);
+    const wxString dst_bp_name = BudgetPeriodModel::instance().get_id_name_n(dst_bp_id);
 
     // Only deduct monthly amounts if a monthly budget is being created based on a yearly budget
-    optionDeductMonthly &= (baseBudgetYearName.length() == 4 && newBudgetYearName.length() > 4);
+    optionDeductMonthly &= (src_bp_name.length() == 4 && dst_bp_name.length() > 4);
 
     if (optionDeductMonthly) {
-        for (int month = 0; month < 12; month++) {
-            const wxString budgetYearMonth = wxString::Format("%s-%02d", newBudgetYearName.SubString(0,3), month + 1);
-            int64 budgetYearID = BudgetPeriodModel::instance().get_name_id(budgetYearMonth);
-            BudgetModel::DataA budget_a = find(
-                BudgetCol::BUDGETYEARID(budgetYearID)
+        for (int month = 0; month < 12; ++month) {
+            const wxString dst_month_name = wxString::Format("%s-%02d",
+                dst_bp_name.SubString(0,3),
+                month + 1
             );
-            if (!budget_a.empty())
-                budgetedMonths++;
+            int64 dst_month_id_n = BudgetPeriodModel::instance().get_name_id_n(dst_month_name);
+            if (dst_month_id_n <= 0)
+                continue;
+            BudgetModel::DataA dst_budget_a = find(
+                BudgetCol::BUDGETYEARID(dst_month_id_n)
+            );
+            if (!dst_budget_a.empty())
+                budgetedMonths += 1;
             //calculate deduction
-            for (const auto& budget_d : budget_a) {
-                yearDeduction[budget_d.m_category_id] += getEstimate(true, budget_d.m_frequency, budget_d.m_amount);
+            for (const auto& dst_budget_d : dst_budget_a) {
+                yearDeduction[dst_budget_d.m_category_id] += dst_budget_d.amount_per_month();
             }
         }
     }
 
-    for (const Data& budget_d : find(
-        BudgetCol::BUDGETYEARID(baseYearID)
+    for (const Data& src_budget_d : find(
+        BudgetCol::BUDGETYEARID(src_bp_id)
     )) {
         Data new_budget_d = Data();
-        new_budget_d.clone_from(budget_d);
-        new_budget_d.m_period_id = newYearID;
-        double yearAmount = getEstimate(false, budget_d.m_frequency, budget_d.m_amount);
+        new_budget_d.clone_from(src_budget_d);
+        new_budget_d.m_period_id = dst_bp_id;
         if (optionDeductMonthly && budgetedMonths > 0) {
+            double yearAmount = src_budget_d.amount_per_year();
             new_budget_d.m_frequency = BudgetFrequency(BudgetFrequency::e_monthly);
-            new_budget_d.m_amount    = (yearDeduction[new_budget_d.m_category_id] / yearAmount < 1)
+            // CHECK: budgetedMonths can be 12
+            new_budget_d.m_amount    = (yearDeduction[new_budget_d.m_category_id] < yearAmount)
                 ? (yearAmount - yearDeduction[new_budget_d.m_category_id]) / (12 - budgetedMonths)
                 : 0;
         }

--- a/src/model/BudgetModel.h
+++ b/src/model/BudgetModel.h
@@ -32,39 +32,26 @@
 class BudgetModel : public TableFactory<BudgetTable, BudgetData>
 {
 public:
-    /**
-    Initialize the global BudgetModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for BudgetModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static BudgetModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for BudgetModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static BudgetModel& instance();
 
 public:
     static BudgetCol::PERIOD FREQUENCY(OP op, BudgetFrequency freq);
-
-    static double getEstimate(bool is_monthly, const BudgetFrequency freq, double amount);
 
 public:
     BudgetModel();
     ~BudgetModel();
 
     void getBudgetEntry(
-        int64 budgetYearID,
+        int64 bp_id,
         std::map<int64, BudgetFrequency>& budgetFreq,
-        std::map<int64, double> &budgetAmt,
-        std::map<int64, wxString> &budgetNotes
+        std::map<int64, double>& budgetAmt,
+        std::map<int64, wxString>& budgetNotes
     );
     void getBudgetStats(
         std::map<int64, std::map<int, double>>& budgetStats,
         mmDateRange* date_range,
         bool groupByMonth
     );
-    void copyBudgetYear(int64 newYearID, int64 baseYearID);
+    void copyBudgetYear(int64 dst_bp_id, int64 src_bp_id);
 };

--- a/src/model/BudgetPeriodModel.cpp
+++ b/src/model/BudgetPeriodModel.cpp
@@ -46,39 +46,39 @@ BudgetPeriodModel& BudgetPeriodModel::instance()
     return Singleton<BudgetPeriodModel>::instance();
 }
 
-bool BudgetPeriodModel::purge_id(int64 id)
+bool BudgetPeriodModel::purge_id(int64 bp_id)
 {
     for (const BudgetData& budget_d : BudgetModel::instance().find(
-        BudgetCol::BUDGETYEARID(id)
+        BudgetCol::BUDGETYEARID(bp_id)
     ))
         BudgetModel::instance().purge_id(budget_d.m_period_id);
-    return unsafe_remove_id(id);
+    return unsafe_remove_id(bp_id);
 }
 
-const wxString BudgetPeriodModel::get_id_name(int64 period_id)
+const wxString BudgetPeriodModel::get_id_name_n(int64 bp_id)
 {
-    const Data* bp_n = get_id_data_n(period_id);
+    const Data* bp_n = get_id_data_n(bp_id);
     return bp_n ? bp_n->m_name : "";
 }
 
-int64 BudgetPeriodModel::get_name_id(const wxString& period_name)
+int64 BudgetPeriodModel::get_name_id_n(const wxString& bp_name)
 {
-    // TODO: lookup period_name in cache
+    // TODO: lookup bp_name in cache
     for (const auto& bp_d : find_all()) {
-        if (bp_d.m_name == period_name)
+        if (bp_d.m_name == bp_name)
             return bp_d.m_id;
     }
     return -1;
 }
 
-int64 BudgetPeriodModel::ensure_name(const wxString& period_name)
+int64 BudgetPeriodModel::ensure_name(const wxString& bp_name)
 {
-    int64 period_id = get_name_id(period_name);
-    if (period_id < 0) {
+    int64 bp_id_n = get_name_id_n(bp_name);
+    if (bp_id_n < 0) {
         Data new_bp_d = Data();
-        new_bp_d.m_name = period_name;
+        new_bp_d.m_name = bp_name;
         add_data_n(new_bp_d);
-        period_id = new_bp_d.id();
+        bp_id_n = new_bp_d.id();
     }
-    return period_id;
+    return bp_id_n;
 }

--- a/src/model/BudgetPeriodModel.h
+++ b/src/model/BudgetPeriodModel.h
@@ -37,10 +37,10 @@ public:
 
 public:
     // override
-    bool purge_id(int64 id) override;
+    bool purge_id(int64 bp_id) override;
 
-    auto get_id_name(int64 period_id) -> const wxString;
-    auto get_name_id(const wxString& period_name) -> int64;
-    auto ensure_name(const wxString& period_name) -> int64;
+    auto get_id_name_n(int64 bp_id) -> const wxString;
+    auto get_name_id_n(const wxString& bp_name) -> int64;
+    auto ensure_name(const wxString& bp_name) -> int64;
 };
 

--- a/src/model/CategoryModel.cpp
+++ b/src/model/CategoryModel.cpp
@@ -37,10 +37,8 @@ CategoryModel::~CategoryModel()
 {
 }
 
-/**
-* Initialize the global CategoryModel table.
-* Reset the CategoryModel table or create the table if it does not exist.
-*/
+// Initialize the global CategoryModel table.
+// Reset the CategoryModel table or create the table if it does not exist.
 CategoryModel& CategoryModel::instance(wxSQLite3Database* db)
 {
     CategoryModel& ins = Singleton<CategoryModel>::instance();
@@ -52,86 +50,83 @@ CategoryModel& CategoryModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of CategoryModel table */
+// Return the static instance of CategoryModel table
 CategoryModel& CategoryModel::instance()
 {
     return Singleton<CategoryModel>::instance();
 }
 
-const wxArrayString CategoryModel::FilterCategory(const wxString& category_pattern)
+const CategoryData* CategoryModel::get_key_data_n(const wxString& name, const int64 parentid)
+{
+    const Data* cat_n = search_cache_n(
+        CategoryCol::CATEGNAME(name),
+        CategoryCol::PARENTID(parentid)
+    );
+    if (cat_n)
+        return cat_n;
+
+    DataA cat_a = find(
+        CategoryCol::CATEGNAME(name),
+        CategoryCol::PARENTID(parentid)
+    );
+    if (!cat_a.empty())
+        cat_n = get_id_data_n(cat_a[0].m_id);
+    return cat_n;
+}
+
+CategoryModel::DataA CategoryModel::find_data_sub_a(const Data& cat_d)
+{
+    return find(CategoryCol::PARENTID(cat_d.m_id));
+}
+
+const wxArrayString CategoryModel::FilterCategory(const wxString& cat_pattern)
 {
     wxArrayString categories;
-    for (auto& category_d : CategoryModel::instance().find_all()) {
-        if (category_d.m_name.Lower().Matches(category_pattern.Lower().Append("*")))
-            categories.push_back(category_d.m_name);
+    for (auto& cat_d : CategoryModel::instance().find_all()) {
+        if (cat_d.m_name.Lower().Matches(cat_pattern.Lower().Append("*")))
+            categories.push_back(cat_d.m_name);
     }
     return categories;
 }
 
-const CategoryData* CategoryModel::get_name(const wxString& name, const wxString& parentname)
+// FIXME: This method is ill-defined (there can be multiple matches)
+const CategoryData* CategoryModel::get_name(const wxString& name, const wxString& parent_name)
 {
-    const Data* category_n = nullptr;
-    DataA category_a = this->find(CategoryCol::CATEGNAME(name));
-    for (const auto& category_d : category_a) {
-        if (category_d.m_parent_id_n != -1) {
-            if (instance().get_id_data_n(category_d.m_parent_id_n)->m_name.Lower() == parentname.Lower()) {
-                category_n = get_id_data_n(category_d.m_id);
+    const Data* cat_n = nullptr;
+    DataA cat_a = find(CategoryCol::CATEGNAME(name));
+    for (const auto& cat_d : cat_a) {
+        if (cat_d.m_parent_id_n != -1) {
+            const Data* parent_n = get_id_data_n(cat_d.m_parent_id_n);
+            if (parent_n->m_name.Lower() == parent_name.Lower()) {
+                cat_n = get_id_data_n(cat_d.m_id);
                 break;
             }
         }
     }
 
-    return category_n;
-}
-
-const CategoryData* CategoryModel::get_key(const wxString& name, const int64 parentid)
-{
-    const Data* category_n = search_cache_n(
-        CategoryCol::CATEGNAME(name),
-        CategoryCol::PARENTID(parentid)
-    );
-    if (category_n)
-        return category_n;
-
-    DataA category_a = this->find(
-        CategoryCol::CATEGNAME(name),
-        CategoryCol::PARENTID(parentid)
-    );
-    if (!category_a.empty())
-        category_n = get_id_data_n(category_a[0].m_id);
-    return category_n;
+    return cat_n;
 }
 
 const std::map<wxString, int64> CategoryModel::all_categories(bool excludeHidden)
 {
     std::map<wxString, int64> full_categs;
-    for (const auto& category_d : instance().find_all(Col::COL_ID_CATEGID)) {
-        if (excludeHidden && !category_d.m_active)
+    for (const auto& cat_d : instance().find_all(Col::COL_ID_CATEGID)) {
+        if (excludeHidden && !cat_d.m_active)
             continue;
 
-        full_categs[full_name(category_d.m_id)] = category_d.m_id;
+        full_categs[full_name(cat_d.m_id)] = cat_d.m_id;
     }
     return full_categs;
 }
 
-CategoryModel::DataA CategoryModel::sub_category(const Data* category_n)
-{
-    return instance().find(CategoryCol::PARENTID(category_n->m_id));
-}
-
-CategoryModel::DataA CategoryModel::sub_category(const Data& category_d)
-{
-    return instance().find(CategoryCol::PARENTID(category_d.m_id));
-}
-
-CategoryModel::DataA CategoryModel::sub_tree(const Data* category_n)
+CategoryModel::DataA CategoryModel::find_data_subtree_a(const Data& cat_d)
 {
     DataA tree;
-    DataA sub_a = instance().find(CategoryCol::PARENTID(category_n->m_id));
+    DataA sub_a = find(CategoryCol::PARENTID(cat_d.m_id));
     std::stable_sort(sub_a.begin(), sub_a.end(), CategoryData::SorterByCATEGNAME());
     for (const auto& sub_d : sub_a) {
         tree.push_back(sub_d);
-        DataA subtree_a = sub_tree(sub_d);
+        DataA subtree_a = find_data_subtree_a(sub_d);
         for (const auto& subtree_d : subtree_a) {
             tree.push_back(subtree_d);
         }
@@ -139,47 +134,45 @@ CategoryModel::DataA CategoryModel::sub_tree(const Data* category_n)
     return tree;
 }
 
-CategoryModel::DataA CategoryModel::sub_tree(const Data& category_d)
-{
-    return sub_tree(&category_d);
-}
-
-const wxString CategoryModel::full_name(const Data* category_n)
+const wxString CategoryModel::full_name(const Data* cat_n)
 {
     static wxString delimiter;
     if (delimiter.empty()) {
         delimiter = InfoModel::instance().getString("CATEG_DELIMITER", ":");
     }
-    if (!category_n) return "";
-    if (category_n->m_parent_id_n == -1)
-        return category_n->m_name;
-    else {
-        wxString name = category_n->m_name;
-        const Data* parent_n = instance().get_id_data_n(category_n->m_parent_id_n);
-        while (parent_n) {
-            name = name.Prepend(delimiter).Prepend(parent_n->m_name);
-            parent_n = instance().get_id_data_n(parent_n->m_parent_id_n);
-        }
-        return name;
-    }
-}
 
-const wxString CategoryModel::full_name(int64 category_id)
-{
-    const Data* category_n = instance().get_id_data_n(category_id);
-    return full_name(category_n);
-}
-
-const wxString CategoryModel::full_name(int64 category_id, wxString delimiter)
-{
-    const Data* category_n = instance().get_id_data_n(category_id);
-    if (!category_n)
+    if (!cat_n)
         return "";
-    if (category_n->m_parent_id_n == -1)
-        return category_n->m_name;
+
+    if (cat_n->m_parent_id_n == -1)
+        return cat_n->m_name;
     else {
-        wxString name = category_n->m_name;
-        const Data* parent_n = instance().get_id_data_n(category_n->m_parent_id_n);
+        wxString full_name = cat_n->m_name;
+        const Data* parent_n = get_id_data_n(cat_n->m_parent_id_n);
+        while (parent_n) {
+            full_name = full_name.Prepend(delimiter).Prepend(parent_n->m_name);
+            parent_n = get_id_data_n(parent_n->m_parent_id_n);
+        }
+        return full_name;
+    }
+}
+
+const wxString CategoryModel::full_name(int64 cat_id)
+{
+    const Data* cat_n = get_id_data_n(cat_id);
+    return full_name(cat_n);
+}
+
+const wxString CategoryModel::full_name(int64 cat_id, wxString delimiter)
+{
+    const Data* cat_n = instance().get_id_data_n(cat_id);
+    if (!cat_n)
+        return "";
+    if (cat_n->m_parent_id_n == -1)
+        return cat_n->m_name;
+    else {
+        wxString name = cat_n->m_name;
+        const Data* parent_n = instance().get_id_data_n(cat_n->m_parent_id_n);
         while (parent_n) {
             name = name.Prepend(delimiter).Prepend(parent_n->m_name);
             parent_n = instance().get_id_data_n(parent_n->m_parent_id_n);
@@ -188,22 +181,21 @@ const wxString CategoryModel::full_name(int64 category_id, wxString delimiter)
     }
 }
 
-// -- Check if Category should be made available for use.
-//    Hiding a category hides all sub-categories
-
-bool CategoryModel::is_hidden(int64 catID)
+// Check if Category should be made available for use.
+// Hiding a category hides all sub-categories
+bool CategoryModel::is_hidden(int64 cat_id)
 {
-    const auto category_n = CategoryModel::instance().get_id_data_n(catID);
-    return (category_n && !category_n->m_active);
+    const auto cat_n = CategoryModel::instance().get_id_data_n(cat_id);
+    return (cat_n && !cat_n->m_active);
 }
 
-bool CategoryModel::is_used(int64 id)
+bool CategoryModel::is_used(int64 cat_id)
 {
-    if (id <= 0)
+    if (cat_id <= 0)
         return false;
 
     const auto& trx_a = TrxModel::instance().find(
-        TrxCol::CATEGID(id)
+        TrxCol::CATEGID(cat_id)
     );
     // FIXME: do not exclude deleted transactions
     for (const auto& trx_d : trx_a)
@@ -211,25 +203,25 @@ bool CategoryModel::is_used(int64 id)
             return true;
 
     const auto& split_a = TrxSplitModel::instance().find(
-        TrxCol::CATEGID(id)
+        TrxCol::CATEGID(cat_id)
     );
     for (const auto& split_d : split_a)
         if (TrxModel::instance().get_id_data_n(split_d.m_trx_id)->DELETEDTIME.IsEmpty())
             return true;
 
     const auto& sched_a = SchedModel::instance().find(
-        SchedCol::CATEGID(id)
+        SchedCol::CATEGID(cat_id)
     );
     if (!sched_a.empty())
         return true;
 
     const auto& sched_split_a = SchedSplitModel::instance().find(
-        SchedCol::CATEGID(id)
+        SchedCol::CATEGID(cat_id)
     );
     if (!sched_split_a.empty())
         return true;
 
-    DataA child_a = instance().find(CategoryCol::PARENTID(id));
+    DataA child_a = find(CategoryCol::PARENTID(cat_id));
     if (!child_a.empty()){
         bool used = false;
         for(const auto& child_d : child_a){
@@ -238,41 +230,41 @@ bool CategoryModel::is_used(int64 id)
         return used;
     }
 
-    // FIXME: check if id is used in PayeeData
-    // FIXME: check if id is used in BudgetData
+    // FIXME: check if cat_id is used in PayeeData
+    // FIXME: check if cat_id is used in BudgetData
 
     return false;
 }
 
-bool CategoryModel::has_income(int64 id)
+bool CategoryModel::has_income(int64 cat_id)
 {
     double sum = 0.0;
     auto splits = TrxSplitModel::instance().get_all_id();
-    for (const auto& tran: TrxModel::instance().find(TrxCol::CATEGID(id)))
-    {
-        if (!tran.DELETEDTIME.IsEmpty()) continue;
-
-        switch (TrxModel::type_id(tran))
+    // FIXME: ignore Void transactions
+    for (const auto& trx_d : TrxModel::instance().find(
+        TrxCol::CATEGID(cat_id),
+        TrxCol::DELETEDTIME(wxEmptyString)
+    )) {
+        switch (TrxModel::type_id(trx_d))
         {
         case TrxModel::TYPE_ID_WITHDRAWAL:
-            sum -= tran.m_amount;
+            sum -= trx_d.m_amount;
             break;
         case TrxModel::TYPE_ID_DEPOSIT:
-            sum += tran.m_amount;
+            sum += trx_d.m_amount;
         case TrxModel::TYPE_ID_TRANSFER:
         default:
             break;
         }
 
-        for (const auto& split: splits[tran.id()])
-        {
-            switch (TrxModel::type_id(tran))
+        for (const auto& tp_d : splits[trx_d.m_id]) {
+            switch (TrxModel::type_id(trx_d))
             {
             case TrxModel::TYPE_ID_WITHDRAWAL:
-                sum -= split.m_amount;
+                sum -= tp_d.m_amount;
                 break;
             case TrxModel::TYPE_ID_DEPOSIT:
-                sum += split.m_amount;
+                sum += tp_d.m_amount;
             case TrxModel::TYPE_ID_TRANSFER:
             default:
                 break;

--- a/src/model/CategoryModel.h
+++ b/src/model/CategoryModel.h
@@ -31,58 +31,46 @@ class mmDateRange;
 class CategoryModel : public TableFactory<CategoryTable, CategoryData>
 {
 public:
-    struct SorterByFULLNAME
-    {
-        template<class DATA>
-        bool operator()(const DATA& x, const DATA& y)
-        {
-            return full_name(x.CATEGID) < full_name(y.CATEGID);
-        }
-    };
-
-public:
     CategoryModel();
     ~CategoryModel();
 
 public:
-    /**
-    Initialize the global CategoryModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for CategoryModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static CategoryModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for CategoryModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static CategoryModel& instance();
 
 public:
-    /** Return the Data record for the given category name */
-    const Data* get_key(const wxString& name, const int64 parentid);
-    const Data* get_name(const wxString& name, const wxString& parentname);
+    bool is_used(int64 cat_id);
 
-    const wxArrayString FilterCategory(const wxString& category_pattern);
-    static const std::map<wxString, int64 > all_categories(bool excludeHidden = false);
-    static CategoryModel::DataA sub_category(const Data* r);
-    static CategoryModel::DataA sub_category(const Data& r);
-    static CategoryModel::DataA sub_tree(const Data& r);
-    static CategoryModel::DataA sub_tree(const Data* r);
-    static const wxString full_name(int64 category_id);
-    static const wxString full_name(int64 category_id, wxString delimiter);
-    static bool is_hidden(int64 catID);
-    static bool is_used(int64 id);
-    static bool has_income(int64 id);
+    auto get_key_data_n(const wxString& name, const int64 parentid) -> const Data*;
+    auto find_data_sub_a(const Data& cat_d) -> CategoryModel::DataA;
+    auto find_data_subtree_a(const Data& cat_d) -> CategoryModel::DataA;
+
+    auto all_categories(bool excludeHidden = false) -> const std::map<wxString, int64>;
+    auto full_name(const Data* cat_n) -> const wxString;
+    auto full_name(int64 cat_id) -> const wxString;
+    auto full_name(int64 cat_id, wxString delimiter) -> const wxString;
+    bool is_hidden(int64 cat_id);
+    bool has_income(int64 cat_id);
+
+    auto get_name(const wxString& name, const wxString& parentname) -> const Data*;
+    auto FilterCategory(const wxString& cat_pattern) -> const wxArrayString;
     static void getCategoryStats(
-        std::map<int64, std::map<int, double>> &categoryStats
-        , wxSharedPtr<wxArrayString> accountArray
-        , mmDateRange* date_range, bool ignoreFuture
-        , bool group_by_month = true
-        , std::map<int64, double >*budgetAmt = nullptr
-        , bool fin_months = false);
-    static const wxString full_name(const Data* category);
+        std::map<int64, std::map<int, double>>& categoryStats,
+        wxSharedPtr<wxArrayString> accountArray,
+        mmDateRange* date_range,
+        bool ignoreFuture,
+        bool group_by_month = true,
+        std::map<int64, double>* budgetAmt = nullptr,
+        bool fin_months = false
+    );
 
+public:
+    struct SorterByFULLNAME
+    {
+        bool operator()(const Data& x, const Data& y)
+        {
+            return CategoryModel::instance().full_name(&x) < CategoryModel::instance().full_name(&y);
+        }
+    };
 };
 

--- a/src/model/FieldModel.cpp
+++ b/src/model/FieldModel.cpp
@@ -23,17 +23,6 @@
 #include "FieldValueModel.h"
 #include "TrxModel.h"
 
-mmChoiceNameA FieldModel::TYPE_CHOICES = mmChoiceNameA({
-    { TYPE_ID_STRING,       _n("String") },
-    { TYPE_ID_INTEGER,      _n("Integer") },
-    { TYPE_ID_DECIMAL,      _n("Decimal") },
-    { TYPE_ID_BOOLEAN,      _n("Boolean") },
-    { TYPE_ID_DATE,         _n("Date") },
-    { TYPE_ID_TIME,         _n("Time") },
-    { TYPE_ID_SINGLECHOICE, _n("SingleChoice") },
-    { TYPE_ID_MULTICHOICE,  _n("MultiChoice") }
-}, -1, true);
-
 FieldModel::FieldModel() :
     TableFactory<FieldTable, FieldData>()
 {
@@ -61,29 +50,40 @@ FieldModel& FieldModel::instance()
     return Singleton<FieldModel>::instance();
 }
 
-///** Return a dataset with fields linked to a specific object */
-//const FieldModel::DataA FieldModel::GetFields(ModelBase::REFTYPE_ID RefType)
-//{
-//    DataA fields;
-//    wxString reftype_str = ModelBase::reftype_name(RefType);
-//    for (const auto & field : this->find(FieldCol::REFTYPE(RefType)))
-//    {
-//        fields.push_back(field);
-//    }
-//    return field;
-//}
-
-/** Delete a field and all his data */
-bool FieldModel::Delete(const int64& field_id)
+const wxArrayString FieldModel::UDFC_FIELDS()
 {
-    db_savepoint();
-    for (const auto& fv_d : FieldValueModel::instance().find(
-        FieldValueCol::FIELDID(field_id)
-    )) {
-        FieldValueModel::instance().purge_id(fv_d.id());
+    wxArrayString choices;
+    choices.Add("");
+    choices.Add("UDFC01");
+    choices.Add("UDFC02");
+    choices.Add("UDFC03");
+    choices.Add("UDFC04");
+    choices.Add("UDFC05");
+    return choices;
+}
+
+const wxString FieldModel::getUDFC(const wxString& properties)
+{
+    Document json_doc;
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()
+    ) {
+        Value& s = json_doc["UDFC"];
+        return s.GetString();
     }
-    db_release_savepoint();
-    return unsafe_remove_id(field_id);
+    return "";
+}
+
+const wxString FieldModel::getRegEx(const wxString& properties)
+{
+    Document json_doc;
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("RegEx") && json_doc["RegEx"].IsString()
+    ) {
+        Value& s = json_doc["RegEx"];
+        return wxString::FromUTF8Unchecked(s.GetString());
+    }
+    return "";
 }
 
 const wxString FieldModel::getTooltip(const wxString& properties)
@@ -98,214 +98,55 @@ const wxString FieldModel::getTooltip(const wxString& properties)
     return "";
 }
 
-const wxString FieldModel::getRegEx(const wxString& properties)
+const wxString FieldModel::getDefault(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
-        if (json_doc.HasMember("RegEx") && json_doc["RegEx"].IsString()) {
-            Value& s = json_doc["RegEx"];
-            return wxString::FromUTF8Unchecked(s.GetString());
-        }
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("Default") && json_doc["Default"].IsString()
+    ) {
+        Value& s = json_doc["Default"];
+        return wxString::FromUTF8Unchecked(s.GetString());
     }
     return "";
+}
+
+int FieldModel::getDigitScale(const wxString& properties)
+{
+    Document json_doc;
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("DigitScale") && json_doc["DigitScale"].IsInt()
+    ) {
+        Value& s = json_doc["DigitScale"];
+        return s.GetInt();
+    }
+    return 0;
 }
 
 bool FieldModel::getAutocomplete(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
-        if (json_doc.HasMember("Autocomplete") && json_doc["Autocomplete"].IsBool()) {
-            Value& b = json_doc["Autocomplete"];
-            return b.GetBool();
-        }
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("Autocomplete") && json_doc["Autocomplete"].IsBool()
+    ) {
+        Value& b = json_doc["Autocomplete"];
+        return b.GetBool();
     }
     return false;
-}
-
-const wxString FieldModel::getDefault(const wxString& properties)
-{
-    Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
-        if (json_doc.HasMember("Default") && json_doc["Default"].IsString()) {
-            Value& s = json_doc["Default"];
-            return wxString::FromUTF8Unchecked(s.GetString());
-        }
-    }
-    return "";
 }
 
 const wxArrayString FieldModel::getChoices(const wxString& properties)
 {
     wxArrayString choices;
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
-        if (json_doc.HasMember("Choice") && json_doc["Choice"].IsArray()) {
-            Value& sa = json_doc["Choice"];
-            for (const auto& entry : sa.GetArray()) {
-                choices.Add(wxString::FromUTF8Unchecked(entry.GetString()));
-            }
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError() &&
+        json_doc.HasMember("Choice") && json_doc["Choice"].IsArray()
+    ) {
+        Value& sa = json_doc["Choice"];
+        for (const auto& entry : sa.GetArray()) {
+            choices.Add(wxString::FromUTF8Unchecked(entry.GetString()));
         }
     }
-
     return choices;
-}
-
-const wxString FieldModel::getUDFC(const wxString& properties)
-{
-    Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
-        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-            Value& s = json_doc["UDFC"];
-            return s.GetString();
-        }
-    }
-    return "";
-}
-
-const std::map<wxString, int64> FieldModel::getMatrix(const wxString& reftype)
-{
-    std::map<wxString, int64> m;
-    for (const auto& entry : UDFC_FIELDS()) {
-        if (entry.empty()) continue;
-        m[entry] = getUDFCID(reftype, entry);
-    }
-    return m;
-}
-
-int64 FieldModel::getUDFCID(const wxString& ref_type, const wxString& name)
-{
-    Document json_doc;
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
-    )) {
-        if (!json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError()) {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-                Value& s = json_doc["UDFC"];
-                const wxString& desc = s.GetString();
-                if (desc == name) {
-                    return field_d.m_id;
-                }
-            }
-        }
-    }
-    return -1;
-}
-
-const wxString FieldModel::getUDFCName(const wxString& ref_type, const wxString& name)
-{
-    Document json_doc;
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
-    )) {
-        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
-            continue;
-        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-            Value& s = json_doc["UDFC"];
-            const wxString& desc = s.GetString();
-            if (desc == name) {
-                return field_d.m_description;
-            }
-        }
-    }
-    return wxEmptyString;
-}
-
-FieldModel::TYPE_ID FieldModel::getUDFCType(const wxString& ref_type, const wxString& name)
-{
-    Document json_doc;
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
-    )) {
-        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
-            continue;
-        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-            Value& s = json_doc["UDFC"];
-            const wxString& desc = s.GetString();
-            if (desc == name) {
-                return static_cast<TYPE_ID>(field_d.m_type_n.id_n());
-            }
-        }
-    }
-    return FieldModel::TYPE_ID_UNKNOWN;
-}
-
-const wxString FieldModel::getUDFCProperties(const wxString& ref_type, const wxString& name)
-{
-    Document json_doc;
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
-    )) {
-        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
-            continue;
-        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-            Value& s = json_doc["UDFC"];
-            const wxString& desc = s.GetString();
-            if (desc == name) {
-                return field_d.m_properties;
-            }
-        }
-    }
-    return wxEmptyString;
-}
-
-const wxArrayString FieldModel::UDFC_FIELDS()
-{
-    wxArrayString choices;
-    choices.Add("");
-    choices.Add("UDFC01");
-    choices.Add("UDFC02");
-    choices.Add("UDFC03");
-    choices.Add("UDFC04");
-    choices.Add("UDFC05");
-    return choices;
-}
-
-const wxArrayString FieldModel::getUDFCList(const FieldData* field_n)
-{
-    const wxString& ref_type = TrxModel::refTypeName;
-
-    wxArrayString choices = UDFC_FIELDS();
-
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(ref_type)
-    )) {
-        Document json_doc;
-        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
-            continue;
-        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-            Value& s = json_doc["UDFC"];
-            if (choices.Index(s.GetString()) != wxNOT_FOUND) {
-                choices.Remove(s.GetString());
-            }
-        }
-    }
-
-    if (field_n) {
-        Document json_doc;
-        if (!json_doc.Parse(field_n->m_properties.utf8_str()).HasParseError() &&
-            json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()
-        ) {
-            Value& s = json_doc["UDFC"];
-            std::string str = s.GetString();
-            choices.Add(s.GetString());
-        }
-    }
-
-    choices.Sort();
-    return choices;
-}
-
-int FieldModel::getDigitScale(const wxString& properties)
-{
-    Document json_doc;
-    if (json_doc.Parse(properties.utf8_str()).HasParseError())
-        return 0;
-
-    if (json_doc.HasMember("DigitScale") && json_doc["DigitScale"].IsInt()) {
-        Value& s = json_doc["DigitScale"];
-        return s.GetInt();
-    }
-    return 0;
 }
 
 const wxString FieldModel::formatProperties(
@@ -366,6 +207,19 @@ const wxString FieldModel::formatProperties(
     return wxString::FromUTF8(json_buffer.GetString());
 }
 
+// Delete a field and all his data
+bool FieldModel::purge_id(int64 field_id)
+{
+    db_savepoint();
+    for (const auto& fv_d : FieldValueModel::instance().find(
+        FieldValueCol::FIELDID(field_id)
+    )) {
+        FieldValueModel::instance().purge_id(fv_d.m_id);
+    }
+    db_release_savepoint();
+    return unsafe_remove_id(field_id);
+}
+
 // Return all values
 // CHECK: chenge wxArrayString to std::set<wxString>
 wxArrayString FieldModel::find_id_value_a(const int64 field_id)
@@ -387,3 +241,77 @@ wxArrayString FieldModel::find_id_value_a(const int64 field_id)
     return value_a;
 }
 
+
+const FieldData* FieldModel::get_udfc_data_n(RefTypeN ref_type, const wxString& udfc)
+{
+    Document json_doc;
+    for (const auto& field_d : find(
+        FieldCol::REFTYPE(ref_type.name_n())
+    )) {
+        if (!json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError() &&
+            json_doc.HasMember("UDFC") &&
+            json_doc["UDFC"].IsString() &&
+            json_doc["UDFC"].GetString() == udfc
+        ) {
+            return get_id_data_n(field_d.m_id);
+        }
+    }
+    return nullptr;
+}
+
+int64 FieldModel::get_udfc_id_n(RefTypeN ref_type, const wxString& udfc)
+{
+    const Data* field_n = get_udfc_data_n(ref_type, udfc);
+    return field_n ? field_n->m_id : -1;
+}
+
+const wxString FieldModel::get_udfc_name_n(RefTypeN ref_type, const wxString& udfc)
+{
+    const Data* field_n = get_udfc_data_n(ref_type, udfc);
+    return field_n ? field_n->m_description : "";
+}
+
+FieldTypeN FieldModel::get_udfc_type_n(RefTypeN ref_type, const wxString& udfc)
+{
+    const Data* field_n = get_udfc_data_n(ref_type, udfc);
+    return field_n ? field_n->m_type_n : FieldTypeN();
+}
+
+const wxString FieldModel::get_udfc_properties_n(RefTypeN ref_type, const wxString& udfc)
+{
+    const Data* field_n = get_udfc_data_n(ref_type, udfc);
+    return field_n ? field_n->m_properties : "";
+}
+
+const std::map<wxString, int64> FieldModel::get_all_ucfd_id_m(RefTypeN ref_type)
+{
+    std::map<wxString, int64> ucfd_id_m;
+    for (const auto& ucfd : UDFC_FIELDS()) {
+        if (ucfd.empty())
+            continue;
+        ucfd_id_m[ucfd] = get_udfc_id_n(ref_type, ucfd);
+    }
+    return ucfd_id_m;
+}
+
+const wxArrayString FieldModel::get_data_udfc_a(const FieldData* field_n)
+{
+    wxArrayString udfc_a = UDFC_FIELDS();
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+    )) {
+        const wxString udfc = FieldModel::getUDFC(field_d.m_properties);
+        if (!udfc.empty() && udfc_a.Index(udfc) != wxNOT_FOUND) {
+            udfc_a.Remove(udfc);
+        }
+    }
+
+    if (field_n) {
+        const wxString udfc = FieldModel::getUDFC(field_n->m_properties);
+        if (!udfc.empty())
+            udfc_a.Add(udfc);
+    }
+
+    udfc_a.Sort();
+    return udfc_a;
+}

--- a/src/model/FieldModel.cpp
+++ b/src/model/FieldModel.cpp
@@ -43,10 +43,8 @@ FieldModel::~FieldModel()
 {
 }
 
-/**
-* Initialize the global FieldModel table.
-* Reset the FieldModel table or create the table if it does not exist.
-*/
+// Initialize the global FieldModel table.
+// Reset the FieldModel table or create the table if it does not exist.
 FieldModel& FieldModel::instance(wxSQLite3Database* db)
 {
     FieldModel& ins = Singleton<FieldModel>::instance();
@@ -57,7 +55,7 @@ FieldModel& FieldModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of FieldModel table */
+// Return the static instance of FieldModel table
 FieldModel& FieldModel::instance()
 {
     return Singleton<FieldModel>::instance();
@@ -76,20 +74,22 @@ FieldModel& FieldModel::instance()
 //}
 
 /** Delete a field and all his data */
-bool FieldModel::Delete(const int64& FieldID)
+bool FieldModel::Delete(const int64& field_id)
 {
     db_savepoint();
-    for (const auto& r : FieldValueModel::instance().find(FieldValueCol::FIELDID(FieldID)))
-        FieldValueModel::instance().purge_id(r.id());
+    for (const auto& fv_d : FieldValueModel::instance().find(
+        FieldValueCol::FIELDID(field_id)
+    )) {
+        FieldValueModel::instance().purge_id(fv_d.id());
+    }
     db_release_savepoint();
-    return unsafe_remove_id(FieldID);
+    return unsafe_remove_id(field_id);
 }
 
 const wxString FieldModel::getTooltip(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
         if (json_doc.HasMember("Tooltip") && json_doc["Tooltip"].IsString()) {
             Value& s = json_doc["Tooltip"];
             return wxString::FromUTF8Unchecked(s.GetString());
@@ -101,8 +101,7 @@ const wxString FieldModel::getTooltip(const wxString& properties)
 const wxString FieldModel::getRegEx(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
         if (json_doc.HasMember("RegEx") && json_doc["RegEx"].IsString()) {
             Value& s = json_doc["RegEx"];
             return wxString::FromUTF8Unchecked(s.GetString());
@@ -114,8 +113,7 @@ const wxString FieldModel::getRegEx(const wxString& properties)
 bool FieldModel::getAutocomplete(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
         if (json_doc.HasMember("Autocomplete") && json_doc["Autocomplete"].IsBool()) {
             Value& b = json_doc["Autocomplete"];
             return b.GetBool();
@@ -127,8 +125,7 @@ bool FieldModel::getAutocomplete(const wxString& properties)
 const wxString FieldModel::getDefault(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
         if (json_doc.HasMember("Default") && json_doc["Default"].IsString()) {
             Value& s = json_doc["Default"];
             return wxString::FromUTF8Unchecked(s.GetString());
@@ -141,13 +138,10 @@ const wxArrayString FieldModel::getChoices(const wxString& properties)
 {
     wxArrayString choices;
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
-        if (json_doc.HasMember("Choice") && json_doc["Choice"].IsArray())
-        {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
+        if (json_doc.HasMember("Choice") && json_doc["Choice"].IsArray()) {
             Value& sa = json_doc["Choice"];
-            for (const auto& entry : sa.GetArray())
-            {
+            for (const auto& entry : sa.GetArray()) {
                 choices.Add(wxString::FromUTF8Unchecked(entry.GetString()));
             }
         }
@@ -159,8 +153,7 @@ const wxArrayString FieldModel::getChoices(const wxString& properties)
 const wxString FieldModel::getUDFC(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
+    if (!json_doc.Parse(properties.utf8_str()).HasParseError()) {
         if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
             Value& s = json_doc["UDFC"];
             return s.GetString();
@@ -172,8 +165,7 @@ const wxString FieldModel::getUDFC(const wxString& properties)
 const std::map<wxString, int64> FieldModel::getMatrix(const wxString& reftype)
 {
     std::map<wxString, int64> m;
-    for (const auto& entry : UDFC_FIELDS())
-    {
+    for (const auto& entry : UDFC_FIELDS()) {
         if (entry.empty()) continue;
         m[entry] = getUDFCID(reftype, entry);
     }
@@ -183,17 +175,15 @@ const std::map<wxString, int64> FieldModel::getMatrix(const wxString& reftype)
 int64 FieldModel::getUDFCID(const wxString& ref_type, const wxString& name)
 {
     Document json_doc;
-    const auto& a = FieldModel::instance().find(FieldCol::REFTYPE(ref_type));
-    for (const auto& item : a)
-    {
-        if (!json_doc.Parse(item.PROPERTIES.utf8_str()).HasParseError())
-        {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString())
-            {
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(ref_type)
+    )) {
+        if (!json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError()) {
+            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
                 Value& s = json_doc["UDFC"];
                 const wxString& desc = s.GetString();
                 if (desc == name) {
-                    return item.FIELDID;
+                    return field_d.m_id;
                 }
             }
         }
@@ -204,18 +194,16 @@ int64 FieldModel::getUDFCID(const wxString& ref_type, const wxString& name)
 const wxString FieldModel::getUDFCName(const wxString& ref_type, const wxString& name)
 {
     Document json_doc;
-    const auto& a = FieldModel::instance().find(FieldCol::REFTYPE(ref_type));
-    for (const auto& item : a)
-    {
-        if (!json_doc.Parse(item.PROPERTIES.utf8_str()).HasParseError())
-        {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString())
-            {
-                Value& s = json_doc["UDFC"];
-                const wxString& desc = s.GetString();
-                if (desc == name) {
-                    return item.DESCRIPTION;
-                }
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(ref_type)
+    )) {
+        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
+            continue;
+        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
+            Value& s = json_doc["UDFC"];
+            const wxString& desc = s.GetString();
+            if (desc == name) {
+                return field_d.m_description;
             }
         }
     }
@@ -225,18 +213,16 @@ const wxString FieldModel::getUDFCName(const wxString& ref_type, const wxString&
 FieldModel::TYPE_ID FieldModel::getUDFCType(const wxString& ref_type, const wxString& name)
 {
     Document json_doc;
-    const auto& a = FieldModel::instance().find(FieldCol::REFTYPE(ref_type));
-    for (const auto& item : a)
-    {
-        if (!json_doc.Parse(item.PROPERTIES.utf8_str()).HasParseError())
-        {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString())
-            {
-                Value& s = json_doc["UDFC"];
-                const wxString& desc = s.GetString();
-                if (desc == name) {
-                    return static_cast<TYPE_ID>(type_id(item.TYPE));
-                }
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(ref_type)
+    )) {
+        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
+            continue;
+        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
+            Value& s = json_doc["UDFC"];
+            const wxString& desc = s.GetString();
+            if (desc == name) {
+                return static_cast<TYPE_ID>(field_d.m_type_n.id_n());
             }
         }
     }
@@ -246,18 +232,16 @@ FieldModel::TYPE_ID FieldModel::getUDFCType(const wxString& ref_type, const wxSt
 const wxString FieldModel::getUDFCProperties(const wxString& ref_type, const wxString& name)
 {
     Document json_doc;
-    const auto& a = FieldModel::instance().find(FieldCol::REFTYPE(ref_type));
-    for (const auto& item : a)
-    {
-        if (!json_doc.Parse(item.PROPERTIES.utf8_str()).HasParseError())
-        {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString())
-            {
-                Value& s = json_doc["UDFC"];
-                const wxString& desc = s.GetString();
-                if (desc == name) {
-                    return item.PROPERTIES;
-                }
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(ref_type)
+    )) {
+        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
+            continue;
+        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
+            Value& s = json_doc["UDFC"];
+            const wxString& desc = s.GetString();
+            if (desc == name) {
+                return field_d.m_properties;
             }
         }
     }
@@ -276,35 +260,34 @@ const wxArrayString FieldModel::UDFC_FIELDS()
     return choices;
 }
 
-const wxArrayString FieldModel::getUDFCList(const FieldData* r)
+const wxArrayString FieldModel::getUDFCList(const FieldData* field_n)
 {
     const wxString& ref_type = TrxModel::refTypeName;
-    const auto& a = FieldModel::instance().find(FieldCol::REFTYPE(ref_type));
 
     wxArrayString choices = UDFC_FIELDS();
 
-    for (const auto& item : a) {
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(ref_type)
+    )) {
         Document json_doc;
-        if (!json_doc.Parse(item.PROPERTIES.utf8_str()).HasParseError()) {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
-                Value& s = json_doc["UDFC"];
-                if (choices.Index(s.GetString()) != wxNOT_FOUND) {
-                    choices.Remove(s.GetString());
-                }
+        if (json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError())
+            continue;
+        if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()) {
+            Value& s = json_doc["UDFC"];
+            if (choices.Index(s.GetString()) != wxNOT_FOUND) {
+                choices.Remove(s.GetString());
             }
         }
     }
 
-    if (r) {
+    if (field_n) {
         Document json_doc;
-        if (!json_doc.Parse(r->PROPERTIES.utf8_str()).HasParseError())
-        {
-            if (json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString())
-            {
-                Value& s = json_doc["UDFC"];
-                std::string str = s.GetString();
-                choices.Add(s.GetString());
-            }
+        if (!json_doc.Parse(field_n->m_properties.utf8_str()).HasParseError() &&
+            json_doc.HasMember("UDFC") && json_doc["UDFC"].IsString()
+        ) {
+            Value& s = json_doc["UDFC"];
+            std::string str = s.GetString();
+            choices.Add(s.GetString());
         }
     }
 
@@ -315,59 +298,62 @@ const wxArrayString FieldModel::getUDFCList(const FieldData* r)
 int FieldModel::getDigitScale(const wxString& properties)
 {
     Document json_doc;
-    if (!json_doc.Parse(properties.utf8_str()).HasParseError())
-    {
-        if (json_doc.HasMember("DigitScale") && json_doc["DigitScale"].IsInt()) {
-            Value& s = json_doc["DigitScale"];
-            return s.GetInt();
-        }
+    if (json_doc.Parse(properties.utf8_str()).HasParseError())
+        return 0;
+
+    if (json_doc.HasMember("DigitScale") && json_doc["DigitScale"].IsInt()) {
+        Value& s = json_doc["DigitScale"];
+        return s.GetInt();
     }
     return 0;
 }
 
-const wxString FieldModel::formatProperties(const wxString& Tooltip, const wxString& RegEx
-    , bool Autocomplete, const wxString& Default, const wxArrayString& Choices
-    , const int DigitScale, const wxString& udfc_str)
-{
+const wxString FieldModel::formatProperties(
+    const wxString& tooltip,
+    const wxString& regEx,
+    bool autocomplete,
+    const wxString& default_value,
+    const wxArrayString& choice_a,
+    const int digitScale,
+    const wxString& udfc_str
+) {
     StringBuffer json_buffer;
     Writer<StringBuffer> json_writer(json_buffer);
 
     json_writer.StartObject();
 
-    if (!Tooltip.empty()) {
+    if (!tooltip.empty()) {
         json_writer.Key("Tooltip");
-        json_writer.String(Tooltip.ToUTF8());
+        json_writer.String(tooltip.ToUTF8());
     }
 
-    if (!RegEx.empty()) {
+    if (!regEx.empty()) {
         json_writer.Key("RegEx");
-        json_writer.String(RegEx.ToUTF8());
+        json_writer.String(regEx.ToUTF8());
     }
 
-    if (Autocomplete) {
+    if (autocomplete) {
         json_writer.Key("Autocomplete");
-        json_writer.Bool(Autocomplete);
+        json_writer.Bool(autocomplete);
     }
 
-    if (!Default.empty()) {
+    if (!default_value.empty()) {
         json_writer.Key("Default");
-        json_writer.String(Default.ToUTF8());
+        json_writer.String(default_value.ToUTF8());
     }
 
-    if (!Choices.empty())
-    {
+    if (!choice_a.empty()) {
         json_writer.Key("Choice");
         json_writer.StartArray();
-        for (const auto &choice : Choices)
-        {
+        for (const auto &choice : choice_a) {
             json_writer.String(choice.ToUTF8());
         }
         json_writer.EndArray();
     }
 
-    if (DigitScale) {
+    if (digitScale) {
         json_writer.Key("DigitScale");
-        json_writer.Int(DigitScale);
+        json_writer.Int(digitScale);
     }
 
     if (!udfc_str.empty()) {

--- a/src/model/FieldModel.cpp
+++ b/src/model/FieldModel.cpp
@@ -365,3 +365,25 @@ const wxString FieldModel::formatProperties(
 
     return wxString::FromUTF8(json_buffer.GetString());
 }
+
+// Return all values
+// CHECK: chenge wxArrayString to std::set<wxString>
+wxArrayString FieldModel::find_id_value_a(const int64 field_id)
+{
+    wxArrayString value_a;
+    wxString prev_value;
+
+    FieldValueModel::DataA fv_a = FieldValueModel::instance().find(
+        FieldValueCol::FIELDID(field_id)
+    );
+    std::sort(fv_a.begin(), fv_a.end(), FieldValueData::SorterByCONTENT());
+
+    for (const auto& fv_d : fv_a) {
+        if (fv_d.m_content != prev_value) {
+            value_a.Add(fv_d.m_content);
+            prev_value = fv_d.m_content;
+        }
+    }
+    return value_a;
+}
+

--- a/src/model/FieldModel.h
+++ b/src/model/FieldModel.h
@@ -29,24 +29,6 @@
 class FieldModel : public TableFactory<FieldTable, FieldData>
 {
 public:
-    enum TYPE_ID
-    {
-        TYPE_ID_UNKNOWN = -1,
-        TYPE_ID_STRING = 0,
-        TYPE_ID_INTEGER,
-        TYPE_ID_DECIMAL,
-        TYPE_ID_BOOLEAN,
-        TYPE_ID_DATE,
-        TYPE_ID_TIME,
-        TYPE_ID_SINGLECHOICE,
-        TYPE_ID_MULTICHOICE,
-        TYPE_ID_size
-    };
-
-private:
-    static mmChoiceNameA TYPE_CHOICES;
-
-public:
     FieldModel();
     ~FieldModel();
 
@@ -54,52 +36,30 @@ public:
     static FieldModel& instance(wxSQLite3Database* db);
     static FieldModel& instance();
 
-public:
-    static const wxString type_name(int id);
-    static int type_id(const wxString& name);
-    static TYPE_ID type_id(const Data* r);
-    static TYPE_ID type_id(const Data& r);
+    static auto UDFC_FIELDS() -> const wxArrayString;
 
-    bool Delete(const int64& FieldID);
-    static const wxString getRegEx(const wxString& properties);
-    static const wxString getTooltip(const wxString& properties);
+    // TODO: create struct FieldProperties; move to FieldProperties
+    static auto getUDFC(const wxString& properties) -> const wxString;
+    static auto getRegEx(const wxString& properties) -> const wxString;
+    static auto getTooltip(const wxString& properties) -> const wxString;
+    static auto getDefault(const wxString& properties) -> const wxString;
+    static int  getDigitScale(const wxString& Properties);
     static bool getAutocomplete(const wxString& properties);
-    static const wxString getDefault(const wxString& properties);
-    static const wxArrayString getChoices(const wxString& properties);
-    static const wxArrayString getUDFCList(const Data* r);
-    static const wxString getUDFC(const wxString& properties);
-    static const wxString getUDFCName(const wxString& ref_type, const wxString& name);
-    static TYPE_ID getUDFCType(const wxString& ref_type, const wxString& name);
-    static const wxString getUDFCProperties(const wxString& ref_type, const wxString& name);
-    static int64 getUDFCID(const wxString& ref_type, const wxString& name);
-    static const std::map<wxString, int64> getMatrix(const wxString& reftype);
-    static int getDigitScale(const wxString& Properties);
-    static const wxString formatProperties(
+    static auto getChoices(const wxString& properties) -> const wxArrayString;
+    static auto formatProperties(
         const wxString& Tooltip, const wxString& RegEx,
         bool Autocomplete, const wxString& Default, const wxArrayString& Choices,
         const int DigitScale, const wxString& udfc_str
-    );
-    static const wxArrayString UDFC_FIELDS();
+    ) -> const wxString;
 
+public:
+    bool purge_id(int64 field_id) override;
     auto find_id_value_a(const int64 FieldID) -> wxArrayString;
+    auto get_udfc_data_n(RefTypeN ref_type, const wxString& udfc) -> const Data*;
+    auto get_udfc_id_n(RefTypeN ref_type, const wxString& udfc) -> int64;
+    auto get_udfc_name_n(RefTypeN ref_type, const wxString& udfc) -> const wxString;
+    auto get_udfc_type_n(RefTypeN ref_type, const wxString& udfc) -> FieldTypeN;
+    auto get_udfc_properties_n(RefTypeN ref_type, const wxString& udfc) -> const wxString;
+    auto get_all_ucfd_id_m(RefTypeN ref_type) -> const std::map<wxString, int64>;
+    auto get_data_udfc_a(const Data* field_n) -> const wxArrayString;
 };
-
-//----------------------------------------------------------------------------
-
-inline const wxString FieldModel::type_name(int id)
-{
-    return TYPE_CHOICES.get_name(id);
-}
-inline int FieldModel::type_id(const wxString& name)
-{
-    return TYPE_CHOICES.find_name_n(name);
-}
-inline FieldModel::TYPE_ID FieldModel::type_id(const Data* r)
-{
-    return static_cast<TYPE_ID>(r->m_type_n.id_n());
-}
-inline FieldModel::TYPE_ID FieldModel::type_id(const Data& r)
-{
-    return type_id(&r);
-}
-

--- a/src/model/FieldModel.h
+++ b/src/model/FieldModel.h
@@ -51,18 +51,7 @@ public:
     ~FieldModel();
 
 public:
-    /**
-    Initialize the global FieldModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for FieldModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static FieldModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for FieldModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static FieldModel& instance();
 
 public:
@@ -85,10 +74,14 @@ public:
     static int64 getUDFCID(const wxString& ref_type, const wxString& name);
     static const std::map<wxString, int64> getMatrix(const wxString& reftype);
     static int getDigitScale(const wxString& Properties);
-    static const wxString formatProperties(const wxString& Tooltip, const wxString& RegEx
-        , bool Autocomplete, const wxString& Default, const wxArrayString& Choices
-        , const int DigitScale, const wxString& udfc_str);
+    static const wxString formatProperties(
+        const wxString& Tooltip, const wxString& RegEx,
+        bool Autocomplete, const wxString& Default, const wxArrayString& Choices,
+        const int DigitScale, const wxString& udfc_str
+    );
     static const wxArrayString UDFC_FIELDS();
+
+    auto find_id_value_a(const int64 FieldID) -> wxArrayString;
 };
 
 //----------------------------------------------------------------------------

--- a/src/model/FieldModel.h
+++ b/src/model/FieldModel.h
@@ -103,7 +103,7 @@ inline int FieldModel::type_id(const wxString& name)
 }
 inline FieldModel::TYPE_ID FieldModel::type_id(const Data* r)
 {
-    return static_cast<TYPE_ID>(type_id(r->TYPE));
+    return static_cast<TYPE_ID>(r->m_type_n.id_n());
 }
 inline FieldModel::TYPE_ID FieldModel::type_id(const Data& r)
 {

--- a/src/model/FieldValueModel.cpp
+++ b/src/model/FieldValueModel.cpp
@@ -77,14 +77,14 @@ const FieldValueData* FieldValueModel::get_key_data_n(
     return nullptr;
 }
 
-std::map<int64, FieldValueModel::DataA> FieldValueModel::find_reftype_refid_data_m(
+std::map<int64, FieldValueModel::DataA> FieldValueModel::find_refType_mRefId(
     RefTypeN ref_type
 ) {
-    std::map<int64, FieldValueModel::DataA> refid_data_m;
+    std::map<int64, FieldValueModel::DataA> refId_dataA_m;
     for (const Data& fv_d : find_all()) {
         if (fv_d.m_ref_type.id_n() == ref_type.id_n())
-            refid_data_m[fv_d.m_ref_id].push_back(fv_d);
+            refId_dataA_m[fv_d.m_ref_id].push_back(fv_d);
     }
-    return refid_data_m;
+    return refId_dataA_m;
 }
 

--- a/src/model/FieldValueModel.cpp
+++ b/src/model/FieldValueModel.cpp
@@ -31,10 +31,8 @@ FieldValueModel::~FieldValueModel()
 {
 }
 
-/**
-* Initialize the global FieldValueModel table.
-* Reset the FieldValueModel table or create the table if it does not exist.
-*/
+// Initialize the global FieldValueModel table.
+// Reset the FieldValueModel table or create the table if it does not exist.
 FieldValueModel& FieldValueModel::instance(wxSQLite3Database* db)
 {
     FieldValueModel& ins = Singleton<FieldValueModel>::instance();
@@ -45,66 +43,66 @@ FieldValueModel& FieldValueModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of FieldValueModel table */
+// Return the static instance of FieldValueModel table
 FieldValueModel& FieldValueModel::instance()
 {
     return Singleton<FieldValueModel>::instance();
 }
 
-const FieldValueData* FieldValueModel::get_key(int64 FieldID, int64 RefID)
+const FieldValueData* FieldValueModel::get_key(int64 field_id, int64 ref_id)
 {
-    FieldValueModel::DataA items = this->find(
-        FieldValueCol::FIELDID(FieldID),
-        FieldValueCol::REFID(RefID)
+    FieldValueModel::DataA fv_a = this->find(
+        FieldValueCol::FIELDID(field_id),
+        FieldValueCol::REFID(ref_id)
     );
-    if (!items.empty())
-        return get_id_data_n(items[0].FIELDATADID);
+    if (!fv_a.empty())
+        return get_id_data_n(fv_a[0].FIELDATADID);
     return nullptr;
 }
 
 std::map<int64, FieldValueModel::DataA> FieldValueModel::get_all_id(const wxString& reftype)
 {
-    FieldModel::DataA custom_fields = FieldModel::instance().find(
+    std::map<int64, FieldValueModel::DataA> id_data_a_m;
+    for (const auto& field_d : FieldModel::instance().find(
         FieldCol::REFTYPE(reftype)
-    );
-    std::map<int64, FieldValueModel::DataA> data;
-    for (const auto& entry : custom_fields) {
-        for (const auto& custom_field : find(FieldValueCol::FIELDID(entry.FIELDID))) {
-            data[custom_field.REFID].push_back(custom_field);
+    )) {
+        for (const auto& fv_d : find(
+            FieldValueCol::FIELDID(field_d.m_id))
+        ) {
+            id_data_a_m[fv_d.REFID].push_back(fv_d);
         }
     }
-    return data;
+    return id_data_a_m;
 }
 
 // Return all CustomFieldData value
-wxArrayString FieldValueModel::allValue(const int64 FieldID)
+wxArrayString FieldValueModel::allValue(const int64 field_id)
 {
     wxArrayString values;
     wxString PreviousValue;
 
-    FieldValueModel::DataA items = this->find(FieldValueCol::FIELDID(FieldID));
-    std::sort(items.begin(), items.end(), FieldValueData::SorterByCONTENT());
+    FieldValueModel::DataA fv_a = find(
+        FieldValueCol::FIELDID(field_id)
+    );
+    std::sort(fv_a.begin(), fv_a.end(), FieldValueData::SorterByCONTENT());
 
-    for (const auto &item : items)
-    {
-        if (item.CONTENT != PreviousValue)
-        {
-            values.Add(item.CONTENT);
-            PreviousValue = item.CONTENT;
+    for (const auto& fv_d : fv_a) {
+        if (fv_d.CONTENT != PreviousValue) {
+            values.Add(fv_d.CONTENT);
+            PreviousValue = fv_d.CONTENT;
         }
     }
     return values;
 }
 
-bool FieldValueModel::DeleteAllData(const wxString& RefType, int64 RefID)
+bool FieldValueModel::DeleteAllData(const wxString& RefType, int64 ref_id)
 {
-    const auto& fields = FieldModel::instance().find(FieldCol::REFTYPE(RefType));
-
-    for (const auto& field : fields)
-    {
-        const Data* data = FieldValueModel::instance().get_key(field.FIELDID, RefID);
-        if (data)
-            FieldValueModel::instance().purge_id(data->FIELDATADID);
+    for (const auto& field_d : FieldModel::instance().find(
+        FieldCol::REFTYPE(RefType)
+    )) {
+        const Data* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
+        if (fv_n)
+            FieldValueModel::instance().purge_id(fv_n->FIELDATADID);
     }
     return true;
 }

--- a/src/model/FieldValueModel.cpp
+++ b/src/model/FieldValueModel.cpp
@@ -49,60 +49,42 @@ FieldValueModel& FieldValueModel::instance()
     return Singleton<FieldValueModel>::instance();
 }
 
-const FieldValueData* FieldValueModel::get_key(int64 field_id, int64 ref_id)
+FieldValueCol::REFID FieldValueModel::REFTYPEID(RefTypeN ref_type, int64 ref_id)
 {
-    FieldValueModel::DataA fv_a = this->find(
-        FieldValueCol::FIELDID(field_id),
-        FieldValueCol::REFID(ref_id)
+    return FieldValueCol::REFID(FieldValueData::encode_REFID(ref_type, ref_id));
+}
+
+bool FieldValueModel::purge_ref(RefTypeN ref_type, int64 ref_id)
+{
+    const DataA fv_a = find(
+        FieldValueModel::REFTYPEID(ref_type, ref_id)
     );
-    if (!fv_a.empty())
-        return get_id_data_n(fv_a[0].FIELDATADID);
-    return nullptr;
-}
-
-std::map<int64, FieldValueModel::DataA> FieldValueModel::get_all_id(const wxString& reftype)
-{
-    std::map<int64, FieldValueModel::DataA> id_data_a_m;
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(reftype)
-    )) {
-        for (const auto& fv_d : find(
-            FieldValueCol::FIELDID(field_d.m_id))
-        ) {
-            id_data_a_m[fv_d.REFID].push_back(fv_d);
-        }
-    }
-    return id_data_a_m;
-}
-
-// Return all CustomFieldData value
-wxArrayString FieldValueModel::allValue(const int64 field_id)
-{
-    wxArrayString values;
-    wxString PreviousValue;
-
-    FieldValueModel::DataA fv_a = find(
-        FieldValueCol::FIELDID(field_id)
-    );
-    std::sort(fv_a.begin(), fv_a.end(), FieldValueData::SorterByCONTENT());
-
-    for (const auto& fv_d : fv_a) {
-        if (fv_d.CONTENT != PreviousValue) {
-            values.Add(fv_d.CONTENT);
-            PreviousValue = fv_d.CONTENT;
-        }
-    }
-    return values;
-}
-
-bool FieldValueModel::DeleteAllData(const wxString& RefType, int64 ref_id)
-{
-    for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(RefType)
-    )) {
-        const Data* fv_n = FieldValueModel::instance().get_key(field_d.m_id, ref_id);
-        if (fv_n)
-            FieldValueModel::instance().purge_id(fv_n->FIELDATADID);
+    for (const Data& fv_d : fv_a) {
+        purge_id(fv_d.m_id);
     }
     return true;
 }
+
+const FieldValueData* FieldValueModel::get_key_data_n(
+    int64 field_id, RefTypeN ref_type, int64 ref_id
+) {
+    FieldValueModel::DataA fv_a = find(
+        FieldValueCol::FIELDID(field_id),
+        FieldValueModel::REFTYPEID(ref_type, ref_id)
+    );
+    if (!fv_a.empty())
+        return get_id_data_n(fv_a[0].m_id);
+    return nullptr;
+}
+
+std::map<int64, FieldValueModel::DataA> FieldValueModel::find_reftype_refid_data_m(
+    RefTypeN ref_type
+) {
+    std::map<int64, FieldValueModel::DataA> refid_data_m;
+    for (const Data& fv_d : find_all()) {
+        if (fv_d.m_ref_type.id_n() == ref_type.id_n())
+            refid_data_m[fv_d.m_ref_id].push_back(fv_d);
+    }
+    return refid_data_m;
+}
+

--- a/src/model/FieldValueModel.h
+++ b/src/model/FieldValueModel.h
@@ -32,24 +32,14 @@ public:
     ~FieldValueModel();
 
 public:
-    /**
-    Initialize the global FieldValueModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for FieldValueModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static FieldValueModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for FieldValueModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static FieldValueModel& instance();
 
+    static FieldValueCol::REFID REFTYPEID(RefTypeN ref_type, int64 ref_id);
+
 public:
-    std::map<int64, DataA> get_all_id(const wxString& reftype);
-    const Data* get_key(int64 FieldID, int64 RefID);
-    wxArrayString allValue(const int64 FieldID);
-    static bool DeleteAllData(const wxString& RefType, int64 RefID);
+    bool purge_ref(RefTypeN ref_type, int64 ref_id);
+    auto get_key_data_n(int64 field_id, RefTypeN ref_type, int64 ref_id) -> const Data*;
+    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
 };
 

--- a/src/model/FieldValueModel.h
+++ b/src/model/FieldValueModel.h
@@ -40,6 +40,6 @@ public:
 public:
     bool purge_ref(RefTypeN ref_type, int64 ref_id);
     auto get_key_data_n(int64 field_id, RefTypeN ref_type, int64 ref_id) -> const Data*;
-    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
+    auto find_refType_mRefId(RefTypeN ref_type) -> std::map<int64, DataA>;
 };
 

--- a/src/model/PayeeModel.cpp
+++ b/src/model/PayeeModel.cpp
@@ -23,6 +23,8 @@
 #include "TrxModel.h"
 #include "SchedModel.h"
 
+const RefTypeN PayeeModel::s_ref_type = RefTypeN(RefTypeN::e_payee);
+
 PayeeModel::PayeeModel() :
     TableFactory<PayeeTable, PayeeData>()
 {
@@ -51,12 +53,12 @@ PayeeModel& PayeeModel::instance()
     return Singleton<PayeeModel>::instance();
 }
 
-int PayeeModel::find_id_aux_cnt(int64 payee_id)
+int PayeeModel::find_id_aux_c(int64 payee_id)
 {
-    return AttachmentModel::NrAttachments(PayeeModel::refTypeName, payee_id);
+    return AttachmentModel::instance().find_id_c(PayeeModel::s_ref_type, payee_id);
 }
 
-int PayeeModel::find_id_dep_cnt(int64 payee_id)
+int PayeeModel::find_id_dep_c(int64 payee_id)
 {
     // FIX (2026-03-01): Do not exclude deleted transactions. Deleted transactions
     // are shown in a panel and they can be restored; they must have a valid payee id.
@@ -73,7 +75,7 @@ int PayeeModel::find_id_dep_cnt(int64 payee_id)
 
 bool PayeeModel::purge_id(int64 payee_id)
 {
-    if (PayeeModel::find_id_dep_cnt(payee_id) > 0)
+    if (PayeeModel::find_id_dep_c(payee_id) > 0)
         return false;
 
     // FIXME: remove AttachmentData owned by payee_id

--- a/src/model/PayeeModel.cpp
+++ b/src/model/PayeeModel.cpp
@@ -55,7 +55,7 @@ PayeeModel& PayeeModel::instance()
 
 int PayeeModel::find_id_aux_c(int64 payee_id)
 {
-    return AttachmentModel::instance().find_id_c(PayeeModel::s_ref_type, payee_id);
+    return AttachmentModel::instance().find_ref_c(s_ref_type, payee_id);
 }
 
 int PayeeModel::find_id_dep_c(int64 payee_id)

--- a/src/model/PayeeModel.h
+++ b/src/model/PayeeModel.h
@@ -23,6 +23,7 @@
 #include "base/defs.h"
 
 #include "table/PayeeTable.h"
+#include "data/_DataEnum.h"
 #include "data/PayeeData.h"
 
 #include "_ModelBase.h"
@@ -31,6 +32,7 @@ class PayeeModel : public TableFactory<PayeeTable, PayeeData>
 {
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     PayeeModel();
@@ -42,8 +44,8 @@ public:
 
 public:
     // TODO: add to virtual methods in TableFactory
-    int find_id_aux_cnt(int64 payee_id);
-    int find_id_dep_cnt(int64 payee_id);
+    int find_id_aux_c(int64 payee_id);
+    int find_id_dep_c(int64 payee_id);
 
     // override
     bool purge_id(int64 payee_id) override;

--- a/src/model/PayeeModel.h
+++ b/src/model/PayeeModel.h
@@ -31,7 +31,6 @@
 class PayeeModel : public TableFactory<PayeeTable, PayeeData>
 {
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/ReportModel.cpp
+++ b/src/model/ReportModel.cpp
@@ -234,7 +234,7 @@ int ReportModel::generate_html(const Data& report_d, wxString& out)
     }
 
     wxSQLite3ResultSet q;
-    int column_cnt = 0;
+    int column_c = 0;
     std::map <wxString, wxString> label_value_m;
     try {
         ReportParam::prepare_sql(query, label_value_m);
@@ -248,7 +248,7 @@ int ReportModel::generate_html(const Data& report_d, wxString& out)
         }
         else {
             q = stmt.ExecuteQuery();
-            column_cnt = q.GetColumnCount();
+            column_c = q.GetColumnCount();
         }
     }
     catch (const wxSQLite3Exception& e) {
@@ -266,7 +266,7 @@ int ReportModel::generate_html(const Data& report_d, wxString& out)
     row_t error;
     loop_t columns;
 
-    for (int i = 0; i < column_cnt; ++i) {
+    for (int i = 0; i < column_c; ++i) {
         int column_type = q.GetColumnType(i);
         const std::wstring column_name = q.GetColumnName(i).ToStdWstring();
         column_name_type_m[column_name] = column_type;
@@ -298,7 +298,7 @@ int ReportModel::generate_html(const Data& report_d, wxString& out)
 
     while (q.NextRow()) {
         ReportRecord rec;
-        for (int i = 0; i < column_cnt; ++i) {
+        for (int i = 0; i < column_c; ++i) {
             const wxString column_name = q.GetColumnName(i);
             rec[column_name.ToStdWstring()] = q.GetAsString(i);
         }

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -327,16 +327,16 @@ bool SchedModel::AllowTransaction(const Data& r)
     return allow_transaction;
 }
 
-void SchedModel::completeBDInSeries(int64 bdID)
+void SchedModel::completeBDInSeries(int64 sched_id)
 {
-    Data* sched_n = unsafe_get_id_data_n(bdID);
+    Data* sched_n = unsafe_get_id_data_n(sched_id);
     if (!sched_n)
         return;
 
     RepeatNum rn;
     if (!decode_repeat_num(*sched_n, rn) || rn.num == 1) {
-        mmAttachmentManage::DeleteAllAttachments(this->refTypeName, bdID);
-        purge_id(bdID);
+        mmAttachmentManage::DeleteAllAttachments(s_ref_type, sched_id);
+        purge_id(sched_id);
         return;
     }
 

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -266,19 +266,19 @@ SchedModel::~SchedModel()
 
 // Remove the Data record instance from memory and the database
 // including any splits associated with the Data Record.
-bool SchedModel::purge_id(int64 id)
+bool SchedModel::purge_id(int64 sched_id)
 {
-    // purge SchedSplitData owned by id
-    for (auto& qp_d : SchedModel::split(*get_id_data_n(id)))
+    // purge SchedSplitData owned by sched_id
+    for (auto& qp_d : SchedModel::split(*get_id_data_n(sched_id)))
         SchedSplitModel::instance().purge_id(qp_d.m_id);
 
-    // remove TagLinkData owned by id
-    TagLinkModel::instance().DeleteAllTags(this->refTypeName, id);
+    // remove TagLinkData owned by sched_id
+    TagLinkModel::instance().purge_ref(s_ref_type, sched_id);
 
-    // FIXME: remove FieldValueData owned by id
-    // FIXME: remove AttachmentData owned by id
+    // FIXME: remove FieldValueData owned by sched_id
+    // FIXME: remove AttachmentData owned by sched_id
 
-    return unsafe_remove_id(id);
+    return unsafe_remove_id(sched_id);
 }
 
 bool SchedModel::AllowTransaction(const Data& r)
@@ -372,7 +372,7 @@ SchedModel::Full_Data::Full_Data(const Data& r) :
     if (!m_tags.empty()) {
         wxArrayString tagnames;
         for (const auto& gl_d : m_tags)
-            tagnames.Add(TagModel::instance().get_id_data_n(gl_d.TAGID)->m_name);
+            tagnames.Add(TagModel::instance().get_id_data_n(gl_d.m_tag_id)->m_name);
         // Sort TAGNAMES
         tagnames.Sort();
         for (const auto& name : tagnames)
@@ -385,8 +385,11 @@ SchedModel::Full_Data::Full_Data(const Data& r) :
                 + CategoryModel::full_name(qp_d.m_category_id);
 
             wxString splitTags;
-            for (const auto& tag : TagLinkModel::instance().get_ref(SchedSplitModel::refTypeName, qp_d.m_id))
-                splitTags.Append(tag.first + " ");
+            for (const auto& tag_name_id : TagLinkModel::instance().find_ref_tag_m(
+                SchedSplitModel::s_ref_type, qp_d.m_id
+            )) {
+                splitTags.Append(tag_name_id.first + " ");
+            }
             if (!splitTags.IsEmpty())
                 TAGNAMES.Append((TAGNAMES.IsEmpty() ? "" : ", ") + splitTags.Trim());
         }

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -382,7 +382,7 @@ SchedModel::Full_Data::Full_Data(const Data& r) :
     if (!m_bill_splits.empty()) {
         for (const auto& qp_d : m_bill_splits) {
             CATEGNAME += (CATEGNAME.empty() ? " + " : ", ")
-                + CategoryModel::full_name(qp_d.m_category_id);
+                + CategoryModel::instance().full_name(qp_d.m_category_id);
 
             wxString splitTags;
             for (const auto& tag_name_id : TagLinkModel::instance().find_ref_tag_m(
@@ -395,7 +395,7 @@ SchedModel::Full_Data::Full_Data(const Data& r) :
         }
     }
     else
-        CATEGNAME = CategoryModel::full_name(r.m_category_id_n);
+        CATEGNAME = CategoryModel::instance().full_name(r.m_category_id_n);
 
     ACCOUNTNAME = AccountModel::instance().get_id_name(r.m_account_id);
 

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -29,6 +29,8 @@
  // TODO: Move attachment management outside of AttachmentDialog
 #include "dialog/AttachmentDialog.h"
 
+const RefTypeN SchedModel::s_ref_type = RefTypeN(RefTypeN::e_sched);
+
 // -- static methods --
 
 // Initialize the global SchedModel table.

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -246,7 +246,7 @@ const SchedSplitModel::DataA SchedModel::split(const Data& sched_d)
 const TagLinkModel::DataA SchedModel::taglink(const Data& sched_d)
 {
     return TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedModel::refTypeName),
+        TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
         TagLinkCol::REFID(sched_d.m_id)
     );
 }
@@ -365,7 +365,7 @@ SchedModel::Full_Data::Full_Data(const Data& r) :
     Data(r),
     m_bill_splits(split(r)),
     m_tags(TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedModel::refTypeName),
+        TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
         TagLinkCol::REFID(r.m_id)
     ))
 {

--- a/src/model/SchedModel.h
+++ b/src/model/SchedModel.h
@@ -22,6 +22,7 @@
 #include "base/defs.h"
 
 #include "table/SchedTable.h"
+#include "data/_DataEnum.h"
 #include "data/SchedData.h"
 
 #include "_ModelBase.h"
@@ -132,6 +133,7 @@ public:
 
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     // Initialize the global SchedModel table on initial call.

--- a/src/model/SchedModel.h
+++ b/src/model/SchedModel.h
@@ -132,7 +132,6 @@ public:
     typedef std::vector<Full_Data> Full_DataA;
 
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/SchedSplitModel.cpp
+++ b/src/model/SchedSplitModel.cpp
@@ -32,10 +32,8 @@ SchedSplitModel::~SchedSplitModel()
 {
 }
 
-/**
-* Initialize the global SchedSplitModel table.
-* Reset the SchedSplitModel table or create the table if it does not exist.
-*/
+// Initialize the global SchedSplitModel table.
+// Reset the SchedSplitModel table or create the table if it does not exist.
 SchedSplitModel& SchedSplitModel::instance(wxSQLite3Database* db)
 {
     SchedSplitModel& ins = Singleton<SchedSplitModel>::instance();
@@ -46,19 +44,10 @@ SchedSplitModel& SchedSplitModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of SchedSplitModel table */
+// Return the static instance of SchedSplitModel table
 SchedSplitModel& SchedSplitModel::instance()
 {
     return Singleton<SchedSplitModel>::instance();
-}
-
-double SchedSplitModel::get_total(const DataA& qp_a)
-{
-    double total = 0.0;
-    for (auto& qp_d : qp_a)
-        total += qp_d.m_amount;
-
-    return total;
 }
 
 bool SchedSplitModel::purge_id(int64 qp_id)
@@ -67,29 +56,37 @@ bool SchedSplitModel::purge_id(int64 qp_id)
     return unsafe_remove_id(qp_id);
 }
 
-std::map<int64, SchedSplitModel::DataA> SchedSplitModel::get_all_id()
+double SchedSplitModel::get_data_amount(const DataA& qp_a)
 {
-    std::map<int64, SchedSplitModel::DataA> data;
-    for (const auto& qp_d : instance().find_all()) {
-        data[qp_d.m_sched_id].push_back(qp_d);
-    }
-    return data;
+    double amount = 0.0;
+    for (const Data& qp_d : qp_a)
+        amount += qp_d.m_amount;
+    return amount;
 }
 
-int SchedSplitModel::update(DataA& src_qp_a, int64 sched_id)
+std::map<int64, SchedSplitModel::DataA> SchedSplitModel::find_all_mSchedId()
+{
+    std::map<int64, SchedSplitModel::DataA> schedId_qpA_m;
+    for (const auto& qp_d : find_all()) {
+        schedId_qpA_m[qp_d.m_sched_id].push_back(qp_d);
+    }
+    return schedId_qpA_m;
+}
+
+int SchedSplitModel::update(int64 dst_sched_id, DataA& src_qp_a)
 {
 
-    for (const auto& qp_d : instance().find(
-        SchedSplitCol::TRANSID(sched_id)
+    for (const auto& qp_d : find(
+        SchedSplitCol::TRANSID(dst_sched_id)
     )) {
-        instance().purge_id(qp_d.id());
+        instance().purge_id(qp_d.m_id);
     }
 
     if (!src_qp_a.empty()) {
         DataA new_qp_a;
         for (const auto& src_qp_d : src_qp_a) {
             Data new_qp_d = Data();
-            new_qp_d.m_sched_id    = sched_id;
+            new_qp_d.m_sched_id    = dst_sched_id;
             new_qp_d.m_amount      = src_qp_d.m_amount;
             new_qp_d.m_category_id = src_qp_d.m_category_id;
             new_qp_d.m_notes       = src_qp_d.m_notes;

--- a/src/model/SchedSplitModel.cpp
+++ b/src/model/SchedSplitModel.cpp
@@ -21,6 +21,8 @@
 #include "AttachmentModel.h"
 #include "TagLinkModel.h"
 
+const RefTypeN SchedSplitModel::s_ref_type = RefTypeN(RefTypeN::e_sched_split);
+
 SchedSplitModel::SchedSplitModel() :
     TableFactory<SchedSplitTable, SchedSplitData>()
 {

--- a/src/model/SchedSplitModel.cpp
+++ b/src/model/SchedSplitModel.cpp
@@ -61,12 +61,10 @@ double SchedSplitModel::get_total(const DataA& qp_a)
     return total;
 }
 
-bool SchedSplitModel::purge_id(int64 id)
+bool SchedSplitModel::purge_id(int64 qp_id)
 {
-    // remove TagLinkData owned by id
-    TagLinkModel::instance().DeleteAllTags(SchedSplitModel::refTypeName, id);
-
-    return unsafe_remove_id(id);
+    TagLinkModel::instance().purge_ref(s_ref_type, qp_id);
+    return unsafe_remove_id(qp_id);
 }
 
 std::map<int64, SchedSplitModel::DataA> SchedSplitModel::get_all_id()

--- a/src/model/SchedSplitModel.h
+++ b/src/model/SchedSplitModel.h
@@ -54,7 +54,6 @@ public:
     bool purge_id(int64 id) override;
 
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 };
 

--- a/src/model/SchedSplitModel.h
+++ b/src/model/SchedSplitModel.h
@@ -21,6 +21,7 @@
 #include "base/defs.h"
 
 #include "table/SchedSplitTable.h"
+#include "data/_DataEnum.h"
 #include "data/SchedSplitData.h"
 
 #include "_ModelBase.h"
@@ -54,5 +55,6 @@ public:
 
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 };
 

--- a/src/model/SchedSplitModel.h
+++ b/src/model/SchedSplitModel.h
@@ -29,31 +29,21 @@
 class SchedSplitModel : public TableFactory<SchedSplitTable, SchedSplitData>
 {
 public:
+    static const RefTypeN s_ref_type;
+
+public:
     SchedSplitModel();
     ~SchedSplitModel();
 
 public:
-    /**
-    Initialize the global SchedSplitModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for SchedSplitModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static SchedSplitModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for SchedSplitModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static SchedSplitModel& instance();
 
 public:
-    double get_total(const DataA& rows);
-    std::map<int64, DataA> get_all_id();
-    int update(DataA& rows, int64 transactionID);
-    bool purge_id(int64 id) override;
+    bool purge_id(int64 qp_id) override;
 
-public:
-    static const RefTypeN s_ref_type;
+    auto get_data_amount(const DataA& qp_a) -> double;
+    auto find_all_mSchedId() -> std::map<int64, DataA>;
+    int  update(int64 dst_sched_id, DataA& src_qp_a);
 };
 

--- a/src/model/SettingModel.cpp
+++ b/src/model/SettingModel.cpp
@@ -267,7 +267,7 @@ void SettingModel::setViewAccounts(const wxString& newValue)
 {
     setString("VIEWACCOUNTS", newValue);
 }
-wxString SettingModel::getViewAccounts()
+const wxString SettingModel::getViewAccounts()
 {
     return getString("VIEWACCOUNTS", VIEW_ACCOUNTS_ALL_STR);
 }
@@ -277,13 +277,13 @@ void SettingModel::setTheme(const wxString& newValue)
 {
     setString("THEME", newValue);
 }
-wxString SettingModel::getTheme()
+const wxString SettingModel::getTheme()
 {
     return getString("THEME", "default");
 }
 
 // LASTFILENAME
-wxString SettingModel::getLastDbPath()
+const wxString SettingModel::getLastDbPath()
 {
     wxString path = getString("LASTFILENAME", "");
     if (!mmex::isPortableMode())
@@ -309,11 +309,12 @@ void SettingModel::shrinkUsageTable()
         return;
 
     const wxString save_point = "SETTINGS_TRIM_USAGE";
-    wxDate date(wxDate::Now());
-    date.Subtract(wxDateSpan::Months(2));
+    wxDate date = wxDate::Now().Subtract(wxDateSpan::Months(2));
     m_db->Savepoint(save_point);
     try {
-        wxString sql = wxString::Format("delete from USAGE_V1 where USAGEDATE < \"%s\";", date.FormatISODate());
+        wxString sql = wxString::Format("delete from USAGE_V1 where USAGEDATE < \"%s\";",
+            date.FormatISODate()
+        );
         m_db->ExecuteUpdate(sql);
     }
     catch (const wxSQLite3Exception& /*e*/) {
@@ -326,7 +327,7 @@ void SettingModel::shrinkUsageTable()
 row_t SettingModel::to_html_row()
 {
     row_t row;
-    for (const auto& setting_a: instance().find_all())
+    for (const auto& setting_a: find_all())
         row(setting_a.m_name.ToStdWstring()) = setting_a.m_value;
     return row;
 }

--- a/src/model/SettingModel.h
+++ b/src/model/SettingModel.h
@@ -34,24 +34,19 @@ public:
     ~SettingModel();
 
 public:
-    // Initialize the global SettingModel table on initial call.
-    // Resets the global table on subsequent calls.
-    // Return the static instance address for SettingModel table.
-    // Note: Assigning the address to a local variable can destroy the instance.
     static SettingModel& instance(wxSQLite3Database* db);
-
-    // Return the static instance address for SettingModel table.
-    // Note: Assigning the address to a local variable can destroy the instance.
     static SettingModel& instance();
-    void Savepoint()
+
+public:
+    void setting_savepoint()
     {
         this->m_db->Savepoint("MMEX_Setting");
     }
-    void ReleaseSavepoint()
+    void setting_release_savepoint()
     {
         this->m_db->ReleaseSavepoint("MMEX_Setting");
     }
-    void Rollback()
+    void setting_rollback()
     {
         this->m_db->Rollback("MMEX_Setting");
     }
@@ -60,40 +55,38 @@ public:
     bool contains(const wxString& key);
 
     void setRaw(const wxString& key, const wxString& newValue);
-    const wxString getRaw(const wxString& key, const wxString& defaultValue);
+    auto getRaw(const wxString& key, const wxString& defaultValue) -> const wxString;
 
     void setString(const wxString& key, const wxString& newValue);
-    const wxString getString(const wxString& key, const wxString& defaultValue);
+    auto getString(const wxString& key, const wxString& defaultValue) -> const wxString;
 
     void setBool(const wxString& key, bool newValue);
     bool getBool(const wxString& key, bool defaultValue);
 
     void setInt(const wxString& key, int newValue);
-    int getInt(const wxString& key, int defaultValue);
+    int  getInt(const wxString& key, int defaultValue);
 
     void setColour(const wxString& key, const wxColour& newValue);
-    const wxColour getColour(const wxString& key, const wxColour& defaultValue);
+    auto getColour(const wxString& key, const wxColour& defaultValue) -> const wxColour;
 
     void setJdoc(const wxString& key, Document& newValue);
     void setJdoc(const wxString& key, StringBuffer& newValue);
-    Document getJdoc(const wxString& key, const wxString& defaultValue);
+    auto getJdoc(const wxString& key, const wxString& defaultValue) -> Document;
 
     void setArrayString(const wxString& key, const wxArrayString& a);
-    const wxArrayString getArrayString(const wxString& key);
+    auto getArrayString(const wxString& key) -> const wxArrayString;
 
     void prependArrayItem(const wxString& key, const wxString& value, int limit);
 
-public:
     void setViewAccounts(const wxString& newValue);
-    wxString getViewAccounts();
+    auto getViewAccounts() -> const wxString;
     
     void setTheme(const wxString& newValue);
-    wxString getTheme();
+    auto getTheme() -> const wxString;
 
-    wxString getLastDbPath();
+    auto getLastDbPath() -> const wxString;
 
-public:
     void shrinkUsageTable();
-    static row_t to_html_row();
+    auto to_html_row() -> row_t;
 };
 

--- a/src/model/StockHistoryModel.cpp
+++ b/src/model/StockHistoryModel.cpp
@@ -93,7 +93,7 @@ int64 StockHistoryModel::addUpdate(
         StockHistoryCol::SYMBOL(symbol),
         StockHistoryModel::DATE(OP_GT, date)
     ).size() == 0) {
-        StockModel::UpdateCurrentPrice(symbol, price);
+        StockModel::instance().update_symbol_current_price(symbol, price);
     }
 
     save_data_n(sh_d);

--- a/src/model/StockModel.cpp
+++ b/src/model/StockModel.cpp
@@ -170,17 +170,19 @@ double StockModel::getDailyBalanceAt(const AccountData& account_d, const wxDate&
 
         double numShares = 0.0;
 
-        TrxLinkModel::DataA tl_a = TrxLinkModel::TranslinkList<StockModel>(stock_d.m_id);
+        TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+            StockModel::s_ref_type, stock_d.m_id
+        );
         for (const auto& tl_d : tl_a) {
             const TrxData* trx_n = TrxModel::instance().get_id_data_n(
-                tl_d.CHECKINGACCOUNTID
+                tl_d.m_trx_id
             );
             if (trx_n->m_id > -1 &&
                 trx_n->DELETEDTIME.IsEmpty() &&
                 mmDate(TrxModel::getTransDateTime(*trx_n)) <= mmDate(date)
             ) {
                 numShares += TrxShareModel::instance().unsafe_get_trx_share_n(
-                    tl_d.CHECKINGACCOUNTID
+                    tl_d.m_trx_id
                 )->m_number;
             }
         }
@@ -206,7 +208,9 @@ double StockModel::RealGainLoss(const Data& stock_d, bool to_base_curr)
     const CurrencyData* currency = AccountModel::instance().get_id_currency_p(
         stock_d.m_account_id_n
     );
-    TrxLinkModel::DataA tl_a = TrxLinkModel::TranslinkList<StockModel>(stock_d.m_id);
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        StockModel::s_ref_type, stock_d.m_id
+    );
     double real_gain_loss = 0;
     double total_shares = 0;
     double total_initial_value = 0;
@@ -216,7 +220,7 @@ double StockModel::RealGainLoss(const Data& stock_d, bool to_base_curr)
     TrxModel::DataA trx_a;
     for (const auto& tl_d : tl_a) {
         const TrxData* trx_d = TrxModel::instance().get_id_data_n(
-            tl_d.CHECKINGACCOUNTID
+            tl_d.m_trx_id
         );
         if (trx_d->m_id > -1 && trx_d->DELETEDTIME.IsEmpty())
             trx_a.push_back(*trx_d);
@@ -265,7 +269,9 @@ double StockModel::UnrealGainLoss(const Data& stock_d, bool to_base_curr)
         stock_d.m_account_id_n
     );
     double conv_rate = CurrencyHistoryModel::getDayRate(currency_n->m_id);
-    TrxLinkModel::DataA tl_a = TrxLinkModel::TranslinkList<StockModel>(stock_d.m_id);
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        StockModel::s_ref_type, stock_d.m_id
+    );
     if (!tl_a.empty()) {
         double total_shares = 0;
         double total_initial_value = 0;
@@ -274,7 +280,7 @@ double StockModel::UnrealGainLoss(const Data& stock_d, bool to_base_curr)
         TrxModel::DataA trx_a;
         for (const auto& tl_d : tl_a) {
             const TrxData* trx_d = TrxModel::instance().get_id_data_n(
-                tl_d.CHECKINGACCOUNTID
+                tl_d.m_trx_id
             );
             if (trx_d->m_id > -1 && trx_d->DELETEDTIME.IsEmpty())
                 trx_a.push_back(*trx_d);
@@ -339,7 +345,9 @@ void StockModel::UpdateCurrentPrice(const wxString& symbol, const double price)
 
 void StockModel::UpdatePosition(StockData* stock_n)
 {
-    TrxLinkModel::DataA tl_a = TrxLinkModel::TranslinkList<StockModel>(stock_n->m_id);
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        StockModel::s_ref_type, stock_n->m_id
+    );
     double total_shares = 0;
     double total_initial_value = 0;
     double total_commission = 0;
@@ -347,7 +355,7 @@ void StockModel::UpdatePosition(StockData* stock_n)
     wxString earliest_date = wxDate::Today().FormatISODate();
     TrxModel::DataA trx_a;
     for (const auto& tl_d : tl_a) {
-        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.CHECKINGACCOUNTID);
+        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
         if (trx_n->m_id > -1 && trx_n->DELETEDTIME.IsEmpty() &&
             TrxModel::status_id(trx_n->STATUS) != TrxModel::STATUS_ID_VOID
         )

--- a/src/model/StockModel.cpp
+++ b/src/model/StockModel.cpp
@@ -46,35 +46,10 @@ StockModel& StockModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-wxString StockModel::get_id_name(int64 stock_id)
-{
-    const Data* stock_n = instance().get_id_data_n(stock_id);
-    if (stock_n)
-        return stock_n->m_name;
-    else
-        return _t("Stock Error");
-}
-
 // Return the static instance of StockModel table
 StockModel& StockModel::instance()
 {
     return Singleton<StockModel>::instance();
-}
-
-wxDate StockModel::PURCHASEDATE(const Data& stock_d)
-{
-    return stock_d.m_purchase_date.getDateTime();
-}
-
-// Original value of Stocks
-double StockModel::InvestmentValue(const Data& stock_d)
-{
-    return stock_d.m_purchase_value;
-}
-
-double StockModel::CurrentValue(const Data& stock_d)
-{
-    return stock_d.m_num_shares * stock_d.m_current_price;
 }
 
 // Remove the Data record from memory and the database.
@@ -82,7 +57,7 @@ double StockModel::CurrentValue(const Data& stock_d)
 bool StockModel::purge_id(int64 id)
 {
     const StockData *stock_n = get_id_data_n(id);
-    const auto& stock_a = StockModel::instance().find(
+    const auto& stock_a = find(
         StockCol::SYMBOL(stock_n->m_symbol)
     );
     if (stock_a.size() == 1) {
@@ -99,103 +74,103 @@ bool StockModel::purge_id(int64 id)
     return unsafe_remove_id(id);
 }
 
-// Return the last price date of a given stock
-wxString StockModel::lastPriceDate(const Data& stock_d)
+const wxString StockModel::get_id_name(int64 stock_id)
 {
-    wxString dtStr = stock_d.m_purchase_date.isoDate();
+    const Data* stock_n = instance().get_id_data_n(stock_id);
+    return stock_n ? stock_n->m_name : _t("Stock Error");
+}
+
+// Return the last price date of a given stock
+const mmDate StockModel::find_last_hist_date(const Data& stock_d)
+{
+    mmDate date = stock_d.m_purchase_date;
     StockHistoryModel::DataA sh_a = StockHistoryModel::instance().find(
         StockCol::SYMBOL(stock_d.m_symbol)
     );
 
     std::sort(sh_a.begin(), sh_a.end(), StockHistoryData::SorterByDATE());
     if (!sh_a.empty())
-        dtStr = sh_a.back().m_date.isoDate();
+        date = sh_a.back().m_date;
 
-    return dtStr;
+    return date;
 }
 
 // Return the total stock balance at a given date
-double StockModel::getDailyBalanceAt(const AccountData& account_d, const wxDate& date)
+double StockModel::calculate_account_balance(const AccountData& account_d, const mmDate& date)
 {
-    std::map<int64, double> totBalance;
+    double balance = 0.0;
 
     for (const Data& stock_d : find(
         StockCol::HELDAT(account_d.m_id)
     )) {
-        mmDateN precValueDate, nextValueDate;
         StockHistoryModel::DataA sh_a = StockHistoryModel::instance().find(
             StockCol::SYMBOL(stock_d.m_symbol)
         );
         std::stable_sort(sh_a.begin(), sh_a.end(), StockHistoryData::SorterByDATE());
         std::reverse(sh_a.begin(), sh_a.end());
 
-        double valueAtDate = 0.0,  precValue = 0.0, nextValue = 0.0;
-
-        for (const auto & sh_d : sh_a) {
-            // test for the date requested
-            if (sh_d.m_date == mmDate(date)) {
-                valueAtDate = sh_d.m_price;
+        mmDateN prev_date; double prev_price = 0.0;
+        mmDateN next_date; double next_price = 0.0;
+        for (const StockHistoryData& sh_d : sh_a) {
+            // stop if the exact date is found
+            if (sh_d.m_date == date) {
+                prev_date = sh_d.m_date; prev_price = sh_d.m_price;
+                next_date = sh_d.m_date; next_price = sh_d.m_price;
                 break;
             }
-            // if not found, search for previous and next date
-            if (precValue == 0.0 && sh_d.m_date < mmDate(date)) {
-                precValue = sh_d.m_price;
-                precValueDate = sh_d.m_date;
-            }
-            if (sh_d.m_date > mmDate(date)) {
-                nextValue = sh_d.m_price;
-                nextValueDate = sh_d.m_date;
-            }
-            // end conditions: prec value assigned and price date < requested date
-            if (precValue != 0.0 && sh_d.m_date < mmDate(date))
+            // stop at the first past date
+            if (sh_d.m_date < date) {
+                prev_date = sh_d.m_date; prev_price = sh_d.m_price;
                 break;
-        }
-        if (valueAtDate == 0.0) {
-            //  if previous not found but if the given date is after purchase date, takes purchase price
-            if (precValue == 0.0 && date >= PURCHASEDATE(stock_d)) {
-                precValue = stock_d.m_purchase_price;
-                precValueDate = stock_d.m_purchase_date;
             }
-            //  if next not found and the accoung is open, takes previous date
-            if (nextValue == 0.0 && account_d.is_open()) {
-                nextValue = precValue;
-                nextValueDate = precValueDate;
+            // scan all future dates
+            if (sh_d.m_date > date) {
+                next_date = sh_d.m_date; next_price = sh_d.m_price;
             }
-            if (precValue > 0.0 && nextValue > 0.0 &&
-                precValueDate.has_value() && precValueDate.value() >= stock_d.m_purchase_date &&
-                nextValueDate.has_value() && nextValueDate.value() >= stock_d.m_purchase_date
-            )
-                valueAtDate = precValue;
         }
+        // if no previous date is found, fallback to purchase date and price
+        if (!prev_date.has_value() && stock_d.m_purchase_date <= date) {
+            prev_date = stock_d.m_purchase_date;
+            prev_price = stock_d.m_purchase_price;
+        }
+        //  if no next date is found and the account is open, fallback to previous
+        if (!next_date.has_value() && account_d.is_open()) {
+            next_date = prev_date; next_price = prev_price;
+        }
+        // if previous and next date is still not found, skip this stock
+        if (!prev_date.has_value() || prev_date.value() < stock_d.m_purchase_date ||
+            !next_date.has_value() || next_date.value() < stock_d.m_purchase_date
+        ) {
+            continue;
+        }
+        // take the previous price
+        double price = prev_price;
 
-        double numShares = 0.0;
-
+        double num_shares = 0.0;
         TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
-            StockModel::s_ref_type, stock_d.m_id
+            s_ref_type, stock_d.m_id
         );
-        for (const auto& tl_d : tl_a) {
+        for (const TrxLinkModel::Data& tl_d : tl_a) {
             const TrxData* trx_n = TrxModel::instance().get_id_data_n(
                 tl_d.m_trx_id
             );
-            if (trx_n->m_id > -1 &&
+            // CHECK: ignore Void transactions
+            if (trx_n && trx_n->m_id > 0 &&
                 trx_n->DELETEDTIME.IsEmpty() &&
-                mmDate(TrxModel::getTransDateTime(*trx_n)) <= mmDate(date)
+                mmDate(TrxModel::getTransDateTime(*trx_n)) <= date
             ) {
-                numShares += TrxShareModel::instance().unsafe_get_trx_share_n(
+                const TrxShareData* ts_n = TrxShareModel::instance().get_trxId_data_n(
                     tl_d.m_trx_id
-                )->m_number;
+                );
+                if (ts_n)
+                    num_shares += ts_n->m_number;
             }
         }
+        if (tl_a.empty() && stock_d.m_purchase_date <= date)
+            num_shares = stock_d.m_num_shares;
 
-        if (tl_a.empty() && stock_d.m_purchase_date <= mmDate(date))
-            numShares = stock_d.m_num_shares;
-
-        totBalance[stock_d.id()] += numShares * valueAtDate;
+        balance += num_shares * price;
     }
-
-    double balance = 0.0;
-    for (const auto& it : totBalance)
-        balance += it.second;
 
     return balance;
 }
@@ -203,13 +178,13 @@ double StockModel::getDailyBalanceAt(const AccountData& account_d, const wxDate&
 // Returns the realized gain/loss of the stock due to sold shares.
 // If the optional parameter to_base_curr = true is passed values are converted
 // to base currency.
-double StockModel::RealGainLoss(const Data& stock_d, bool to_base_curr)
+double StockModel::calculate_realized_gain(const Data& stock_d, bool to_base_curr)
 {
     const CurrencyData* currency = AccountModel::instance().get_id_currency_p(
         stock_d.m_account_id_n
     );
     TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
-        StockModel::s_ref_type, stock_d.m_id
+        s_ref_type, stock_d.m_id
     );
     double real_gain_loss = 0;
     double total_shares = 0;
@@ -228,7 +203,7 @@ double StockModel::RealGainLoss(const Data& stock_d, bool to_base_curr)
     std::stable_sort(trx_a.begin(), trx_a.end(), TrxData::SorterByTRANSDATE());
 
     for (const auto& trx_d : trx_a) {
-        const TrxShareData* ts_n = TrxShareModel::instance().unsafe_get_trx_share_n(
+        const TrxShareData* ts_n = TrxShareModel::instance().get_trxId_data_n(
             trx_d.m_id
         );
         conv_rate = to_base_curr
@@ -260,17 +235,17 @@ double StockModel::RealGainLoss(const Data& stock_d, bool to_base_curr)
 // Returns the current unrealized gain/loss.
 // If the optional parameter to_base_curr = true is passed values are converted
 // to base currency.
-double StockModel::UnrealGainLoss(const Data& stock_d, bool to_base_curr)
+double StockModel::calculate_unrealiazed_gain(const Data& stock_d, bool to_base_curr)
 {
     if (!to_base_curr)
-        return CurrentValue(stock_d) - InvestmentValue(stock_d);
+        return stock_d.current_value() - stock_d.m_purchase_value;
 
     const CurrencyData* currency_n = AccountModel::instance().get_id_currency_p(
         stock_d.m_account_id_n
     );
     double conv_rate = CurrencyHistoryModel::getDayRate(currency_n->m_id);
     TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
-        StockModel::s_ref_type, stock_d.m_id
+        s_ref_type, stock_d.m_id
     );
     if (!tl_a.empty()) {
         double total_shares = 0;
@@ -290,7 +265,7 @@ double StockModel::UnrealGainLoss(const Data& stock_d, bool to_base_curr)
         );
 
         for (const auto& trx_d : trx_a) {
-            const TrxShareData* ts_d = TrxShareModel::instance().unsafe_get_trx_share_n(
+            const TrxShareData* ts_d = TrxShareModel::instance().get_trxId_data_n(
                 trx_d.m_id
             );
             conv_rate = CurrencyHistoryModel::getDayRate(currency_n->m_id, trx_d.TRANSDATE);
@@ -310,18 +285,19 @@ double StockModel::UnrealGainLoss(const Data& stock_d, bool to_base_curr)
             if (total_shares > 0) avg_share_price = total_initial_value / total_shares;
         }
         conv_rate = CurrencyHistoryModel::getDayRate(currency_n->m_id);
-        return CurrentValue(stock_d) * conv_rate - total_initial_value;
+        return stock_d.current_value() * conv_rate - total_initial_value;
     }
     else {
-        return (CurrentValue(stock_d) - InvestmentValue(stock_d)) * conv_rate;
+        return (stock_d.current_value() - stock_d.m_purchase_value) * conv_rate;
     }
 }
 
-/** Updates the current price across all accounts which hold the stock */
-void StockModel::UpdateCurrentPrice(const wxString& symbol, const double price)
+// Updates the current price across all accounts which hold the stock
+// TODO: use std::optional<double> price
+void StockModel::update_symbol_current_price(const wxString& symbol, double price)
 {
     double current_price = price;
-    if (price == -1) {
+    if (current_price == -1) {
         StockHistoryModel::DataA sh_a = StockHistoryModel::instance().find(
             StockHistoryCol::SYMBOL(symbol)
         );
@@ -330,29 +306,33 @@ void StockModel::UpdateCurrentPrice(const wxString& symbol, const double price)
             current_price = sh_a.back().m_price;
         }
     }
-    if (current_price != -1) {
-        StockModel::DataA stock_a = StockModel::instance().find(
-            StockCol::SYMBOL(symbol)
-        );
-        for (auto& stock_d : stock_a) {
-            // CHECK: use stock_d directly
-            StockData* stock_n = StockModel::instance().unsafe_get_id_data_n(stock_d.m_id);
-            stock_n->m_current_price = current_price;
-            StockModel::instance().unsafe_update_data_n(stock_n);
-        }
+    if (current_price == -1)
+        return;
+
+    for (const Data& stock_d : find(
+        StockCol::SYMBOL(symbol)
+    )) {
+        // TODO: use stock_d directly
+        StockData* stock_n = unsafe_get_id_data_n(stock_d.m_id);
+        stock_n->m_current_price = current_price;
+        unsafe_update_data_n(stock_n);
     }
 }
 
-void StockModel::UpdatePosition(StockData* stock_n)
+// stock_entry.m_purchase_price = avg price of shares purchased.
+// stock_entry.m_num_shares = total amount of shares purchased.
+// stock_entry.VALUE     = value of shares based on:
+// ... share_entry.SHARENUMBER * share_entry.SHAREPRICE
+void StockModel::update_data_position(StockData* stock_n)
 {
     TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
-        StockModel::s_ref_type, stock_n->m_id
+        s_ref_type, stock_n->m_id
     );
     double total_shares = 0;
     double total_initial_value = 0;
     double total_commission = 0;
     double avg_share_price = 0;
-    wxString earliest_date = wxDate::Today().FormatISODate();
+    mmDate min_trx_date = mmDate::today();
     TrxModel::DataA trx_a;
     for (const auto& tl_d : tl_a) {
         const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
@@ -363,7 +343,7 @@ void StockModel::UpdatePosition(StockData* stock_n)
     }
     std::stable_sort(trx_a.begin(), trx_a.end(), TrxData::SorterByTRANSDATE());
     for (const auto& trx_d : trx_a) {
-        const TrxShareData* ts_n = TrxShareModel::instance().unsafe_get_trx_share_n(
+        const TrxShareData* ts_n = TrxShareModel::instance().get_trxId_data_n(
             trx_d.m_id
         );
 
@@ -383,9 +363,9 @@ void StockModel::UpdatePosition(StockData* stock_n)
 
         total_commission += ts_n->m_commission;
 
-        wxString transdate = trx_d.TRANSDATE;
-        if (transdate < earliest_date)
-            earliest_date = transdate;
+        mmDate trx_date = mmDate(trx_d.TRANSDATE);
+        if (trx_date < min_trx_date)
+            min_trx_date = trx_date;
     }
 
     // The stock record contains the total of share transactions.
@@ -394,12 +374,11 @@ void StockModel::UpdatePosition(StockData* stock_n)
     }
     else {
         wxDateTime purchasedate;
-        purchasedate.ParseDateTime(earliest_date) || purchasedate.ParseDate(earliest_date);
-        stock_n->m_purchase_date  = mmDate(purchasedate);
+        stock_n->m_purchase_date  = min_trx_date;
         stock_n->m_purchase_price = avg_share_price;
         stock_n->m_num_shares     = total_shares;
         stock_n->m_purchase_value = total_initial_value;
         stock_n->m_commission     = total_commission;
     }
-    StockModel::instance().unsafe_save_data_n(stock_n);
+    unsafe_save_data_n(stock_n);
 }

--- a/src/model/StockModel.cpp
+++ b/src/model/StockModel.cpp
@@ -23,6 +23,8 @@
 #include "TrxShareModel.h"
 #include "CurrencyHistoryModel.h"
 
+const RefTypeN StockModel::s_ref_type = RefTypeN(RefTypeN::e_stock);
+
 StockModel::StockModel() :
     TableFactory<StockTable, StockData>()
 {

--- a/src/model/StockModel.h
+++ b/src/model/StockModel.h
@@ -31,6 +31,7 @@ class StockModel : public TableFactory<StockTable, StockData>
 {
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     StockModel();

--- a/src/model/StockModel.h
+++ b/src/model/StockModel.h
@@ -30,7 +30,6 @@
 class StockModel : public TableFactory<StockTable, StockData>
 {
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/StockModel.h
+++ b/src/model/StockModel.h
@@ -44,27 +44,14 @@ public:
     // override
     bool purge_id(int64 id) override;
 
-    static wxString get_id_name(int64 stock_id);
+    auto get_id_name(int64 stock_id) -> const wxString;
+    auto find_last_hist_date(const Data& stock_d) -> const mmDate;
 
-    static wxDate PURCHASEDATE(const Data& stock_d);
+    auto calculate_account_balance(const AccountData& account_d, const mmDate& date) -> double;
+    auto calculate_realized_gain(const Data& stock_d, bool base_curr = false) -> double;
+    auto calculate_unrealiazed_gain(const Data& stock_d, bool base_curr = false) -> double;
 
-    static double InvestmentValue(const Data& stock_d);
-    static double CurrentValue(const Data& stock_d);
-
-    static double RealGainLoss(const Data& stock_d, bool base_curr = false);
-    static double UnrealGainLoss(const Data& stock_d, bool base_curr = false);
-
-    static void UpdateCurrentPrice(const wxString& symbol, const double price = -1);
-
-    wxString lastPriceDate(const Data& stock_d);
-    double getDailyBalanceAt(const AccountData& account_d, const wxDate& date);
-
-    /*
-    stock_entry.m_purchase_price = avg price of shares purchased.
-    stock_entry.m_num_shares = total amount of shares purchased.
-    stock_entry.VALUE     = value of shares based on:
-    ... share_entry.SHARENUMBER * share_entry.SHAREPRICE
-    */
-    static void UpdatePosition(Data* stock_n);
+    void update_symbol_current_price(const wxString& symbol, double price = -1);
+    void update_data_position(Data* stock_n);
 };
 

--- a/src/model/TagLinkModel.cpp
+++ b/src/model/TagLinkModel.cpp
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2016 Guan Lisheng
+ Copyright (C) 2026 George Ef (george.a.ef@gmail.com)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -30,9 +31,7 @@ TagLinkModel::~TagLinkModel()
 {
 }
 
-/**
-* Initialize the global TagLinkModel.
-*/
+// Initialize the global TagLinkModel.
 TagLinkModel& TagLinkModel::instance(wxSQLite3Database* db)
 {
     TagLinkModel& ins = Singleton<TagLinkModel>::instance();
@@ -44,91 +43,113 @@ TagLinkModel& TagLinkModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of TagLinkModel */
+// Return the static instance of TagLinkModel
 TagLinkModel& TagLinkModel::instance()
 {
     return Singleton<TagLinkModel>::instance();
 }
 
-const TagLinkData* TagLinkModel::get_key(const wxString& refType, int64 refId, int64 tagId)
+// Delete all tag links for a (REFTYPE, REFID)
+void TagLinkModel::purge_ref(RefTypeN ref_type, int64 ref_id)
+{
+    const auto& gl_a = instance().find(
+        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFID(ref_id)
+    );
+    instance().db_savepoint();
+    for (const auto& gl_d : gl_a)
+        instance().purge_id(gl_d.m_id);
+    instance().db_release_savepoint();
+}
+
+const TagLinkData* TagLinkModel::get_key_data_n(int64 tag_id, RefTypeN ref_type, int64 ref_id)
 {
     const Data* gl_n = search_cache_n(
-        TagLinkCol::REFTYPE(refType), TagLinkCol::REFID(refId), TagLinkCol::TAGID(tagId)
+        TagLinkCol::TAGID(tag_id),
+        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFID(ref_id)
     );
     if (gl_n)
         return gl_n;
 
-    DataA items = this->find(
-        TagLinkCol::REFTYPE(refType), TagLinkCol::REFID(refId), TagLinkCol::TAGID(tagId)
+    DataA gl_a = find(
+        TagLinkCol::TAGID(tag_id),
+        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFID(ref_id)
     );
-    if (!items.empty())
-        gl_n = get_id_data_n(items[0].TAGLINKID);
+    if (!gl_a.empty())
+        gl_n = get_id_data_n(gl_a[0].m_id);
     return gl_n;
 }
 
-std::map<wxString, int64> TagLinkModel::get_ref(const wxString& refType, int64 refId)
+std::map<wxString, int64> TagLinkModel::find_ref_tag_m(RefTypeN ref_type, int64 ref_id)
 {
-    std::map<wxString, int64> tags;
+    std::map<wxString, int64> tag_name_id_m;
+    for (const auto& gl_d : find(
+        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFID(ref_id)
+    )) {
+        const TagData* tag_n = TagModel::instance().get_id_data_n(gl_d.m_tag_id);
+        tag_name_id_m[tag_n->m_name] = gl_d.m_tag_id;
+    }
+    return tag_name_id_m;
+}
+
+std::map<int64, TagLinkModel::DataA> TagLinkModel::find_reftype_refid_data_m(
+    RefTypeN ref_type
+) {
+    std::map<int64, DataA> refid_data_m;
     for (const auto& gl_d : instance().find(
-        TagLinkCol::REFTYPE(refType), TagLinkCol::REFID(refId)
-    ))
-        tags[TagModel::instance().get_id_data_n(gl_d.TAGID)->m_name] = gl_d.TAGID;
-
-    return tags;
+        TagLinkCol::REFTYPE(ref_type.name_n())
+    )) {
+        refid_data_m[gl_d.m_ref_id].push_back(gl_d);
+    }
+    return refid_data_m;
 }
 
-/* Delete all tags for a REFTYPE + REFID */
-void TagLinkModel::DeleteAllTags(const wxString& refType, int64 refID)
-{
-    const auto& links = instance().find(
-        TagLinkCol::REFTYPE(refType), TagLinkCol::REFID(refID)
-    );
-    instance().db_savepoint();
-    for (const auto& link : links)
-        instance().purge_id(link.TAGLINKID);
-    instance().db_release_savepoint();
-}
-
-int TagLinkModel::update(const DataA& rows, const wxString& refType, int64 ref_id)
+int TagLinkModel::update(RefTypeN ref_type, int64 ref_id, const DataA& src_gl_a)
 {
     TagLinkModel::instance().db_savepoint();
     bool save_timestamp = false;
-    std::map<int, int64> row_id_map;
+    std::map<int, int64> index_id_m;
 
-    DataA links = instance().find(
-        TagLinkCol::REFTYPE(refType), TagLinkCol::REFID(ref_id)
+    DataA old_gl_a = instance().find(
+        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFID(ref_id)
     );
-    if (links.size() != rows.size())
+    if (old_gl_a.size() != src_gl_a.size())
         save_timestamp = true;
 
-    for (const auto& link : links) {
+    for (const auto& old_gl_d : old_gl_a) {
         if (!save_timestamp) {
             bool match = false;
-            for (decltype(rows.size()) i = 0; i < rows.size(); i++) {
-                match = (rows[i].TAGID == link.TAGID && row_id_map.find(i) == row_id_map.end());
+            for (decltype(src_gl_a.size()) i = 0; i < src_gl_a.size(); i++) {
+                match = (src_gl_a[i].m_tag_id == old_gl_d.m_tag_id &&
+                    index_id_m.find(i) == index_id_m.end()
+                );
                 if (match) {
-                    row_id_map[i] = link.TAGLINKID;
+                    index_id_m[i] = old_gl_d.m_id;
                     break;
                 }
             }
             save_timestamp = save_timestamp || !match;
         }
 
-        instance().purge_id(link.TAGLINKID);
+        instance().purge_id(old_gl_d.m_id);
     }
 
-    for (const auto& item : rows) {
+    for (const auto& src_gl_d : src_gl_a) {
         Data new_gl_d = Data();
-        new_gl_d.REFTYPE = refType;
-        new_gl_d.REFID   = ref_id;
-        new_gl_d.TAGID   = item.TAGID;
+        new_gl_d.m_tag_id   = src_gl_d.m_tag_id;
+        new_gl_d.m_ref_type = ref_type;
+        new_gl_d.m_ref_id   = ref_id;
         instance().add_data_n(new_gl_d);
     }
 
     if (save_timestamp) {
-        if (refType == TrxModel::refTypeName)
+        if (ref_type == TrxModel::s_ref_type)
             TrxModel::instance().save_timestamp(ref_id);
-        else if (refType == TrxSplitModel::refTypeName)
+        else if (ref_type == TrxSplitModel::s_ref_type)
             TrxModel::instance().save_timestamp(
                 TrxSplitModel::instance().get_id_data_n(ref_id)->m_trx_id
             );
@@ -136,16 +157,5 @@ int TagLinkModel::update(const DataA& rows, const wxString& refType, int64 ref_i
 
     TagLinkModel::instance().db_release_savepoint();
 
-    return rows.size();
-}
-
-std::map<int64, TagLinkModel::DataA> TagLinkModel::get_all_id(const wxString& refType)
-{
-    DataA taglinks = instance().find(TagLinkCol::REFTYPE(refType));
-
-    std::map<int64, DataA> data;
-    for (const auto& taglink : taglinks) {
-        data[taglink.REFID].push_back(taglink);
-    }
-    return data;
+    return src_gl_a.size();
 }

--- a/src/model/TagLinkModel.cpp
+++ b/src/model/TagLinkModel.cpp
@@ -95,16 +95,16 @@ std::map<wxString, int64> TagLinkModel::find_ref_tag_m(RefTypeN ref_type, int64 
     return tag_name_id_m;
 }
 
-std::map<int64, TagLinkModel::DataA> TagLinkModel::find_reftype_refid_data_m(
+std::map<int64, TagLinkModel::DataA> TagLinkModel::find_refType_mRefId(
     RefTypeN ref_type
 ) {
-    std::map<int64, DataA> refid_data_m;
+    std::map<int64, DataA> refId_dataA_m;
     for (const auto& gl_d : instance().find(
         TagLinkCol::REFTYPE(ref_type.name_n())
     )) {
-        refid_data_m[gl_d.m_ref_id].push_back(gl_d);
+        refId_dataA_m[gl_d.m_ref_id].push_back(gl_d);
     }
-    return refid_data_m;
+    return refId_dataA_m;
 }
 
 int TagLinkModel::update(RefTypeN ref_type, int64 ref_id, const DataA& src_gl_a)

--- a/src/model/TagLinkModel.h
+++ b/src/model/TagLinkModel.h
@@ -42,5 +42,5 @@ public:
 
     auto get_key_data_n(int64 tag_id, RefTypeN ref_type, int64 ref_id) -> const Data*;
     auto find_ref_tag_m(RefTypeN ref_type, int64 ref_id) -> std::map<wxString, int64>;
-    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
+    auto find_refType_mRefId(RefTypeN ref_type) -> std::map<int64, DataA>;
 };

--- a/src/model/TagLinkModel.h
+++ b/src/model/TagLinkModel.h
@@ -1,5 +1,6 @@
 /*******************************************************
  Copyright (C) 2016 Guan Lisheng (guanlisheng@gmail.com)
+ Copyright (C) 2026 George Ef (george.a.ef@gmail.com)
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -32,40 +33,14 @@ public:
     ~TagLinkModel();
 
 public:
-    /**
-    Initialize the global TagLinkModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for TagLinkModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TagLinkModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for TagLinkModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TagLinkModel& instance();
 
-    /**
-    * Return the Data record pointer for the given payee name
-    * Returns 0 when payee not found.
-    */
-    const Data* get_key(const wxString& refType, int64 refId, int64 tagId);
+public:
+    void purge_ref(RefTypeN ref_type, int64 ref_id);
+    int  update(RefTypeN ref_type, int64 ref_id, const DataA& src_gl_a);
 
-    /**
-    * Return a map of all tags for the specified transaction
-    * Mostly useful to return a sorted list of tagnames associated with a transaction
-    */
-    std::map<wxString, int64> get_ref(const wxString& refType, int64 refId);
-
-    /**
-    * Return a map of all tags
-    */
-    std::map<int64, TagLinkModel::DataA> get_all_id(const wxString& refType);
-
-    /* Delete all tags for a REFTYPE + REFID */
-    void DeleteAllTags(const wxString& refType, int64 refID);
-
-    int update(const DataA& rows, const wxString& refType, int64 refId);
+    auto get_key_data_n(int64 tag_id, RefTypeN ref_type, int64 ref_id) -> const Data*;
+    auto find_ref_tag_m(RefTypeN ref_type, int64 ref_id) -> std::map<wxString, int64>;
+    auto find_reftype_refid_data_m(RefTypeN ref_type) -> std::map<int64, DataA>;
 };
-

--- a/src/model/TagModel.cpp
+++ b/src/model/TagModel.cpp
@@ -72,13 +72,13 @@ int TagModel::is_used(int64 id)
 
     for (const auto& gl_d : gl_a) {
         // FIXME: do not exclude deleted transactions
-        if (gl_d.REFTYPE == TrxModel::refTypeName) {
-            const TrxData* trx_n = TrxModel::instance().get_id_data_n(gl_d.REFID);
+        if (gl_d.m_ref_type == TrxModel::s_ref_type) {
+            const TrxData* trx_n = TrxModel::instance().get_id_data_n(gl_d.m_ref_id);
             if (trx_n && trx_n->DELETEDTIME.IsEmpty())
                 return 1;
         }
-        else if (gl_d.REFTYPE == TrxSplitModel::refTypeName) {
-            const TrxSplitData* tp_n = TrxSplitModel::instance().get_id_data_n(gl_d.REFID);
+        else if (gl_d.m_ref_type == TrxSplitModel::s_ref_type) {
+            const TrxSplitData* tp_n = TrxSplitModel::instance().get_id_data_n(gl_d.m_ref_id);
             if (tp_n) {
                 const TrxData* trx_n = TrxModel::instance().get_id_data_n(tp_n->m_trx_id);
                 if (trx_n && trx_n->DELETEDTIME.IsEmpty())

--- a/src/model/TagModel.cpp
+++ b/src/model/TagModel.cpp
@@ -30,9 +30,7 @@ TagModel::~TagModel()
 {
 }
 
-/**
-* Initialize the global TagModel.
-*/
+// Initialize the global TagModel.
 TagModel& TagModel::instance(wxSQLite3Database* db)
 {
     TagModel& ins = Singleton<TagModel>::instance();
@@ -43,28 +41,16 @@ TagModel& TagModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of TagModel */
+// Return the static instance of TagModel
 TagModel& TagModel::instance()
 {
     return Singleton<TagModel>::instance();
 }
 
-const TagData* TagModel::get_key(const wxString& name)
-{
-    const Data* tag_n = search_cache_n(TagCol::TAGNAME(name));
-    if (tag_n)
-        return tag_n;
-
-    DataA tag_a = this->find(TagCol::TAGNAME(name));
-    if (!tag_a.empty())
-        tag_n = get_id_data_n(tag_a[0].m_id);
-    return tag_n;
-}
-
-int TagModel::is_used(int64 id)
+int TagModel::is_used(int64 tag_id)
 {
     TagLinkModel::DataA gl_a = TagLinkModel::instance().find(
-        TagLinkCol::TAGID(id)
+        TagLinkCol::TAGID(tag_id)
     );
 
     if (gl_a.empty())
@@ -90,5 +76,17 @@ int TagModel::is_used(int64 id)
     }
 
     return -1;
+}
+
+const TagData* TagModel::get_name_data_n(const wxString& name)
+{
+    const Data* tag_n = search_cache_n(TagCol::TAGNAME(name));
+    if (tag_n)
+        return tag_n;
+
+    DataA tag_a = this->find(TagCol::TAGNAME(name));
+    if (!tag_a.empty())
+        tag_n = get_id_data_n(tag_a[0].m_id);
+    return tag_n;
 }
 

--- a/src/model/TagModel.h
+++ b/src/model/TagModel.h
@@ -32,27 +32,11 @@ public:
     ~TagModel();
 
 public:
-    /**
-    Initialize the global TagModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for TagModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TagModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for TagModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TagModel& instance();
 
-    /**
-    * Return the Data record pointer for the given tag name
-    * Returns 0 when tag not found.
-    */
-    const Data* get_key(const wxString& name);
-
-    /* Returns 0 if not used, 1 if used, and -1 if used only in deleted transactions */
-    int is_used(int64 id);
+public:
+    int  is_used(int64 tag_id);
+    auto get_name_data_n(const wxString& name) -> const Data*;
 };
 

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -236,7 +236,7 @@ table {
 
         // Attachments
         wxString AttachmentsLink = "";
-        if (AttachmentModel::instance().NrAttachments(TrxModel::refTypeName, trx_xd.m_id)) {
+        if (AttachmentModel::instance().find_id_c(TrxModel::s_ref_type, trx_xd.m_id)) {
             AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
                 TrxModel::refTypeName, trx_xd.m_id,
                 mmAttachmentManage::GetAttachmentNoteSign());

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -236,7 +236,7 @@ table {
 
         // Attachments
         wxString AttachmentsLink = "";
-        if (AttachmentModel::instance().find_id_c(TrxModel::s_ref_type, trx_xd.m_id)) {
+        if (AttachmentModel::instance().find_ref_c(TrxModel::s_ref_type, trx_xd.m_id)) {
             AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
                 TrxModel::refTypeName, trx_xd.m_id,
                 mmAttachmentManage::GetAttachmentNoteSign());

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -151,7 +151,7 @@ wxString TrxFilter::getHTML()
                 }
 
                 if (found) {
-                    full_tran.CATEGNAME = CategoryModel::full_name(tp_d.m_category_id);
+                    full_tran.CATEGNAME = CategoryModel::instance().full_name(tp_d.m_category_id);
                     full_tran.m_amount = tp_d.m_amount;
                     full_tran.m_notes.Append((trx_d.m_notes.IsEmpty() ? "" : " ") + tp_d.m_notes);
                     m_trans.push_back(full_tran);

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -238,7 +238,7 @@ table {
         wxString AttachmentsLink = "";
         if (AttachmentModel::instance().find_ref_c(TrxModel::s_ref_type, trx_xd.m_id)) {
             AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
-                TrxModel::refTypeName, trx_xd.m_id,
+                TrxModel::s_ref_type.name_n(), trx_xd.m_id,
                 mmAttachmentManage::GetAttachmentNoteSign());
         }
 

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -129,11 +129,11 @@ wxString TrxFilter::getHTML()
     mmHTMLBuilder hb;
     m_trans.clear();
     const auto splits = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(TrxModel::s_ref_type);
+    const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(TrxModel::s_ref_type);
     //TODO: find should be faster
     for (const auto& trx_d : TrxModel::instance().find_all()) {
         if (!mmIsRecordMatches(trx_d, splits)) continue;
-        TrxModel::Full_Data full_tran(trx_d, splits, tags);
+        TrxModel::Full_Data full_tran(trx_d, splits, trxId_glA_m);
 
         full_tran.PAYEENAME = full_tran.real_payee_name(full_tran.m_account_id);
         if (full_tran.has_split()) {

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -129,7 +129,7 @@ wxString TrxFilter::getHTML()
     mmHTMLBuilder hb;
     m_trans.clear();
     const auto splits = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().get_all_id(TrxModel::refTypeName);
+    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(TrxModel::s_ref_type);
     //TODO: find should be faster
     for (const auto& trx_d : TrxModel::instance().find_all()) {
         if (!mmIsRecordMatches(trx_d, splits)) continue;

--- a/src/model/TrxLinkModel.cpp
+++ b/src/model/TrxLinkModel.cpp
@@ -31,10 +31,8 @@ TrxLinkModel::~TrxLinkModel()
 {
 }
 
-/**
-* Initialize the global TrxLinkModel table.
-* Reset the TrxLinkModel table or create the table if it does not exist.
-*/
+// Initialize the global TrxLinkModel table.
+// Reset the TrxLinkModel table or create the table if it does not exist.
 TrxLinkModel& TrxLinkModel::instance(wxSQLite3Database* db)
 {
     TrxLinkModel& ins = Singleton<TrxLinkModel>::instance();
@@ -45,7 +43,7 @@ TrxLinkModel& TrxLinkModel::instance(wxSQLite3Database* db)
     return ins;
 }
 
-/** Return the static instance of TrxLinkModel table */
+// Return the static instance of TrxLinkModel table
 TrxLinkModel& TrxLinkModel::instance()
 {
     return Singleton<TrxLinkModel>::instance();
@@ -53,136 +51,113 @@ TrxLinkModel& TrxLinkModel::instance()
 
 TrxLinkModel::CHECKING_TYPE TrxLinkModel::type_checking(const int64 tt)
 {
-    if (tt == AS_INCOME_EXPENSE || tt == -1)
-    {
+    if (tt == AS_INCOME_EXPENSE || tt == -1) {
         return AS_INCOME_EXPENSE;
     }
-    else
-    {
+    else {
         return AS_TRANSFER;
     }
 }
 
-void TrxLinkModel::SetAssetTranslink(const int64 asset_id
-    , const int64 checking_id
-    , const CHECKING_TYPE checking_type)
-{
-    SetTranslink(checking_id, checking_type, AssetModel::refTypeName, asset_id);
-}
-
-void TrxLinkModel::SetStockTranslink(
-    const int64 stock_id,
-    const int64 checking_id,
-    const CHECKING_TYPE checking_type
-) {
-    SetTranslink(checking_id, checking_type, StockModel::refTypeName, stock_id);
-}
-
 void TrxLinkModel::SetTranslink(
-    const int64 checking_id,
-    [[maybe_unused]] const CHECKING_TYPE checking_type,
-    const wxString& link_type,
-    const int64 link_record_id
+    int64 trx_id,
+    RefTypeN ref_type,
+    int64 ref_id,
+    [[maybe_unused]] const CHECKING_TYPE checking_type
 ) {
     TrxLinkData new_tl_d = TrxLinkData();
-    new_tl_d.CHECKINGACCOUNTID = checking_id;
-    new_tl_d.LINKTYPE          = link_type;
-    new_tl_d.LINKRECORDID      = link_record_id;
-    TrxLinkModel::instance().add_data_n(new_tl_d);
+    new_tl_d.m_trx_id   = trx_id;
+    new_tl_d.m_ref_type = ref_type;
+    new_tl_d.m_ref_id   = ref_id;
+    add_data_n(new_tl_d);
 
     // set the checking entry to recognise it as a foreign transaction
     // set the checking type as AS_INCOME_EXPENSE = 32701 or AS_TRANSFER
-    TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(checking_id);
+    TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(trx_id);
+    // FIXME
     // trx_n->m_to_account_id_n = checking_type;
     TrxModel::instance().unsafe_save_trx_n(trx_n);
     //TrxLinkModel::instance().get_id_data_n(new_tl_d.id());
 }
 
-template <typename T>
-TrxLinkModel::DataA TrxLinkModel::TranslinkList(const int64 link_entry_id)
+// Create the translink record as Asset
+void TrxLinkModel::SetAssetTranslink(
+    int64 trx_id,
+    int64 asset_id,
+    const CHECKING_TYPE checking_type
+){
+    SetTranslink(trx_id, AssetModel::s_ref_type, asset_id, checking_type);
+}
+
+// Create a translink record as Stock
+void TrxLinkModel::SetStockTranslink(
+    int64 trx_id,
+    int64 stock_id,
+    const CHECKING_TYPE checking_type
+) {
+    SetTranslink(trx_id, StockModel::s_ref_type, stock_id, checking_type);
+}
+
+// Return a list of translink records for the associated foreign table type.
+// Equivalent SQL statements:
+//    select * from TRANSLINK_V1 where LINKTYPE = "Asset" AND LINKRECORDID = ref_id;
+//    select * from TRANSLINK_V1 where LINKTYPE = "Stock" AND LINKRECORDID = ref_id;
+TrxLinkModel::DataA TrxLinkModel::find_ref_data_a(RefTypeN ref_type, int64 ref_id)
 {
-    TrxLinkModel::DataA translink_list = TrxLinkModel::instance().find(
-        TrxLinkCol::LINKTYPE(T::refTypeName),
-        TrxLinkCol::LINKRECORDID(link_entry_id)
+    return find(
+        TrxLinkCol::LINKTYPE(ref_type.name_n()),
+        TrxLinkCol::LINKRECORDID(ref_id)
     );
-
-    return translink_list;
 }
 
-TrxLinkModel::DataA TrxLinkModel::TranslinkListBySymbol(const wxString symbol)
+// Return the link record for the symbol
+// Equivalent SQL statements:
+//     SELECT * FROM TRANSLINK_V1 WHERE LINKTYPE = "Stock" AND LINKRECORDID IN
+//       (SELECT STOCKID FROM STOCK_V1 WHERE SYMBOL = ?)
+TrxLinkModel::DataA TrxLinkModel::find_symbol_data_a(const wxString stock_symbol)
 {
-    TrxLinkModel::DataA result;
-    StockModel::DataA stocks = StockModel::instance().find(StockCol::SYMBOL(symbol));
-    for (auto& stock : stocks) {
-       TrxLinkModel::DataA t = TrxLinkModel::instance().find(
-            TrxLinkCol::LINKRECORDID(stock.m_id)
-        );
-       result.insert(result.end(), t.begin(), t.end());
+    DataA symbol_tl_a;
+    for (auto& stock_d : StockModel::instance().find(
+        StockCol::SYMBOL(stock_symbol)
+    )) {
+        DataA stock_tl_a = find_ref_data_a(StockModel::s_ref_type, stock_d.m_id);
+        symbol_tl_a.insert(symbol_tl_a.end(), stock_tl_a.begin(), stock_tl_a.end());
     }
-    return result;
+    return symbol_tl_a;
 }
 
-bool TrxLinkModel::HasShares(const int64 stock_id)
+size_t TrxLinkModel::find_stock_id_c(const int64 stock_id)
 {
-    if (TranslinkList<StockModel>(stock_id).empty())
-    {
-        return false;
-    }
-
-    return true;
+    return find_ref_data_a(StockModel::s_ref_type, stock_id).size();
 }
 
-TrxLinkData TrxLinkModel::TranslinkRecord(const int64 checking_id)
+// Return the link record for the checking account
+// Equivalent SQL statements:
+//     select * from TRANSLINK_V1 where CHECKINGACCOUNTID = checking_id;
+const TrxLinkData* TrxLinkModel::get_trx_data_n(int64 trx_id)
 {
-    auto i = TrxLinkCol::CHECKINGACCOUNTID(checking_id);
-    TrxLinkModel::DataA translink_list = TrxLinkModel::instance().find(i);
-
-    if (!translink_list.empty())
-        return *translink_list.begin();
-    else {
-        wxSharedPtr<TrxLinkData> t(new TrxLinkData);
-        return *t;
-    }
+    DataA tl_a = find(TrxLinkCol::CHECKINGACCOUNTID(trx_id));
+    return !tl_a.empty() ? get_id_data_n(tl_a[0].m_id) : nullptr;
 }
 
-template <typename T>
-void TrxLinkModel::RemoveTransLinkRecords(const int64 entry_id)
+// Remove all records associated with the Translink list
+void TrxLinkModel::purge_ref(RefTypeN ref_type, int64 ref_id)
 {
-    for (const auto& translink : TranslinkList<T>(entry_id))
-    {
-        TrxModel::instance().purge_id(translink.CHECKINGACCOUNTID);
-    }
-}
-
-// Explicit Instantiation
-template void TrxLinkModel::RemoveTransLinkRecords<AssetModel>(const int64);
-template void TrxLinkModel::RemoveTransLinkRecords<StockModel>(const int64);
-
-void TrxLinkModel::RemoveTranslinkEntry(const int64 checking_account_id)
-{
-    Data translink = TranslinkRecord(checking_account_id);
-    TrxShareModel::instance().remove_trx_share(translink.CHECKINGACCOUNTID);
-    TrxLinkModel::instance().purge_id(translink.TRANSLINKID);
-
-    if (translink.LINKTYPE == AssetModel::refTypeName) {
-        AssetData* asset_entry = AssetModel::instance().unsafe_get_id_data_n(translink.LINKRECORDID);
-        UpdateAssetValue(asset_entry);
-    }
-
-    if (translink.LINKTYPE == StockModel::refTypeName) {
-        StockData* stock_entry = StockModel::instance().unsafe_get_id_data_n(translink.LINKRECORDID);
-        StockModel::UpdatePosition(stock_entry);
+    for (const auto& tl_d : find_ref_data_a(ref_type, ref_id)) {
+        TrxModel::instance().purge_id(tl_d.m_trx_id);
     }
 }
 
 void TrxLinkModel::UpdateAssetValue(AssetData* asset_n)
 {
-    DataA trans_list = TranslinkList<AssetModel>(asset_n->m_id);
+    DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        AssetModel::s_ref_type, asset_n->m_id
+    );
     double new_value = 0;
-    for (const auto &trans : trans_list) {
-        const TrxData* trx_n = TrxModel::instance().get_id_data_n(trans.CHECKINGACCOUNTID);
-        if (trx_n && trx_n->DELETEDTIME.IsEmpty()
-            && TrxModel::status_id(trx_n->STATUS) != TrxModel::STATUS_ID_VOID
+    for (const auto& tl_d : tl_a) {
+        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
+        if (trx_n && trx_n->DELETEDTIME.IsEmpty() &&
+            TrxModel::status_id(trx_n->STATUS) != TrxModel::STATUS_ID_VOID
         ) {
             const CurrencyData* currency_n = AccountModel::instance().get_id_currency_p(
                 trx_n->m_account_id
@@ -205,23 +180,4 @@ void TrxLinkModel::UpdateAssetValue(AssetData* asset_n)
         asset_n->m_value = new_value;
         AssetModel::instance().unsafe_save_data_n(asset_n);
     }
-}
-
-bool TrxLinkModel::ShareAccountId(int64& stock_entry_id)
-{
-    TrxLinkModel::DataA stock_translink_list = TranslinkList<StockModel>(stock_entry_id);
-
-    if (!stock_translink_list.empty())
-    {
-        TrxModel::DataA checking_entry = TrxModel::instance().find(
-            TrxCol::TRANSID(stock_translink_list.at(0).CHECKINGACCOUNTID));
-        if (!checking_entry.empty())
-        {
-            const AccountData* account_entry = AccountModel::instance().get_id_data_n(checking_entry.at(0).m_account_id);
-            stock_entry_id = account_entry->m_id;
-            return true;
-        }
-    }
-
-    return false;
 }

--- a/src/model/TrxLinkModel.h
+++ b/src/model/TrxLinkModel.h
@@ -34,80 +34,47 @@
 class TrxLinkModel : public TableFactory<TrxLinkTable, TrxLinkData>
 {
 public:
-    enum CHECKING_TYPE { AS_INCOME_EXPENSE = 32701, AS_TRANSFER }; /* Transfers ignore accounting */
+    enum CHECKING_TYPE {
+        AS_INCOME_EXPENSE = 32701,
+        AS_TRANSFER
+    }; /* Transfers ignore accounting */
 
 public:
     TrxLinkModel();
     ~TrxLinkModel();
 
 public:
-    /**
-    Initialize the global TrxLinkModel table on initial call.
-    Resets the global table on subsequent calls.
-    * Return the static instance address for TrxLinkModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TrxLinkModel& instance(wxSQLite3Database* db);
-
-    /**
-    * Return the static instance address for TrxLinkModel table
-    * Note: Assigning the address to a local variable can destroy the instance.
-    */
     static TrxLinkModel& instance();
 
-public:
+    // TODO: move to *Data
     static CHECKING_TYPE type_checking(const int64 tt);
 
-public:
-    /* Create the translink record as Asset */
-    static void SetAssetTranslink(const int64 asset_id
-        , const int64 checking_id
-        , const CHECKING_TYPE checking_type = AS_INCOME_EXPENSE);
-
-    /* Create a translink record as Stock */
-    static void SetStockTranslink(const int64 stock_id
-        , const int64 checking_id
-        , const CHECKING_TYPE checking_type = AS_INCOME_EXPENSE);
-
-    /*
-    Return a list of translink records for the associated foreign table type.
-    Equivalent SQL statements:
-    select * from TRANSLINK_V1 where LINKTYPE = "Asset" AND LINKRECORDID = link_id;
-    select * from TRANSLINK_V1 where LINKTYPE = "Stock" AND LINKRECORDID = link_id;
-    */
-    template <typename T>
-    static TrxLinkModel::DataA TranslinkList(const int64 link_id);
-
-    /*
-    Return the link record for the symbol
-    Equivalent SQL statements:
-    SELECT * FROM TRANSLINK_V1 WHERE LINKRECORDID IN (SELECT STOCKID FROM STOCK_V1 WHERE SYMBOL = ?)
-    */
-    static TrxLinkModel::DataA TranslinkListBySymbol(const wxString symbol);
-
-    static bool HasShares(const int64 stock_id);
-
-    /*
-    Return the link record for the checking account
-    Equivalent SQL statements:
-    select * from TRANSLINK_V1 where CHECKINGACCOUNTID = checking_id;
-    */
-    static TrxLinkData TranslinkRecord(const int64 checking_id);
-
-    /* Remove all records associated with the Translink list */
-    template <typename T>
-    static void RemoveTransLinkRecords(const int64 entry_id);
-
-    /* Remove the checking account entry and its associated transfer transaction. */
-    static void RemoveTranslinkEntry(const int64 checking_account_id);
-
+    // TODO: move to AssetModel
     static void UpdateAssetValue(AssetData* asset_entry);
 
-    /* Return true with the account id of the first share entry in the stock translink list */
-    static bool ShareAccountId(int64& stock_entry_id);
+public:
+    void purge_ref(RefTypeN ref_type, int64 ref_id);
 
-private:
+    auto get_trx_data_n(int64 trx_id) -> const Data*;
+    auto find_ref_data_a(RefTypeN ref_type, int64 ref_id) -> DataA;
+    auto find_symbol_data_a(const wxString stock_symbol) -> DataA;
+    auto find_stock_id_c(const int64 stock_id) -> size_t;
 
-    static void SetTranslink(const int64 checking_id, const CHECKING_TYPE checking_type
-        , const wxString& link_type, const int64 link_record_id);
+    void SetTranslink(
+        int64 trx_id,
+        RefTypeN ref_type,
+        int64 ref_id,
+        const CHECKING_TYPE checking_type
+    );
+    void SetAssetTranslink(
+        int64 trx_id,
+        int64 asset_id,
+        const CHECKING_TYPE checking_type = AS_INCOME_EXPENSE
+    );
+    void SetStockTranslink(
+        int64 trx_id,
+        int64 stock_id,
+        const CHECKING_TYPE checking_type = AS_INCOME_EXPENSE
+    );
 };

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -356,7 +356,7 @@ bool TrxModel::purge_id(int64 trx_id)
     if (is_foreign(*instance().get_id_data_n(trx_id))) {
         const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_id);
         if (tl_n) {
-            TrxShareModel::instance().remove_trx_share(tl_n->m_trx_id);
+            TrxShareModel::instance().purge_trxId(tl_n->m_trx_id);
             TrxLinkModel::instance().purge_id(tl_n->m_id);
             if (tl_n->m_ref_type == AssetModel::s_ref_type) {
                 AssetData* asset_n = AssetModel::instance().unsafe_get_id_data_n(tl_n->m_ref_id);
@@ -364,7 +364,7 @@ bool TrxModel::purge_id(int64 trx_id)
             }
             else if (tl_n->m_ref_type == StockModel::s_ref_type) {
                 StockData* stock_n = StockModel::instance().unsafe_get_id_data_n(tl_n->m_ref_id);
-                StockModel::UpdatePosition(stock_n);
+                StockModel::instance().update_data_position(stock_n);
             }
         }
     }

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -357,8 +357,8 @@ bool TrxModel::purge_id(int64 trx_id)
     // remove all attachments
     mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_id);
     // remove all custom fields for the transaction
-    FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, trx_id);
-    TagLinkModel::instance().DeleteAllTags(TrxModel::refTypeName, trx_id);
+    FieldValueModel::instance().purge_ref(s_ref_type, trx_id);
+    TagLinkModel::instance().purge_ref(s_ref_type, trx_id);
     return unsafe_remove_id(trx_id);
 }
 
@@ -473,13 +473,13 @@ void TrxModel::Full_Data::fill_data()
     }
 
     if (!m_tags.empty()) {
-        wxArrayString tagnames;
+        wxArrayString tag_name_a;
         for (const auto& gl_d : m_tags)
-            tagnames.Add(TagModel::instance().get_id_data_n(gl_d.TAGID)->m_name);
+            tag_name_a.Add(TagModel::instance().get_id_data_n(gl_d.m_tag_id)->m_name);
         // Sort TAGNAMES
-        tagnames.Sort(CaseInsensitiveCmp);
-        for (const auto& name : tagnames)
-            TAGNAMES += (TAGNAMES.empty() ? "" : " ") + name;
+        tag_name_a.Sort(CaseInsensitiveCmp);
+        for (const auto& tag_name : tag_name_a)
+            TAGNAMES += (TAGNAMES.empty() ? "" : " ") + tag_name;
     }
 
     if (type_id(TRANSCODE) == TYPE_ID_WITHDRAWAL) {

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -28,6 +28,7 @@
 #include "PrefModel.h"
 #include "TagModel.h"
 #include "TrxLinkModel.h"
+#include "TrxShareModel.h"
 #include "TrxModel.h"
 
 #include "dialog/AttachmentDialog.h"
@@ -351,8 +352,22 @@ bool TrxModel::purge_id(int64 trx_id)
     )) {
         TrxSplitModel::instance().purge_id(tp_d.m_id);
     }
-    if (is_foreign(*instance().get_id_data_n(trx_id)))
-        TrxLinkModel::RemoveTranslinkEntry(trx_id);
+
+    if (is_foreign(*instance().get_id_data_n(trx_id))) {
+        const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_id);
+        if (tl_n) {
+            TrxShareModel::instance().remove_trx_share(tl_n->m_trx_id);
+            TrxLinkModel::instance().purge_id(tl_n->m_id);
+            if (tl_n->m_ref_type == AssetModel::s_ref_type) {
+                AssetData* asset_n = AssetModel::instance().unsafe_get_id_data_n(tl_n->m_ref_id);
+                TrxLinkModel::UpdateAssetValue(asset_n);
+            }
+            else if (tl_n->m_ref_type == StockModel::s_ref_type) {
+                StockData* stock_n = StockModel::instance().unsafe_get_id_data_n(tl_n->m_ref_id);
+                StockModel::UpdatePosition(stock_n);
+            }
+        }
+    }
 
     // remove all attachments
     mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_id);

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -481,10 +481,10 @@ void TrxModel::Full_Data::fill_data()
     if (!m_splits.empty()) {
         for (const auto& tp_d : m_splits)
             CATEGNAME += (CATEGNAME.empty() ? " + " : ", ")
-                + CategoryModel::full_name(tp_d.m_category_id);
+                + CategoryModel::instance().full_name(tp_d.m_category_id);
     }
     else {
-        CATEGNAME = CategoryModel::full_name(m_category_id_n);
+        CATEGNAME = CategoryModel::instance().full_name(m_category_id_n);
     }
 
     if (!m_tags.empty()) {
@@ -604,7 +604,7 @@ const wxString TrxModel::Full_Data::to_json()
         json_writer.StartArray();
         for (const auto& tp_d : m_splits) {
             json_writer.StartObject();
-            json_writer.Key(CategoryModel::full_name(tp_d.m_category_id).utf8_str());
+            json_writer.Key(CategoryModel::instance().full_name(tp_d.m_category_id).utf8_str());
             json_writer.Double(tp_d.m_amount);
             json_writer.EndObject();
         }
@@ -615,7 +615,7 @@ const wxString TrxModel::Full_Data::to_json()
         json_writer.StartArray();
         for (const auto & tp_d : m_splits) {
             json_writer.StartObject();
-            json_writer.Key(CategoryModel::full_name(tp_d.m_category_id).utf8_str());
+            json_writer.Key(CategoryModel::instance().full_name(tp_d.m_category_id).utf8_str());
             json_writer.Double(tp_d.m_amount);
             json_writer.EndObject();
         }
@@ -623,7 +623,7 @@ const wxString TrxModel::Full_Data::to_json()
     }
     else {
         json_writer.Key("CATEG");
-        json_writer.String(CategoryModel::full_name(this->m_category_id_n).utf8_str());
+        json_writer.String(CategoryModel::instance().full_name(this->m_category_id_n).utf8_str());
     }
 
     json_writer.EndObject();

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -32,6 +32,8 @@
 
 #include "dialog/AttachmentDialog.h"
 
+const RefTypeN TrxModel::s_ref_type = RefTypeN(RefTypeN::e_trx);
+
 mmChoiceNameA TrxModel::TYPE_CHOICES = mmChoiceNameA({
     { TYPE_ID_WITHDRAWAL, _n("Withdrawal") },
     { TYPE_ID_DEPOSIT,    _n("Deposit") },

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -342,31 +342,30 @@ bool TrxModel::is_locked(const Data& trx_d)
     return trx_date_n.has_value() && account_n->is_locked_for(trx_date_n.value());
 }
 
-bool TrxModel::purge_id(int64 id)
+bool TrxModel::purge_id(int64 trx_id)
 {
     // TODO: remove all split at once
-    // TrxSplitModel::instance().purge_id(TrxSplitModel::instance().find(TrxSplitCol::TRANSID(id)));
+    // TrxSplitModel::instance().purge_id(TrxSplitModel::instance().find(TrxSplitCol::TRANSID(trx_id)));
     for (const auto& tp_d : TrxSplitModel::instance().find(
-        TrxSplitCol::TRANSID(id)
+        TrxSplitCol::TRANSID(trx_id)
     )) {
         TrxSplitModel::instance().purge_id(tp_d.m_id);
     }
-    if (is_foreign(*instance().get_id_data_n(id)))
-        TrxLinkModel::RemoveTranslinkEntry(id);
+    if (is_foreign(*instance().get_id_data_n(trx_id)))
+        TrxLinkModel::RemoveTranslinkEntry(trx_id);
 
-    const wxString& RefType = TrxModel::refTypeName;
     // remove all attachments
-    mmAttachmentManage::DeleteAllAttachments(RefType, id);
+    mmAttachmentManage::DeleteAllAttachments(TrxModel::s_ref_type, trx_id);
     // remove all custom fields for the transaction
-    FieldValueModel::DeleteAllData(RefType, id);
-    TagLinkModel::instance().DeleteAllTags(RefType, id);
-    return unsafe_remove_id(id);
+    FieldValueModel::instance().purge_ref(TrxModel::s_ref_type, trx_id);
+    TagLinkModel::instance().DeleteAllTags(TrxModel::refTypeName, trx_id);
+    return unsafe_remove_id(trx_id);
 }
 
-void TrxModel::save_timestamp(int64 id)
+void TrxModel::save_timestamp(int64 trx_id)
 {
-    Data* trx_n = instance().unsafe_get_id_data_n(id);
-    if (trx_n && trx_n->m_id == id) {
+    Data* trx_n = instance().unsafe_get_id_data_n(trx_id);
+    if (trx_n && trx_n->m_id == trx_id) {
         trx_n->LASTUPDATEDTIME = wxDateTime::Now().ToUTC().FormatISOCombined();
         unsafe_update_data_n(trx_n);
     }

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -441,7 +441,7 @@ TrxModel::Full_Data::Full_Data(const Data& r) :
     m_splits(TrxSplitModel::instance().find(
         TrxSplitCol::TRANSID(r.m_id))),
     m_tags(TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxModel::refTypeName),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
         TagLinkCol::REFID(r.m_id))),
     ACCOUNTID_W(-1), ACCOUNTID_D(-1), TRANSAMOUNT_W(0), TRANSAMOUNT_D(0),
     SN(0), ACCOUNT_FLOW(0), ACCOUNT_BALANCE(0)

--- a/src/model/TrxModel.h
+++ b/src/model/TrxModel.h
@@ -101,12 +101,12 @@ public:
         double ACCOUNT_FLOW;
         double ACCOUNT_BALANCE;
         wxArrayString ATTACHMENT_DESCRIPTION;
-        FieldModel::TYPE_ID UDFC_type[5] = {
-            FieldModel::TYPE_ID_UNKNOWN,
-            FieldModel::TYPE_ID_UNKNOWN,
-            FieldModel::TYPE_ID_UNKNOWN,
-            FieldModel::TYPE_ID_UNKNOWN,
-            FieldModel::TYPE_ID_UNKNOWN
+        FieldTypeN UDFC_type[5] = {
+            FieldTypeN(),
+            FieldTypeN(),
+            FieldTypeN(),
+            FieldTypeN(),
+            FieldTypeN()
         };
         wxString UDFC_content[5];
         double UDFC_value[5] = {0, 0, 0, 0, 0};

--- a/src/model/TrxModel.h
+++ b/src/model/TrxModel.h
@@ -136,6 +136,7 @@ public:
 
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 
 public:
     // Initialize the global TrxModel table on initial call.

--- a/src/model/TrxModel.h
+++ b/src/model/TrxModel.h
@@ -135,7 +135,6 @@ public:
     typedef std::vector<Full_Data> Full_DataA;
 
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 
 public:

--- a/src/model/TrxShareModel.cpp
+++ b/src/model/TrxShareModel.cpp
@@ -47,55 +47,57 @@ TrxShareModel& TrxShareModel::instance()
     return Singleton<TrxShareModel>::instance();
 }
 
-int64 TrxShareModel::find_trx_share_id(const int64 trx_id)
+void TrxShareModel::purge_trxId(const int64 trx_id)
+{
+    int64 ts_id = get_trxId_id(trx_id);
+    if (ts_id > 0) {
+        purge_id(ts_id);
+    }
+}
+
+int64 TrxShareModel::get_trxId_id(const int64 trx_id)
 {
     DataA ts_a = find(TrxShareCol::CHECKINGACCOUNTID(trx_id));
     return !ts_a.empty() ? ts_a.at(0).m_id : -1;
 }
 
-TrxShareData* TrxShareModel::unsafe_get_trx_share_n(const int64 trx_id)
+TrxShareData* TrxShareModel::unsafe_get_trxId_data_n(const int64 trx_id)
 {
-    int64 ts_id = find_trx_share_id(trx_id);
-    return ts_id > 0 ? unsafe_get_id_data_n(ts_id) : nullptr;
+    return unsafe_get_id_data_n(get_trxId_id(trx_id));
 }
 
-void TrxShareModel::ShareEntry(
+const TrxShareData* TrxShareModel::get_trxId_data_n(const int64 trx_id)
+{
+    return get_id_data_n(get_trxId_id(trx_id));
+}
+
+// Create a Share record if it does not exist.
+// Save the share record linked to the transaction.
+void TrxShareModel::update_trxID(
     int64 trx_id,
     double share_number,
     double share_price,
     double share_commission,
-    const std::vector<Split>& commission_splits,
-    const wxString& share_lot
+    const wxString& share_lot,
+    const std::vector<Split>& commission_splits
 ) {
-    int64 ts_id = TrxShareModel().instance().find_trx_share_id(trx_id);
+    const Data* old_ts_n = get_trxId_data_n(trx_id);
     Data new_ts_d;
-    Data old_ts_d;
-    bool save_timestamp = false;
-
-    if (ts_id > 0) {
-        new_ts_d = *(TrxShareModel::instance().get_id_data_n(ts_id));
-        old_ts_d = new_ts_d;
+    if (old_ts_n) {
+        new_ts_d = *old_ts_n;
     }
     else {
         new_ts_d = Data();
         new_ts_d.m_trx_id = trx_id;
-        save_timestamp = true;
     }
 
     new_ts_d.m_number     = share_number;
     new_ts_d.m_price      = share_price;
     new_ts_d.m_commission = share_commission;
     new_ts_d.m_lot        = share_lot;
-    TrxShareModel::instance().save_data_n(new_ts_d);
-    TrxSplitModel::instance().update(commission_splits, new_ts_d.id());
-    if (save_timestamp || !new_ts_d.equals(&old_ts_d))
-        TrxModel::instance().save_timestamp(trx_id);
-}
+    save_data_n(new_ts_d);
 
-void TrxShareModel::remove_trx_share(const int64 trx_id)
-{
-    int64 ts_id = find_trx_share_id(trx_id);
-    if (ts_id > 0) {
-        purge_id(ts_id);
-    }
+    TrxSplitModel::instance().update(commission_splits, new_ts_d.m_id);
+    if (!old_ts_n || !new_ts_d.equals(old_ts_n))
+        TrxModel::instance().save_timestamp(trx_id);
 }

--- a/src/model/TrxShareModel.h
+++ b/src/model/TrxShareModel.h
@@ -30,33 +30,26 @@
 class TrxShareModel : public TableFactory<TrxShareTable, TrxShareData>
 {
 public:
-    // Initialize the global TrxShareModel table on initial call.
-    // Resets the global table on subsequent calls.
-    // Return the static instance address for TrxShareModel table
-    // Note: Assigning the address to a local variable can destroy the instance.
-    static TrxShareModel& instance(wxSQLite3Database* db);
+    TrxShareModel();
+    ~TrxShareModel();
 
-    // Return the static instance address for TrxShareModel table
-    // Note: Assigning the address to a local variable can destroy the instance.
+public:
+    static TrxShareModel& instance(wxSQLite3Database* db);
     static TrxShareModel& instance();
 
 public:
-    // Create a Share record if it does not exist.
-    // Save the share record linked to the transaction.
-    static void ShareEntry(
+    void purge_trxId(const int64 trx_id);
+
+    auto get_trxId_id(const int64 trx_id) -> int64;
+    auto unsafe_get_trxId_data_n(const int64 trx_id) -> Data*;
+    auto get_trxId_data_n(const int64 trx_id) -> const Data*;
+
+    void update_trxID(
         int64 trx_id,
         double share_number,
         double share_price,
         double share_commission,
-        const std::vector<Split>& commission_splits,
-        const wxString& share_lot
+        const wxString& share_lot,
+        const std::vector<Split>& commission_splits
     );
-
-public:
-    TrxShareModel();
-    ~TrxShareModel();
-
-    int64 find_trx_share_id(const int64 trx_id);
-    TrxShareData* unsafe_get_trx_share_n(const int64 trx_id);
-    void remove_trx_share(const int64 trx_id);
 };

--- a/src/model/TrxSplitModel.cpp
+++ b/src/model/TrxSplitModel.cpp
@@ -150,7 +150,7 @@ const wxString TrxSplitModel::get_tooltip(
     wxString split_tooltip = "";
     for (const auto& entry : split_a) {
         split_tooltip += wxString::Format("%s = %s",
-            CategoryModel::full_name(entry.CATEGID),
+            CategoryModel::instance().full_name(entry.CATEGID),
             CurrencyModel::toCurrency(entry.SPLITTRANSAMOUNT, currency)
         );
         if (!entry.NOTES.IsEmpty()) {

--- a/src/model/TrxSplitModel.cpp
+++ b/src/model/TrxSplitModel.cpp
@@ -21,6 +21,8 @@
 #include "CategoryModel.h"
 #include "TrxModel.h"
 
+const RefTypeN TrxSplitModel::s_ref_type = RefTypeN(RefTypeN::e_trx_split);
+
 TrxSplitModel::TrxSplitModel() :
     TableFactory<TrxSplitTable, TrxSplitData>()
 {

--- a/src/model/TrxSplitModel.cpp
+++ b/src/model/TrxSplitModel.cpp
@@ -52,12 +52,10 @@ TrxSplitModel& TrxSplitModel::instance()
     return Singleton<TrxSplitModel>::instance();
 }
 
-bool TrxSplitModel::purge_id(int64 id)
+bool TrxSplitModel::purge_id(int64 tp_id)
 {
-    // remove TagLinkData owned by id
-    TagLinkModel::instance().DeleteAllTags(TrxSplitModel::refTypeName, id);
-
-    return unsafe_remove_id(id);
+    TagLinkModel::instance().purge_ref(s_ref_type, tp_id);
+    return unsafe_remove_id(tp_id);
 }
 
 double TrxSplitModel::get_total(const DataA& tp_a)

--- a/src/model/TrxSplitModel.h
+++ b/src/model/TrxSplitModel.h
@@ -22,6 +22,7 @@
 #include "base/defs.h"
 
 #include "table/TrxSplitTable.h"
+#include "data/_DataEnum.h"
 #include "data/TrxSplitData.h"
 
 #include "_ModelBase.h"
@@ -67,5 +68,6 @@ public:
 
 public:
     static const wxString refTypeName;
+    static const RefTypeN s_ref_type;
 };
 

--- a/src/model/TrxSplitModel.h
+++ b/src/model/TrxSplitModel.h
@@ -67,7 +67,6 @@ public:
     bool purge_id(int64 id) override;
 
 public:
-    static const wxString refTypeName;
     static const RefTypeN s_ref_type;
 };
 

--- a/src/model/_ModelBase.cpp
+++ b/src/model/_ModelBase.cpp
@@ -17,36 +17,4 @@
  ********************************************************/
 
 #include "_ModelBase.h"
-#include "_all.h"
-
-mmChoiceNameA ModelBase::REFTYPE_CHOICES = mmChoiceNameA({
-    { REFTYPE_ID_TRANSACTION,       _n("Transaction") },
-    { REFTYPE_ID_STOCK,             _n("Stock") },
-    { REFTYPE_ID_ASSET,             _n("Asset") },
-    { REFTYPE_ID_BANKACCOUNT,       _n("BankAccount") },
-    { REFTYPE_ID_BILLSDEPOSIT,      _n("RecurringTransaction") },
-    { REFTYPE_ID_PAYEE,             _n("Payee") },
-    { REFTYPE_ID_TRANSACTIONSPLIT,  _n("TransactionSplit") },
-    { REFTYPE_ID_BILLSDEPOSITSPLIT, _n("RecurringTransactionSplit") },
-}, -1, true);
-
-const wxString ModelBase::REFTYPE_NAME_TRANSACTION       = reftype_name(REFTYPE_ID_TRANSACTION);
-const wxString ModelBase::REFTYPE_NAME_STOCK             = reftype_name(REFTYPE_ID_STOCK);
-const wxString ModelBase::REFTYPE_NAME_ASSET             = reftype_name(REFTYPE_ID_ASSET);
-const wxString ModelBase::REFTYPE_NAME_BANKACCOUNT       = reftype_name(REFTYPE_ID_BANKACCOUNT);
-const wxString ModelBase::REFTYPE_NAME_BILLSDEPOSIT      = reftype_name(REFTYPE_ID_BILLSDEPOSIT);
-const wxString ModelBase::REFTYPE_NAME_PAYEE             = reftype_name(REFTYPE_ID_PAYEE);
-const wxString ModelBase::REFTYPE_NAME_TRANSACTIONSPLIT  = reftype_name(REFTYPE_ID_TRANSACTIONSPLIT);
-const wxString ModelBase::REFTYPE_NAME_BILLSDEPOSITSPLIT = reftype_name(REFTYPE_ID_BILLSDEPOSITSPLIT);
-
-// *Model::refTypeName are initialized here because they depend on REFTYPE_NAME_,
-// which depend on REFTYPE_CHOICES.
-const wxString AccountModel::refTypeName    = ModelBase::REFTYPE_NAME_BANKACCOUNT;
-const wxString AssetModel::refTypeName      = ModelBase::REFTYPE_NAME_ASSET;
-const wxString StockModel::refTypeName      = ModelBase::REFTYPE_NAME_STOCK;
-const wxString PayeeModel::refTypeName      = ModelBase::REFTYPE_NAME_PAYEE;
-const wxString TrxModel::refTypeName        = ModelBase::REFTYPE_NAME_TRANSACTION;
-const wxString TrxSplitModel::refTypeName   = ModelBase::REFTYPE_NAME_TRANSACTIONSPLIT;
-const wxString SchedModel::refTypeName      = ModelBase::REFTYPE_NAME_BILLSDEPOSIT;
-const wxString SchedSplitModel::refTypeName = ModelBase::REFTYPE_NAME_BILLSDEPOSITSPLIT;
 

--- a/src/model/_ModelBase.h
+++ b/src/model/_ModelBase.h
@@ -27,13 +27,7 @@ Copyright (C) 2018 Stefano Giorgio (stef145g)
 #include <wx/log.h>
 
 #include "util/mmSingleton.h"
-#include "util/mmChoice.h"
-
 #include "table/_TableFactory.h"
-
-class wxSQLite3Statement;
-class wxSQLite3Database;
-class wxSQLite3ResultSet;
 
 typedef wxDateTime wxDate;
 typedef std::vector<int64> wxArrayInt64;
@@ -57,40 +51,6 @@ namespace std
 class ModelBase
 {
 public:
-    enum REFTYPE_ID {
-        REFTYPE_ID_TRANSACTION = 0,
-        REFTYPE_ID_STOCK,
-        REFTYPE_ID_ASSET,
-        REFTYPE_ID_BANKACCOUNT,
-        REFTYPE_ID_BILLSDEPOSIT,
-        REFTYPE_ID_PAYEE,
-        REFTYPE_ID_TRANSACTIONSPLIT,
-        REFTYPE_ID_BILLSDEPOSITSPLIT,
-        REFTYPE_ID_size
-    };
-
-    static mmChoiceNameA REFTYPE_CHOICES;
-    static const wxString REFTYPE_NAME_TRANSACTION;
-    static const wxString REFTYPE_NAME_STOCK;
-    static const wxString REFTYPE_NAME_ASSET;
-    static const wxString REFTYPE_NAME_BANKACCOUNT;
-    static const wxString REFTYPE_NAME_BILLSDEPOSIT;
-    static const wxString REFTYPE_NAME_PAYEE;
-    static const wxString REFTYPE_NAME_TRANSACTIONSPLIT;
-    static const wxString REFTYPE_NAME_BILLSDEPOSITSPLIT;
-    static const wxString reftype_name(int id);
-    static int reftype_id(const wxString& name);
-
-public:
     ModelBase() {};
     ~ModelBase() {};
 };
-
-inline const wxString ModelBase::reftype_name(int id)
-{
-    return REFTYPE_CHOICES.get_name(id);
-}
-inline int ModelBase::reftype_id(const wxString& name)
-{
-    return REFTYPE_CHOICES.find_name_n(name);
-}

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -217,7 +217,7 @@ void AssetList::OnDeleteAsset(wxCommandEvent& /*event*/)
         const AssetData& asset = m_panel->m_assets[m_selected_row];
         AssetModel::instance().purge_id(asset.m_id);
         mmAttachmentManage::DeleteAllAttachments(AssetModel::s_ref_type, asset.m_id);
-        TrxLinkModel::RemoveTransLinkRecords<AssetModel>(asset.m_id);
+        TrxLinkModel::instance().purge_ref(AssetModel::s_ref_type, asset.m_id);
 
         m_panel->initVirtualListControl();
         m_selected_row = -1;
@@ -785,13 +785,17 @@ void AssetPanel::AddAssetTrans(const int selected_index)
         asset_dialog.SetTransactionAccountName(account ? asset->m_name : asset->m_type.name());
     }
     else {
-        TrxLinkModel::DataA translist = TrxLinkModel::TranslinkList<AssetModel>(asset->m_id);
-        if (translist.empty()) {
-            wxMessageBox(_t(
-                "This asset does not have its own account\n\n"
-                "Multiple transactions for this asset are not recommended.")
-                , _t("Asset Management"), wxOK | wxICON_INFORMATION);
-
+        TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+            AssetModel::s_ref_type, asset->m_id
+        );
+        if (tl_a.empty()) {
+            wxMessageBox(
+                _t("This asset does not have its own account\n\n"
+                    "Multiple transactions for this asset are not recommended."
+                ),
+                _t("Asset Management"),
+                wxOK | wxICON_INFORMATION
+            );
             return; // abort process
         }
     }
@@ -852,13 +856,15 @@ wxListCtrl* AssetPanel::InitAssetTxnListCtrl(wxWindow* parent)
 }
 
 // Load asset transactions into the list control
-void AssetPanel::LoadAssetTransactions(wxListCtrl* listCtrl, int64 assetId)
+void AssetPanel::LoadAssetTransactions(wxListCtrl* listCtrl, int64 asset_id)
 {
-    TrxLinkModel::DataA asset_a = TrxLinkModel::TranslinkList<AssetModel>(assetId);
+    TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+        AssetModel::s_ref_type, asset_id
+    );
 
     int row = 0;
-    for (const auto& asset_d : asset_a) {
-        const TrxData* trx_n = TrxModel::instance().get_id_data_n(asset_d.CHECKINGACCOUNTID);
+    for (const auto& tl_d : tl_a) {
+        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
         if (!trx_n)
             continue;
 
@@ -885,8 +891,9 @@ void AssetPanel::BindAssetListEvents(wxListCtrl* listCtrl)
         if (!trx_n)
             return;
 
-        auto link = TrxLinkModel::TranslinkRecord(trx_n->m_id);
-        AssetDialog dlg(listCtrl, &link, trx_n);
+        const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_n->m_id);
+        TrxLinkData tl_d = tl_n ? *tl_n : TrxLinkData();
+        AssetDialog dlg(listCtrl, &tl_d, trx_n);
         dlg.ShowModal();
 
         this->FillAssetListRow(listCtrl, index, *trx_n);
@@ -933,15 +940,17 @@ void AssetPanel::CopySelectedRowsToClipboard(wxListCtrl* listCtrl)
 
 void AssetPanel::GotoAssetAccount(const int selected_index)
 {
-    AssetData* asset = &m_assets[selected_index];
-    const AccountData* account_n = AccountModel::instance().get_name_data_n(asset->m_name);
+    AssetData* asset_n = &m_assets[selected_index];
+    const AccountData* account_n = AccountModel::instance().get_name_data_n(asset_n->m_name);
     if (account_n) {
         SetAccountParameters(account_n);
     }
     else {
-        TrxLinkModel::DataA asset_a = TrxLinkModel::TranslinkList<AssetModel>(asset->m_id);
-        for (const auto &asset_d : asset_a) {
-            const TrxData* trx_n = TrxModel::instance().get_id_data_n(asset_d.CHECKINGACCOUNTID);
+        TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(
+            AssetModel::s_ref_type, asset_n->m_id
+        );
+        for (const auto& tl_a : tl_a) {
+            const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_a.m_trx_id);
             if (trx_n) {
                 account_n = AccountModel::instance().get_id_data_n(trx_n->m_account_id);
                 SetAccountParameters(account_n);

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -648,7 +648,7 @@ wxString AssetPanel::getItem(long item, int col_id)
     case AssetList::LIST_ID_NOTES: {
         wxString full_notes = asset.m_notes;
         full_notes.Replace("\n", " ");
-        if (AttachmentModel::NrAttachments(AssetModel::refTypeName, asset.m_id))
+        if (AttachmentModel::instance().find_id_c(AssetModel::s_ref_type, asset.m_id))
             full_notes = full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -275,13 +275,12 @@ void AssetList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
     if (m_selected_row < 0) return;
 
-    wxString RefType = AssetModel::refTypeName;
-    int64 RefId = m_panel->m_assets[m_selected_row].m_id;
+    int64 ref_id = m_panel->m_assets[m_selected_row].m_id;
 
-    AttachmentDialog dlg(this, RefType, RefId);
+    AttachmentDialog dlg(this, AssetModel::s_ref_type, ref_id);
     dlg.ShowModal();
 
-    doRefreshItems(RefId);
+    doRefreshItems(ref_id);
 }
 
 void AssetList::OnOpenAttachment(wxCommandEvent& /*event*/)

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -216,7 +216,7 @@ void AssetList::OnDeleteAsset(wxCommandEvent& /*event*/)
     if (msgDlg.ShowModal() == wxID_YES) {
         const AssetData& asset = m_panel->m_assets[m_selected_row];
         AssetModel::instance().purge_id(asset.m_id);
-        mmAttachmentManage::DeleteAllAttachments(AssetModel::refTypeName, asset.m_id);
+        mmAttachmentManage::DeleteAllAttachments(AssetModel::s_ref_type, asset.m_id);
         TrxLinkModel::RemoveTransLinkRecords<AssetModel>(asset.m_id);
 
         m_panel->initVirtualListControl();
@@ -286,13 +286,12 @@ void AssetList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 
 void AssetList::OnOpenAttachment(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row < 0) return;
+    if (m_selected_row < 0)
+        return;
 
-    wxString RefType = AssetModel::refTypeName;
-    int64 RefId = m_panel->m_assets[m_selected_row].m_id;
-
-    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);
-    doRefreshItems(RefId);
+    int64 ref_id = m_panel->m_assets[m_selected_row].m_id;
+    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, AssetModel::s_ref_type, ref_id);
+    doRefreshItems(ref_id);
 }
 
 void AssetList::OnListItemActivated(wxListEvent& event)
@@ -648,7 +647,7 @@ wxString AssetPanel::getItem(long item, int col_id)
     case AssetList::LIST_ID_NOTES: {
         wxString full_notes = asset.m_notes;
         full_notes.Replace("\n", " ");
-        if (AttachmentModel::instance().find_id_c(AssetModel::s_ref_type, asset.m_id))
+        if (AttachmentModel::instance().find_ref_c(AssetModel::s_ref_type, asset.m_id))
             full_notes = full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }

--- a/src/panel/BudgetPanel.cpp
+++ b/src/panel/BudgetPanel.cpp
@@ -165,28 +165,34 @@ void BudgetPanel::OnMouseLeftDown(wxCommandEvent& event)
 
 wxString BudgetPanel::GetPanelTitle() const
 {
-    wxString yearStr = BudgetPeriodModel::instance().get_id_name(budgetYearID_);
-    if ((yearStr.length() < 5)) {
+    wxString bp_name_n = BudgetPeriodModel::instance().get_id_name_n(budgetYearID_);
+    wxString title;
+    if ((bp_name_n.length() < 5)) {
         if (PrefModel::instance().getBudgetFinancialYears()) {
             long year;
-            yearStr.ToLong(&year);
+            bp_name_n.ToLong(&year);
             year++;
-            yearStr = wxString::Format(_t("Financial Year: %s - %li"), yearStr, year);
+            title = wxString::Format(_t("Financial Year: %s - %li"), bp_name_n, year);
         }
         else {
-            yearStr = wxString::Format(_t("Year: %s"), yearStr);
+            title = wxString::Format(_t("Year: %s"), bp_name_n);
         }
     }
     else {
-        yearStr = wxString::Format(_t("Month: %s"), yearStr);
-        yearStr += wxString::Format(" (%s)", m_monthName);
+        title = wxString::Format(_t("Month: %s"), bp_name_n);
+        title += wxString::Format(" (%s)", m_monthName);
     }
 
     if (PrefModel::instance().getBudgetDaysOffset() != 0) {
-        yearStr = wxString::Format(_t("%1$s    Start Date of: %2$s"), yearStr, mmGetDateTimeForDisplay(m_budget_offset_date));
+        title = wxString::Format(_t("%1$s    Start Date of: %2$s"),
+            title,
+            mmGetDateTimeForDisplay(m_budget_offset_date)
+        );
     }
 
-    return wxString::Format(_t("Budget Planner for %s"), yearStr);
+    title = wxString::Format(_t("Budget Planner for %s"), title);
+
+    return title;
 }
 
 void BudgetPanel::UpdateBudgetHeading()
@@ -349,15 +355,14 @@ void BudgetPanel::initVirtualListControl()
     mmReportBudget budgetDetails;
 
     bool evaluateTransfer = false;
-    if (PrefModel::instance().getBudgetIncludeTransfers())
-    {
+    if (PrefModel::instance().getBudgetIncludeTransfers()) {
         evaluateTransfer = true;
     }
 
     currentView_ = InfoModel::instance().getString("BUDGET_FILTER", VIEW_ALL);
-    const wxString budgetYearStr = BudgetPeriodModel::instance().get_id_name(budgetYearID_);
+    const wxString bp_name_n = BudgetPeriodModel::instance().get_id_name_n(budgetYearID_);
     long year = 0;
-    budgetYearStr.ToLong(&year);
+    bp_name_n.ToLong(&year);
 
     int startDay = 1;
     wxDate::Month startMonth = wxDateTime::Jan;
@@ -367,11 +372,10 @@ void BudgetPanel::initVirtualListControl()
     wxDateTime dtEnd = dtBegin;
     dtEnd.Add(wxDateSpan::Year()).Subtract(wxDateSpan::Day());
 
-    monthlyBudget_ = (budgetYearStr.length() > 5);
+    monthlyBudget_ = (bp_name_n.length() > 5);
 
-    if (monthlyBudget_)
-    {
-        budgetDetails.SetBudgetMonth(budgetYearStr, dtBegin, dtEnd);
+    if (monthlyBudget_) {
+        budgetDetails.SetBudgetMonth(bp_name_n, dtBegin, dtEnd);
         m_monthName = wxGetTranslation(wxDateTime::GetEnglishMonthName(dtBegin.GetMonth()));
     }
 
@@ -385,10 +389,14 @@ void BudgetPanel::initVirtualListControl()
 
     //Get statistics
     BudgetModel::instance().getBudgetEntry(budgetYearID_, budgetPeriod_, budgetAmt_, budgetNotes_);
-    CategoryModel::instance().getCategoryStats(categoryStats_
-        , static_cast<wxSharedPtr<wxArrayString>>(nullptr)
-        , &date_range, PrefModel::instance().getIgnoreFutureTransactions()
-        , false, (evaluateTransfer ? &budgetAmt_ : 0));
+    CategoryModel::instance().getCategoryStats(
+        categoryStats_,
+        static_cast<wxSharedPtr<wxArrayString>>(nullptr),
+        &date_range,
+        PrefModel::instance().getIgnoreFutureTransactions(),
+        false,
+        (evaluateTransfer ? &budgetAmt_ : nullptr)
+    );
 
     //start with only the root categories
     CategoryModel::DataA category_a = CategoryModel::instance().find(
@@ -530,7 +538,9 @@ double BudgetPanel::getEstimate(int64 category_id) const
     try {
         BudgetFrequency freq = budgetPeriod_.at(category_id);
         double amt = budgetAmt_.at(category_id);
-        return BudgetModel::getEstimate(monthlyBudget_, freq, amt);
+        return monthlyBudget_
+            ? amt * freq.times_per_month()
+            : amt * freq.times_per_year();
     }
     catch (std::out_of_range const& exc) {
         wxASSERT(false);

--- a/src/panel/BudgetPanel.cpp
+++ b/src/panel/BudgetPanel.cpp
@@ -299,21 +299,19 @@ void BudgetPanel::sortList()
     //TODO: Sort budget panel
 }
 
-bool BudgetPanel::DisplayEntryAllowed(int64 categoryID, int64 subcategoryID)
+bool BudgetPanel::DisplayEntryAllowed(int64 cat_id, int64 subcategoryID)
 {
     bool result = false;
 
     double actual = 0;
     double estimated = 0;
-    if (categoryID < 0)
-    {
+    if (cat_id < 0) {
         actual = budgetTotals_[subcategoryID].second;
         estimated = budgetTotals_[subcategoryID].first;
     }
-    else
-    {
-        actual = categoryStats_[categoryID][0];
-        estimated = getEstimate(categoryID);
+    else {
+        actual = categoryStats_[cat_id][0];
+        estimated = getEstimate(cat_id);
     }
 
     if (currentView_ == VIEW_NON_ZERO)
@@ -325,15 +323,14 @@ bool BudgetPanel::DisplayEntryAllowed(int64 categoryID, int64 subcategoryID)
     else if (currentView_ == VIEW_EXPENSE)
         result = ((estimated < 0.0) || (actual < 0.0));
     else if (currentView_ == VIEW_SUMM)
-        result = (categoryID < 0);
+        result = (cat_id < 0);
     else
         result = true;
 
-    if (categoryID > 0) {
-        displayDetails_[categoryID].second = result;
-        for (const auto& subcat_d : CategoryModel::sub_tree(
-            CategoryModel::instance().get_id_data_n(categoryID)
-        )) {
+    if (cat_id > 0) {
+        const CategoryData* cat_n = CategoryModel::instance().get_id_data_n(cat_id);
+        displayDetails_[cat_id].second = result;
+        for (const auto& subcat_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
             result = result || DisplayEntryAllowed(subcat_d.m_id, -1);
         }
     }
@@ -399,14 +396,13 @@ void BudgetPanel::initVirtualListControl()
     );
 
     //start with only the root categories
-    CategoryModel::DataA category_a = CategoryModel::instance().find(
+    CategoryModel::DataA cat_a = CategoryModel::instance().find(
         CategoryCol::PARENTID(-1)
     );
-    std::stable_sort(category_a.begin(), category_a.end(), CategoryData::SorterByCATEGNAME());
-    for (const auto& category_d : category_a)
-    {
-        displayDetails_[category_d.m_id].first = 0;
-        double estimated = getEstimate(category_d.m_id);
+    std::stable_sort(cat_a.begin(), cat_a.end(), CategoryData::SorterByCATEGNAME());
+    for (const auto& cat_d : cat_a) {
+        displayDetails_[cat_d.m_id].first = 0;
+        double estimated = getEstimate(cat_d.m_id);
         if (estimated < 0)
             estExpenses += estimated;
         else
@@ -415,7 +411,7 @@ void BudgetPanel::initVirtualListControl()
         double actual = 0;
         if (currentView_ != VIEW_PLANNED || estimated != 0)
         {
-            actual = categoryStats_[category_d.m_id][0];
+            actual = categoryStats_[cat_d.m_id][0];
             if (actual < 0)
                 actExpenses += actual;
             else
@@ -423,15 +419,15 @@ void BudgetPanel::initVirtualListControl()
         }
 
 
-        budgetTotals_[category_d.m_id].first = estimated;
-        budgetTotals_[category_d.m_id].second = actual;
+        budgetTotals_[cat_d.m_id].first = estimated;
+        budgetTotals_[cat_d.m_id].second = actual;
 
-        if (DisplayEntryAllowed(category_d.m_id, -1))
-            budget_.emplace_back(category_d.m_id, -1);
+        if (DisplayEntryAllowed(cat_d.m_id, -1))
+            budget_.emplace_back(cat_d.m_id, -1);
 
         std::vector<int> totals_queue;
-        //now a depth-first walk of the subtree of this root category_d
-        CategoryModel::DataA subcat_a = CategoryModel::sub_tree(category_d);
+        //now a depth-first walk of the subtree of this root cat_d
+        CategoryModel::DataA subcat_a = CategoryModel::instance().find_data_subtree_a(cat_d);
         for (int i = 0; i < static_cast<int>(subcat_a.size()); i++) {
             estimated = getEstimate(subcat_a[i].m_id);
             if (estimated < 0)
@@ -452,8 +448,8 @@ void BudgetPanel::initVirtualListControl()
             budgetTotals_[subcat_a[i].m_id].second = actual;
 
             //update totals of the category
-            budgetTotals_[category_d.m_id].first += estimated;
-            budgetTotals_[category_d.m_id].second += actual;
+            budgetTotals_[cat_d.m_id].first += estimated;
+            budgetTotals_[cat_d.m_id].second += actual;
 
             //walk up the hierarchy and update all the parent totals as well
             int64 nextParent = subcat_a[i].m_parent_id_n;
@@ -464,7 +460,7 @@ void BudgetPanel::initVirtualListControl()
                     budgetTotals_[subcat_a[j - 1].m_id].first += estimated;
                     budgetTotals_[subcat_a[j - 1].m_id].second += actual;
                     nextParent = subcat_a[j - 1].m_parent_id_n;
-                    if (nextParent == category_d.m_id)
+                    if (nextParent == cat_d.m_id)
                         break;
                 }
             }
@@ -503,8 +499,8 @@ void BudgetPanel::initVirtualListControl()
         }
 
         // show the total of the category after all subcats have been shown
-        if (DisplayEntryAllowed(-1, category_d.m_id)) {
-            budget_.emplace_back(-1, category_d.m_id);
+        if (DisplayEntryAllowed(-1, cat_d.m_id)) {
+            budget_.emplace_back(-1, cat_d.m_id);
             size_t transCatTotalIndex = budget_.size() - 1;
             m_lc->RefreshItem(transCatTotalIndex);
         }

--- a/src/panel/DashboardWidget.cpp
+++ b/src/panel/DashboardWidget.cpp
@@ -254,7 +254,7 @@ void htmlWidgetTop7Categories::getTopCategoryStats(
     for (const auto& i : stat) {
         if (i.second < 0) {
             std::pair <wxString, double> stat_pair;
-            stat_pair.first = CategoryModel::full_name(i.first);
+            stat_pair.first = CategoryModel::instance().full_name(i.first);
             stat_pair.second = i.second;
             categoryStats.push_back(stat_pair);
         }

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -1489,10 +1489,10 @@ void JournalList::onOrganizeAttachments(wxCommandEvent& /*event*/)
     findSelectedTransactions();
     Journal::IdRepeat id = m_selected_id[0];
 
-    const wxString refType = !id.second ?
-        TrxModel::refTypeName :
-        SchedModel::refTypeName;
-    AttachmentDialog dlg(this, refType, id.first);
+    RefTypeN ref_type = !id.second ?
+        TrxModel::s_ref_type :
+        SchedModel::s_ref_type;
+    AttachmentDialog dlg(this, ref_type, id.first);
     dlg.ShowModal();
     refreshVisualList();
 }
@@ -1724,9 +1724,8 @@ int64 JournalList::onPaste(const TrxData* tran)
 
     // Clone transaction tags
     TagLinkModel::DataA new_gl_a;
-    wxString reftype = TrxModel::refTypeName;
     for (const auto& tl_d : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(reftype),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
         TagLinkCol::REFID(tran->m_id)
     )) {
         TagLinkData new_gl_d;
@@ -1736,7 +1735,6 @@ int64 JournalList::onPaste(const TrxData* tran)
     }
 
     // Clone split transactions
-    reftype = TrxSplitModel::refTypeName;
     for (const auto& tp_d : TrxModel::find_split(*tran)) {
         TrxSplitData new_tp_d;
         new_tp_d.clone_from(tp_d);
@@ -1745,7 +1743,7 @@ int64 JournalList::onPaste(const TrxData* tran)
 
         // Clone split tags
         for (const auto& tl_d : TagLinkModel::instance().find(
-            TagLinkCol::REFTYPE(reftype),
+            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
             TagLinkCol::REFID(tp_d.m_id)
         )) {
             TagLinkData new_gl_d;
@@ -1874,8 +1872,8 @@ void JournalList::onOpenAttachment(wxCommandEvent& WXUNUSED(event))
     findSelectedTransactions();
     Journal::IdRepeat id = m_selected_id[0];
 
-    RefTypeN refType = !id.second ? TrxModel::s_ref_type : SchedModel::s_ref_type;
-    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, refType, id.first);
+    RefTypeN ref_type = !id.second ? TrxModel::s_ref_type : SchedModel::s_ref_type;
+    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, ref_type, id.first);
     refreshVisualList();
 }
 

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -1704,8 +1704,8 @@ int64 JournalList::onPaste(const TrxData* tran)
     )
     new_trx.m_account_id = m_cp->m_account_id;
     TrxModel::instance().save_trx_n(new_trx);
-    int64 transactionID = new_trx.id();
-    m_pasted_id.push_back({transactionID, 0});   // add the newly pasted transaction
+    int64 new_trx_id = new_trx.id();
+    m_pasted_id.push_back({new_trx_id, 0});   // add the newly pasted transaction
 
     // Clone transaction tags
     TagLinkModel::DataA new_gl_a;
@@ -1716,7 +1716,7 @@ int64 JournalList::onPaste(const TrxData* tran)
     )) {
         TagLinkData new_gl_d;
         new_gl_d.clone_from(tl_d);
-        new_gl_d.REFID = transactionID;
+        new_gl_d.REFID = new_trx_id;
         new_gl_a.push_back(new_gl_d);
     }
 
@@ -1725,7 +1725,7 @@ int64 JournalList::onPaste(const TrxData* tran)
     for (const auto& tp_d : TrxModel::find_split(*tran)) {
         TrxSplitData new_tp_d;
         new_tp_d.clone_from(tp_d);
-        new_tp_d.m_trx_id = transactionID;
+        new_tp_d.m_trx_id = new_trx_id;
         TrxSplitModel::instance().add_data_n(new_tp_d);
 
         // Clone split tags
@@ -1749,9 +1749,10 @@ int64 JournalList::onPaste(const TrxData* tran)
         FieldValueModel::instance().db_savepoint();
         for (const auto& fv_d : fv_a) {
             FieldValueData new_fv_d = FieldValueData();
-            new_fv_d.FIELDID = fv_d.FIELDID;
-            new_fv_d.REFID   = transactionID;
-            new_fv_d.CONTENT = fv_d.CONTENT;
+            new_fv_d.m_field_id = fv_d.m_field_id;
+            new_fv_d.m_ref_type = RefTypeN(RefTypeN::e_trx);
+            new_fv_d.m_ref_id   = new_trx_id;
+            new_fv_d.m_content  = fv_d.m_content;
             FieldValueModel::instance().add_data_n(new_fv_d);
         }
         FieldValueModel::instance().db_release_savepoint();
@@ -1759,11 +1760,12 @@ int64 JournalList::onPaste(const TrxData* tran)
 
     // Clone attachments if wanted
     if (InfoModel::instance().getBool("ATTACHMENTSDUPLICATE", false)) {
-        const wxString& RefType = TrxModel::refTypeName;
-        mmAttachmentManage::CloneAllAttachments(RefType, tran->m_id, transactionID);
+        mmAttachmentManage::CloneAllAttachments(
+            TrxModel::s_ref_type, tran->m_id, new_trx_id
+        );
     }
 
-    return transactionID;
+    return new_trx_id;
 }
 
 void JournalList::onDuplicateTransaction(wxCommandEvent& WXUNUSED(event))
@@ -1857,9 +1859,7 @@ void JournalList::onOpenAttachment(wxCommandEvent& WXUNUSED(event))
     findSelectedTransactions();
     Journal::IdRepeat id = m_selected_id[0];
 
-    const wxString refType = !id.second ?
-        TrxModel::refTypeName :
-        SchedModel::refTypeName;
+    RefTypeN refType = !id.second ? TrxModel::s_ref_type : SchedModel::s_ref_type;
     mmAttachmentManage::OpenAttachmentFromPanelIcon(this, refType, id.first);
     refreshVisualList();
 }

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -1165,7 +1165,7 @@ void JournalList::onDeleteTransaction(wxCommandEvent& WXUNUSED(event))
 
     if (msgDlg.ShowModal() == wxID_YES) {
         wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
-        std::set<std::pair<wxString, int64>> assetStockAccts;
+        std::set<std::pair<RefTypeN, int64>> assetStockAccts;
         TrxModel::instance().db_savepoint();
         AttachmentModel::instance().db_savepoint();
         TrxSplitModel::instance().db_savepoint();
@@ -1189,7 +1189,7 @@ void JournalList::onDeleteTransaction(wxCommandEvent& WXUNUSED(event))
                     TrxLinkCol::CHECKINGACCOUNTID(trx_n->m_id)
                 );
                 if (!tl_a.empty()) {
-                    assetStockAccts.emplace(tl_a.at(0).LINKTYPE, tl_a.at(0).LINKRECORDID);
+                    assetStockAccts.emplace(tl_a.at(0).m_ref_type, tl_a.at(0).m_ref_id);
                 }
             }
             m_selectedForCopy.erase(
@@ -1205,11 +1205,11 @@ void JournalList::onDeleteTransaction(wxCommandEvent& WXUNUSED(event))
 
         if (!assetStockAccts.empty()) {
             for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset")
+                if (i.first == AssetModel::s_ref_type)
                     TrxLinkModel::UpdateAssetValue(
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
-                else if (i.first == "Stock")
+                else if (i.first == StockModel::s_ref_type)
                     StockModel::UpdatePosition(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
@@ -1245,7 +1245,7 @@ void JournalList::onRestoreTransaction(wxCommandEvent& WXUNUSED(event))
     );
 
     if (msgDlg.ShowModal() == wxID_YES) {
-        std::set<std::pair<wxString, int64>> assetStockAccts;
+        std::set<std::pair<RefTypeN, int64>> assetStockAccts;
         for (const auto& id : m_selected_id) {
             if (!id.second) {
                 TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(id.first);
@@ -1255,18 +1255,18 @@ void JournalList::onRestoreTransaction(wxCommandEvent& WXUNUSED(event))
                     TrxLinkCol::CHECKINGACCOUNTID(trx_n->m_id)
                 );
                 if (!tl_a.empty()) {
-                    assetStockAccts.emplace(tl_a.at(0).LINKTYPE, tl_a.at(0).LINKRECORDID);
+                    assetStockAccts.emplace(tl_a.at(0).m_ref_type, tl_a.at(0).m_ref_id);
                 }
             }
         }
         m_selected_id.clear();
         if (!assetStockAccts.empty()) {
             for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset")
+                if (i.first == AssetModel::s_ref_type)
                     TrxLinkModel::UpdateAssetValue(
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
-                else if (i.first == "Stock")
+                else if (i.first == StockModel::s_ref_type)
                     StockModel::UpdatePosition(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
@@ -1287,7 +1287,7 @@ void JournalList::onRestoreViewedTransaction(wxCommandEvent&)
         wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
     );
     if (msgDlg.ShowModal() == wxID_YES) {
-        std::set<std::pair<wxString, int64>> assetStockAccts;
+        std::set<std::pair<RefTypeN, int64>> assetStockAccts;
         for (const auto& tran : this->m_journal_xa) {
             if (tran.m_repeat_num) continue;
             TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(tran.m_id);
@@ -1297,16 +1297,16 @@ void JournalList::onRestoreViewedTransaction(wxCommandEvent&)
                 TrxLinkCol::CHECKINGACCOUNTID(trx_n->m_id)
             );
             if (!tl_a.empty()) {
-                assetStockAccts.emplace(tl_a.at(0).LINKTYPE, tl_a.at(0).LINKRECORDID);
+                assetStockAccts.emplace(tl_a.at(0).m_ref_type, tl_a.at(0).m_ref_id);
             }
         }
         if (!assetStockAccts.empty()) {
             for (const auto& i : assetStockAccts) {
-                if (i.first == "Asset")
+                if (i.first == AssetModel::s_ref_type)
                     TrxLinkModel::UpdateAssetValue(
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
-                else if (i.first == "Stock")
+                else if (i.first == StockModel::s_ref_type)
                     StockModel::UpdatePosition(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
@@ -1326,13 +1326,15 @@ void JournalList::onEditTransaction(wxCommandEvent& /*event*/)
 
     // edit multiple transactions
     if (m_selected_id.size() > 1) {
-        std::vector<int64> transid;
+        std::vector<int64> trx_id_a;
         for (const auto& id : m_selected_id)
             if (!id.second)
-                transid.push_back(id.first);
-        if (transid.size() == 0) return;
-        if (!checkForClosedAccounts()) return;
-        TrxUpdateDialog dlg(this, transid);
+                trx_id_a.push_back(id.first);
+        if (trx_id_a.size() == 0)
+            return;
+        if (!checkForClosedAccounts())
+            return;
+        TrxUpdateDialog dlg(this, trx_id_a);
         if (dlg.ShowModal() == wxID_OK)
             refreshVisualList();
         return;
@@ -1341,21 +1343,23 @@ void JournalList::onEditTransaction(wxCommandEvent& /*event*/)
     // edit single transaction
     Journal::IdRepeat id = m_selected_id[0];
     if (!id.second) {
-        TrxData* checking_entry = TrxModel::instance().unsafe_get_id_data_n(id.first);
-        if (checkTransactionLocked(checking_entry->m_account_id, checking_entry->TRANSDATE))
+        TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(id.first);
+        if (checkTransactionLocked(trx_n->m_account_id, trx_n->TRANSDATE))
             return;
 
         if (!TrxLinkModel::instance().find(
             TrxLinkCol::CHECKINGACCOUNTID(id.first)
         ).empty()) {
-            TrxLinkData translink = TrxLinkModel::TranslinkRecord(id.first);
-            if (translink.LINKTYPE == StockModel::refTypeName) {
-                TrxShareDialog dlg(this, &translink, checking_entry);
+            const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(id.first);
+            if (tl_n && tl_n->m_ref_type == StockModel::s_ref_type) {
+                TrxLinkData tl_d = *tl_n;
+                TrxShareDialog dlg(this, &tl_d, trx_n);
                 if (dlg.ShowModal() == wxID_OK)
                     refreshVisualList();
             }
-            else if (translink.LINKTYPE == AssetModel::refTypeName) {
-                AssetDialog dlg(this, &translink, checking_entry);
+            else if (tl_n && tl_n->m_ref_type == AssetModel::s_ref_type) {
+                TrxLinkData tl_d = *tl_n;
+                AssetDialog dlg(this, &tl_d, trx_n);
                 if (dlg.ShowModal() == wxID_OK)
                     refreshVisualList();
             }
@@ -2193,7 +2197,7 @@ void JournalList::deleteTransactionsByStatus(const wxString& status)
 {
     int retainDays = SettingModel::instance().getInt("DELETED_TRANS_RETAIN_DAYS", 30);
     wxString deletionTime = wxDateTime::Now().ToUTC().FormatISOCombined();
-    std::set<std::pair<wxString, int64>> assetStockAccts;
+    std::set<std::pair<RefTypeN, int64>> assetStockAccts;
     const auto s = TrxModel::status_key(status);
     TrxModel::instance().db_savepoint();
     AttachmentModel::instance().db_savepoint();
@@ -2214,7 +2218,7 @@ void JournalList::deleteTransactionsByStatus(const wxString& status)
                     TrxLinkCol::CHECKINGACCOUNTID(trx_n->m_id)
                 );
                 if (!translink.empty()) {
-                    assetStockAccts.emplace(translink.at(0).LINKTYPE, translink.at(0).LINKRECORDID);
+                    assetStockAccts.emplace(translink.at(0).m_ref_type, translink.at(0).m_ref_id);
                 }
             }
         }
@@ -2222,11 +2226,11 @@ void JournalList::deleteTransactionsByStatus(const wxString& status)
 
     if (!assetStockAccts.empty()) {
         for (const auto& i : assetStockAccts) {
-            if (i.first == "Asset")
+            if (i.first == AssetModel::s_ref_type)
                 TrxLinkModel::UpdateAssetValue(
                     AssetModel::instance().unsafe_get_id_data_n(i.second)
                 );
-            else if (i.first == "Stock")
+            else if (i.first == StockModel::s_ref_type)
                 StockModel::UpdatePosition(
                     StockModel::instance().unsafe_get_id_data_n(i.second)
                 );

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -334,19 +334,19 @@ void JournalList::setColumnsInfo()
     if (m_cp->isDeletedTrans())
         m_col_id_nr.push_back(LIST_ID_DELETEDTIME);
 
-    const auto& ref_type = TrxModel::refTypeName;
     int col_id = LIST_ID_UDFC01;
-    for (const auto& udfc_entry : FieldModel::UDFC_FIELDS()) {
+    for (const auto& udfc : FieldModel::UDFC_FIELDS()) {
         if (col_id > LIST_ID_UDFC05) break;
-        if (udfc_entry.empty()) continue;
+        if (udfc.empty())
+            continue;
 
-        const auto& name = FieldModel::getUDFCName(ref_type, udfc_entry);
-        if (!name.IsEmpty() && name != udfc_entry) {
+        const auto& name = FieldModel::instance().get_udfc_name_n(TrxModel::s_ref_type, udfc);
+        if (!name.IsEmpty() && name != udfc) {
             m_col_info_id[col_id].header = name;
-            const auto& type = FieldModel::getUDFCType(ref_type, udfc_entry);
-            if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+            const auto& type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, udfc).id_n();
+            if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
                 m_col_info_id[col_id].format = _FR;
-            else if (type == FieldModel::TYPE_ID_BOOLEAN)
+            else if (type_id_n == FieldTypeN::e_boolean)
                 m_col_info_id[col_id].format = _FC;
             m_col_id_nr.push_back(col_id);
         }
@@ -457,8 +457,7 @@ void JournalList::sortBy(Compare comp, bool ascend)
 
 void JournalList::sortTransactions(int col_id, bool ascend)
 {
-    const auto& ref_type = TrxModel::refTypeName;
-    FieldModel::TYPE_ID type;
+    mmChoiceIdN type_id_n;
 
     switch (col_id) {
     case JournalList::LIST_ID_SN:
@@ -513,36 +512,36 @@ void JournalList::sortTransactions(int col_id, bool ascend)
         sortBy(TrxData::SorterByDELETEDTIME(), ascend);
         break;
     case JournalList::LIST_ID_UDFC01:
-        type = FieldModel::getUDFCType(ref_type, "UDFC01");
-        if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+        type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, "UDFC01").id_n();
+        if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
             sortBy(SorterByUDFC01_val, ascend);
         else
             sortBy(SorterByUDFC01, ascend);
         break;
     case JournalList::LIST_ID_UDFC02:
-        type = FieldModel::getUDFCType(ref_type, "UDFC02");
-        if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+        type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, "UDFC02").id_n();
+        if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
             sortBy(SorterByUDFC02_val, ascend);
         else
             sortBy(SorterByUDFC02, ascend);
         break;
     case JournalList::LIST_ID_UDFC03:
-        type = FieldModel::getUDFCType(ref_type, "UDFC03");
-        if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+        type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, "UDFC03").id_n();
+        if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
             sortBy(SorterByUDFC03_val, ascend);
         else
             sortBy(SorterByUDFC03, ascend);
         break;
     case JournalList::LIST_ID_UDFC04:
-        type = FieldModel::getUDFCType(ref_type, "UDFC04");
-        if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+        type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, "UDFC04").id_n();
+        if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
             sortBy(SorterByUDFC04_val, ascend);
         else
             sortBy(SorterByUDFC04, ascend);
         break;
     case JournalList::LIST_ID_UDFC05:
-        type = FieldModel::getUDFCType(ref_type, "UDFC05");
-        if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+        type_id_n = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, "UDFC05").id_n();
+        if (type_id_n == FieldTypeN::e_decimal || type_id_n == FieldTypeN::e_integer)
             sortBy(SorterByUDFC05_val, ascend);
         else
             sortBy(SorterByUDFC05, ascend);
@@ -809,7 +808,6 @@ void JournalList::onMouseRightClick(wxMouseEvent& event)
     if (row < m_journal_xa.size() && (flags & wxLIST_HITTEST_ONITEM) && col_nr < getColNrSize()) {
         int col_id = getColId_Nr(col_nr);
         wxString menuItemText;
-        wxString refType = TrxModel::refTypeName;
         wxDateTime datetime;
         wxString dateFormat = PrefModel::instance().getDateFormat();
 
@@ -912,23 +910,33 @@ void JournalList::onMouseRightClick(wxMouseEvent& event)
             break;
         case LIST_ID_UDFC01:
             copyText_ = menuItemText = m_journal_xa[row].UDFC_content[0];
-            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", FieldModel::getUDFCID(refType, "UDFC01"));
+            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}",
+                FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, "UDFC01")
+            );
             break;
         case LIST_ID_UDFC02:
             copyText_ = menuItemText = m_journal_xa[row].UDFC_content[1];
-            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", FieldModel::getUDFCID(refType, "UDFC02"));
+            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}",
+                FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, "UDFC02")
+            );
             break;
         case LIST_ID_UDFC03:
             copyText_ = menuItemText = m_journal_xa[row].UDFC_content[2];
-            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", FieldModel::getUDFCID(refType, "UDFC03"));
+            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}",
+                FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, "UDFC03")
+            );
             break;
         case LIST_ID_UDFC04:
             copyText_ = menuItemText = m_journal_xa[row].UDFC_content[3];
-            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", FieldModel::getUDFCID(refType, "UDFC04"));
+            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}",
+                FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, "UDFC04")
+            );
             break;
         case LIST_ID_UDFC05:
             copyText_ = menuItemText = m_journal_xa[row].UDFC_content[4];
-            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}", FieldModel::getUDFCID(refType, "UDFC05"));
+            rightClickFilter_ = wxString::Format("{\n\"CUSTOM%lld\": \"" + menuItemText + "\"\n}",
+                FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, "UDFC05")
+            );
             break;
         default:
             break;
@@ -1873,16 +1881,16 @@ void JournalList::onOpenAttachment(wxCommandEvent& WXUNUSED(event))
 
 //----------------------------------------------------------------------------
 
-wxString UDFCFormatHelper(FieldModel::TYPE_ID type, wxString data)
+wxString UDFCFormatHelper(FieldTypeN type, wxString data)
 {
     wxString formattedData = data;
     bool v = false;
     if (!data.empty()) {
-        switch (type) {
-        case FieldModel::TYPE_ID_DATE:
+        switch (type.id_n()) {
+        case FieldTypeN::e_date:
             formattedData = mmGetDateTimeForDisplay(data);
             break;
-        case FieldModel::TYPE_ID_BOOLEAN:
+        case FieldTypeN::e_boolean:
             v = wxString("TRUE|true|1").Contains(data);
             formattedData = (v) ? L"\u2713" : L"\u2717";
             break;

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -764,7 +764,7 @@ void JournalList::onMouseRightClick(wxMouseEvent& event)
 
         menu.Append(MENU_TREEPOPUP_MOVE2, (1 == selected) ? _tu("&Move Transaction…") : _tu("&Move Transactions…"));
         if (is_nothing_selected || type_transfer ||
-            AccountModel::instance().find_money_type_cnt() < 2 ||
+            AccountModel::instance().find_money_type_c() < 2 ||
             is_foreign
         )
             menu.Enable(MENU_TREEPOPUP_MOVE2, false);

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -1218,7 +1218,7 @@ void JournalList::onDeleteTransaction(wxCommandEvent& WXUNUSED(event))
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
                 else if (i.first == StockModel::s_ref_type)
-                    StockModel::UpdatePosition(
+                    StockModel::instance().update_data_position(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
             }
@@ -1275,7 +1275,7 @@ void JournalList::onRestoreTransaction(wxCommandEvent& WXUNUSED(event))
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
                 else if (i.first == StockModel::s_ref_type)
-                    StockModel::UpdatePosition(
+                    StockModel::instance().update_data_position(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
             }
@@ -1315,7 +1315,7 @@ void JournalList::onRestoreViewedTransaction(wxCommandEvent&)
                         AssetModel::instance().unsafe_get_id_data_n(i.second)
                     );
                 else if (i.first == StockModel::s_ref_type)
-                    StockModel::UpdatePosition(
+                    StockModel::instance().update_data_position(
                         StockModel::instance().unsafe_get_id_data_n(i.second)
                     );
             }
@@ -2237,7 +2237,7 @@ void JournalList::deleteTransactionsByStatus(const wxString& status)
                     AssetModel::instance().unsafe_get_id_data_n(i.second)
                 );
             else if (i.first == StockModel::s_ref_type)
-                StockModel::UpdatePosition(
+                StockModel::instance().update_data_position(
                     StockModel::instance().unsafe_get_id_data_n(i.second)
                 );
         }

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -856,8 +856,11 @@ void JournalList::onMouseRightClick(wxMouseEvent& event)
             if (!m_journal_xa[row].has_split() && m_journal_xa[row].has_tags()) {
                 copyText_ = menuItemText = m_journal_xa[row].TAGNAMES;
                 // build the tag filter json
-                for (const auto& tag : m_journal_xa[row].m_tags) {
-                    rightClickFilter_ += (rightClickFilter_.IsEmpty() ? "{\n\"TAGS\": [\n" : ",\n") + wxString::Format("%lld", tag.TAGID);
+                for (const auto& gl_d : m_journal_xa[row].m_tags) {
+                    rightClickFilter_ += (rightClickFilter_.IsEmpty()
+                        ? "{\n\"TAGS\": [\n"
+                        : ",\n"
+                    ) + wxString::Format("%lld", gl_d.m_tag_id);
                 }
                 rightClickFilter_ += "\n]\n}";
             }
@@ -1716,7 +1719,7 @@ int64 JournalList::onPaste(const TrxData* tran)
     )) {
         TagLinkData new_gl_d;
         new_gl_d.clone_from(tl_d);
-        new_gl_d.REFID = new_trx_id;
+        new_gl_d.m_ref_id = new_trx_id;
         new_gl_a.push_back(new_gl_d);
     }
 
@@ -1735,7 +1738,7 @@ int64 JournalList::onPaste(const TrxData* tran)
         )) {
             TagLinkData new_gl_d;
             new_gl_d.clone_from(tl_d);
-            new_gl_d.REFID = new_tp_d.id();
+            new_gl_d.m_ref_id = new_tp_d.id();
             new_gl_a.push_back(new_gl_d);
         }
     }
@@ -1933,13 +1936,14 @@ const wxString JournalList::getItem(long item, int col_id) const
     case LIST_ID_TAGS:
         value = journal_xd.TAGNAMES;
         if (!journal_xd.displayID.Contains(".")) {
-            const wxString splitRefType = TrxSplitModel::refTypeName;
             for (const auto& tp_d : journal_xd.m_splits) {
                 wxString tagnames;
-                std::map<wxString, int64> tags = TagLinkModel::instance().get_ref(splitRefType, tp_d.m_id);
-                std::map<wxString, int64, caseInsensitiveComparator> sortedTags(tags.begin(), tags.end());
-                for (const auto& tag : sortedTags)
-                    tagnames.Append(tag.first + " ");
+                std::map<wxString, int64> tag_name_id_m = TagLinkModel::instance().find_ref_tag_m(
+                    TrxSplitModel::s_ref_type, tp_d.m_id
+                );
+                std::map<wxString, int64, caseInsensitiveComparator> sortedTags(tag_name_id_m.begin(), tag_name_id_m.end());
+                for (const auto& tag_name_id : sortedTags)
+                    tagnames.Append(tag_name_id.first + " ");
                 if (!tagnames.IsEmpty())
                     value.Append((value.IsEmpty() ? "" : ", ") + tagnames.Trim());
             }

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -651,7 +651,8 @@ void JournalPanel::filterList()
         );
     }
 
-    auto tranFieldData = FieldValueModel::instance().get_all_id(TrxModel::refTypeName);
+    auto trx_fv_m = FieldValueModel::instance().find_reftype_refid_data_m(TrxModel::s_ref_type);
+    auto sched_fv_m = FieldValueModel::instance().find_reftype_refid_data_m(SchedModel::s_ref_type);
 
     bool ignore_future = PrefModel::instance().getIgnoreFutureTransactions();
     const wxString today_date = PrefModel::instance().UseTransDateTime() ?
@@ -813,28 +814,28 @@ void JournalPanel::filterList()
             journal_xd.UDFC_value[i] = -DBL_MAX;
         }
 
-        if (repeat_num == 0 && tranFieldData.find(trx_n->m_id) != tranFieldData.end()) {
-            for (const auto& udfc : tranFieldData.at(trx_n->m_id)) {
+        if (repeat_num == 0 && trx_fv_m.find(trx_n->m_id) != trx_fv_m.end()) {
+            for (const auto& udfc : trx_fv_m.at(trx_n->m_id)) {
                 for (int i = 0; i < 5; i++) {
-                    if (udfc.FIELDID == udfc_id[i]) {
+                    if (udfc.m_field_id == udfc_id[i]) {
                         journal_xd.UDFC_type[i] = udfc_type[i];
-                        journal_xd.UDFC_content[i] = udfc.CONTENT;
+                        journal_xd.UDFC_content[i] = udfc.m_content;
                         journal_xd.UDFC_value[i] = cleanseNumberStringToDouble(
-                            udfc.CONTENT, udfc_scale[i] > 0
+                            udfc.m_content, udfc_scale[i] > 0
                         );
                         break;
                     }
                 }
             }
         }
-        else if (repeat_num > 0 && tranFieldData.find(-journal_xd.m_bdid) != tranFieldData.end()) {
-            for (const auto& udfc : tranFieldData.at(-journal_xd.m_bdid)) {
+        else if (repeat_num > 0 && sched_fv_m.find(journal_xd.m_bdid) != sched_fv_m.end()) {
+            for (const auto& udfc : sched_fv_m.at(journal_xd.m_bdid)) {
                 for (int i = 0; i < 5; i++) {
-                    if (udfc.FIELDID == udfc_id[i]) {
+                    if (udfc.m_field_id == udfc_id[i]) {
                         journal_xd.UDFC_type[i] = udfc_type[i];
-                        journal_xd.UDFC_content[i] = udfc.CONTENT;
+                        journal_xd.UDFC_content[i] = udfc.m_content;
                         journal_xd.UDFC_value[i] = cleanseNumberStringToDouble(
-                            udfc.CONTENT, udfc_scale[i] > 0
+                            udfc.m_content, udfc_scale[i] > 0
                         );
                         break;
                     }
@@ -947,8 +948,9 @@ void JournalPanel::updateExtraTransactionData(bool single, int repeat_num, bool 
                     notesStr += tp_d.m_notes;
                 }
             if (journal_xd.has_attachment()) {
-                const wxString& refType = TrxModel::refTypeName;
-                for (const auto& att_d : AttachmentModel::instance().find_id_data_a(RefTypeN(refType), journal_xd.m_id)) {
+                for (const auto& att_d : AttachmentModel::instance().find_ref_data_a(
+                    TrxModel::s_ref_type, journal_xd.m_id)
+                ) {
                     notesStr += notesStr.empty() ? "" : "\n";
                     notesStr += _t("Attachment") + " " + att_d.m_description + " " + att_d.m_filename;
                 }
@@ -964,8 +966,9 @@ void JournalPanel::updateExtraTransactionData(bool single, int repeat_num, bool 
                     notesStr += qp_d.m_notes;
                 }
             if (journal_xd.has_attachment()) {
-                const wxString& refType = SchedModel::refTypeName;
-                for (const auto& att_d : AttachmentModel::instance().find_id_data_a(RefTypeN(refType), journal_xd.m_bdid)) {
+                for (const auto& att_d : AttachmentModel::instance().find_ref_data_a(
+                    SchedModel::s_ref_type, journal_xd.m_bdid)
+                ) {
                     notesStr += notesStr.empty() ? "" : "\n";
                     notesStr += _t("Attachment") + " " + att_d.m_description + " " + att_d.m_filename;
                 }

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -634,15 +634,15 @@ void JournalPanel::filterList()
 
     static wxArrayString udfc_fields = FieldModel::UDFC_FIELDS();
     int64 udfc_id[5];
-    FieldModel::TYPE_ID udfc_type[5];
+    FieldTypeN udfc_type[5];
     int udfc_scale[5];
     for (int i = 0; i < 5; i++) {
         // note: udfc_fields starts with ""
         wxString field = udfc_fields[i+1];
-        udfc_id[i] = FieldModel::getUDFCID(TrxModel::refTypeName, field);
-        udfc_type[i] = FieldModel::getUDFCType(TrxModel::refTypeName, field);
+        udfc_id[i] = FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, field);
+        udfc_type[i] = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, field);
         udfc_scale[i] = FieldModel::getDigitScale(
-            FieldModel::getUDFCProperties(TrxModel::refTypeName, field)
+            FieldModel::instance().get_udfc_properties_n(TrxModel::s_ref_type, field)
         );
     }
 
@@ -813,7 +813,7 @@ void JournalPanel::filterList()
         }
 
         for (int i = 0; i < 5; i++) {
-            journal_xd.UDFC_type[i] = FieldModel::TYPE_ID_UNKNOWN;
+            journal_xd.UDFC_type[i] = FieldTypeN();
             journal_xd.UDFC_value[i] = -DBL_MAX;
         }
 

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -663,7 +663,7 @@ void JournalPanel::filterList()
         : TrxModel::instance().find_allByDateTimeId();
     const auto trans_splits = TrxSplitModel::instance().get_all_id();
     const auto trans_tags = TagLinkModel::instance().get_all_id(tranRefType);
-    const auto trans_attachments = AttachmentModel::instance().get_reftype(TrxModel::refTypeName);
+    const auto trans_attachments = AttachmentModel::instance().find_type_id_data_a_m(TrxModel::s_ref_type);
 
     wxString date_start_str, date_end_str;
     wxDateTime date_end = wxDateTime::Now() + wxTimeSpan::Days(30);
@@ -700,7 +700,7 @@ void JournalPanel::filterList()
     if (m_scheduled_enable && m_scheduled_selected) {
         bills_splits = SchedSplitModel::instance().get_all_id();
         bills_tags = TagLinkModel::instance().get_all_id(billRefType);
-        bills_attachments = AttachmentModel::instance().get_reftype(SchedModel::refTypeName);
+        bills_attachments = AttachmentModel::instance().find_type_id_data_a_m(SchedModel::s_ref_type);
         bills = m_account_n
             ? AccountModel::instance().find_id_sched_a(m_account_n->m_id)
             : SchedModel::instance().find_all();
@@ -800,12 +800,12 @@ void JournalPanel::filterList()
         }
 
         if (repeat_num == 0 && trans_attachments.find(trx_n->m_id) != trans_attachments.end()) {
-            for (const auto& entry : trans_attachments.at(trx_n->m_id))
-                journal_xd.ATTACHMENT_DESCRIPTION.Add(entry.DESCRIPTION);
+            for (const auto& att_d : trans_attachments.at(trx_n->m_id))
+                journal_xd.ATTACHMENT_DESCRIPTION.Add(att_d.m_description);
         }
         else if (repeat_num > 0 && bills_attachments.find(journal_xd.m_bdid) != bills_attachments.end()) {
-            for (const auto& entry : bills_attachments.at(journal_xd.m_bdid))
-                journal_xd.ATTACHMENT_DESCRIPTION.Add(entry.DESCRIPTION);
+            for (const auto& att_d : bills_attachments.at(journal_xd.m_bdid))
+                journal_xd.ATTACHMENT_DESCRIPTION.Add(att_d.m_description);
         }
 
         for (int i = 0; i < 5; i++) {
@@ -948,10 +948,9 @@ void JournalPanel::updateExtraTransactionData(bool single, int repeat_num, bool 
                 }
             if (journal_xd.has_attachment()) {
                 const wxString& refType = TrxModel::refTypeName;
-                AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(refType, journal_xd.m_id);
-                for (const auto& i : attachments) {
+                for (const auto& att_d : AttachmentModel::instance().find_id_data_a(RefTypeN(refType), journal_xd.m_id)) {
                     notesStr += notesStr.empty() ? "" : "\n";
-                    notesStr += _t("Attachment") + " " + i.DESCRIPTION + " " + i.FILENAME;
+                    notesStr += _t("Attachment") + " " + att_d.m_description + " " + att_d.m_filename;
                 }
             }
         }
@@ -966,10 +965,9 @@ void JournalPanel::updateExtraTransactionData(bool single, int repeat_num, bool 
                 }
             if (journal_xd.has_attachment()) {
                 const wxString& refType = SchedModel::refTypeName;
-                AttachmentModel::DataA attachments = AttachmentModel::instance().FilterAttachments(refType, journal_xd.m_bdid);
-                for (const auto& i : attachments) {
+                for (const auto& att_d : AttachmentModel::instance().find_id_data_a(RefTypeN(refType), journal_xd.m_bdid)) {
                     notesStr += notesStr.empty() ? "" : "\n";
-                    notesStr += _t("Attachment") + " " + i.DESCRIPTION + " " + i.FILENAME;
+                    notesStr += _t("Attachment") + " " + att_d.m_description + " " + att_d.m_filename;
                 }
             }
         }

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -646,8 +646,8 @@ void JournalPanel::filterList()
         );
     }
 
-    auto trx_fv_m = FieldValueModel::instance().find_reftype_refid_data_m(TrxModel::s_ref_type);
-    auto sched_fv_m = FieldValueModel::instance().find_reftype_refid_data_m(SchedModel::s_ref_type);
+    auto trxId_fvA_m = FieldValueModel::instance().find_refType_mRefId(TrxModel::s_ref_type);
+    auto schedId_fvA_m = FieldValueModel::instance().find_refType_mRefId(SchedModel::s_ref_type);
 
     bool ignore_future = PrefModel::instance().getIgnoreFutureTransactions();
     const wxString today_date = PrefModel::instance().UseTransDateTime() ?
@@ -658,10 +658,10 @@ void JournalPanel::filterList()
         ? AccountModel::instance().find_id_trx_aBySN(m_account_n->m_id)
         : TrxModel::instance().find_allByDateTimeId();
     const auto trans_splits = TrxSplitModel::instance().get_all_id();
-    const auto trans_tags = TagLinkModel::instance().find_reftype_refid_data_m(
+    const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(
         TrxModel::s_ref_type
     );
-    const auto trans_attachments = AttachmentModel::instance().find_reftype_refid_data_m(
+    const auto refId_attA_m = AttachmentModel::instance().find_refType_mRefId(
         TrxModel::s_ref_type
     );
 
@@ -687,9 +687,9 @@ void JournalPanel::filterList()
         date_end_str = m_current_date_range.rangeEnd()
             .value_or(mmDate(date_end)).isoEnd();
     }
-    std::map<int64, SchedSplitModel::DataA> bills_splits;
-    std::map<int64, TagLinkModel::DataA> bills_tags;
-    std::map<int64, AttachmentModel::DataA> bills_attachments;
+    std::map<int64, SchedSplitModel::DataA> schedId_qpA_m;
+    std::map<int64, TagLinkModel::DataA> schedId_glA_m;
+    std::map<int64, AttachmentModel::DataA> schedId_attA_m;
     SchedModel::DataA bills;
     typedef std::tuple<
         int /* i */,
@@ -698,11 +698,11 @@ void JournalPanel::filterList()
     > bills_index_t;
     std::vector<bills_index_t> bills_index;
     if (m_scheduled_enable && m_scheduled_selected) {
-        bills_splits = SchedSplitModel::instance().get_all_id();
-        bills_tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        schedId_qpA_m = SchedSplitModel::instance().find_all_mSchedId();
+        schedId_glA_m = TagLinkModel::instance().find_refType_mRefId(
             SchedModel::s_ref_type
         );
-        bills_attachments = AttachmentModel::instance().find_reftype_refid_data_m(
+        schedId_attA_m = AttachmentModel::instance().find_refType_mRefId(
             SchedModel::s_ref_type
         );
         bills = m_account_n
@@ -777,8 +777,8 @@ void JournalPanel::filterList()
             continue;
 
         Journal::Full_Data journal_xd = (repeat_num == 0) ?
-            Journal::Full_Data(*trx_n, trans_splits, trans_tags) :
-            Journal::Full_Data(bills[bill_i], tran_date, repeat_num, bills_splits, bills_tags);
+            Journal::Full_Data(*trx_n, trans_splits, trxId_glA_m) :
+            Journal::Full_Data(bills[bill_i], tran_date, repeat_num, schedId_qpA_m, schedId_glA_m);
 
         bool expandSplits = false;
         if (m_filter_advanced) {
@@ -803,12 +803,12 @@ void JournalPanel::filterList()
             journal_xd.ACCOUNT_BALANCE = m_balance;
         }
 
-        if (repeat_num == 0 && trans_attachments.find(trx_n->m_id) != trans_attachments.end()) {
-            for (const auto& att_d : trans_attachments.at(trx_n->m_id))
+        if (repeat_num == 0 && refId_attA_m.find(trx_n->m_id) != refId_attA_m.end()) {
+            for (const auto& att_d : refId_attA_m.at(trx_n->m_id))
                 journal_xd.ATTACHMENT_DESCRIPTION.Add(att_d.m_description);
         }
-        else if (repeat_num > 0 && bills_attachments.find(journal_xd.m_bdid) != bills_attachments.end()) {
-            for (const auto& att_d : bills_attachments.at(journal_xd.m_bdid))
+        else if (repeat_num > 0 && schedId_attA_m.find(journal_xd.m_bdid) != schedId_attA_m.end()) {
+            for (const auto& att_d : schedId_attA_m.at(journal_xd.m_bdid))
                 journal_xd.ATTACHMENT_DESCRIPTION.Add(att_d.m_description);
         }
 
@@ -817,8 +817,8 @@ void JournalPanel::filterList()
             journal_xd.UDFC_value[i] = -DBL_MAX;
         }
 
-        if (repeat_num == 0 && trx_fv_m.find(trx_n->m_id) != trx_fv_m.end()) {
-            for (const auto& udfc : trx_fv_m.at(trx_n->m_id)) {
+        if (repeat_num == 0 && trxId_fvA_m.find(trx_n->m_id) != trxId_fvA_m.end()) {
+            for (const auto& udfc : trxId_fvA_m.at(trx_n->m_id)) {
                 for (int i = 0; i < 5; i++) {
                     if (udfc.m_field_id == udfc_id[i]) {
                         journal_xd.UDFC_type[i] = udfc_type[i];
@@ -831,8 +831,8 @@ void JournalPanel::filterList()
                 }
             }
         }
-        else if (repeat_num > 0 && sched_fv_m.find(journal_xd.m_bdid) != sched_fv_m.end()) {
-            for (const auto& udfc : sched_fv_m.at(journal_xd.m_bdid)) {
+        else if (repeat_num > 0 && schedId_fvA_m.find(journal_xd.m_bdid) != schedId_fvA_m.end()) {
+            for (const auto& udfc : schedId_fvA_m.at(journal_xd.m_bdid)) {
                 for (int i = 0; i < 5; i++) {
                     if (udfc.m_field_id == udfc_id[i]) {
                         journal_xd.UDFC_type[i] = udfc_type[i];

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -632,11 +632,6 @@ void JournalPanel::filterList()
     m_reconciled_balance = m_today_reconciled_balance = m_balance;
     m_show_reconciled = false;
 
-    const wxString tranRefType = TrxModel::refTypeName;
-    const wxString billRefType = SchedModel::refTypeName;
-    const wxString tranSplitRefType = TrxSplitModel::refTypeName;
-    const wxString billSplitRefType = SchedSplitModel::refTypeName;
-
     static wxArrayString udfc_fields = FieldModel::UDFC_FIELDS();
     int64 udfc_id[5];
     FieldModel::TYPE_ID udfc_type[5];
@@ -644,10 +639,10 @@ void JournalPanel::filterList()
     for (int i = 0; i < 5; i++) {
         // note: udfc_fields starts with ""
         wxString field = udfc_fields[i+1];
-        udfc_id[i] = FieldModel::getUDFCID(tranRefType, field);
-        udfc_type[i] = FieldModel::getUDFCType(tranRefType, field);
+        udfc_id[i] = FieldModel::getUDFCID(TrxModel::refTypeName, field);
+        udfc_type[i] = FieldModel::getUDFCType(TrxModel::refTypeName, field);
         udfc_scale[i] = FieldModel::getDigitScale(
-            FieldModel::getUDFCProperties(tranRefType, field)
+            FieldModel::getUDFCProperties(TrxModel::refTypeName, field)
         );
     }
 
@@ -663,8 +658,12 @@ void JournalPanel::filterList()
         ? AccountModel::instance().find_id_trx_aBySN(m_account_n->m_id)
         : TrxModel::instance().find_allByDateTimeId();
     const auto trans_splits = TrxSplitModel::instance().get_all_id();
-    const auto trans_tags = TagLinkModel::instance().get_all_id(tranRefType);
-    const auto trans_attachments = AttachmentModel::instance().find_type_id_data_a_m(TrxModel::s_ref_type);
+    const auto trans_tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        TrxModel::s_ref_type
+    );
+    const auto trans_attachments = AttachmentModel::instance().find_reftype_refid_data_m(
+        TrxModel::s_ref_type
+    );
 
     wxString date_start_str, date_end_str;
     wxDateTime date_end = wxDateTime::Now() + wxTimeSpan::Days(30);
@@ -700,8 +699,12 @@ void JournalPanel::filterList()
     std::vector<bills_index_t> bills_index;
     if (m_scheduled_enable && m_scheduled_selected) {
         bills_splits = SchedSplitModel::instance().get_all_id();
-        bills_tags = TagLinkModel::instance().get_all_id(billRefType);
-        bills_attachments = AttachmentModel::instance().find_type_id_data_a_m(SchedModel::s_ref_type);
+        bills_tags = TagLinkModel::instance().find_reftype_refid_data_m(
+            SchedModel::s_ref_type
+        );
+        bills_attachments = AttachmentModel::instance().find_reftype_refid_data_m(
+            SchedModel::s_ref_type
+        );
         bills = m_account_n
             ? AccountModel::instance().find_id_sched_a(m_account_n->m_id)
             : SchedModel::instance().find_all();
@@ -888,9 +891,12 @@ void JournalPanel::filterList()
             }
             journal_xd.m_notes.Append((trx_n->m_notes.IsEmpty() ? "" : " ") + tp_d.m_notes);
             wxString tagnames;
-            const wxString reftype = (repeat_num == 0) ? tranSplitRefType : billSplitRefType;
-            for (const auto& tag : TagLinkModel::instance().get_ref(reftype, tp_d.m_id))
+            for (const auto& tag : TagLinkModel::instance().find_ref_tag_m(
+                (repeat_num == 0 ? TrxSplitModel::s_ref_type : SchedSplitModel::s_ref_type),
+                tp_d.m_id
+            )) {
                 tagnames.Append(tag.first + " ");
+            }
             if (!tagnames.IsEmpty())
                 journal_xd.TAGNAMES.Append((journal_xd.TAGNAMES.IsEmpty() ? "" : ", ") + tagnames.Trim());
             m_lc->m_journal_xa.push_back(journal_xd);

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -872,7 +872,7 @@ void JournalPanel::filterList()
             journal_xd.displayID = tranDisplayID + "." + wxString::Format("%i", splitIndex);
             splitIndex++;
             journal_xd.m_category_id_n = tp_d.m_category_id;
-            journal_xd.CATEGNAME       = CategoryModel::full_name(tp_d.m_category_id);
+            journal_xd.CATEGNAME       = CategoryModel::instance().full_name(tp_d.m_category_id);
             journal_xd.m_amount        = tp_d.m_amount;
             journal_xd.m_notes         = trx_n->m_notes;
             journal_xd.TAGNAMES        = tranTagnames;

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -1324,10 +1324,10 @@ void JournalPanel::onButtonRightDown(wxMouseEvent& event)
     case wxID_FILE: {
         auto selected_id = m_lc->getSelectedId();
         if (selected_id.size() == 1) {
-            const wxString refType = !selected_id[0].second ?
-                TrxModel::refTypeName :
-                SchedModel::refTypeName;
-            AttachmentDialog dlg(this, refType, selected_id[0].first);
+            RefTypeN ref_type = !selected_id[0].second ?
+                TrxModel::s_ref_type :
+                SchedModel::s_ref_type;
+            AttachmentDialog dlg(this, ref_type, selected_id[0].first);
             dlg.ShowModal();
             refreshList();
         }

--- a/src/panel/ReportPanel.cpp
+++ b/src/panel/ReportPanel.cpp
@@ -665,12 +665,12 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
         }
     }
     else if (uri.StartsWith("attachment:", &sData)) {
-        const wxString RefType = sData.BeforeFirst('|');
-        long long refId;
-        sData.AfterFirst('|').ToLongLong(&refId);
+        RefTypeN ref_type = RefTypeN(sData.BeforeFirst('|'));
+        long long ref_id;
+        sData.AfterFirst('|').ToLongLong(&ref_id);
 
-        if (ModelBase::reftype_id(RefType) != -1 && refId > 0) {
-            mmAttachmentManage::OpenAttachmentFromPanelIcon(w_frame, RefType, refId);
+        if (ref_type.has_value() && ref_id > 0) {
+            mmAttachmentManage::OpenAttachmentFromPanelIcon(w_frame, ref_type, ref_id);
             const auto name = getVFname4print("rep", getReportBase()->getHTMLText());
             w_browser->LoadURL(name);
         }

--- a/src/panel/ReportPanel.cpp
+++ b/src/panel/ReportPanel.cpp
@@ -636,16 +636,18 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
             TrxData* trx_n = TrxModel::instance().unsafe_get_id_data_n(transId);
             if (trx_n && trx_n->m_id > -1) {
                 if (TrxModel::is_foreign(*trx_n)) {
-                    TrxLinkData translink = TrxLinkModel::TranslinkRecord(transId);
-                    if (translink.LINKTYPE == StockModel::refTypeName) {
-                        TrxShareDialog dlg(w_frame, &translink, trx_n);
+                    const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(transId);
+                    if (tl_n && tl_n->m_ref_type == StockModel::s_ref_type) {
+                        TrxLinkData tl_d = *tl_n;
+                        TrxShareDialog dlg(w_frame, &tl_d, trx_n);
                         if (dlg.ShowModal() == wxID_OK) {
                             m_rb->getHTMLText();
                             saveReportText();
                         }
                     }
-                    else {
-                        AssetDialog dlg(w_frame, &translink, trx_n);
+                    else if (tl_n && tl_n->m_ref_type == AssetModel::s_ref_type) {
+                        TrxLinkData tl_d = *tl_n;
+                        AssetDialog dlg(w_frame, &tl_d, trx_n);
                         if (dlg.ShowModal() == wxID_OK) {
                             m_rb->getHTMLText();
                             saveReportText();

--- a/src/panel/ReportPanel.cpp
+++ b/src/panel/ReportPanel.cpp
@@ -693,32 +693,32 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
         std::string formattedMonth = oss.str();
 
         //get yearId from year_name
-        int64 budgetYearID = BudgetPeriodModel::instance().get_name_id(
+        int64 bp_id_n = BudgetPeriodModel::instance().get_name_id_n(
             parms[3] + "-" + formattedMonth
         );
 
-        //if budgetYearID doesn't exist then return
-        if (budgetYearID == -1) {
+        //if bp_id_n doesn't exist then return
+        if (bp_id_n < 0) {
             wxLogInfo("Monthly budget not found!");
             return;
         }
 
         //get model budget for yearID and catID
-        BudgetModel::DataA budget = BudgetModel::instance().find(
-            BudgetCol::BUDGETYEARID(budgetYearID),
+        BudgetModel::DataA budget_a = BudgetModel::instance().find(
+            BudgetCol::BUDGETYEARID(bp_id_n),
             BudgetCol::CATEGID(std::stoll(parms[2]))
         );
 
         BudgetData budget_d;
-        if (budget.empty()) {
+        if (budget_a.empty()) {
             budget_d = BudgetData();
-            budget_d.m_period_id   = budgetYearID;
+            budget_d.m_period_id   = bp_id_n;
             budget_d.m_category_id = std::stoll(parms[2]);
             budget_d.m_amount      = 0.0;
             BudgetModel::instance().add_data_n(budget_d);
         }
         else
-            budget_d = budget[0];
+            budget_d = budget_a[0];
 
         double estimated;
         CurrencyModel::fromString(parms[0], estimated, CurrencyModel::GetBaseCurrency());

--- a/src/panel/ReportPanel.cpp
+++ b/src/panel/ReportPanel.cpp
@@ -570,44 +570,43 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
     else if (uri.StartsWith("viewtrans:", &sData)) {
         wxStringTokenizer tokenizer(sData, ":");
         int i =0;
-        int64 catID = -1;
-        int64 subCatID = -1;
-        int64 payeeID = -1;
-        // categoryID, subcategoryID, payeeID
+        int64 cat_id = -1;
+        int64 sub_id = -1;
+        int64 payee_id = -1;
+        // categoryID, subcategoryID, payee_id
         //      subcategoryID = -2 means inlude all sub categories for the given category
         while ( tokenizer.HasMoreTokens() ) {
             switch (i++) {
             case 0:
-                catID = std::stoll(tokenizer.GetNextToken().ToStdString());
+                cat_id = std::stoll(tokenizer.GetNextToken().ToStdString());
                 break;
             case 1:
-                subCatID = std::stoll(tokenizer.GetNextToken().ToStdString());
+                sub_id = std::stoll(tokenizer.GetNextToken().ToStdString());
                 break;
             case 2:
-                payeeID = std::stoll(tokenizer.GetNextToken().ToStdString());
+                payee_id = std::stoll(tokenizer.GetNextToken().ToStdString());
                 break;
             default:
                 break;
             }
         }
 
-        if (catID > 0) {
-            std::vector<int64> cats;
+        if (cat_id > 0) {
+            std::vector<int64> sub_id_a;
             // include all sub categories
-            if (-2 == subCatID) {
-                for (const auto& subcat_d :
-                    CategoryModel::sub_tree(CategoryModel::instance().get_id_data_n(catID))
-                ) {
-                    cats.push_back(subcat_d.m_id);
+            if (sub_id == -2) {
+                const CategoryData* cat_n = CategoryModel::instance().get_id_data_n(cat_id);
+                for (const auto& sub_d : CategoryModel::instance().find_data_subtree_a(*cat_n)) {
+                    sub_id_a.push_back(sub_d.m_id);
                 }
             }
-            cats.push_back(catID);
-            m_rb->m_filter.setCategoryList(cats);
+            sub_id_a.push_back(cat_id);
+            m_rb->m_filter.setCategoryList(sub_id_a);
         }
 
-        if (payeeID > 0) {
+        if (payee_id > 0) {
             wxArrayInt64 payees;
-            payees.push_back(payeeID);
+            payees.push_back(payee_id);
             m_rb->m_filter.setPayeeList(payees);
         }
 
@@ -682,7 +681,7 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
         std::vector<std::string> parms;
         wxStringTokenizer tokenizer(sData, "|");
         while (tokenizer.HasMoreTokens()) {
-            //"budget: " << estimateVal << "|" << CurrencyModel::toString(actual, CurrencyModel::GetBaseCurrency()) << "|" << catID << "|" << budget_year << "|" << month + 1;
+            //"budget: " << estimateVal << "|" << CurrencyModel::toString(actual, CurrencyModel::GetBaseCurrency()) << "|" << cat_id << "|" << budget_year << "|" << month + 1;
             wxString token = tokenizer.GetNextToken();
             parms.push_back(std::string(token.mb_str()));
 
@@ -703,7 +702,7 @@ void ReportPanel::onNewWindow(wxWebViewEvent& evt)
             return;
         }
 
-        //get model budget for yearID and catID
+        //get model budget for yearID and cat_id
         BudgetModel::DataA budget_a = BudgetModel::instance().find(
             BudgetCol::BUDGETYEARID(bp_id_n),
             BudgetCol::CATEGID(std::stoll(parms[2]))

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -532,7 +532,7 @@ wxString SchedPanel::getItem(long item, int col_id)
     case SchedList::LIST_ID_NOTES: {
         wxString value = sched_xd.m_notes;
         value.Replace("\n", " ");
-        if (AttachmentModel::instance().find_id_c(SchedModel::s_ref_type, sched_xd.m_id))
+        if (AttachmentModel::instance().find_ref_c(SchedModel::s_ref_type, sched_xd.m_id))
             value.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return value;
     }
@@ -663,15 +663,16 @@ void SchedList::OnDeleteBDSeries(wxCommandEvent& WXUNUSED(event))
     if (m_bdp->bills_.empty()) return;
     if (m_selected_row < 0) return;
 
-    wxMessageDialog msgDlg(this, _t("Do you want to delete the scheduled transaction?")
-        , _t("Confirm Deletion")
-        , wxYES_NO | wxNO_DEFAULT | wxICON_ERROR);
-    if (msgDlg.ShowModal() == wxID_YES)
-    {
-        int64 BdId = m_bdp->bills_[m_selected_row].m_id;
-        SchedModel::instance().purge_id(BdId);
-        mmAttachmentManage::DeleteAllAttachments(SchedModel::refTypeName, BdId);
-        m_bdp->do_delete_custom_values(-BdId);
+    wxMessageDialog msgDlg(this,
+        _t("Do you want to delete the scheduled transaction?"),
+        _t("Confirm Deletion"),
+        wxYES_NO | wxNO_DEFAULT | wxICON_ERROR
+    );
+    if (msgDlg.ShowModal() == wxID_YES) {
+        int64 sched_id = m_bdp->bills_[m_selected_row].m_id;
+        SchedModel::instance().purge_id(sched_id);
+        mmAttachmentManage::DeleteAllAttachments(SchedModel::s_ref_type, sched_id);
+        FieldValueModel::instance().purge_ref(SchedModel::s_ref_type, sched_id);
         m_bdp->initVirtualListControl();
         refreshVisualList(m_selected_row);
     }
@@ -717,12 +718,12 @@ void SchedList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 
 void SchedList::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))
 {
-    if (m_selected_row == -1) return;
-    int64 RefId = m_bdp->bills_[m_selected_row].m_id;
-    const wxString& RefType = SchedModel::refTypeName;
+    if (m_selected_row == -1)
+        return;
 
-    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);
-    refreshVisualList(m_bdp->initVirtualListControl(RefId));
+    int64 ref_id = m_bdp->bills_[m_selected_row].m_id;
+    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, SchedModel::s_ref_type, ref_id);
+    refreshVisualList(m_bdp->initVirtualListControl(ref_id));
 }
 
 void SchedList::OnListItemActivated(wxListEvent& WXUNUSED(event))
@@ -958,10 +959,4 @@ void SchedPanel::OnFilterTransactions(wxCommandEvent& WXUNUSED(event))
 wxString  SchedPanel::BuildPage() const
 {
     return m_lc->BuildPage(_t("Scheduled Transactions"));
-}
-
-void SchedPanel::do_delete_custom_values(int64 id)
-{
-    const wxString& RefType = TrxModel::refTypeName;
-    FieldValueModel::DeleteAllData(RefType, id);
 }

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -340,13 +340,12 @@ int SchedPanel::initVirtualListControl(int64 id)
     m_lc->DeleteAllItems();
 
     bills_.clear();
-    const auto split = SchedSplitModel::instance().get_all_id();
-    for (const SchedData& data
-        : SchedModel::instance().find_all(SchedCol::COL_ID_NEXTOCCURRENCEDATE))
-    {
-        if (transFilterActive_ && !transFilterDlg_->mmIsRecordMatches(data, split))
+    const auto schedId_qpA_m = SchedSplitModel::instance().find_all_mSchedId();
+    for (const SchedData& data : SchedModel::instance().find_all(
+        SchedCol::COL_ID_NEXTOCCURRENCEDATE
+    )) {
+        if (transFilterActive_ && !transFilterDlg_->mmIsRecordMatches(data, schedId_qpA_m))
             continue;
-
         SchedModel::Full_Data r(data);
         bills_.push_back(r);
     }
@@ -354,10 +353,8 @@ int SchedPanel::initVirtualListControl(int64 id)
     sortList();
 
     int cnt = 0, selected_item = -1;
-    for (const auto& entry: bills_)
-    {
-        if (id == entry.m_id)
-        {
+    for (const auto& entry: bills_) {
+        if (id == entry.m_id) {
             selected_item = cnt;
             break;
         }
@@ -413,8 +410,7 @@ void SchedList::OnItemRightClick(wxMouseEvent& event)
     int Flags = wxLIST_HITTEST_ONITEM;
     m_selected_row = HitTest(wxPoint(event.m_x, event.m_y), Flags);
 
-    if (m_selected_row >= 0)
-    {
+    if (m_selected_row >= 0) {
         SetItemState(m_selected_row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
         SetItemState(m_selected_row, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
     }
@@ -467,54 +463,52 @@ wxString SchedPanel::getItem(long item, int col_id)
         return sched_xd.CATEGNAME;
     case SchedList::LIST_ID_TAGS:
         return sched_xd.TAGNAMES;
-    case SchedList::LIST_ID_WITHDRAWAL:
-        {
-            wxString value = wxEmptyString;
-            int64 accountid;
-            double transamount;
-            if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_WITHDRAWAL) {
-                accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
-            }
-            else if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_TRANSFER) {
-                accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
-            }
-            else
-                return value;
-            const AccountData* account = AccountModel::instance().get_id_data_n(accountid);
-            const CurrencyData* currency = account ?
-                CurrencyModel::instance().get_id_data_n(account->m_currency_id) : nullptr;
-            if (currency)
-                value = CurrencyModel::toCurrency(transamount, currency);
-            if (!value.IsEmpty() && TrxModel::status_id(sched_xd.STATUS) == TrxModel::STATUS_ID_VOID)
-                value = "* " + value;
-            return value;
+    case SchedList::LIST_ID_WITHDRAWAL: {
+        wxString value = wxEmptyString;
+        int64 accountid;
+        double transamount;
+        if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_WITHDRAWAL) {
+            accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
         }
-    case SchedList::LIST_ID_DEPOSIT:
-        {
-            wxString value = wxEmptyString;
-            int64 accountid;
-            double transamount;
-            if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_DEPOSIT) {
-                accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
-            }
-            else if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_TRANSFER) {
-                accountid = sched_xd.m_to_account_id_n; transamount = sched_xd.m_to_amount;
-            }
-            else
-                return value;
-            const AccountData* account = AccountModel::instance().get_id_data_n(accountid);
-            const CurrencyData* currency = account ?
-                CurrencyModel::instance().get_id_data_n(account->m_currency_id) : nullptr;
-            if (currency)
-                value = CurrencyModel::toCurrency(transamount, currency);
-            if (!value.IsEmpty() && TrxModel::status_id(sched_xd.STATUS) == TrxModel::STATUS_ID_VOID)
-                value = "* " + value;
-            return value;
+        else if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_TRANSFER) {
+            accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
         }
+        else
+            return value;
+        const AccountData* account = AccountModel::instance().get_id_data_n(accountid);
+        const CurrencyData* currency = account ?
+            CurrencyModel::instance().get_id_data_n(account->m_currency_id) : nullptr;
+        if (currency)
+            value = CurrencyModel::toCurrency(transamount, currency);
+        if (!value.IsEmpty() && TrxModel::status_id(sched_xd.STATUS) == TrxModel::STATUS_ID_VOID)
+            value = "* " + value;
+        return value;
+    }
+    case SchedList::LIST_ID_DEPOSIT: {
+        wxString value = wxEmptyString;
+        int64 accountid;
+        double transamount;
+        if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_DEPOSIT) {
+            accountid = sched_xd.m_account_id; transamount = sched_xd.m_amount;
+        }
+        else if (TrxModel::type_id(sched_xd.TRANSCODE) == TrxModel::TYPE_ID_TRANSFER) {
+            accountid = sched_xd.m_to_account_id_n; transamount = sched_xd.m_to_amount;
+        }
+        else
+            return value;
+        const AccountData* account = AccountModel::instance().get_id_data_n(accountid);
+        const CurrencyData* currency = account ?
+            CurrencyModel::instance().get_id_data_n(account->m_currency_id) : nullptr;
+        if (currency)
+            value = CurrencyModel::toCurrency(transamount, currency);
+        if (!value.IsEmpty() && TrxModel::status_id(sched_xd.STATUS) == TrxModel::STATUS_ID_VOID)
+            value = "* " + value;
+        return value;
+    }
     case SchedList::LIST_ID_FREQUENCY:
         return GetFrequency(rn);
     case SchedList::LIST_ID_REPEATS: {
-        return !is_active                                 ? L"\x2015" : // HORIZONTAL BAR
+        return !is_active                             ? L"\x2015" : // HORIZONTAL BAR
             rn.num == SchedModel::REPEAT_NUM_INFINITY ? L"\x221E" : // INFITITY
             wxString::Format("%i", rn.num).Trim();
     }
@@ -522,7 +516,7 @@ wxString SchedPanel::getItem(long item, int col_id)
         wxString repeatSTR =
             (rn.exec == SchedModel::REPEAT_EXEC_SILENT) ? _t("Automated") :
             (rn.exec == SchedModel::REPEAT_EXEC_MANUAL) ? _t("Suggested") :
-                                                              _t("Manual");
+                                                          _t("Manual");
         return repeatSTR;
     }
     case SchedList::LIST_ID_REMAINING:
@@ -586,8 +580,7 @@ void SchedList::OnListLeftClick(wxMouseEvent& event)
 {
     int Flags = wxLIST_HITTEST_ONITEM;
     long index = HitTest(wxPoint(event.m_x, event.m_y), Flags);
-    if (index == -1)
-    {
+    if (index == -1) {
         m_selected_row = -1;
         m_bdp->updateBottomPanelData(m_selected_row);
     }
@@ -618,16 +611,13 @@ int SchedList::OnGetItemImage(long item) const
 
 void SchedList::OnListKeyDown(wxListEvent& event)
 {
-    switch ( event.GetKeyCode() )
-    {
-    case WXK_DELETE:
-    {
+    switch ( event.GetKeyCode() ) {
+    case WXK_DELETE: {
         wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED,
             MENU_TREEPOPUP_DELETE);
         OnDeleteBDSeries(evt);
+        break;
     }
-    break;
-
     default:
         event.Skip();
     }
@@ -642,7 +632,8 @@ void SchedList::OnNewBDSeries(wxCommandEvent& /*event*/)
 
 void SchedList::OnEditBDSeries(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row == -1) return;
+    if (m_selected_row == -1)
+        return;
 
     SchedDialog dlg(this, m_bdp->bills_[m_selected_row].m_id, false, false);
     if ( dlg.ShowModal() == wxID_OK )
@@ -660,8 +651,10 @@ void SchedList::OnDuplicateBDSeries(wxCommandEvent& /*event*/)
 
 void SchedList::OnDeleteBDSeries(wxCommandEvent& WXUNUSED(event))
 {
-    if (m_bdp->bills_.empty()) return;
-    if (m_selected_row < 0) return;
+    if (m_bdp->bills_.empty())
+        return;
+    if (m_selected_row < 0)
+        return;
 
     wxMessageDialog msgDlg(this,
         _t("Do you want to delete the scheduled transaction?"),
@@ -680,12 +673,12 @@ void SchedList::OnDeleteBDSeries(wxCommandEvent& WXUNUSED(event))
 
 void SchedList::OnEnterBDTransaction(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row == -1) return;
+    if (m_selected_row == -1)
+        return;
 
     int64 id = m_bdp->bills_[m_selected_row].m_id;
     SchedDialog dlg(this, id, false, true);
-    if ( dlg.ShowModal() == wxID_OK )
-    {
+    if ( dlg.ShowModal() == wxID_OK ) {
         if (++m_selected_row < long(m_bdp->bills_.size()))
             id = m_bdp->bills_[m_selected_row].m_id;
         refreshVisualList(m_bdp->initVirtualListControl(id));
@@ -694,7 +687,8 @@ void SchedList::OnEnterBDTransaction(wxCommandEvent& /*event*/)
 
 void SchedList::OnSkipBDTransaction(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row == -1) return;
+    if (m_selected_row == -1)
+        return;
 
     int64 id = m_bdp->bills_[m_selected_row].m_id;
     SchedModel::instance().completeBDInSeries(id);
@@ -705,7 +699,8 @@ void SchedList::OnSkipBDTransaction(wxCommandEvent& /*event*/)
 
 void SchedList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row == -1) return;
+    if (m_selected_row == -1)
+        return;
 
     int64 ref_id = m_bdp->bills_[m_selected_row].m_id;
 
@@ -727,7 +722,8 @@ void SchedList::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))
 
 void SchedList::OnListItemActivated(wxListEvent& WXUNUSED(event))
 {
-    if (m_selected_row == -1) return;
+    if (m_selected_row == -1)
+        return;
 
     SchedDialog dlg(this, m_bdp->bills_[m_selected_row].m_id, false, false);
     if ( dlg.ShowModal() == wxID_OK )
@@ -737,8 +733,7 @@ void SchedList::OnListItemActivated(wxListEvent& WXUNUSED(event))
 void SchedPanel::updateBottomPanelData(int selIndex)
 {
     enableEditDeleteButtons(selIndex >= 0);
-    if (selIndex != -1)
-    {
+    if (selIndex != -1) {
         m_infoTextMini->SetLabelText(CategoryModel::full_name(bills_[selIndex].m_category_id_n));
         m_infoText->SetLabelText(bills_[selIndex].m_notes);
     }
@@ -766,8 +761,7 @@ void SchedPanel::enableEditDeleteButtons(bool en)
 void SchedPanel::sortList()
 {
     std::sort(bills_.begin(), bills_.end());
-    switch (m_lc->getSortColId())
-    {
+    switch (m_lc->getSortColId()) {
     case SchedList::LIST_ID_ID:
         std::stable_sort(bills_.begin(), bills_.end(), SchedData::SorterByBDID());
         break;
@@ -841,7 +835,8 @@ void SchedPanel::sortList()
     default:
         break;
     }
-    if (!m_lc->getSortAsc()) std::reverse(bills_.begin(), bills_.end());
+    if (!m_lc->getSortAsc())
+        std::reverse(bills_.begin(), bills_.end());
 }
 
 wxString SchedPanel::tips()
@@ -854,14 +849,15 @@ void SchedList::refreshVisualList(int selected_index)
 
     if (selected_index >= static_cast<long>(m_bdp->bills_.size()) || selected_index < 0)
         selected_index = - 1;
+
     if (!m_bdp->bills_.empty()) {
         RefreshItems(0, m_bdp->bills_.size() - 1);
     }
-    else
+    else {
         selected_index = -1;
+    }
 
-    if (selected_index >= 0 && !m_bdp->bills_.empty())
-    {
+    if (selected_index >= 0 && !m_bdp->bills_.empty()) {
         SetItemState(selected_index, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
         SetItemState(selected_index, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
         EnsureVisible(selected_index);
@@ -874,8 +870,7 @@ void SchedList::RefreshList()
 {
     if (m_bdp->bills_.size() == 0) return;
     int64 id = -1;
-    if (m_selected_row != -1)
-    {
+    if (m_selected_row != -1) {
         id = m_bdp->bills_[m_selected_row].m_id;
     }
     refreshVisualList(m_bdp->initVirtualListControl(id));
@@ -883,26 +878,39 @@ void SchedList::RefreshList()
 
 wxListItemAttr* SchedList::OnGetItemAttr(long item) const
 {
-    if (item < 0 || item >= static_cast<int>(m_bdp->bills_.size())) return 0;
+    if (item < 0 || item >= static_cast<int>(m_bdp->bills_.size()))
+        return 0;
 
     int color_id = m_bdp->bills_[item].m_color.GetValue();
 
     static std::map<int, wxSharedPtr<wxListItemAttr> > cache;
-    if (color_id > 0)
-    {
+    if (color_id > 0) {
         color_id = std::min(7, color_id);
         if (const auto it = cache.find(color_id); it != cache.end())
             return it->second.get();
         else {
-            switch (color_id)
-            {
-            case 1: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor1), mmColors::userDefColor1, wxNullFont); break;
-            case 2: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor2), mmColors::userDefColor2, wxNullFont); break;
-            case 3: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor3), mmColors::userDefColor3, wxNullFont); break;
-            case 4: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor4), mmColors::userDefColor4, wxNullFont); break;
-            case 5: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor5), mmColors::userDefColor5, wxNullFont); break;
-            case 6: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor6), mmColors::userDefColor6, wxNullFont); break;
-            case 7: cache[color_id] = new wxListItemAttr(*bestFontColour(mmColors::userDefColor7), mmColors::userDefColor7, wxNullFont); break;
+            switch (color_id) {
+            case 1: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor1), mmColors::userDefColor1, wxNullFont
+            ); break;
+            case 2: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor2), mmColors::userDefColor2, wxNullFont
+            ); break;
+            case 3: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor3), mmColors::userDefColor3, wxNullFont
+            ); break;
+            case 4: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor4), mmColors::userDefColor4, wxNullFont
+            ); break;
+            case 5: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor5), mmColors::userDefColor5, wxNullFont
+            ); break;
+            case 6: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor6), mmColors::userDefColor6, wxNullFont
+            ); break;
+            case 7: cache[color_id] = new wxListItemAttr(
+                *bestFontColour(mmColors::userDefColor7), mmColors::userDefColor7, wxNullFont
+            ); break;
             }
             return cache[color_id].get();
         }
@@ -941,13 +949,11 @@ void SchedPanel::RefreshList()
 void SchedPanel::OnFilterTransactions(wxCommandEvent& WXUNUSED(event))
 {
 
-    if (transFilterDlg_->ShowModal() == wxID_OK && transFilterDlg_->mmIsSomethingChecked())
-    {
+    if (transFilterDlg_->ShowModal() == wxID_OK && transFilterDlg_->mmIsSomethingChecked()) {
         transFilterActive_ = true;
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER_ACTIVE, mmBitmapButtonSize));
     }
-    else
-    {
+    else {
         transFilterActive_ = false;
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
     }

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -707,13 +707,12 @@ void SchedList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
     if (m_selected_row == -1) return;
 
-    int64 RefId = m_bdp->bills_[m_selected_row].m_id;
-    const wxString& RefType = SchedModel::refTypeName;
+    int64 ref_id = m_bdp->bills_[m_selected_row].m_id;
 
-    AttachmentDialog dlg(this, RefType, RefId);
+    AttachmentDialog dlg(this, SchedModel::s_ref_type, ref_id);
     dlg.ShowModal();
 
-    refreshVisualList(m_bdp->initVirtualListControl(RefId));
+    refreshVisualList(m_bdp->initVirtualListControl(ref_id));
 }
 
 void SchedList::OnOpenAttachment(wxCommandEvent& WXUNUSED(event))

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -734,7 +734,7 @@ void SchedPanel::updateBottomPanelData(int selIndex)
 {
     enableEditDeleteButtons(selIndex >= 0);
     if (selIndex != -1) {
-        m_infoTextMini->SetLabelText(CategoryModel::full_name(bills_[selIndex].m_category_id_n));
+        m_infoTextMini->SetLabelText(CategoryModel::instance().full_name(bills_[selIndex].m_category_id_n));
         m_infoText->SetLabelText(bills_[selIndex].m_notes);
     }
 }

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -532,7 +532,7 @@ wxString SchedPanel::getItem(long item, int col_id)
     case SchedList::LIST_ID_NOTES: {
         wxString value = sched_xd.m_notes;
         value.Replace("\n", " ");
-        if (AttachmentModel::NrAttachments(SchedModel::refTypeName, sched_xd.m_id))
+        if (AttachmentModel::instance().find_id_c(SchedModel::s_ref_type, sched_xd.m_id))
             value.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return value;
     }

--- a/src/panel/SchedPanel.h
+++ b/src/panel/SchedPanel.h
@@ -139,8 +139,6 @@ public:
     wxString BuildPage() const;
     wxDate getToday() const;
 
-    void do_delete_custom_values(int64 id);
-
 private:
     void CreateControls();
     bool Create(wxWindow *parent, wxWindowID winid,

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -208,7 +208,7 @@ wxString StockList::OnGetItemText(long item, long col_nr) const
     case LIST_ID_NOTES: {
         wxString full_notes = m_stocks[item].m_notes;
         full_notes.Replace("\n", " ");
-        if (AttachmentModel::instance().find_id_c(StockModel::s_ref_type, m_stocks[item].m_id))
+        if (AttachmentModel::instance().find_ref_c(StockModel::s_ref_type, m_stocks[item].m_id))
             full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }
@@ -307,7 +307,7 @@ void StockList::OnDeleteStocks(wxCommandEvent& /*event*/)
     if (msgDlg.ShowModal() == wxID_YES)
     {
         StockModel::instance().purge_id(m_stocks[m_selected_row].m_id);
-        mmAttachmentManage::DeleteAllAttachments(StockModel::refTypeName, m_stocks[m_selected_row].m_id);
+        mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, m_stocks[m_selected_row].m_id);
         TrxLinkModel::RemoveTransLinkRecords<StockModel>(m_stocks[m_selected_row].m_id);
         DeleteItem(m_selected_row);
         doRefreshItems(-1);
@@ -389,30 +389,27 @@ void StockList::OnStockWebPage(wxCommandEvent& /*event*/)
 
 void StockList::OnOpenAttachment(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row < 0) return;
+    if (m_selected_row < 0)
+        return;
 
-    wxString RefType = StockModel::refTypeName;
-    int64 RefId = m_stocks[m_selected_row].m_id;
-
-    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, RefType, RefId);
-    doRefreshItems(RefId);
+    int64 ref_id = m_stocks[m_selected_row].m_id;
+    mmAttachmentManage::OpenAttachmentFromPanelIcon(this, StockModel::s_ref_type, ref_id);
+    doRefreshItems(ref_id);
 }
 
 void StockList::OnListItemActivated(wxListEvent& event)
 {
-    if ((event.GetId() == wxID_ADD) || (event.GetId() == MENU_TREEPOPUP_ADDTRANS))
-    {
-        if (m_stock_panel->AddStockTransaction(m_selected_row) == wxID_OK)
-        {
+    if ((event.GetId() == wxID_ADD) || (event.GetId() == MENU_TREEPOPUP_ADDTRANS)) {
+        if (m_stock_panel->AddStockTransaction(m_selected_row) == wxID_OK) {
             m_stock_panel->m_frame->RefreshNavigationTree();
         }
     }
-    else if ((event.GetId() == wxID_VIEW_DETAILS) || (event.GetId() == MENU_TREEPOPUP_VIEWTRANS))
-    {
+    else if ((event.GetId() == wxID_VIEW_DETAILS) ||
+        (event.GetId() == MENU_TREEPOPUP_VIEWTRANS)
+    ) {
         m_stock_panel->ViewStockTransactions(m_selected_row);
     }
-    else
-    {
+    else {
         m_stock_panel->OnListItemActivated(m_selected_row);
     }
 }

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -308,7 +308,9 @@ void StockList::OnDeleteStocks(wxCommandEvent& /*event*/)
     {
         StockModel::instance().purge_id(m_stocks[m_selected_row].m_id);
         mmAttachmentManage::DeleteAllAttachments(StockModel::s_ref_type, m_stocks[m_selected_row].m_id);
-        TrxLinkModel::RemoveTransLinkRecords<StockModel>(m_stocks[m_selected_row].m_id);
+        TrxLinkModel::instance().purge_ref(
+            StockModel::s_ref_type, m_stocks[m_selected_row].m_id
+        );
         DeleteItem(m_selected_row);
         doRefreshItems(-1);
         m_stock_panel->m_frame->RefreshNavigationTree();

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -365,15 +365,15 @@ void StockList::OnEditStocks(wxCommandEvent& event)
 
 void StockList::OnOrganizeAttachments(wxCommandEvent& /*event*/)
 {
-    if (m_selected_row < 0) return;
+    if (m_selected_row < 0)
+        return;
 
-    wxString RefType = StockModel::refTypeName;
-    int64 RefId = m_stocks[m_selected_row].m_id;
+    int64 ref_id = m_stocks[m_selected_row].m_id;
 
-    AttachmentDialog dlg(this, RefType, RefId);
+    AttachmentDialog dlg(this, StockModel::s_ref_type, ref_id);
     dlg.ShowModal();
 
-    doRefreshItems(RefId);
+    doRefreshItems(ref_id);
 }
 
 void StockList::OnStockWebPage(wxCommandEvent& /*event*/)

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -200,16 +200,27 @@ wxString StockList::OnGetItemText(long item, long col_nr) const
     case LIST_ID_CURRENT:
         return CurrencyModel::toString(m_stocks[item].m_current_price, m_stock_panel->m_currency, 4);
     case LIST_ID_CURRVALUE:
-        return CurrencyModel::toString(StockModel::CurrentValue(m_stocks[item]), m_stock_panel->m_currency);
+        return CurrencyModel::toString(
+            m_stocks[item].current_value(),
+            m_stock_panel->m_currency
+        );
     case LIST_ID_PRICEDATE:
-        return mmGetDateTimeForDisplay(StockModel::instance().lastPriceDate(m_stocks[item]));
+        return mmGetDateTimeForDisplay(
+            StockModel::instance().find_last_hist_date(m_stocks[item]).isoDate()
+        );
     case LIST_ID_COMMISSION:
-        return CurrencyModel::toString(m_stocks[item].m_commission, m_stock_panel->m_currency);
+        return CurrencyModel::toString(
+            m_stocks[item].m_commission,
+            m_stock_panel->m_currency
+        );
     case LIST_ID_NOTES: {
         wxString full_notes = m_stocks[item].m_notes;
         full_notes.Replace("\n", " ");
-        if (AttachmentModel::instance().find_ref_c(StockModel::s_ref_type, m_stocks[item].m_id))
+        if (AttachmentModel::instance().find_ref_c(
+            StockModel::s_ref_type, m_stocks[item].m_id
+        )) {
             full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
+        }
         return full_notes;
     }
     default:
@@ -224,7 +235,7 @@ double StockList::GetGainLoss(long item) const
 
 double StockList::getGainLoss(const StockData& stock_d)
 {
-    return StockModel::CurrentValue(stock_d) - stock_d.m_purchase_value;
+    return stock_d.current_value() - stock_d.m_purchase_value;
 }
 
 double StockList::GetRealGainLoss(long item) const
@@ -234,7 +245,7 @@ double StockList::GetRealGainLoss(long item) const
 
 double StockList::getRealGainLoss(const StockData& stock)
 {
-    return StockModel::RealGainLoss(stock);
+    return StockModel::instance().calculate_realized_gain(stock);
 }
 
 void StockList::OnListItemSelected(wxListEvent& event)
@@ -493,7 +504,7 @@ int StockList::initVirtualListControl(int64 trx_id)
             break;
         }
         if (!stock.m_purchase_price) {
-            StockModel::UpdatePosition(&stock);
+            StockModel::instance().update_data_position(&stock);
         }
         ++cnt;
     }
@@ -550,13 +561,11 @@ void StockList::sortList()
         std::stable_sort(m_stocks.begin(), m_stocks.end(), StockData::SorterByCURRENTPRICE());
         break;
     case StockList::LIST_ID_CURRVALUE:
-        std::stable_sort(m_stocks.begin(), m_stocks.end()
-            , [](const StockData& x, const StockData& y)
-            {
-                double valueX = StockModel::CurrentValue(x);
-                double valueY = StockModel::CurrentValue(y);
-                return valueX < valueY;
-            });
+        std::stable_sort(m_stocks.begin(), m_stocks.end(),
+            [](const StockData& x, const StockData& y) {
+                return x.current_value() < y.current_value();
+            }
+        );
         break;
     case StockList::LIST_ID_PRICEDATE:
         //TODO

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -208,7 +208,7 @@ wxString StockList::OnGetItemText(long item, long col_nr) const
     case LIST_ID_NOTES: {
         wxString full_notes = m_stocks[item].m_notes;
         full_notes.Replace("\n", " ");
-        if (AttachmentModel::NrAttachments(StockModel::refTypeName, m_stocks[item].m_id))
+        if (AttachmentModel::instance().find_id_c(StockModel::s_ref_type, m_stocks[item].m_id))
             full_notes.Prepend(mmAttachmentManage::GetAttachmentNoteSign());
         return full_notes;
     }

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -289,15 +289,15 @@ void StockPanel::LoadStockTransactions(wxListCtrl* listCtrl, wxString symbol, in
     TrxLinkModel::DataA tl_a;
     TrxModel::DataA trx_a;
     if (symbol.IsEmpty()) {
-        tl_a = TrxLinkModel::TranslinkList<StockModel>(stockId);
+        tl_a = TrxLinkModel::instance().find_ref_data_a(StockModel::s_ref_type, stockId);
     }
     else {
         // search for all
-        tl_a = TrxLinkModel::TranslinkListBySymbol(symbol);
+        tl_a = TrxLinkModel::instance().find_symbol_data_a(symbol);
     }
 
     for (const auto& tl_d : tl_a) {
-        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.CHECKINGACCOUNTID);
+        const TrxData* trx_n = TrxModel::instance().get_id_data_n(tl_d.m_trx_id);
         if (trx_n && trx_n->DELETEDTIME.IsEmpty()) {
             trx_a.push_back(*trx_n);
         }
@@ -344,8 +344,9 @@ void StockPanel::BindListEvents(wxListCtrl* listCtrl)
         if (!trx_n)
             return;
 
-        auto link = TrxLinkModel::TranslinkRecord(trx_n->m_id);
-        TrxShareDialog dlg(listCtrl, &link, trx_n);
+        const TrxLinkData* tl_n = TrxLinkModel::instance().get_trx_data_n(trx_n->m_id);
+        TrxLinkData tl_d = tl_n ? *tl_n : TrxLinkData();
+        TrxShareDialog dlg(listCtrl, &tl_d, trx_n);
         dlg.ShowModal();
 
         // Update the modified row

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -306,10 +306,9 @@ void StockPanel::LoadStockTransactions(wxListCtrl* listCtrl, wxString symbol, in
 
     int row = 0;
     for (const auto& trx_d : trx_a) {
-        auto* ts_n = TrxShareModel::instance().unsafe_get_trx_share_n(trx_d.m_id);
+        const TrxShareData* ts_n = TrxShareModel::instance().get_trxId_data_n(trx_d.m_id);
         if (!ts_n || (ts_n->m_number <= 0 && ts_n->m_price <= 0))
             continue;
-
         long index = listCtrl->InsertItem(row++, "");
         listCtrl->SetItemData(index, trx_d.m_id.GetValue());
         FillListRow(listCtrl, index, trx_d, *ts_n);
@@ -350,7 +349,7 @@ void StockPanel::BindListEvents(wxListCtrl* listCtrl)
         dlg.ShowModal();
 
         // Update the modified row
-        auto* ts_n = TrxShareModel::instance().unsafe_get_trx_share_n(trx_n->m_id);
+        const TrxShareData* ts_n = TrxShareModel::instance().get_trxId_data_n(trx_n->m_id);
         if (ts_n) {
             this->FillListRow(listCtrl, index, *trx_n, *ts_n);
         }

--- a/src/report/BalanceReport.cpp
+++ b/src/report/BalanceReport.cpp
@@ -75,14 +75,14 @@ double BalanceReport::getCheckingBalance(const AccountData* account, const wxDat
 
 std::pair<double, double> BalanceReport::getBalance(
     const AccountData* account,
-    const wxDate& date
+    const mmDate& date
 ) {
     std::pair<double /*cash bal*/, double /*market bal*/> bal = { 0.0, 0.0 };
-    if (mmDate(date) < account->m_open_date)
+    if (date < account->m_open_date)
         return bal;
-    bal.first = getCheckingBalance(account, date);
+    bal.first = getCheckingBalance(account, date.getDateTime());
     if (AccountModel::type_id(*account) == NavigatorTypes::TYPE_ID_INVESTMENT) {
-        bal.second = StockModel::instance().getDailyBalanceAt(*account, date);
+        bal.second = StockModel::instance().calculate_account_balance(*account, date);
     }
     return bal;
 }
@@ -147,7 +147,7 @@ wxString BalanceReport::getHTMLText()
             histItem.acctId          = account.id();
             histItem.stockId         = stock.m_id;
             histItem.purchasePrice   = stock.m_purchase_price;
-            histItem.purchaseDate    = StockModel::PURCHASEDATE(stock);
+            histItem.purchaseDate    = stock.m_purchase_date.getDateTime();
             histItem.purchaseDateStr = stock.m_purchase_date.isoDate();
             histItem.numShares       = stock.m_num_shares;
             histItem.stockHist       = StockHistoryModel::instance().find(
@@ -202,7 +202,7 @@ wxString BalanceReport::getHTMLText()
                 idx = NavigatorTypes::instance().getAccountTypeIdx(NavigatorTypes::TYPE_ID_CHECKING);
             }
             if (idx > -1) {
-                std::pair<double, double> dailybal = getBalance(&account, end_date);
+                std::pair<double, double> dailybal = getBalance(&account, mmDate(end_date));
                 balancePerDay[idx] += dailybal.first * getCurrencyDateRate(account.m_currency_id, end_date);
                 if (AccountModel::type_id(account) == NavigatorTypes::TYPE_ID_INVESTMENT) {
                     balancePerDay[idx] += dailybal.second * getCurrencyDateRate(account.m_currency_id, end_date);

--- a/src/report/BalanceReport.h
+++ b/src/report/BalanceReport.h
@@ -60,7 +60,7 @@ public:
 private:
     std::map<wxDate, double> loadCheckingDateBalance(const AccountData& account);
     double getCheckingBalance(const AccountData* account, const wxDate& date);
-    std::pair<double, double> getBalance(const AccountData* account, const wxDate& date);
+    std::pair<double, double> getBalance(const AccountData* account, const mmDate& date);
     double getCurrencyDateRate(int64 currencyid, const wxDate& date);
 };
 

--- a/src/report/CategoryReport.cpp
+++ b/src/report/CategoryReport.cpp
@@ -46,23 +46,36 @@ CategoryReport::~CategoryReport()
 double CategoryReport::AppendData(
     [[maybe_unused]] const std::vector<CategoryReport::data_holder> &data,
     std::map<int64, std::map<int, double>> &categoryStats,
-    const CategoryData* category,
+    const CategoryData* category_n,
     int64 groupID,
     int level
 ) {
-    double amt = categoryStats[category->m_id][0];
-    if (type_ == COME && amt < 0.0) amt = 0;
-    if (type_ == GOES && amt > 0.0) amt = 0;
-    CategoryModel::DataA subcategories = CategoryModel::sub_category(category);
-    std::stable_sort(subcategories.begin(), subcategories.end(), CategoryData::SorterByCATEGNAME());
-    std::reverse(subcategories.begin(), subcategories.end());
+    double amt = categoryStats[category_n->m_id][0];
+    if (type_ == COME && amt < 0.0)
+        amt = 0;
+    if (type_ == GOES && amt > 0.0)
+        amt = 0;
+
+    CategoryModel::DataA subcategory_a = CategoryModel::instance().find_data_sub_a(*category_n);
+    std::stable_sort(subcategory_a.begin(), subcategory_a.end(),
+        CategoryData::SorterByCATEGNAME()
+    );
+    std::reverse(subcategory_a.begin(), subcategory_a.end());
     double subamount = 0;
-    for (const auto& subcategory : subcategories) {
-        double amount = AppendData(data_, categoryStats, &subcategory, groupID, level + 1);
-        if (amount != 0) data_.insert(data_.begin(), { category->m_id, subcategory.m_id, category->m_name, amount, groupID, level });
+    for (const auto& subcategory_d : subcategory_a) {
+        double amount = AppendData(data_, categoryStats, &subcategory_d, groupID, level + 1);
+        if (amount != 0)
+            data_.insert(data_.begin(), {
+                category_n->m_id, subcategory_d.m_id, category_n->m_name,
+                amount, groupID, level
+            });
         subamount += amount;
     }
-    if (amt != 0 || subamount != 0) data_.insert(data_.begin(), { category->m_id, -1, category->m_name, amt, groupID, level });
+    if (amt != 0 || subamount != 0)
+        data_.insert(data_.begin(), {
+            category_n->m_id, -1, category_n->m_name,
+            amt, groupID, level
+        });
     return amt + subamount;
 }
 
@@ -80,26 +93,36 @@ void  CategoryReport::refreshData()
 
     data_holder line;
     int groupID = 0;
-    CategoryModel::DataA categories = CategoryModel::instance().find(CategoryCol::PARENTID(-1));
-    std::stable_sort(categories.begin(), categories.end(), CategoryData::SorterByCATEGNAME());
-    std::reverse(categories.begin(), categories.end());
-    for (const auto& category : categories)
-    {
-        double amt = categoryStats[category.m_id][0];
+    CategoryModel::DataA category_a = CategoryModel::instance().find(CategoryCol::PARENTID(-1));
+    std::stable_sort(category_a.begin(), category_a.end(),
+        CategoryData::SorterByCATEGNAME()
+    );
+    std::reverse(category_a.begin(), category_a.end());
+    for (const auto& category_d : category_a) {
+        double amt = categoryStats[category_d.m_id][0];
         if (type_ == COME && amt < 0.0) amt = 0;
         if (type_ == GOES && amt > 0.0) amt = 0;
 
-        auto subcategories = CategoryModel::sub_category(category);
-        std::stable_sort(subcategories.begin(), subcategories.end(), CategoryData::SorterByCATEGNAME());
-        std::reverse(subcategories.begin(), subcategories.end());
+        auto subcategory_a = CategoryModel::instance().find_data_sub_a(category_d);
+        std::stable_sort(subcategory_a.begin(), subcategory_a.end(),
+            CategoryData::SorterByCATEGNAME()
+        );
+        std::reverse(subcategory_a.begin(), subcategory_a.end());
         double subamount = 0;
-        for (const auto& sub_category : subcategories)
-        {
-            double amount = AppendData(data_, categoryStats, &sub_category, category.m_id, 1);
-            if (amount != 0) data_.insert(data_.begin(), { category.m_id, sub_category.m_id, category.m_name, amount, category.m_id, 0 });
+        for (const auto& subcategory_d : subcategory_a) {
+            double amount = AppendData(data_, categoryStats, &subcategory_d, category_d.m_id, 1);
+            if (amount != 0)
+                data_.insert(data_.begin(), {
+                    category_d.m_id, subcategory_d.m_id, category_d.m_name,
+                    amount, category_d.m_id, 0
+                });
             subamount += amount;
         }
-        if (amt != 0 || subamount != 0) data_.insert(data_.begin(), { category.m_id, -1, category.m_name, amt, category.m_id, 0 });
+        if (amt != 0 || subamount != 0)
+            data_.insert(data_.begin(), {
+                category_d.m_id, -1, category_d.m_name,
+                amt, category_d.m_id, 0
+            });
 
         groupID++;
     }
@@ -140,11 +163,11 @@ wxString CategoryReport::getHTMLText()
             {
                 if (entry.amount < 0)
                 {
-                    expense_vector.emplace_back(CategoryModel::full_name(entry.catID), entry.amount);
+                    expense_vector.emplace_back(CategoryModel::instance().full_name(entry.catID), entry.amount);
                 }
                 else if (entry.amount > 0)
                 {
-                    income_vector.emplace_back(CategoryModel::full_name(entry.catID), entry.amount);
+                    income_vector.emplace_back(CategoryModel::instance().full_name(entry.catID), entry.amount);
                 }
             }
         }
@@ -376,7 +399,7 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
         double overall;
     } line;
     std::vector<html_data_holder> data;
-    std::map<wxString, int64> categories = CategoryModel::all_categories();
+    std::map<wxString, int64> categories = CategoryModel::instance().all_categories();
     for (const auto& category : categories) {
         int64 categID = category.second;
         line.catID = categID;

--- a/src/report/FlowReport.cpp
+++ b/src/report/FlowReport.cpp
@@ -445,7 +445,7 @@ wxString mmReportCashFlowTransactions::getHTMLText()
         hb.addTableCell(AccountModel::instance().get_id_name(trx.m_account_id));
         hb.addTableCell((trx.m_to_account_id_n == -1) ? PayeeModel::instance().get_id_name(trx.m_payee_id_n)
             : "> " + AccountModel::instance().get_id_name(trx.m_to_account_id_n));
-        hb.addTableCell(CategoryModel::full_name(trx.m_category_id_n));
+        hb.addTableCell(CategoryModel::instance().full_name(trx.m_category_id_n));
         double amount = trx.m_amount;
         hb.addMoneyCell(amount);
         runningBalance += amount;

--- a/src/report/StocksReport.cpp
+++ b/src/report/StocksReport.cpp
@@ -73,13 +73,13 @@ void  StocksReport::refreshData()
         )) {
             const CurrencyData* currency_n = AccountModel::instance().get_data_currency_p(a);
             const double today_rate = CurrencyHistoryModel::getDayRate(currency_n->m_id, today);
-            m_stock_balance += today_rate * StockModel::CurrentValue(stock_d);
-            line.realgainloss = StockModel::RealGainLoss(stock_d);
+            m_stock_balance += today_rate * stock_d.current_value();
+            line.realgainloss = StockModel::instance().calculate_realized_gain(stock_d);
             account_holder.realgainloss += line.realgainloss;
-            line.unrealgainloss = StockModel::UnrealGainLoss(stock_d);
+            line.unrealgainloss = StockModel::instance().calculate_unrealiazed_gain(stock_d);
             account_holder.unrealgainloss += line.unrealgainloss;
-            m_unreal_gain_loss_sum_total += StockModel::UnrealGainLoss(stock_d, true);
-            m_real_gain_loss_sum_total += StockModel::RealGainLoss(stock_d, true);
+            m_unreal_gain_loss_sum_total += StockModel::instance().calculate_unrealiazed_gain(stock_d, true);
+            m_real_gain_loss_sum_total += StockModel::instance().calculate_realized_gain(stock_d, true);
             m_real_gain_loss_excl_forex += line.realgainloss * today_rate;
             m_unreal_gain_loss_excl_forex += line.unrealgainloss * today_rate;
 
@@ -87,10 +87,10 @@ void  StocksReport::refreshData()
             line.symbol     = stock_d.m_symbol;
             line.date       = stock_d.m_purchase_date.isoDate();
             line.qty        = stock_d.m_num_shares;
-            line.purchase   = StockModel::InvestmentValue(stock_d);
+            line.purchase   = stock_d.m_purchase_value;
             line.current    = stock_d.m_current_price;
             line.commission = stock_d.m_commission;
-            line.value      = StockModel::CurrentValue(stock_d);
+            line.value      = stock_d.current_value();
             account_holder.data.push_back(line);
         }
         m_stocks.push_back(account_holder);

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -371,8 +371,7 @@ table {
 
                 // Attachments
                 wxString AttachmentsLink = "";
-                if (AttachmentModel::instance().NrAttachments(AttRefType, trx_xd.m_id))
-                {
+                if (AttachmentModel::instance().find_id_c(RefTypeN(AttRefType), trx_xd.m_id)) {
                     AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
                         AttRefType, trx_xd.m_id, mmAttachmentManage::GetAttachmentNoteSign());
                 }

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -66,18 +66,22 @@ void TrxReport::displayTotals(const std::map<int64, double>& total, std::map<int
     hb.addTotalRow(_t("Grand Total:"), noOfCols, v);
 }
 
-void TrxReport::UDFCFormatHelper(FieldModel::TYPE_ID type, int64 ref, wxString data, double val, int scale)
+void TrxReport::UDFCFormatHelper(FieldTypeN type, int64 ref, wxString data, double val, int scale)
 {
-    if (type == FieldModel::TYPE_ID_DECIMAL || type == FieldModel::TYPE_ID_INTEGER)
+    if (type.id_n() == FieldTypeN::e_decimal || type.id_n() == FieldTypeN::e_integer) {
         hb.addMoneyCell(val, scale);
-    else if (ref != -1)
-    {
-        if (type == FieldModel::TYPE_ID_BOOLEAN && !data.empty())
-        {
+    }
+    else if (ref != -1) {
+        if (type.id_n() == FieldTypeN::e_boolean && !data.empty()) {
             bool v = wxString("TRUE|true|1").Contains(data);
             hb.addTableCell(v ? "&check;" : "&cross;", false, true);
-        } else
-            hb.addTableCell(type == FieldModel::TYPE_ID_DATE && !data.empty() ? mmGetDateTimeForDisplay(data) : data);
+        }
+        else {
+            hb.addTableCell(type.id_n() == FieldTypeN::e_date && !data.empty()
+                ? mmGetDateTimeForDisplay(data)
+                : data
+            );
+        }
     }
 }
 
@@ -147,16 +151,15 @@ table {
     std::map<int64, double> grand_total_in_base_curr_extrans; //Grand - Store transactions amount daily converted to base currency - excluding TRANSFERS
     std::map<wxString, double> values_chart; // Store grouped values for chart
 
-    const wxString refType = TrxModel::refTypeName;
     static wxArrayString udfc_fields = FieldModel::UDFC_FIELDS();
-    FieldModel::TYPE_ID udfc_type[5];
+    FieldTypeN udfc_type[5];
     int udfc_scale[5];
     for (int i = 0; i < 5; i++) {
         // note: udfc_fields starts with ""
         wxString field = udfc_fields[i+1];
-        udfc_type[i] = FieldModel::getUDFCType(refType, field);
+        udfc_type[i] = FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, field);
         udfc_scale[i] = FieldModel::getDigitScale(
-            FieldModel::getUDFCProperties(refType, field)
+            FieldModel::instance().get_udfc_properties_n(TrxModel::s_ref_type, field)
         );
     }
 
@@ -236,21 +239,19 @@ table {
                 hb.addTableHeaderCell(_t("FX Rate"), "Rate text-right");
             if (showColumnById(TrxFilterDialog::COL_NOTES))
                 hb.addTableHeaderCell(_t("Notes"), "Notes");
-            const auto& ref_type = TrxModel::refTypeName;
             int colNo = TrxFilterDialog::COL_UDFC01;
-            for (const auto& udfc_entry : FieldModel::UDFC_FIELDS())
-            {
-                if (udfc_entry.empty()) continue;
-                const auto& name = FieldModel::getUDFCName(ref_type, udfc_entry);
-                if (showColumnById(colNo++) && name != udfc_entry)
-                {
+            for (const auto& ucfd : FieldModel::UDFC_FIELDS()) {
+                if (ucfd.empty())
+                    continue;
+                const auto& name = FieldModel::instance().get_udfc_name_n(TrxModel::s_ref_type, ucfd);
+                if (showColumnById(colNo++) && name != ucfd) {
                     wxString nameCSS = name;
-                    switch (FieldModel::getUDFCType(ref_type, udfc_entry)) {
-                    case FieldModel::TYPE_ID_DECIMAL:
-                    case FieldModel::TYPE_ID_INTEGER:
+                    switch (FieldModel::instance().get_udfc_type_n(TrxModel::s_ref_type, ucfd).id_n()) {
+                    case FieldTypeN::e_decimal:
+                    case FieldTypeN::e_integer:
                         nameCSS.Append(" text-right");
                         break;
-                    case FieldModel::TYPE_ID_BOOLEAN:
+                    case FieldTypeN::e_boolean:
                         nameCSS.Append(" text-center");
                         break;
                     default: break;
@@ -379,7 +380,7 @@ table {
                 int64 udfc_id[5];
                 for (int i = 0; i < 5; i++) {
                     wxString field = udfc_fields[i+1];
-                    udfc_id[i] = FieldModel::getUDFCID(refType, field);
+                    udfc_id[i] = FieldModel::instance().get_udfc_id_n(TrxModel::s_ref_type, field);
                     trx_xd.UDFC_value[i] = -DBL_MAX;
                 }
 

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -568,7 +568,7 @@ void TrxReport::Run(wxSharedPtr<TrxFilterDialog>& dlg)
                 trx_xd.displayID       = wxString::Format("%lld", trx_d.m_id) + "." +
                     wxString::Format("%i", splitIndex++);
                 trx_xd.m_category_id_n = tp_d.m_category_id;
-                trx_xd.CATEGNAME       = CategoryModel::full_name(tp_d.m_category_id);
+                trx_xd.CATEGNAME       = CategoryModel::instance().full_name(tp_d.m_category_id);
                 trx_xd.m_amount        = tp_d.m_amount;
                 trx_xd.m_notes         = trx_d.m_notes;
                 trx_xd.TAGNAMES        = tranTagnames;

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -277,7 +277,7 @@ table {
         bool is_time_used = PrefModel::instance().UseTransDateTime();
         const wxString mask = is_time_used ? "%Y-%m-%dT%H:%M:%S" : "%Y-%m-%d";
 
-        auto custom_fields_data = FieldValueModel::instance().find_reftype_refid_data_m(
+        auto trxId_fvA_m = FieldValueModel::instance().find_refType_mRefId(
             TrxModel::s_ref_type
         );
         while (noOfTrans--) {
@@ -384,9 +384,8 @@ table {
                     trx_xd.UDFC_value[i] = -DBL_MAX;
                 }
 
-                if (custom_fields_data.find(trx_xd.m_id) != custom_fields_data.end()) {
-                    const auto& fv_a = custom_fields_data.at(trx_xd.m_id);
-                    for (const auto& fv_d : fv_a) {
+                if (trxId_fvA_m.find(trx_xd.m_id) != trxId_fvA_m.end()) {
+                    for (const auto& fv_d : trxId_fvA_m.at(trx_xd.m_id)) {
                         for (int i = 0; i < 5; i++) {
                             if (fv_d.m_field_id == udfc_id[i]) {
                                 trx_xd.UDFC_content[i] = fv_d.m_content;
@@ -552,12 +551,12 @@ void TrxReport::Run(wxSharedPtr<TrxFilterDialog>& dlg)
 {
     trx_xa.clear();
     const auto splits = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+    const auto trxId_glA_m = TagLinkModel::instance().find_refType_mRefId(
         TrxModel::s_ref_type
     );
     bool combine_splits = dlg.get()->mmIsCombineSplitsChecked();
     for (const auto& trx_d : TrxModel::instance().find_all()) {
-        TrxModel::Full_Data trx_xd(trx_d, splits, tags);
+        TrxModel::Full_Data trx_xd(trx_d, splits, trxId_glA_m);
         trx_xd.PAYEENAME = trx_xd.real_payee_name(trx_xd.m_account_id);
         if (trx_xd.has_split()) {
             TrxModel::Full_Data single_tran = trx_xd;

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -135,7 +135,6 @@ table {
     hb.displayFooter(_t("Accounts: ") + accounts_label);
 
     m_noOfCols = (m_transDialog->mmIsHideColumnsChecked()) ? m_transDialog->mmGetHideColumnsID().GetCount() : 11;
-    const wxString& AttRefType = TrxModel::refTypeName;
     const int groupBy = m_transDialog->mmGetGroupBy();
     const int chart = m_transDialog->mmGetChart();
     wxString lastSortLabel = "";
@@ -277,22 +276,21 @@ table {
         bool is_time_used = PrefModel::instance().UseTransDateTime();
         const wxString mask = is_time_used ? "%Y-%m-%dT%H:%M:%S" : "%Y-%m-%d";
 
-        auto custom_fields_data = FieldValueModel::instance().get_all_id(TrxModel::refTypeName);
-        while (noOfTrans--)
-        {
+        auto custom_fields_data = FieldValueModel::instance().find_reftype_refid_data_m(
+            TrxModel::s_ref_type
+        );
+        while (noOfTrans--) {
             hb.startTableRow();
             {
                 /*  if ((TrxModel::type_id(trx_xd) == TrxModel::TYPE_ID_TRANSFER)
                     && m_transDialog->getTypeCheckBox() && */
-                if (showColumnById(TrxFilterDialog::COL_ID))
-                {
+                if (showColumnById(TrxFilterDialog::COL_ID)) {
                     hb.addTableCellLink(wxString::Format("trx:%lld", trx_xd.m_id)
                         , trx_xd.displayID, true);
                 }
                 if (showColumnById(TrxFilterDialog::COL_COLOR))
                     hb.addColorMarker(getUDColour(trx_xd.m_color.GetValue()).GetAsString(), true);
-                if (showColumnById(TrxFilterDialog::COL_DATE))
-                {
+                if (showColumnById(TrxFilterDialog::COL_DATE)) {
                     wxDateTime dt;
                     dt.ParseFormat(trx_xd.TRANSDATE, mask) || dt.ParseDate(trx_xd.TRANSDATE);
                     hb.addTableCellDate(dt.FormatISODate());
@@ -301,8 +299,7 @@ table {
                     hb.addTableCell(mmGetTimeForDisplay(trx_xd.TRANSDATE));
                 if (showColumnById(TrxFilterDialog::COL_NUMBER))
                     hb.addTableCell(trx_xd.m_number);
-                if (showColumnById(TrxFilterDialog::COL_ACCOUNT))
-                {
+                if (showColumnById(TrxFilterDialog::COL_ACCOUNT)) {
                     hb.addTableCellLink(wxString::Format("trxid:%lld", trx_xd.m_id)
                         , noOfTrans ? trx_xd.TOACCOUNTNAME : trx_xd.ACCOUNTNAME);
                 }
@@ -342,26 +339,22 @@ table {
                     grand_total[curr->m_id] += flow;
                     total_in_base_curr[curr->m_id] += flow * convRate;
                     grand_total_in_base_curr[curr->m_id] += flow * convRate;
-                    if (TrxModel::type_id(trx_xd) != TrxModel::TYPE_ID_TRANSFER)
-                    {
+                    if (TrxModel::type_id(trx_xd) != TrxModel::TYPE_ID_TRANSFER) {
                         grand_total_extrans[curr->m_id] += flow;
                         grand_total_in_base_curr_extrans[curr->m_id] += flow * convRate;
                     }
-                    if (chart > -1 && groupBy == -1)
-                    {
+                    if (chart > -1 && groupBy == -1) {
                         values_chart[trx_xd.m_id.ToString()] += (flow * convRate);
                     }
                 }
-                else
-                {
+                else {
                     wxFAIL_MSG("account for trx_xd not found");
                     if (showColumnById(TrxFilterDialog::COL_AMOUNT))
                         hb.addEmptyTableCell();
                 }
 
                 // Exchange Rate
-                if (showColumnById(TrxFilterDialog::COL_RATE))
-                {
+                if (showColumnById(TrxFilterDialog::COL_RATE)) {
                     if ((TrxModel::type_id(trx_xd) == TrxModel::TYPE_ID_TRANSFER)
                         && (trx_xd.m_amount != trx_xd.m_to_amount))
                         hb.addMoneyCell(trx_xd.m_to_amount / trx_xd.m_amount);
@@ -371,9 +364,10 @@ table {
 
                 // Attachments
                 wxString AttachmentsLink = "";
-                if (AttachmentModel::instance().find_id_c(RefTypeN(AttRefType), trx_xd.m_id)) {
+                if (AttachmentModel::instance().find_ref_c(TrxModel::s_ref_type, trx_xd.m_id)) {
                     AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
-                        AttRefType, trx_xd.m_id, mmAttachmentManage::GetAttachmentNoteSign());
+                        TrxModel::s_ref_type.name_n(), trx_xd.m_id,
+                        mmAttachmentManage::GetAttachmentNoteSign());
                 }
 
                 // Notes
@@ -390,13 +384,13 @@ table {
                 }
 
                 if (custom_fields_data.find(trx_xd.m_id) != custom_fields_data.end()) {
-                    const auto& udfcs = custom_fields_data.at(trx_xd.m_id);
-                    for (const auto& udfc : udfcs) {
+                    const auto& fv_a = custom_fields_data.at(trx_xd.m_id);
+                    for (const auto& fv_d : fv_a) {
                         for (int i = 0; i < 5; i++) {
-                            if (udfc.FIELDID == udfc_id[i]) {
-                                trx_xd.UDFC_content[i] = udfc.CONTENT;
+                            if (fv_d.m_field_id == udfc_id[i]) {
+                                trx_xd.UDFC_content[i] = fv_d.m_content;
                                 trx_xd.UDFC_value[i] = cleanseNumberStringToDouble(
-                                    udfc.CONTENT, udfc_scale[i] > 0
+                                    fv_d.m_content, udfc_scale[i] > 0
                                 );
                                 break;
                             }

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -551,7 +551,9 @@ void TrxReport::Run(wxSharedPtr<TrxFilterDialog>& dlg)
 {
     trx_xa.clear();
     const auto splits = TrxSplitModel::instance().get_all_id();
-    const auto tags = TagLinkModel::instance().get_all_id(TrxModel::refTypeName);
+    const auto tags = TagLinkModel::instance().find_reftype_refid_data_m(
+        TrxModel::s_ref_type
+    );
     bool combine_splits = dlg.get()->mmIsCombineSplitsChecked();
     for (const auto& trx_d : TrxModel::instance().find_all()) {
         TrxModel::Full_Data trx_xd(trx_d, splits, tags);
@@ -582,8 +584,11 @@ void TrxReport::Run(wxSharedPtr<TrxFilterDialog>& dlg)
                     trx_xd.m_notes.Append((trx_d.m_notes.IsEmpty() ? "" : " ") + tp_d.m_notes);
 
                     wxString tagnames;
-                    for (const auto& [tag_name, _] : TagLinkModel::instance().get_ref(TrxSplitModel::refTypeName, tp_d.m_id))
+                    for (const auto& [tag_name, _] : TagLinkModel::instance().find_ref_tag_m(
+                        TrxSplitModel::s_ref_type, tp_d.m_id
+                    )) {
                         tagnames.Append(tag_name + " ");
+                    }
                     if (!tagnames.IsEmpty())
                         trx_xd.TAGNAMES.Append((trx_xd.TAGNAMES.IsEmpty() ? "" : ", ") + tagnames.Trim());
 

--- a/src/report/TrxReport.h
+++ b/src/report/TrxReport.h
@@ -38,7 +38,7 @@ private:
     wxSharedPtr<TrxFilterDialog> m_transDialog;
     bool showColumnById(int num);
     void displayTotals(const std::map<int64, double>& total, std::map<int64, double>& total_in_base_curr, int noOfCols);
-    void UDFCFormatHelper(FieldModel::TYPE_ID type, int64 ref, wxString data, double val, int scale);
+    void UDFCFormatHelper(FieldTypeN type, int64 ref, wxString data, double val, int scale);
 
     mmHTMLBuilder hb;
     int m_noOfCols;

--- a/src/report/budgetcategorysummary.cpp
+++ b/src/report/budgetcategorysummary.cpp
@@ -47,11 +47,10 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     // Grab the data 
     int startDay;
     wxDate::Month startMonth;
-    if (PrefModel::instance().getBudgetFinancialYears())
-    {
+    if (PrefModel::instance().getBudgetFinancialYears()) {
         GetFinancialYearValues(startDay, startMonth);
-    } else
-    {
+    }
+    else {
         startDay = 1;
         startMonth = wxDateTime::Jan;
     }
@@ -59,14 +58,13 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     long tmp;
     int startYear = wxDateTime::Today().GetYear();
 
-    wxString value = BudgetPeriodModel::instance().get_id_name(m_date_selection);
-    wxString budget_month, budget_year = value;
+    wxString bp_name_n = BudgetPeriodModel::instance().get_id_name_n(m_date_selection);
+    wxString budget_month, budget_year = bp_name_n;
 
     wxRegEx pattern("^([0-9]{4})(-([0-9]{2}))?$");
-    if (pattern.Matches(value))
-    {
-        budget_year = pattern.GetMatch(value, 1);
-        budget_month = pattern.GetMatch(value, 3);
+    if (pattern.Matches(bp_name_n)) {
+        budget_year = pattern.GetMatch(bp_name_n, 1);
+        budget_month = pattern.GetMatch(bp_name_n, 3);
     }
 
     if (budget_year.ToLong(&tmp))
@@ -75,8 +73,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     budget_year = wxString::Format("%d", startYear);
 
     long budgetMonth = 0;
-    if (budget_month.ToLong(&budgetMonth))
-    {
+    if (budget_month.ToLong(&budgetMonth)) {
         if (startMonth != wxDateTime::Jan)
             startMonth = wxDateTime(1, startMonth, startYear).Add(wxDateSpan::Months(--budgetMonth)).GetMonth();
         else
@@ -100,8 +97,7 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     mmSpecifiedRange date_range(yearBegin, yearEnd);
 
     bool evaluateTransfer = false;
-    if (PrefModel::instance().getBudgetIncludeTransfers())
-    {
+    if (PrefModel::instance().getBudgetIncludeTransfers()) {
         evaluateTransfer = true;
     }
     //Get statistics
@@ -111,14 +107,17 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     BudgetModel::instance().getBudgetEntry(m_date_selection, budgetFreq, budgetAmt, budgetNotes);
 
     std::map<int64, std::map<int, double> > categoryStats;
-    CategoryModel::instance().getCategoryStats(categoryStats
-        , static_cast<wxSharedPtr<wxArrayString>>(nullptr)
-        , &date_range, PrefModel::instance().getIgnoreFutureTransactions()
-        , false, (evaluateTransfer ? &budgetAmt : nullptr));
+    CategoryModel::instance().getCategoryStats(
+        categoryStats,
+        static_cast<wxSharedPtr<wxArrayString>>(nullptr),
+        &date_range,
+        PrefModel::instance().getIgnoreFutureTransactions(),
+        false,
+        (evaluateTransfer ? &budgetAmt : nullptr)
+    );
 
     std::map<int64, std::map<int, double> > budgetStats;
     BudgetModel::instance().getBudgetStats(budgetStats, &date_range, monthlyBudget);
-
 
     // Build the report
     mmHTMLBuilder hb;
@@ -126,7 +125,8 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     wxString headingStr = AdjustYearValues(startDay, startMonth, startYear, budget_year);
     bool amply = PrefModel::instance().getBudgetSummaryWithoutCategories();
     const wxString headerStartupMsg = amply
-        ? _t("Budget Categories for %s") : _t("Budget Category Summary for %s");
+        ? _t("Budget Categories for %s")
+        : _t("Budget Category Summary for %s");
 
     headingStr = wxString::Format(headerStartupMsg
         , headingStr + "<br>" + _t("(Estimated vs. Actual)"));
@@ -140,13 +140,11 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     std::stable_sort(categs.begin(), categs.end(), CategoryData::SorterByCATEGNAME());
 
     // Chart
-    if (getChartSelection() == 0)
-    {
+    if (getChartSelection() == 0) {
         GraphData gd;
         GraphSeries gsActual, gsEstimated;
 
-        for (const auto& category : categs)
-        {
+        for (const auto& category : categs) {
             wxString categName = category.m_name;
             gsEstimated.name = _t("Estimated");
             gsActual.name = _t("Actual");
@@ -161,14 +159,13 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
                 gsEstimated.values.push_back(budgetStats[subcat.m_id][budgetMonth]);
             }
 
-            if (gd.labels.size() > 1) // Bar/Line are best with at least 2 items 
-            {
+            // Bar/Line are best with at least 2 items 
+            if (gd.labels.size() > 1) {
                 gd.type = GraphData::BARLINE;
                 gsEstimated.type = "column";
                 gsActual.type = "line";
             }
-            else
-            {
+            else {
                 gd.type = GraphData::BAR;
             }
             gd.series.push_back(gsActual);
@@ -221,13 +218,15 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
                     catTotalsActual[category.m_id] += actual;
                     catTotalsEstimated[category.m_id] += estimated;
 
-                    if (amply)
-                    {
+                    if (amply) {
                         hb.startTableRow();
                         {
-                            hb.addTableCellLink(wxString::Format("viewtrans:%lld"
-                                , category.m_id)
-                                , category.m_name);
+                            hb.addTableCellLink(
+                                wxString::Format("viewtrans:%lld",
+                                    category.m_id
+                                ),
+                                category.m_name
+                            );
                             hb.addMoneyCell(estimated);
                             hb.addMoneyCell(actual);
                         }

--- a/src/report/budgetcategorysummary.cpp
+++ b/src/report/budgetcategorysummary.cpp
@@ -136,27 +136,25 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
     m_filter.clear();
     m_filter.setDateRange(yearBegin, yearEnd);
 
-    CategoryModel::DataA categs = CategoryModel::instance().find(CategoryCol::PARENTID(-1));
-    std::stable_sort(categs.begin(), categs.end(), CategoryData::SorterByCATEGNAME());
+    CategoryModel::DataA cat_a = CategoryModel::instance().find(CategoryCol::PARENTID(-1));
+    std::stable_sort(cat_a.begin(), cat_a.end(), CategoryData::SorterByCATEGNAME());
 
     // Chart
     if (getChartSelection() == 0) {
         GraphData gd;
         GraphSeries gsActual, gsEstimated;
 
-        for (const auto& category : categs) {
-            wxString categName = category.m_name;
+        for (const auto& cat_d : cat_a) {
             gsEstimated.name = _t("Estimated");
             gsActual.name = _t("Actual");
-
-            gd.title = categName;
-            gd.labels.push_back(category.m_name);
-            gsActual.values.push_back(categoryStats[category.m_id][0]);
-            gsEstimated.values.push_back(budgetStats[category.m_id][budgetMonth]);
-            for(const auto& subcat : CategoryModel::sub_tree(category)){
-                gd.labels.push_back(CategoryModel::full_name(subcat.m_id));
-                gsActual.values.push_back(categoryStats[subcat.m_id][0]);
-                gsEstimated.values.push_back(budgetStats[subcat.m_id][budgetMonth]);
+            gd.title = cat_d.m_name;
+            gd.labels.push_back(cat_d.m_name);
+            gsActual.values.push_back(categoryStats[cat_d.m_id][0]);
+            gsEstimated.values.push_back(budgetStats[cat_d.m_id][budgetMonth]);
+            for (const auto& sub_d : CategoryModel::instance().find_data_subtree_a(cat_d)){
+                gd.labels.push_back(CategoryModel::instance().full_name(sub_d.m_id));
+                gsActual.values.push_back(categoryStats[sub_d.m_id][0]);
+                gsEstimated.values.push_back(budgetStats[sub_d.m_id][budgetMonth]);
             }
 
             // Bar/Line are best with at least 2 items 
@@ -197,140 +195,157 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
             hb.endThead();
             hb.startTbody();
             {
-                std::map<int64, double> catTotalsEstimated, catTotalsActual;
-                std::map<int64, std::pair<int, wxString>> categLevel;
-                for (const auto& category : categs)
+
+    // -- reduce indentation by 3 tab stops to make more space
+    std::map<int64, double> catTotalsEstimated, catTotalsActual;
+    std::map<int64, std::pair<int, wxString>> categLevel;
+    for (const auto& cat_d : cat_a) {
+        categLevel[cat_d.m_id].first = 0;
+        double estimated = budgetStats[cat_d.m_id][budgetMonth];
+
+        if (estimated < 0)
+            estExpenses += estimated;
+        else
+            estIncome += estimated;
+
+        double actual = categoryStats[cat_d.m_id][0];
+        if (actual < 0)
+            actExpenses += actual;
+        else
+            actIncome += actual;
+
+        catTotalsActual[cat_d.m_id] += actual;
+        catTotalsEstimated[cat_d.m_id] += estimated;
+
+        if (amply) {
+            hb.startTableRow();
+            {
+                hb.addTableCellLink(
+                    wxString::Format("viewtrans:%lld",
+                        cat_d.m_id
+                    ),
+                    cat_d.m_name
+                );
+                hb.addMoneyCell(estimated);
+                hb.addMoneyCell(actual);
+            }
+            hb.endTableRow();
+        }
+        
+        std::vector<int> totals_stack;
+        CategoryModel::DataA sub_a = CategoryModel::instance().find_data_subtree_a(cat_d);
+        for (int i = 0; i < static_cast<int>(sub_a.size()); i++) {
+            categLevel[sub_a[i].m_id].first = 1;
+            estimated = budgetStats[sub_a[i].m_id][budgetMonth];
+
+            if (estimated < 0)
+                estExpenses += estimated;
+            else
+                estIncome += estimated;
+
+            actual = categoryStats[sub_a[i].m_id][0];
+            if (actual < 0)
+                actExpenses += actual;
+            else
+                actIncome += actual;
+
+            //save totals for this subcategory
+            catTotalsEstimated[sub_a[i].m_id] = estimated;
+            catTotalsActual[sub_a[i].m_id] = actual;
+
+            //update totals of the category
+            catTotalsEstimated[cat_d.m_id] += estimated;
+            catTotalsActual[cat_d.m_id] += actual;
+
+            //walk up the hierarchy and update all the parent totals as well
+            int64 nextParent = sub_a[i].m_parent_id_n;
+            for (int j = i; j > 0; j--) {
+                if (sub_a[j - 1].m_id == nextParent) {
+                    categLevel[sub_a[i].m_id].first++;
+                    catTotalsEstimated[sub_a[j - 1].m_id] += estimated;
+                    catTotalsActual[sub_a[j - 1].m_id] += actual;
+                    nextParent = sub_a[j - 1].m_parent_id_n;
+                    if (nextParent == cat_d.m_id)
+                        break;
+                }
+            }
+            categLevel[sub_a[i].m_id].second = "";
+            for (int j = categLevel[sub_a[i].m_id].first; j > 0; j--) {
+                categLevel[sub_a[i].m_id].second.Prepend("&nbsp;&nbsp;&nbsp;&nbsp;");
+            }
+            if (amply) {
+                hb.startTableRow();
                 {
-                    categLevel[category.m_id].first = 0;
-                    double estimated = budgetStats[category.m_id][budgetMonth];
-
-                    if (estimated < 0)
-                        estExpenses += estimated;
-                    else
-                        estIncome += estimated;
-
-                    double actual = categoryStats[category.m_id][0];
-                    if (actual < 0)
-                        actExpenses += actual;
-                    else
-                        actIncome += actual;
-
-                    catTotalsActual[category.m_id] += actual;
-                    catTotalsEstimated[category.m_id] += estimated;
-
-                    if (amply) {
-                        hb.startTableRow();
-                        {
-                            hb.addTableCellLink(
-                                wxString::Format("viewtrans:%lld",
-                                    category.m_id
-                                ),
-                                category.m_name
-                            );
-                            hb.addMoneyCell(estimated);
-                            hb.addMoneyCell(actual);
-                        }
-                        hb.endTableRow();
+                    hb.addTableCell(wxString::Format(
+                        categLevel[sub_a[i].m_id].second + "<a href=\"viewtrans:%lld\" target=\"_blank\">%s</a>",
+                        sub_a[i].m_id,
+                        sub_a[i].m_name
+                    ));
+                    hb.addMoneyCell(estimated);
+                    hb.addMoneyCell(actual);
+                }
+                hb.endTableRow();
+                
+                //not the last subcategory
+                if (i < static_cast<int>(sub_a.size()) - 1) {
+                    //if next subcategory is our child, queue the total for after the children
+                    if (sub_a[i].m_id == sub_a[i + 1].m_parent_id_n) {
+                        totals_stack.push_back(i);
                     }
-                    
-                    std::vector<int> totals_stack;
-                    CategoryModel::DataA subcats = CategoryModel::sub_tree(category);
-                    for (int i = 0; i < static_cast<int>(subcats.size()); i++) {
-                        categLevel[subcats[i].m_id].first = 1;
-                        estimated = budgetStats[subcats[i].m_id][budgetMonth];
-
-                        if (estimated < 0)
-                            estExpenses += estimated;
-                        else
-                            estIncome += estimated;
-
-                        actual = categoryStats[subcats[i].m_id][0];
-                        if (actual < 0)
-                            actExpenses += actual;
-                        else
-                            actIncome += actual;
-
-                        //save totals for this subcategory
-                        catTotalsEstimated[subcats[i].m_id] = estimated;
-                        catTotalsActual[subcats[i].m_id] = actual;
-
-                        //update totals of the category
-                        catTotalsEstimated[category.m_id] += estimated;
-                        catTotalsActual[category.m_id] += actual;
-
-                        //walk up the hierarchy and update all the parent totals as well
-                        int64 nextParent = subcats[i].m_parent_id_n;
-                        for (int j = i; j > 0; j--) {
-                            if (subcats[j - 1].m_id == nextParent) {
-                                categLevel[subcats[i].m_id].first++;
-                                catTotalsEstimated[subcats[j - 1].m_id] += estimated;
-                                catTotalsActual[subcats[j - 1].m_id] += actual;
-                                nextParent = subcats[j - 1].m_parent_id_n;
-                                if (nextParent == category.m_id)
-                                    break;
-                            }
-                        }
-                        categLevel[subcats[i].m_id].second = "";
-                        for (int j = categLevel[subcats[i].m_id].first; j > 0; j--) {
-                            categLevel[subcats[i].m_id].second.Prepend("&nbsp;&nbsp;&nbsp;&nbsp;");
-                        }
-                        if (amply) {
-                            hb.startTableRow();
+                    // last sibling -- we've exhausted this branch, so display all the totals we held on to
+                    else if (sub_a[i].m_parent_id_n != sub_a[i + 1].m_parent_id_n) {
+                        while (!totals_stack.empty() &&
+                            sub_a[totals_stack.back()].m_id != sub_a[i + 1].m_parent_id_n
+                        ) {
+                            hb.startAltTableRow();
                             {
-                                hb.addTableCell(wxString::Format(categLevel[subcats[i].m_id].second + "<a href=\"viewtrans:%lld\" target=\"_blank\">%s</a>"
-                                    , subcats[i].m_id
-                                    , subcats[i].m_name));
-                                hb.addMoneyCell(estimated);
-                                hb.addMoneyCell(actual);
+                                int index = totals_stack.back();
+                                hb.addTableCell(wxString::Format(
+                                    categLevel[sub_a[index].m_id].second + "<a href=\"viewtrans:%lld:-2\" target=\"_blank\">%s</a>",
+                                    sub_a[index].m_id,
+                                    sub_a[index].m_name
+                                ));
+                                hb.addMoneyCell(catTotalsEstimated[sub_a[index].m_id]);
+                                hb.addMoneyCell(catTotalsActual[sub_a[index].m_id]);
                             }
                             hb.endTableRow();
-                            
-                            if (i < static_cast<int>(subcats.size()) - 1) { //not the last subcategory
-                                if (subcats[i].m_id == subcats[i + 1].m_parent_id_n) totals_stack.push_back(i); //if next subcategory is our child, queue the total for after the children
-                                else if (subcats[i].m_parent_id_n != subcats[i + 1].m_parent_id_n) { // last sibling -- we've exhausted this branch, so display all the totals we held on to
-                                    while (!totals_stack.empty() && subcats[totals_stack.back()].m_id != subcats[i + 1].m_parent_id_n) {
-                                        hb.startAltTableRow();
-                                        {
-                                            int index = totals_stack.back();
-                                            hb.addTableCell(wxString::Format(categLevel[subcats[index].m_id].second + "<a href=\"viewtrans:%lld:-2\" target=\"_blank\">%s</a>"
-                                                , subcats[index].m_id
-                                                , subcats[index].m_name));
-                                            hb.addMoneyCell(catTotalsEstimated[subcats[index].m_id]);
-                                            hb.addMoneyCell(catTotalsActual[subcats[index].m_id]);
-                                        }
-                                        hb.endTableRow();
-                                        totals_stack.pop_back();
-                                    }
-                                }
-                            }
-                            // the very last subcategory, so show the rest of the queued totals
-                            else {
-                                while (!totals_stack.empty()) {
-                                    hb.startAltTableRow();
-                                    {
-                                        int index = totals_stack.back();
-                                        hb.addTableCell(wxString::Format(categLevel[subcats[index].m_id].second + "<a href=\"viewtrans:%lld:-2\" target=\"_blank\">%s</a>"
-                                            , subcats[index].m_id
-                                            , subcats[index].m_name));
-                                        hb.addMoneyCell(catTotalsEstimated[subcats[index].m_id]);
-                                        hb.addMoneyCell(catTotalsActual[subcats[index].m_id]);
-                                    }
-                                    hb.endTableRow();
-                                    totals_stack.pop_back();
-                                }
-                            }
+                            totals_stack.pop_back();
                         }
                     }
-                    amply ? hb.startAltTableRow() : hb.startTableRow();
-                    {
-                        hb.addTableCellLink(wxString::Format("viewtrans:%lld:-2"
-                            , category.m_id)
-                            , category.m_name);
-                        hb.addMoneyCell(catTotalsEstimated[category.m_id]);
-                        hb.addMoneyCell(catTotalsActual[category.m_id]);
-                    }
-                    hb.endTableRow();
                 }
+                // the very last subcategory, so show the rest of the queued totals
+                else {
+                    while (!totals_stack.empty()) {
+                        hb.startAltTableRow();
+                        {
+                            int index = totals_stack.back();
+                            hb.addTableCell(wxString::Format(
+                                categLevel[sub_a[index].m_id].second + "<a href=\"viewtrans:%lld:-2\" target=\"_blank\">%s</a>",
+                                sub_a[index].m_id,
+                                sub_a[index].m_name
+                            ));
+                            hb.addMoneyCell(catTotalsEstimated[sub_a[index].m_id]);
+                            hb.addMoneyCell(catTotalsActual[sub_a[index].m_id]);
+                        }
+                        hb.endTableRow();
+                        totals_stack.pop_back();
+                    }
+                }
+            }
+        }
+        amply ? hb.startAltTableRow() : hb.startTableRow();
+        {
+            hb.addTableCellLink(
+                wxString::Format("viewtrans:%lld:-2", cat_d.m_id),
+                cat_d.m_name
+            );
+            hb.addMoneyCell(catTotalsEstimated[cat_d.m_id]);
+            hb.addMoneyCell(catTotalsActual[cat_d.m_id]);
+        }
+        hb.endTableRow();
+    }
+    // -- restore indentation
+
             }
             hb.endTbody();
         }

--- a/src/report/budgetingperf.cpp
+++ b/src/report/budgetingperf.cpp
@@ -56,14 +56,14 @@ wxString mmReportBudgetingPerformance::getHTMLText()
 
     long startYear;
 
-    wxString value = BudgetPeriodModel::instance().get_id_name(m_date_selection);
+    wxString bp_name_n = BudgetPeriodModel::instance().get_id_name_n(m_date_selection);
     wxString budget_year;
     wxString budget_month;
 
     wxRegEx pattern("^([0-9]{4})(-([0-9]{2}))?$");
-    if (pattern.Matches(value)) {
-        budget_year = pattern.GetMatch(value, 1);
-        budget_month = pattern.GetMatch(value, 3);
+    if (pattern.Matches(bp_name_n)) {
+        budget_year = pattern.GetMatch(bp_name_n, 1);
+        budget_month = pattern.GetMatch(bp_name_n, 3);
     }
 
     if (!budget_year.ToLong(&startYear)) {
@@ -93,13 +93,15 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     BudgetModel::instance().getBudgetEntry(m_date_selection, budgetFreq, budgetAmt, budgetNotes);
 
     std::map<int64, std::map<int, double> > categoryStats;
-    CategoryModel::instance().getCategoryStats(categoryStats
-        , m_account_a
-        , &date_range
-        , PrefModel::instance().getIgnoreFutureTransactions()
-        , true
-        , (evaluateTransfer ? &budgetAmt : nullptr)
-        , PrefModel::instance().getBudgetFinancialYears());
+    CategoryModel::instance().getCategoryStats(
+        categoryStats,
+        m_account_a,
+        &date_range,
+        PrefModel::instance().getIgnoreFutureTransactions(),
+        true,
+        (evaluateTransfer ? &budgetAmt : nullptr),
+        PrefModel::instance().getBudgetFinancialYears()
+    );
 
     std::map<int64, std::map<int, double> > budgetStats;
     BudgetModel::instance().getBudgetStats(budgetStats, &date_range, true);

--- a/src/table/_TableFactory.tpp
+++ b/src/table/_TableFactory.tpp
@@ -299,9 +299,9 @@ auto TableFactory<T, D>::stat_json() const -> const wxString
     json_writer.Key("cache_max_size");
     json_writer.Int(cache_stat.max_size);
     json_writer.Key("cache_hit");
-    json_writer.Int(cache_stat.hit_cnt);
+    json_writer.Int(cache_stat.hit_c);
     json_writer.Key("cache_miss");
-    json_writer.Int(cache_stat.miss_cnt);
+    json_writer.Int(cache_stat.miss_c);
     json_writer.EndObject();
 
     wxLogDebug("======== TableFactory::stat_json =======");
@@ -317,7 +317,7 @@ void TableFactory<T, D>::debug_stat() const
     const mmCacheStat& cache_stat = m_cache.get_stat();
     wxLogDebug("%s : (cap %zu, max_size %zu, hit %zu, miss %zu)",
         this->m_table_name,
-        cache_stat.capacity, cache_stat.max_size, cache_stat.hit_cnt, cache_stat.miss_cnt
+        cache_stat.capacity, cache_stat.max_size, cache_stat.hit_c, cache_stat.miss_c
     );
 }
 

--- a/src/util/_simple.cpp
+++ b/src/util/_simple.cpp
@@ -534,7 +534,7 @@ void mmComboBoxCategory::init()
     all_elements_.clear();
     all_categories_ = CategoryModel::instance().all_categories(excludeHidden_);
     if (catID_ > -1)
-        all_categories_.insert(std::make_pair(CategoryModel::full_name(catID_)
+        all_categories_.insert(std::make_pair(CategoryModel::instance().full_name(catID_)
             , catID_));
     for (const auto& item : all_categories_)
     {

--- a/src/util/mmCache.h
+++ b/src/util/mmCache.h
@@ -22,14 +22,14 @@
 
 struct mmCacheStat
 {
-    size_t capacity, max_size, lock_cnt, hit_cnt, miss_cnt;
+    size_t capacity, max_size, lock_c, hit_c, miss_c;
 
     mmCacheStat(size_t capacity_ = 0) :
-        capacity(capacity_), max_size(0), lock_cnt(0), hit_cnt(0), miss_cnt(0)
+        capacity(capacity_), max_size(0), lock_c(0), hit_c(0), miss_c(0)
     {
     }
 
-    void reset() { max_size = 0; lock_cnt = 0; hit_cnt = 0; miss_cnt = 0; }
+    void reset() { max_size = 0; lock_c = 0; hit_c = 0; miss_c = 0; }
 };
 
 template<typename KeyType, typename ValueType>

--- a/src/util/mmCache.tpp
+++ b/src/util/mmCache.tpp
@@ -24,18 +24,18 @@
 // If key is not in cache, return nullptr.
 // The returned pointer can modify the value in cache.
 // The returned pointer is invalidated at the next clear() or reset();
-// if capacity is set (> 0) and the cache is not locked (lock_cnt == 0),
+// if capacity is set (> 0) and the cache is not locked (lock_c == 0),
 // the returned may be invalidated at the next add() or set().
 template<typename K, typename V>
 auto mmCache<K, V>::unsafe_get(const Key& key) -> Value*
 {
     auto it = m_key_value.find(key);
     if (it != m_key_value.end()) {
-        ++m_stat.hit_cnt;
+        ++m_stat.hit_c;
         return it->second;
     }
     else {
-        ++m_stat.miss_cnt;
+        ++m_stat.miss_c;
         return nullptr;
     }
 }
@@ -52,7 +52,7 @@ auto mmCache<K, V>::get(const Key& key) -> const Value*
 // to the copy owned by cache. If key is alredy in cache, return nullptr.
 // value shall not be owned by cache before the call; it is not embraced
 // by cache after the call.
-// If capacity is set (> 0) and the cache is not locked (lock_cnt == 0),
+// If capacity is set (> 0) and the cache is not locked (lock_c == 0),
 // this call may invalidate pointers into cache.
 template<typename K, typename V>
 auto mmCache<K, V>::add(const Key& key, const Value& value) -> const Value*
@@ -60,7 +60,7 @@ auto mmCache<K, V>::add(const Key& key, const Value& value) -> const Value*
     if (m_key_value.find(key) != m_key_value.end())
         return nullptr;
 
-    if (m_stat.lock_cnt == 0 && m_stat.capacity > 0 && m_key_value.size() >= m_stat.capacity)
+    if (m_stat.lock_c == 0 && m_stat.capacity > 0 && m_key_value.size() >= m_stat.capacity)
         clear();
 
     m_key_value[key] = new Value(value);
@@ -86,7 +86,7 @@ auto mmCache<K, V>::update(const Key& key, const Value& value) -> const Value*
 }
 
 // Copy or update value into cache and return a pointer to the copy owned by cache.
-// If capacity is set (> 0) and the cache is not locked (lock_cnt == 0),
+// If capacity is set (> 0) and the cache is not locked (lock_c == 0),
 // this call may invalidate pointers into cache.
 template<typename K, typename V>
 auto mmCache<K, V>::set(const Key& key, const Value& value) -> const Value*
@@ -117,15 +117,15 @@ bool mmCache<K, V>::remove(const Key& key)
 template<typename K, typename V>
 void mmCache<K, V>::lock()
 {
-    ++m_stat.lock_cnt;
+    ++m_stat.lock_c;
 }
 
 // Decrease the lock counter.
 template<typename K, typename V>
 void mmCache<K, V>::unlock()
 {
-    if (m_stat.lock_cnt > 0)
-        --m_stat.lock_cnt;
+    if (m_stat.lock_c > 0)
+        --m_stat.lock_c;
 }
 
 // If the cache is not locked, remove all keys and delete all values;
@@ -134,7 +134,7 @@ void mmCache<K, V>::unlock()
 template<typename K, typename V>
 void mmCache<K, V>::clear()
 {
-    if (m_stat.lock_cnt > 0)
+    if (m_stat.lock_c > 0)
         return;
 
     for (auto& [_, v] : m_key_value)

--- a/src/util/mmChoice.cpp
+++ b/src/util/mmChoice.cpp
@@ -38,7 +38,7 @@ const wxString mmChoiceNameA::get_name(mmChoiceId id) const
 
 mmChoiceIdN mmChoiceNameA::find_name_n(const wxString& name)
 {
-    if (const auto it = m_index_m.find(name); it != m_index_m.end())
+    if (const auto it = m_name_id_m.find(name); it != m_name_id_m.end())
         return it->second;
 
     mmChoiceIdN id_n = m_default_id_n;
@@ -51,7 +51,67 @@ mmChoiceIdN mmChoiceNameA::find_name_n(const wxString& name)
             break;
         }
     }
-    m_index_m.insert({name, id_n});
+    m_name_id_m.insert({name, id_n});
+    return id_n;
+}
+
+// -- mmChoiceCodeNameA --
+
+mmChoiceIdN mmChoiceCodeNameA::valid_id_n(mmChoiceIdN id_n) const
+{
+    wxASSERT(
+        (id_n >= 0 && id_n < static_cast<mmChoiceId>(m_choice_a.size())) ||
+        id_n == m_default_id_n
+    );
+    return id_n;
+}
+
+int mmChoiceCodeNameA::get_code(mmChoiceId id) const
+{
+    wxASSERT(id >= 0 && id < static_cast<mmChoiceId>(m_choice_a.size()));
+    wxASSERT(m_choice_a[id].id == id);
+    return m_choice_a[id].code;
+}
+
+const wxString mmChoiceCodeNameA::get_name(mmChoiceId id) const
+{
+    wxASSERT(id >= 0 && id < static_cast<mmChoiceId>(m_choice_a.size()));
+    wxASSERT(m_choice_a[id].id == id);
+    return m_choice_a[id].name;
+}
+
+mmChoiceIdN mmChoiceCodeNameA::find_code_n(int code)
+{
+    if (const auto it = m_code_id_m.find(code); it != m_code_id_m.end())
+        return it->second;
+
+    mmChoiceIdN id_n = m_default_id_n;
+    for (const Choice& choice : m_choice_a) {
+        if (code == choice.code) {
+            id_n = choice.id;
+            break;
+        }
+    }
+    m_code_id_m.insert({code, id_n});
+    return id_n;
+}
+
+mmChoiceIdN mmChoiceCodeNameA::find_name_n(const wxString& name)
+{
+    if (const auto it = m_name_id_m.find(name); it != m_name_id_m.end())
+        return it->second;
+
+    mmChoiceIdN id_n = m_default_id_n;
+    for (const Choice& choice : m_choice_a) {
+        bool match = m_nocase
+            ? (name.CmpNoCase(choice.name) == 0)
+            : (name == choice.name);
+        if (match) {
+            id_n = choice.id;
+            break;
+        }
+    }
+    m_name_id_m.insert({name, id_n});
     return id_n;
 }
 
@@ -82,7 +142,7 @@ const wxString mmChoiceKeyNameA::get_name(mmChoiceId id) const
 
 mmChoiceIdN mmChoiceKeyNameA::find_keyname_n(const wxString& keyname)
 {
-    if (const auto it = m_index_m.find(keyname); it != m_index_m.end())
+    if (const auto it = m_keyname_id_m.find(keyname); it != m_keyname_id_m.end())
         return it->second;
 
     mmChoiceIdN id_n = m_default_id_n;
@@ -95,6 +155,6 @@ mmChoiceIdN mmChoiceKeyNameA::find_keyname_n(const wxString& keyname)
             break;
         }
     }
-    m_index_m.insert({keyname, id_n});
+    m_keyname_id_m.insert({keyname, id_n});
     return id_n;
 }

--- a/src/util/mmChoice.h
+++ b/src/util/mmChoice.h
@@ -33,7 +33,7 @@ private:
     const std::vector<Choice> m_choice_a;
     const mmChoiceIdN m_default_id_n;
     const bool m_nocase;
-    std::unordered_map<wxString, mmChoiceIdN> m_index_m; // name -> id_n
+    std::unordered_map<wxString, mmChoiceIdN> m_name_id_m; // name -> id_n
 
 public:
     mmChoiceNameA(
@@ -53,6 +53,37 @@ public:
     mmChoiceIdN find_name_n(const wxString& name);
 };
 
+class mmChoiceCodeNameA {
+public:
+    struct Choice { mmChoiceId id; int code; wxString name; };
+
+private:
+    const std::vector<Choice> m_choice_a;
+    const mmChoiceIdN m_default_id_n;
+    const bool m_nocase;
+    std::unordered_map<int,      mmChoiceIdN> m_code_id_m; // code -> id_n
+    std::unordered_map<wxString, mmChoiceIdN> m_name_id_m; // name -> id_n
+
+public:
+    mmChoiceCodeNameA(
+        const std::vector<Choice>& choice_a,
+        mmChoiceIdN default_id_n = -1,
+        bool nocase = true
+    ) :
+        m_choice_a(choice_a),
+        m_default_id_n(default_id_n),
+        m_nocase(nocase)
+    {}
+    ~mmChoiceCodeNameA() {}
+
+    mmChoiceIdN default_id_n() const { return m_default_id_n; }
+    mmChoiceIdN valid_id_n(mmChoiceIdN id_n) const;
+    int get_code(mmChoiceId id) const;
+    const wxString get_name(mmChoiceId id) const;
+    mmChoiceIdN find_code_n(int code);
+    mmChoiceIdN find_name_n(const wxString& name);
+};
+
 class mmChoiceKeyNameA {
 public:
     struct Choice { mmChoiceId id; wxString key; wxString name; };
@@ -61,7 +92,7 @@ private:
     const std::vector<Choice> m_choice_a;
     const mmChoiceIdN m_default_id_n;
     const bool m_nocase;
-    std::unordered_map<wxString, mmChoiceIdN> m_index_m; // key or name -> id_n
+    std::unordered_map<wxString, mmChoiceIdN> m_keyname_id_m; // key or name -> id_n
 
 public:
     mmChoiceKeyNameA(


### PR DESCRIPTION
### Changes
* refine `*Data`, `*Model`
* add `mmChoiceCodeNameA` for choices that are stored in database as numeric codes
* remove `REFTYPE_*`

### Next steps
* refine `TrxData/SchedData::{TRANSCODE, STATUS}`
* create `mmDateTime`
* refine `TrxData/SchedData::TRANSDATE`
* refine `TrxData::{LASTUPDATETIME, DELETEDTIME}`
* refine `SchedData::{REPEATS, NUMOCCURRENCES, NEXTOCCURRENCEDATE}`
* move `FieldModel::get*(properties)` to new struct `FieldProperties`
* add virtual `find_id_aux_c` (number of owned records), `find_id_dep_c` (number of dependencies), `find_all_dep_a` (list of dependencies)
* refine virtual `purge_id`
* remove `ModelBase`
* review `FieldData::m_ref_type` vs. `FieldValueData::m_ref_type`
* review memory management of temporary records (with id <= 0)
* review date comparisons in `{Currency, Stock}HistoryModel`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8212)
<!-- Reviewable:end -->
