### PR TITLE
Fix: Check if database is open before saving tree state on exit

### DIFF
--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -409,8 +409,6 @@ mmGUIFrame::mmGUIFrame(
 
 mmGUIFrame::~mmGUIFrame()
 {
-    navTreeStateToJson();
-
     try {
         cleanup();
     }
@@ -433,6 +431,10 @@ void mmGUIFrame::cleanup()
     if (!m_filename.IsEmpty()) // Exiting before file is opened
         saveSettings();
 
+
+    if (m_db) {
+        navTreeStateToJson();
+    }
     wxTreeItemId rootitem = m_nav_tree_ctrl->GetRootItem();
     cleanupNavTreeControl(rootitem);
     m_mgr.UnInit();


### PR DESCRIPTION
See comment to #8270

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8284)
<!-- Reviewable:end -->
