### PR TITLE
fix(#8283): use key() instead of name() in model

### DIFF
--- a/src/data/SchedData.cpp
+++ b/src/data/SchedData.cpp
@@ -45,7 +45,7 @@ SchedRow SchedData::to_row() const
     row.ACCOUNTID          = m_account_id;
     row.TOACCOUNTID        = m_to_account_id_n;
     row.PAYEEID            = m_payee_id_n;
-    row.TRANSCODE          = m_type.name();
+    row.TRANSCODE          = m_type.key();
     row.TRANSAMOUNT        = m_amount;
     row.STATUS             = m_status.key();
     row.TRANSACTIONNUMBER  = m_number;

--- a/src/dialog/AccountDialog.cpp
+++ b/src/dialog/AccountDialog.cpp
@@ -144,8 +144,8 @@ void AccountDialog::CreateControls()
 
     wxChoice* itemChoice6 = new wxChoice(this, ID_DIALOG_NEWACCT_COMBO_ACCTSTATUS);
     for (int i = 0; i < AccountStatus::size; ++i) {
-        wxString status = AccountStatus(i).name();
-        itemChoice6->Append(wxGetTranslation(status), new wxStringClientData(status));
+        wxString name = AccountStatus(i).name();
+        itemChoice6->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     mmToolTip(itemChoice6, _t("Specify if this account has been closed. Closed accounts are inactive in most calculations, reporting etc."));
     grid_sizer->Add(itemChoice6, g_flagsExpand);

--- a/src/dialog/AssetDialog.cpp
+++ b/src/dialog/AssetDialog.cpp
@@ -116,6 +116,7 @@ void AssetDialog::dataToControls()
         w_assetName->Enable(false);
     w_dpc->SetValue(m_asset_n->m_start_date.dateTime());
     w_assetType->SetSelection(m_asset_n->m_type.id());
+    // TODO: translate asset type
     if (AccountModel::instance().get_name_data_n(m_asset_n->m_type.name()))
         w_assetType->Enable(false);
 
@@ -209,8 +210,8 @@ void AssetDialog::CreateControls()
 
     w_assetType = new wxChoice(asset_details_panel, wxID_STATIC);
     for (int i = 0; i < AssetType::size; ++i) {
-        wxString type = AssetType(i).name();
-        w_assetType->Append(wxGetTranslation(type), new wxStringClientData(type));
+        wxString name = AssetType(i).name();
+        w_assetType->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
 
     mmToolTip(w_assetType, _t("Select type of asset"));
@@ -246,8 +247,8 @@ void AssetDialog::CreateControls()
 
     w_valueChange = new wxChoice(asset_details_panel, IDC_COMBO_TYPE);
     for (mmChoiceId i = 0; i < AssetChange::size; ++i) {
-        wxString change = AssetChange(i).name();
-        w_valueChange->Append(wxGetTranslation(change));
+        wxString name = AssetChange(i).name();
+        w_valueChange->Append(wxGetTranslation(name));
     }
 
     mmToolTip(w_valueChange, _t("Specify if the value of the asset changes over time"));
@@ -490,8 +491,11 @@ void AssetDialog::SetTransactionDate()
 
 void AssetDialog::CreateAssetAccount()
 {
+    // TODO: translate asset type
+    const wxString name = m_asset_n->m_type.name();
+
     AccountData new_account_d = AccountData();
-    new_account_d.m_name         = m_asset_n->m_type.name();
+    new_account_d.m_name         = name;
     new_account_d.m_type_        = NavigatorTypes::instance().getAssetAccountStr();
     new_account_d.m_open_balance = 0;
     new_account_d.m_open_date    = m_asset_n->m_start_date;
@@ -499,7 +503,7 @@ void AssetDialog::CreateAssetAccount()
     AccountModel::instance().add_data_n(new_account_d);
 
     AssetDialog dlg(this, m_asset_n, true);
-    dlg.SetTransactionAccountName(m_asset_n->m_type.name());
+    dlg.SetTransactionAccountName(name);
     dlg.SetTransactionDate();
     dlg.ShowModal();
 }

--- a/src/dialog/AttachmentDialog.cpp
+++ b/src/dialog/AttachmentDialog.cpp
@@ -188,7 +188,7 @@ void AttachmentDialog::fillControls()
         if (debug_)
             data.push_back(wxVariant(wxString::Format("%lld", att_d.m_id)));
         data.push_back(wxVariant(att_d.m_description));
-        data.push_back(wxVariant(att_d.m_ref_type_n.name_n() + m_PathSep + att_d.m_filename));
+        data.push_back(wxVariant(att_d.m_ref_type_n.key_n() + m_PathSep + att_d.m_filename));
         attachmentListBox_->AppendItem(data, static_cast<wxUIntPtr>(att_d.m_id.GetValue()));
     }
 
@@ -227,14 +227,14 @@ void AttachmentDialog::AddAttachment(wxString file_path)
     const wxString folder = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting());
     int last_num = AttachmentModel::instance().find_ref_last_num(m_ref_type, m_ref_id);
 
-    wxString importedFileName = m_ref_type.name_n() + "_" + wxString::Format("%lld", m_ref_id) + "_Attach"
+    wxString importedFileName = m_ref_type.key_n() + "_" + wxString::Format("%lld", m_ref_id) + "_Attach"
         + wxString::Format("%i", last_num + 1);
     if (!file_ext.empty())
         importedFileName += "." + file_ext;
 
     if (mmAttachmentManage::CopyAttachment(
         file_path,
-        folder + m_ref_type.name_n() + m_PathSep + importedFileName
+        folder + m_ref_type.key_n() + m_PathSep + importedFileName
     )) {
         AttachmentData new_att_d = AttachmentData();
         new_att_d.m_ref_type_n  = m_ref_type;
@@ -255,7 +255,7 @@ void AttachmentDialog::OpenAttachment()
 {
     const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
     wxString file_path = mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting())
-        + att_n->m_ref_type_n.name_n() + m_PathSep + att_n->m_filename;
+        + att_n->m_ref_type_n.key_n() + m_PathSep + att_n->m_filename;
     mmAttachmentManage::OpenAttachment(file_path);
 }
 
@@ -303,7 +303,7 @@ void AttachmentDialog::DeleteAttachment()
     if (deleteResponse == wxYES) {
         const wxString AttachmentsFolder = mmex::getPathAttachment(
             mmAttachmentManage::InfotablePathSetting()
-        ) + att_n->m_ref_type_n.name_n();
+        ) + att_n->m_ref_type_n.key_n();
         if (mmAttachmentManage::DeleteAttachment(
             AttachmentsFolder + m_PathSep + att_n->m_filename
         )) {
@@ -342,7 +342,7 @@ void AttachmentDialog::OnListItemActivated(wxDataViewEvent& WXUNUSED(event))
     const AttachmentData* att_n = AttachmentModel::instance().get_id_data_n(m_attachment_id);
     const wxString path = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + att_n->m_ref_type_n.name_n() + m_PathSep + att_n->m_filename;
+    ) + att_n->m_ref_type_n.key_n() + m_PathSep + att_n->m_filename;
 
     mmAttachmentManage::OpenAttachment(path);
 }
@@ -558,7 +558,7 @@ bool mmAttachmentManage::DeleteAllAttachments(RefTypeN ref_type, int64 ref_id)
 {
     wxString folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + m_PathSep + ref_type.name_n();
+    ) + m_PathSep + ref_type.key_n();
 
     for (const AttachmentData& att_d : AttachmentModel::instance().find_ref_data_a(
         ref_type, ref_id
@@ -578,7 +578,7 @@ bool mmAttachmentManage::RelocateAllAttachments(
     RefTypeN new_ref_type, int64 new_ref_id
 ) {
     auto att_a = AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(old_ref_type.name_n()),
+        AttachmentCol::REFTYPE(old_ref_type.key_n()),
         AttachmentCol::REFID(old_ref_id)
     );
 
@@ -587,16 +587,16 @@ bool mmAttachmentManage::RelocateAllAttachments(
 
     const wxString old_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + old_ref_type.name_n() + m_PathSep;
+    ) + old_ref_type.key_n() + m_PathSep;
     const wxString new_folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + new_ref_type.name_n() + m_PathSep;
+    ) + new_ref_type.key_n() + m_PathSep;
 
     for (auto& att_d : att_a) {
         wxString newFileName = att_d.m_filename;
         newFileName.Replace(
-            att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
-            new_ref_type.name_n() + "_" + wxString::Format("%lld", new_ref_id)
+            att_d.m_ref_type_n.key_n() + "_" + wxString::Format("%lld", att_d.m_ref_id),
+            new_ref_type.key_n() + "_" + wxString::Format("%lld", new_ref_id)
         );
         wxRenameFile(
             old_folder + att_d.m_filename,
@@ -623,16 +623,16 @@ bool mmAttachmentManage::CloneAllAttachments(
 ) {
     const wxString folder = mmex::getPathAttachment(
         mmAttachmentManage::InfotablePathSetting()
-    ) + ref_type.name_n() + m_PathSep;
+    ) + ref_type.key_n() + m_PathSep;
 
     for (auto& src_att_d : AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(ref_type.name_n()),
+        AttachmentCol::REFTYPE(ref_type.key_n()),
         AttachmentCol::REFID(src_ref_id)
     )) {
         wxString dst_filename = src_att_d.m_filename;
         dst_filename.Replace(
-            src_att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", src_att_d.m_ref_id),
-            src_att_d.m_ref_type_n.name_n() + "_" + wxString::Format("%lld", dst_ref_id)
+            src_att_d.m_ref_type_n.key_n() + "_" + wxString::Format("%lld", src_att_d.m_ref_id),
+            src_att_d.m_ref_type_n.key_n() + "_" + wxString::Format("%lld", dst_ref_id)
         );
         wxCopyFile(folder + src_att_d.m_filename, folder + dst_filename);
         AttachmentData new_att_d = AttachmentData();
@@ -662,7 +662,7 @@ void mmAttachmentManage::OpenAttachmentFromPanelIcon(
         );
         wxString file_path = mmex::getPathAttachment(
             mmAttachmentManage::InfotablePathSetting()
-        ) + att_a[0].m_ref_type_n.name_n() + m_PathSep + att_a[0].m_filename;
+        ) + att_a[0].m_ref_type_n.key_n() + m_PathSep + att_a[0].m_filename;
         mmAttachmentManage::OpenAttachment(file_path);
     }
     else {

--- a/src/dialog/FieldDialog.cpp
+++ b/src/dialog/FieldDialog.cpp
@@ -128,11 +128,8 @@ void FieldDialog::CreateControls()
     for (int type_id = 0; type_id < RefTypeN::size; ++type_id) {
         if (RefTypeN::field_id_n(type_id) != type_id)
             continue;
-        wxString type_name = RefTypeN(type_id).name_n();
-        m_itemReference->Append(
-            wxGetTranslation(type_name),
-            new wxStringClientData(type_name)
-        );
+        wxString name = RefTypeN(type_id).name_n();
+        m_itemReference->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     mmToolTip(m_itemReference, _t("Select the item that the custom field is associated with"));
     itemFlexGridSizer6->Add(m_itemReference, g_flagsExpand);
@@ -148,11 +145,8 @@ void FieldDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(itemPanel5, wxID_STATIC, _t("Field Type")), g_flagsH);
     m_itemType = new wxChoice(itemPanel5, wxID_HIGHEST);
     for (int type_id = 0; type_id < FieldTypeN::size; ++type_id) {
-        wxString type_name = FieldTypeN(type_id).name_n();
-        m_itemType->Append(
-            wxGetTranslation(type_name),
-            new wxStringClientData(type_name)
-        );
+        wxString name = FieldTypeN(type_id).name_n();
+        m_itemType->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     mmToolTip(m_itemType, _t("Select the custom field type"));
     itemFlexGridSizer6->Add(m_itemType, g_flagsExpand);

--- a/src/dialog/FieldValueDialog.cpp
+++ b/src/dialog/FieldValueDialog.cpp
@@ -49,7 +49,7 @@ FieldValueDialog::FieldValueDialog(
 {
     m_dialog = dialog;
     m_field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(RefTypeN::field_ref_type_n(m_ref_type).name_n())
+        FieldCol::REFTYPE(RefTypeN::field_ref_type_n(m_ref_type).key_n())
     );
     std::sort(m_field_a.begin(), m_field_a.end(), FieldData::SorterByDESCRIPTION());
     m_data_changed.clear();
@@ -109,11 +109,14 @@ bool FieldValueDialog::FillCustomFields(wxBoxSizer* box_sizer)
         wxWindowID controlID = GetBaseID() + field_index++ * FIELDMULTIPLIER;
         wxWindowID labelID = controlID + CONTROLOFFSET;
 
+        // TODO: field_d.m_type_n: use translated name_n() instead of key_n()
         wxCheckBox* Description = new wxCheckBox(
             scrolled_window,
-            labelID, field_d.m_description,
+            labelID,
+            field_d.m_description,
             wxDefaultPosition, wxDefaultSize, wxCHK_2STATE,
-            wxDefaultValidator, field_d.m_type_n.name_n()
+            wxDefaultValidator,
+            field_d.m_type_n.key_n()
         );
         Description->Connect(labelID, wxEVT_CHECKBOX,
             wxCommandEventHandler(FieldValueDialog::OnCheckBoxActivated), nullptr, this
@@ -343,8 +346,8 @@ void FieldValueDialog::OnMultiChoice(wxCommandEvent& event)
     const auto& name = button->GetName();
 
     FieldModel::DataA field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(m_ref_type.name_n()),
-        FieldCol::TYPE(FieldTypeN(FieldTypeN::e_multi_choice).name_n()),
+        FieldCol::REFTYPE(m_ref_type.key_n()),
+        FieldCol::TYPE(FieldTypeN(FieldTypeN::e_multi_choice).key_n()),
         FieldCol::DESCRIPTION(name)
     );
     wxArrayString all_choices = FieldModel::getChoices(field_a.begin()->m_properties);
@@ -533,7 +536,7 @@ bool FieldValueDialog::SaveCustomValues(RefTypeN ref_type, int64 ref_id)
             fv_d.m_content  = data;
             wxLogDebug("Control:%i Type:%s Value:%s",
                 controlID,
-                field_d.m_type_n.name_n(),
+                field_d.m_type_n.key_n(),
                 data
             );
 
@@ -665,7 +668,7 @@ int FieldValueDialog::GetWidgetType(wxWindowID controlID) const
 {
     int control_id = (controlID - GetBaseID()) / FIELDMULTIPLIER;
     for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(m_ref_type.name_n())
+        FieldCol::REFTYPE(m_ref_type.key_n())
     )) {
         if (field_d.m_id == m_field_a[control_id].m_id) {
             return field_d.m_type_n.id_n();

--- a/src/dialog/MergeTagDialog.cpp
+++ b/src/dialog/MergeTagDialog.cpp
@@ -197,19 +197,19 @@ void MergeTagDialog::IsOkOk()
         destTagID_ = dst_tag_n->m_id;
 
     int trxs_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.key_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int split_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int bills_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(SchedModel::s_ref_type.key_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
     int bill_split_size = (sourceTagID_ < 0) ? 0 : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.key_n()),
         TagLinkCol::TAGID(sourceTagID_)
     ).size();
 

--- a/src/dialog/SchedDialog.cpp
+++ b/src/dialog/SchedDialog.cpp
@@ -233,11 +233,8 @@ void SchedDialog::dataToControls()
     for (int i = 0; i < TrxType::size; ++i) {
         if (i == TrxType::e_transfer && AccountModel::instance().find_all().size() < 2)
             break;
-        wxString type_name = TrxType(i).name();
-        w_type_choice->Append(
-            wxGetTranslation(type_name),
-            new wxStringClientData(type_name)
-        );
+        wxString name = TrxType(i).name();
+        w_type_choice->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     w_type_choice->SetSelection(TrxType::e_withdrawal);
 
@@ -517,8 +514,8 @@ void SchedDialog::CreateControls()
     w_status_choice = new wxChoice(this, ID_DIALOG_TRANS_STATUS);
 
     for (int i = 0; i < TrxStatus::size; ++i) {
-        wxString status = TrxStatus(i).name();
-        w_status_choice->Append(wxGetTranslation(status), new wxStringClientData(status));
+        wxString name = TrxStatus(i).name();
+        w_status_choice->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     w_status_choice->SetSelection(PrefModel::instance().getTransStatusReconciled());
     mmToolTip(w_status_choice, _t("Specify the status for the transaction"));

--- a/src/dialog/TrxDialog.cpp
+++ b/src/dialog/TrxDialog.cpp
@@ -132,7 +132,7 @@ TrxDialog::TrxDialog(
         for (const auto& tp_d : Journal::split(m_journal_d)) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(split_ref_type.name_n()),
+                TagLinkCol::REFTYPE(split_ref_type.key_n()),
                 TagLinkCol::REFID(tp_d.m_id))
             )
                 tag_id_a.push_back(gl_d.m_tag_id);
@@ -417,7 +417,7 @@ void TrxDialog::dataToControls()
     if (!skip_tag_init_) {
         wxArrayInt64 tag_id_a;
         for (const auto& gl_d : GL.find(
-            TagLinkCol::REFTYPE(m_journal_d.key().ref_type().name_n()),
+            TagLinkCol::REFTYPE(m_journal_d.key().ref_type().key_n()),
             TagLinkCol::REFID(m_journal_d.key().ref_id())
         ))
             tag_id_a.push_back(gl_d.m_tag_id);
@@ -498,8 +498,8 @@ void TrxDialog::CreateControls()
 
     for (int i = 0; i < TrxType::size; ++i) {
         if (i != TrxType::e_transfer || AccountModel::instance().find_all().size() > 1) {
-            wxString type = TrxType(i).name();
-            transaction_type_->Append(wxGetTranslation(type), new wxStringClientData(type));
+            wxString name = TrxType(i).name();
+            transaction_type_->Append(wxGetTranslation(name), new wxStringClientData(name));
         }
     }
 
@@ -597,8 +597,8 @@ void TrxDialog::CreateControls()
     choiceStatus_ = new wxChoice(static_box, ID_DIALOG_TRANS_STATUS);
 
     for (int i = 0; i < TrxStatus::size; ++i) {
-        wxString status = TrxStatus(i).name();
-        choiceStatus_->Append(wxGetTranslation(status), new wxStringClientData(status));
+        wxString name = TrxStatus(i).name();
+        choiceStatus_->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
 
     flex_sizer->Add(new wxStaticText(static_box, wxID_STATIC, _t("Status")), g_flagsH);
@@ -1325,7 +1325,7 @@ void TrxDialog::OnOk(wxCommandEvent& event)
         new_gl_a.push_back(new_gl_d);
     }
     TagLinkModel::instance().update(
-        TrxModel::s_ref_type.name_n(), m_journal_d.m_id,
+        TrxModel::s_ref_type.key_n(), m_journal_d.m_id,
         new_gl_a
     );
 

--- a/src/dialog/TrxFilterDialog.cpp
+++ b/src/dialog/TrxFilterDialog.cpp
@@ -433,7 +433,7 @@ void TrxFilterDialog::mmDoDataToControls(const wxString& json)
     bool is_custom_found = false;
     int field_index = 0;
     for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+        FieldCol::REFTYPE(TrxModel::s_ref_type.key_n())
     )) {
         const auto entry = wxString::Format("CUSTOM%lld", field_d.m_id);
         if (j_doc.HasMember(entry.c_str())) {
@@ -1286,14 +1286,13 @@ bool TrxFilterDialog::mmIsStatusMatches(const wxString& itemStatus) const
 }
 
 bool TrxFilterDialog::mmIsTypeMaches(
-    const wxString& typeState,
+    const TrxType trx_type,
     int64 accountid,
     int64 toaccountid
 ) const
 {
-    TrxType type = TrxType(typeState);
     bool result = false;
-    if (type.id() == TrxType::e_transfer && w_transferTo_cb->GetValue() && (
+    if (trx_type.id() == TrxType::e_transfer && w_transferTo_cb->GetValue() && (
         !mmIsAccountChecked() ||
         std::find(m_selected_accounts_id.begin(), m_selected_accounts_id.end(),
             accountid
@@ -1301,7 +1300,7 @@ bool TrxFilterDialog::mmIsTypeMaches(
     )) {
         result = true;
     }
-    else if (type.id() == TrxType::e_transfer && w_transferFrom_cb->GetValue() && (
+    else if (trx_type.id() == TrxType::e_transfer && w_transferFrom_cb->GetValue() && (
         !mmIsAccountChecked() ||
         std::find(m_selected_accounts_id.begin(), m_selected_accounts_id.end(),
             toaccountid
@@ -1309,10 +1308,10 @@ bool TrxFilterDialog::mmIsTypeMaches(
     )) {
         result = true;
     }
-    else if (type.id() == TrxType::e_withdrawal && w_withdrawal_cb->IsChecked()) {
+    else if (trx_type.id() == TrxType::e_withdrawal && w_withdrawal_cb->IsChecked()) {
         result = true;
     }
-    else if (type.id() == TrxType::e_deposit && w_deposit_cb->IsChecked()) {
+    else if (trx_type.id() == TrxType::e_deposit && w_deposit_cb->IsChecked()) {
         result = true;
     }
 
@@ -1507,7 +1506,7 @@ bool TrxFilterDialog::mmIsRecordMatches(const DATA& tran, bool mergeSplitTags)
         ok = false;
     else if (mmIsStatusChecked() && !mmIsStatusMatches(tran.m_status.key()))
         ok = false;
-    else if (mmIsTypeChecked() && !mmIsTypeMaches(tran.m_type.name(), tran.m_account_id, tran.m_to_account_id_n))
+    else if (mmIsTypeChecked() && !mmIsTypeMaches(tran.m_type, tran.m_account_id, tran.m_to_account_id_n))
         ok = false;
     else if (mmIsAmountRangeMinChecked() && mmGetAmountMin() > tran.m_amount)
         ok = false;
@@ -1523,13 +1522,13 @@ bool TrxFilterDialog::mmIsRecordMatches(const DATA& tran, bool mergeSplitTags)
     else if (mmIsCustomFieldChecked() && !mmIsCustomFieldMatches(tran.m_id))
         ok = false;
     else if (mmIsTagsChecked()) {
-        RefTypeN refType;
+        RefTypeN ref_type;
         // Check the Data type to determine the tag RefType
         if (typeid(tran).hash_code() == typeid(TrxData).hash_code())
-            refType = TrxModel::s_ref_type;
+            ref_type = TrxModel::s_ref_type;
         else if (typeid(tran).hash_code() == typeid(SchedData).hash_code())
-            refType = SchedModel::s_ref_type;
-        if (!mmIsTagMatches(refType, tran.m_id, mergeSplitTags))
+            ref_type = SchedModel::s_ref_type;
+        if (!mmIsTagMatches(ref_type, tran.m_id, mergeSplitTags))
             ok = false;
     }
     return ok;
@@ -1538,16 +1537,16 @@ bool TrxFilterDialog::mmIsRecordMatches(const DATA& tran, bool mergeSplitTags)
 template <class MODEL, class DATA>
 bool TrxFilterDialog::mmIsSplitRecordMatches(const DATA& split_d)
 {
-    RefTypeN refType;
+    RefTypeN ref_type;
 
     if (typeid(split_d).hash_code() == typeid(TrxSplitData).hash_code()) {
-        refType = TrxSplitModel::s_ref_type;
+        ref_type = TrxSplitModel::s_ref_type;
     }
     else if (typeid(split_d).hash_code() == typeid(SchedSplitData).hash_code()) {
-        refType = SchedSplitModel::s_ref_type;
+        ref_type = SchedSplitModel::s_ref_type;
     }
 
-    if (mmIsTagsChecked() && !mmIsTagMatches(refType, split_d.m_id))
+    if (mmIsTagsChecked() && !mmIsTagMatches(ref_type, split_d.m_id))
         return false;
 
     return true;

--- a/src/dialog/TrxFilterDialog.h
+++ b/src/dialog/TrxFilterDialog.h
@@ -230,7 +230,7 @@ private:
     bool mmIsStatusMatches(const wxString& itemStatus) const;
 
     bool mmIsTypeChecked() const;
-    bool mmIsTypeMaches(const wxString& typeState, int64 accountid, int64 toaccountid) const;
+    bool mmIsTypeMaches(const TrxType trx_type, int64 accountid, int64 toaccountid) const;
     bool mmIsPayeeChecked() const;
     bool mmIsNumberChecked() const;
     bool mmIsNotesChecked() const;

--- a/src/dialog/TrxLinkDialog.cpp
+++ b/src/dialog/TrxLinkDialog.cpp
@@ -66,7 +66,7 @@ TrxLinkDialog::TrxLinkDialog(
         )) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
                 tag_id_a.push_back(gl_d.m_tag_id);
@@ -175,8 +175,8 @@ bool TrxLinkDialog::Create(
         , wxDefaultPosition, std_half_size);
 
     for (int i = 0; i < TrxStatus::size; ++i) {
-        wxString status = TrxStatus(i).name();
-        m_status_selector->Append(wxGetTranslation(status), new wxStringClientData(status));
+        wxString name = TrxStatus(i).name();
+        m_status_selector->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
 
     m_status_selector->SetSelection(TrxStatus::e_reconciled);

--- a/src/dialog/TrxShareDialog.cpp
+++ b/src/dialog/TrxShareDialog.cpp
@@ -95,7 +95,7 @@ TrxShareDialog::TrxShareDialog(
             )) {
                 wxArrayInt64 tag_id_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+                    TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
                     TagLinkCol::REFID(tp_d.m_id)
                 )) {
                     tag_id_a.push_back(gl_d.m_tag_id);
@@ -113,7 +113,7 @@ TrxShareDialog::TrxShareDialog(
         )) {
             wxArrayInt64 tag_id_a;
             for (const auto& gl_d : TagLinkModel::instance().find(
-                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+                TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
                 TagLinkCol::REFID(tp_d.m_id)
             )) {
                 tag_id_a.push_back(gl_d.m_tag_id);

--- a/src/dialog/TrxUpdateDialog.cpp
+++ b/src/dialog/TrxUpdateDialog.cpp
@@ -160,8 +160,8 @@ void TrxUpdateDialog::CreateControls()
     w_status_choice = new wxChoice(this, wxID_ANY
         , wxDefaultPosition, wxDefaultSize);
     for (int i = 0; i < TrxStatus::size; ++i) {
-        wxString status = TrxStatus(i).name();
-        w_status_choice->Append(wxGetTranslation(status), new wxStringClientData(status));
+        wxString name = TrxStatus(i).name();
+        w_status_choice->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
 
     w_status_choice->Enable(false);
@@ -178,8 +178,8 @@ void TrxUpdateDialog::CreateControls()
         , wxDefaultPosition, wxDefaultSize);
     for (int i = 0; i < TrxType::size; ++i) {
         if (!(m_hasSplits && i == TrxType::e_transfer)) {
-            wxString type = TrxType(i).name();
-            w_type_choice->Append(wxGetTranslation(type), new wxStringClientData(type));
+            wxString name = TrxType(i).name();
+            w_type_choice->Append(wxGetTranslation(name), new wxStringClientData(name));
         }
     }
     w_type_choice->Enable(false);
@@ -474,7 +474,7 @@ void TrxUpdateDialog::OnOk(wxCommandEvent& WXUNUSED(event))
             if (tag_append_checkbox_->IsChecked()) {
                 // Since we are appending, start with the existing tags
                 gl_a = TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+                    TagLinkCol::REFTYPE(TrxModel::s_ref_type.key_n()),
                     TagLinkCol::REFID(trx_n->m_id)
                 );
                 // Remove existing tags from the new list to avoid duplicates

--- a/src/import_export/export.cpp
+++ b/src/import_export/export.cpp
@@ -88,7 +88,7 @@ const wxString mmExportTransaction::getTransactionCSV(
             buffer << inQuotes(wxString::Format("%lld", trx_dx.m_id), delimiter) << delimiter;
             buffer << inQuotes(mmGetDateTimeForDisplay(trx_dx.m_isoDateTime(), dateMask), delimiter) << delimiter;
             buffer << inQuotes(trx_dx.m_status.key(), delimiter) << delimiter;
-            buffer << inQuotes(trx_dx.m_type.name(), delimiter) << delimiter;
+            buffer << inQuotes(trx_dx.m_type.key(), delimiter) << delimiter;
 
             buffer << inQuotes(acc_in->m_name, delimiter) << delimiter;
 
@@ -107,7 +107,7 @@ const wxString mmExportTransaction::getTransactionCSV(
         buffer << inQuotes(wxString::Format("%lld", trx_dx.m_id), delimiter) << delimiter;
         buffer << inQuotes(mmGetDateTimeForDisplay(trx_dx.m_isoDateTime(), dateMask), delimiter) << delimiter;
         buffer << inQuotes(trx_dx.m_status.key(), delimiter) << delimiter;
-        buffer << inQuotes(trx_dx.m_type.name(), delimiter) << delimiter;
+        buffer << inQuotes(trx_dx.m_type.key(), delimiter) << delimiter;
 
         buffer << inQuotes(account, delimiter) << delimiter;
 
@@ -196,7 +196,7 @@ const wxString mmExportTransaction::getTransactionQIF(
         wxString split_categ = CategoryModel::instance().get_id_fullname(tp_d.m_category_id, ":");
         split_categ.Replace("/", "-");
         TagLinkModel::DataA splitTags = TagLinkModel::instance().find(
-            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
             TagLinkCol::REFID(tp_d.m_id)
         );
         if (!splitTags.empty()) {
@@ -465,7 +465,7 @@ void mmExportTransaction::getTransactionJSON(
         FieldValueModel::REFTYPEID(TrxModel::s_ref_type, trx_dx.m_id)
     );
     auto f = FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+        FieldCol::REFTYPE(TrxModel::s_ref_type.key_n())
     );
     if (!fv_a.empty()) {
         json_writer.Key("CUSTOM_FIELDS");
@@ -473,7 +473,7 @@ void mmExportTransaction::getTransactionJSON(
         for (const auto& fv_d : fv_a) {
             // TODO: field_d.m_id is equal to fv_d.m_field_id
             auto field_a = FieldModel::instance().find(
-                FieldCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+                FieldCol::REFTYPE(TrxModel::s_ref_type.key_n()),
                 FieldCol::FIELDID(fv_d.m_field_id)
             );
             for (const auto& field_d : field_a) {
@@ -505,7 +505,7 @@ void mmExportTransaction::getAttachmentsJSON(
     json_writer.Key("FULL_PATH");
     json_writer.String(AttachmentsFolder.utf8_str());
     json_writer.Key("REFTYPE");
-    json_writer.String(ref_type.name_n().utf8_str());
+    json_writer.String(ref_type.key_n().utf8_str());
 
     json_writer.Key("ATTACHMENTS_DATA");
     json_writer.StartArray();
@@ -558,7 +558,7 @@ void mmExportTransaction::getCustomFieldsJSON(
 
     //Settings
     FieldModel::DataA field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+        FieldCol::REFTYPE(TrxModel::s_ref_type.key_n())
     );
 
     if (!field_a.empty()) {
@@ -576,11 +576,11 @@ void mmExportTransaction::getCustomFieldsJSON(
             json_writer.Key("ID");
             json_writer.Int64(field_d.m_id.GetValue());
             json_writer.Key("REFTYPE");
-            json_writer.String(field_d.m_ref_type.name_n().utf8_str());
+            json_writer.String(field_d.m_ref_type.key_n().utf8_str());
             json_writer.Key("DESCRIPTION");
             json_writer.String(field_d.m_description.utf8_str());
             json_writer.Key("TYPE");
-            json_writer.String(field_d.m_type_n.name_n().utf8_str());
+            json_writer.String(field_d.m_type_n.key_n().utf8_str());
             json_writer.Key("PROPERTIES");
             json_writer.RawValue(field_d.m_properties.utf8_str(), field_d.m_properties.utf8_str().length(), rapidjson::Type::kObjectType);
             json_writer.EndObject();

--- a/src/import_export/ofx_import_gui.cpp
+++ b/src/import_export/ofx_import_gui.cpp
@@ -53,21 +53,21 @@ EVT_BUTTON(wxID_OK, mmOFXImportSummaryDialog::OnOK)
 wxEND_EVENT_TABLE()
 
 wxBEGIN_EVENT_TABLE(mmPayeeSelectionDialog, wxDialog)
-EVT_RADIOBUTTON(ID_USE_EXISTING, mmPayeeSelectionDialog::OnUseExistingPayee)
-EVT_RADIOBUTTON(ID_CREATE_NEW, mmPayeeSelectionDialog::OnCreateNewPayee)
-EVT_CHECKBOX(wxID_ANY, mmPayeeSelectionDialog::OnUpdateRegex)
-EVT_BUTTON(wxID_OK, mmPayeeSelectionDialog::OnOK)
-EVT_BUTTON(wxID_CANCEL, mmPayeeSelectionDialog::OnCancel)
-EVT_CHOICE(wxID_ANY, mmPayeeSelectionDialog::OnPayeeChoice)
-EVT_BUTTON(ID_TITLE_CASE, mmPayeeSelectionDialog::OnTitleCase)
-EVT_GRID_LABEL_LEFT_CLICK(mmPayeeSelectionDialog::OnGridLabelLeftClick)
-EVT_BUTTON(ID_UPDATE_CATEGORY, mmPayeeSelectionDialog::OnUpdateCategoryToggle)
-EVT_BUTTON(ID_INSERT_ROW, mmPayeeSelectionDialog::OnInsertRow)
-EVT_BUTTON(ID_DELETE_ROW, mmPayeeSelectionDialog::OnDeleteRow)
-EVT_CHOICE(wxID_ANY, mmPayeeSelectionDialog::OnCategorySelection)
-EVT_SET_FOCUS(mmPayeeSelectionDialog::OnCategoryFocus)
-EVT_INIT_DIALOG(mmPayeeSelectionDialog::OnInitDialog)
-EVT_BUTTON(wxID_CANCEL, mmPayeeSelectionDialog::OnCancel)
+    EVT_RADIOBUTTON(ID_USE_EXISTING, mmPayeeSelectionDialog::OnUseExistingPayee)
+    EVT_RADIOBUTTON(ID_CREATE_NEW,   mmPayeeSelectionDialog::OnCreateNewPayee)
+    EVT_CHECKBOX(wxID_ANY,           mmPayeeSelectionDialog::OnUpdateRegex)
+    EVT_BUTTON(wxID_OK,              mmPayeeSelectionDialog::OnOK)
+    EVT_BUTTON(wxID_CANCEL,          mmPayeeSelectionDialog::OnCancel)
+    EVT_CHOICE(wxID_ANY,             mmPayeeSelectionDialog::OnPayeeChoice)
+    EVT_BUTTON(ID_TITLE_CASE,        mmPayeeSelectionDialog::OnTitleCase)
+    EVT_GRID_LABEL_LEFT_CLICK(       mmPayeeSelectionDialog::OnGridLabelLeftClick)
+    EVT_BUTTON(ID_UPDATE_CATEGORY,   mmPayeeSelectionDialog::OnUpdateCategoryToggle)
+    EVT_BUTTON(ID_INSERT_ROW,        mmPayeeSelectionDialog::OnInsertRow)
+    EVT_BUTTON(ID_DELETE_ROW,        mmPayeeSelectionDialog::OnDeleteRow)
+    EVT_CHOICE(wxID_ANY,             mmPayeeSelectionDialog::OnCategorySelection)
+    EVT_SET_FOCUS(                   mmPayeeSelectionDialog::OnCategoryFocus)
+    EVT_INIT_DIALOG(                 mmPayeeSelectionDialog::OnInitDialog)
+    EVT_BUTTON(wxID_CANCEL,          mmPayeeSelectionDialog::OnCancel)
 wxEND_EVENT_TABLE()
 
 wxString DecodeHTMLEntities(const wxString& input)
@@ -563,8 +563,13 @@ void mmPayeeSelectionDialog::LoadRegexPatterns(const wxString& payeeName)
     regexGrid_->SetCellValue(1, 0, "");
 }
 
-void mmPayeeSelectionDialog::AddCategoryToChoice(wxChoice* choice, long long categId, const std::map<long long, CategoryData>& catMap, int level)
-{
+void mmPayeeSelectionDialog::AddCategoryToChoice(
+    wxChoice* choice,
+    long long categId,
+    const std::map<long long,
+    CategoryData>& catMap,
+    int level
+) {
     auto it = catMap.find(categId);
     if (it == catMap.end())
         return;
@@ -585,35 +590,83 @@ void mmPayeeSelectionDialog::AddCategoryToChoice(wxChoice* choice, long long cat
     }
 }
 
-mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString& memo, const wxString& suggestedPayeeName, const wxString& fitid,
-                                               const wxString& date, const wxString& amount, const wxString& transType, int currentTransaction,
-                                               int newTransactions, wxLongLong importStartTime, double matchConfidence, const wxString& matchMethod,
-                                               int totalTransactions)
-    : wxDialog(parent, wxID_ANY, _("Payee Confirmation Required"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
-      matchConfidence_(matchConfidence), matchMethod_(matchMethod), confidenceLabel_(nullptr), suggestedPayeeName_(suggestedPayeeName),
-      useExistingRadio_(nullptr), createNewRadio_(nullptr), payeeChoice_(nullptr), newPayeeTextCtrl_(nullptr), titleCaseButton_(nullptr),
-      categoryChoice_(nullptr), updateRegexCheckBox_(nullptr), regexGrid_(nullptr), okButton_(nullptr), updateCategoryButton_(nullptr),
-      insertRowButton_(nullptr), deleteRowButton_(nullptr), existingPayeeLabel_(nullptr), newPayeeLabel_(nullptr), payeeSizer_(nullptr),
-      selectedPayee_(suggestedPayeeName), regexPattern_(memo), shouldUpdateRegex_(false), updatePayeeCategory_(false), memoAdded_(false),
-      initialCategoryId_(-1), currentTransaction_(currentTransaction), newTransactions_(newTransactions), importStartTime_(importStartTime),
-      categoryManuallyChanged_(false), totalTransactions_(totalTransactions), memo_(memo)
+mmPayeeSelectionDialog::mmPayeeSelectionDialog(
+    wxWindow* parent,
+    const wxString& memo,
+    const wxString& suggestedPayeeName,
+    const wxString& fitid,
+    const wxString& date,
+    const wxString& amount,
+    const wxString& transType,
+    int currentTransaction,
+    int newTransactions,
+    wxLongLong importStartTime,
+    double matchConfidence,
+    const wxString& matchMethod,
+    int totalTransactions
+) :
+    wxDialog(parent, wxID_ANY,
+        _("Payee Confirmation Required"),
+        wxDefaultPosition, wxDefaultSize,
+        wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER
+    ),
+    matchConfidence_(matchConfidence),
+    matchMethod_(matchMethod),
+    confidenceLabel_(nullptr),
+    suggestedPayeeName_(suggestedPayeeName),
+    useExistingRadio_(nullptr),
+    createNewRadio_(nullptr),
+    payeeChoice_(nullptr),
+    newPayeeTextCtrl_(nullptr),
+    titleCaseButton_(nullptr),
+    categoryChoice_(nullptr),
+    updateRegexCheckBox_(nullptr),
+    regexGrid_(nullptr),
+    okButton_(nullptr),
+    updateCategoryButton_(nullptr),
+    insertRowButton_(nullptr),
+    deleteRowButton_(nullptr),
+    existingPayeeLabel_(nullptr),
+    newPayeeLabel_(nullptr),
+    payeeSizer_(nullptr),
+    selectedPayee_(suggestedPayeeName),
+    regexPattern_(memo),
+    shouldUpdateRegex_(false),
+    updatePayeeCategory_(false),
+    memoAdded_(false),
+    initialCategoryId_(-1),
+    currentTransaction_(currentTransaction),
+    newTransactions_(newTransactions),
+    importStartTime_(importStartTime),
+    categoryManuallyChanged_(false),
+    totalTransactions_(totalTransactions),
+    memo_(memo)
 {
-    wxLogDebug("PayeeSelectionDialog: Initialized with current=%d, new=%d, total=%d", currentTransaction_, newTransactions_, totalTransactions_);
+    wxLogDebug("PayeeSelectionDialog: Initialized with current=%d, new=%d, total=%d",
+        currentTransaction_, newTransactions_, totalTransactions_
+    );
 
     wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
     // Progress and ETA
     wxLongLong currentTime = wxGetUTCTimeMillis();
     double elapsedTimeSec = (currentTime - importStartTime_).ToDouble() / 1000.0;
-    double avgTimePerTrans = (currentTransaction_ > 0) ? elapsedTimeSec / currentTransaction_ : 0.0;
+    double avgTimePerTrans = (currentTransaction_ > 0) ?
+        elapsedTimeSec / currentTransaction_
+        : 0.0;
     int remainingTrans = totalTransactions_ - currentTransaction_;
     double estimatedTimeSec = avgTimePerTrans * remainingTrans;
     double estimatedTimeMin = estimatedTimeSec / 60.0;
 
-    wxStaticText* progressLabel = new wxStaticText(
-        this, wxID_ANY, wxString::Format(_("Transaction %1$d of %2$d (%3$d total in file)"), currentTransaction_ + 1, newTransactions_, totalTransactions_));
+    wxStaticText* progressLabel = new wxStaticText(this, wxID_ANY,
+        wxString::Format(_("Transaction %1$d of %2$d (%3$d total in file)"),
+            currentTransaction_ + 1, newTransactions_, totalTransactions_
+        )
+    );
     mainSizer->Add(progressLabel, 0, wxALL, 5);
-    wxString etaText = (avgTimePerTrans > 0) ? wxString::Format(_("Estimated completion time: %.1f minutes"), estimatedTimeMin) : _tu("Estimating time…");
+    wxString etaText = (avgTimePerTrans > 0)
+        ? wxString::Format(_("Estimated completion time: %.1f minutes"), estimatedTimeMin)
+        : _tu("Estimating time…");
     mainSizer->Add(new wxStaticText(this, wxID_ANY, etaText), 0, wxALL, 5);
 
     // Transaction info
@@ -637,14 +690,13 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
 
     // Show original memo and match result
     mainSizer->Add(new wxStaticText(this, wxID_ANY, wxString::Format(_("Memo: %s"), memo_)), 0, wxALL, 5);
-    if (matchMethod_ == "None" || suggestedPayeeName_ == memo_)
-    {
+    if (matchMethod_ == "None" || suggestedPayeeName_ == memo_) {
         mainSizer->Add(new wxStaticText(this, wxID_ANY, _("No matching payee found.")), 0, wxALL, 5);
         confidenceLabel_ = new wxStaticText(this, wxID_ANY, wxString::Format(_("Match Confidence: %.1f%% (%s)"), matchConfidence_, matchMethod_));
         mainSizer->Add(confidenceLabel_, 0, wxALL, 5);
     }
-    else if (matchConfidence_ > 50.0) // Show suggested payee and confidence only if confidence > 50%
-    {
+    // Show suggested payee and confidence only if confidence > 50%
+    else if (matchConfidence_ > 50.0) {
         mainSizer->Add(new wxStaticText(this, wxID_ANY, wxString::Format(_tu("Suggested Payee: “%s”"), suggestedPayeeName_)), 0, wxALL, 5);
         confidenceLabel_ = new wxStaticText(this, wxID_ANY, wxString::Format(_("Match Confidence: %.1f%% (%s)"), matchConfidence_, matchMethod_));
         mainSizer->Add(confidenceLabel_, 0, wxALL, 5);
@@ -665,9 +717,15 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
     }
     // If confidence <= 50%, neither suggested payee nor confidence is shown
 
-    mainSizer->Add(new wxStaticText(this, wxID_ANY, _("Do you want to use an existing payee or create a new one?")), 0, wxALL, 5);
+    mainSizer->Add(new wxStaticText(this, wxID_ANY,
+        _("Do you want to use an existing payee or create a new one?")
+    ), 0, wxALL, 5);
 
-    useExistingRadio_ = new wxRadioButton(this, ID_USE_EXISTING, _("Use Existing Payee"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+    useExistingRadio_ = new wxRadioButton(this, ID_USE_EXISTING,
+        _("Use Existing Payee"),
+        wxDefaultPosition, wxDefaultSize,
+        wxRB_GROUP
+    );
     createNewRadio_ = new wxRadioButton(this, ID_CREATE_NEW, _("Create New Payee"));
     useExistingRadio_->SetValue(true);
     mainSizer->Add(useExistingRadio_, 0, wxALL, 5);
@@ -683,23 +741,23 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
     payeeChoice_->Append("", new wxInt64ClientData(-1));
     int suggestedPayeeIndex = wxNOT_FOUND;
 
-    for (size_t i = 0; i < payees.size(); ++i)
-    {
-        int index = payeeChoice_->Append(payees[i].m_name, new wxInt64ClientData(payees[i].m_id.GetValue()));
+    for (size_t i = 0; i < payees.size(); ++i) {
+        int index = payeeChoice_->Append(
+            payees[i].m_name,
+            new wxInt64ClientData(payees[i].m_id.GetValue())
+        );
         // Only pre-select the suggested payee if confidence > 50%
         if (matchConfidence_ > 50.0 && payees[i].m_name.IsSameAs(suggestedPayeeName_, false))
             suggestedPayeeIndex = index;
     }
 
     // Set selection only if we have a suggested payee with confidence > 50%
-    if (suggestedPayeeIndex != wxNOT_FOUND)
-    {
+    if (suggestedPayeeIndex != wxNOT_FOUND) {
         payeeChoice_->SetSelection(suggestedPayeeIndex);
         wxLogDebug("PayeeSelectionDialog: Pre-selected suggested payee '%s' at index %d (confidence %.1f%%)", suggestedPayeeName_, suggestedPayeeIndex,
                    matchConfidence_);
     }
-    else
-    {
+    else {
         payeeChoice_->SetSelection(0); // Select the blank entry by default
         wxLogDebug("PayeeSelectionDialog: No pre-selection (confidence %.1f%% ≤ 50%% or no match), defaulting to blank entry", matchConfidence_);
     }
@@ -721,12 +779,10 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
     categoryChoice_->Append(_("Uncategorized"), new wxStringClientData("-1"));
     CategoryModel::DataA categories = CategoryModel::instance().find_all(CategoryCol::COL_ID_CATEGNAME);
     categoryMap.clear();
-    for (const auto& cat : categories)
-    {
+    for (const auto& cat : categories) {
         categoryMap[cat.m_id.GetValue()] = cat;
     }
-    for (const auto& cat : categories)
-    {
+    for (const auto& cat : categories) {
         if (cat.m_parent_id_n.GetValue() == -1)
             AddCategoryToChoice(categoryChoice_, cat.m_id.GetValue(), categoryMap, 0);
     }
@@ -782,21 +838,19 @@ mmPayeeSelectionDialog::mmPayeeSelectionDialog(wxWindow* parent, const wxString&
     categoryChoice_->Bind(wxEVT_CHOICE, &mmPayeeSelectionDialog::OnCategorySelection, this);
     categoryChoice_->Bind(wxEVT_SET_FOCUS, &mmPayeeSelectionDialog::OnCategoryFocus, this);
 
-    regexGrid_->Bind(wxEVT_SIZE,
-                     [this](wxSizeEvent& event)
-                     {
-                         int dialogWidth = GetClientSize().GetWidth();
-                         int scrollbarWidth = wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
-                         int padding = (10 * 2 + 2 * 2);
-                         int availableWidth = dialogWidth - padding - scrollbarWidth - 50;
+    regexGrid_->Bind(wxEVT_SIZE, [this](wxSizeEvent& event) {
+        int dialogWidth = GetClientSize().GetWidth();
+        int scrollbarWidth = wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+        int padding = (10 * 2 + 2 * 2);
+        int availableWidth = dialogWidth - padding - scrollbarWidth - 50;
 
-                         if (availableWidth > 50)
-                             regexGrid_->SetColSize(0, availableWidth);
-                         else
-                             regexGrid_->SetColSize(0, 50);
-                         regexGrid_->ForceRefresh();
-                         event.Skip();
-                     });
+        if (availableWidth > 50)
+            regexGrid_->SetColSize(0, availableWidth);
+        else
+            regexGrid_->SetColSize(0, 50);
+        regexGrid_->ForceRefresh();
+        event.Skip();
+    });
 
     int dialogWidth = GetClientSize().GetWidth();
     int scrollbarWidth = wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
@@ -1596,7 +1650,7 @@ bool mmOFXImportDialog::ImportTransactions(wxXmlNode* banktranlist, wxLongLong a
                                 existing_trx_d.m_to_amount = existingAmount;
                             }
                             else {
-                                wxLogWarning("FITID='%s' incompatible (Existing=%s, New=%.2f), skipping", fitid, existing_trx_d.m_type.name(), amount);
+                                wxLogWarning("FITID='%s' incompatible (Existing=%s, New=%.2f), skipping", fitid, existing_trx_d.m_type.key(), amount);
                                 stats.skippedErrors++;
                                 result.imported = false;
                                 result.importedPayee = "TRANSFER ERROR";
@@ -1642,7 +1696,7 @@ bool mmOFXImportDialog::ImportTransactions(wxXmlNode* banktranlist, wxLongLong a
                 ? TrxType::e_deposit
                 : TrxType::e_withdrawal
             );
-            result.transType = new_trx_d.m_type.name();
+            result.transType = new_trx_d.m_type.key();
 
             double matchConfidence = 0.0;
             wxString matchMethod;
@@ -1675,7 +1729,7 @@ bool mmOFXImportDialog::ImportTransactions(wxXmlNode* banktranlist, wxLongLong a
                 mmPayeeSelectionDialog payeeDlg(this,
                     memo, payeeName, fitid, mmDate(date).isoDate(),
                     wxString::Format("%.2f", amount),
-                    new_trx_d.m_type.name(),
+                    new_trx_d.m_type.key(),
                     transactionIndex, newTransactions,
                     importStartTime_, matchConfidence, matchMethod, totalTransactions
                 );

--- a/src/import_export/qif_import_gui.cpp
+++ b/src/import_export/qif_import_gui.cpp
@@ -660,7 +660,7 @@ bool mmQIFImportDialog::completeTransaction(
             else {
                 isTransfer = true;
                 trx[QIF_ID_Category] = _t("Transfer") + (!tags.IsEmpty() ? "/" + tags : "");
-                trx[QIF_ID_TrxType] = TrxType(TrxType::e_transfer).name();
+                trx[QIF_ID_TrxType] = TrxType(TrxType::e_transfer).key();
                 trx[QIF_ID_ToAccountName] = toAccName;
                 trx[QIF_ID_Memo] += (trx[QIF_ID_Memo].empty() ? "" : "\n") + trx[QIF_ID_Payee];
                 if (m_QIFaccounts.find(toAccName) == m_QIFaccounts.end()) {
@@ -701,9 +701,9 @@ bool mmQIFImportDialog::completeTransaction(
     wxString amtStr = (trx.find(QIF_ID_Amount) == trx.end() ? "" : trx[QIF_ID_Amount]);
     if (!isTransfer) {
         if (amtStr.Mid(0, 1) == "-")
-            trx[QIF_ID_TrxType] = TrxType(TrxType::e_withdrawal).name();
+            trx[QIF_ID_TrxType] = TrxType(TrxType::e_withdrawal).key();
         else if (!amtStr.empty())
-            trx[QIF_ID_TrxType] = TrxType(TrxType::e_deposit).name();
+            trx[QIF_ID_TrxType] = TrxType(TrxType::e_deposit).key();
     }
 
     return !amtStr.empty();
@@ -742,13 +742,28 @@ void mmQIFImportDialog::refreshTabs(int tabs)
             }
 
             data.push_back(wxVariant(dateStr));
-            data.push_back(wxVariant(trx.find(QIF_ID_TransNumber) != trx.end() ? trx.at(QIF_ID_TransNumber) : ""));
-            const wxString type = (trx.find(QIF_ID_TrxType) != trx.end() ? trx.at(QIF_ID_TrxType) : "");
-            if (type == TrxType(TrxType::e_transfer).name())
-                data.push_back(wxVariant(trx.find(QIF_ID_ToAccountName) != trx.end() ? trx.at(QIF_ID_ToAccountName) : ""));
+            data.push_back(wxVariant(trx.find(QIF_ID_TransNumber) != trx.end()
+                ? trx.at(QIF_ID_TransNumber)
+                : ""
+            ));
+            const wxString type = (trx.find(QIF_ID_TrxType) != trx.end()
+                ? trx.at(QIF_ID_TrxType)
+                : ""
+            );
+            if (type == TrxType(TrxType::e_transfer).key())
+                data.push_back(wxVariant(trx.find(QIF_ID_ToAccountName) != trx.end()
+                    ? trx.at(QIF_ID_ToAccountName)
+                    : ""
+                ));
             else
-                data.push_back(wxVariant(trx.find(QIF_ID_Payee) != trx.end() ? trx.at(QIF_ID_Payee) : ""));
-            data.push_back(wxVariant(trx.find(QIF_ID_TrxType) != trx.end() ? trx.at(QIF_ID_TrxType) : ""));
+                data.push_back(wxVariant(trx.find(QIF_ID_Payee) != trx.end()
+                    ? trx.at(QIF_ID_Payee)
+                    : ""
+                ));
+            data.push_back(wxVariant(trx.find(QIF_ID_TrxType) != trx.end()
+                ? trx.at(QIF_ID_TrxType)
+                : ""
+            ));
 
             wxString category;
             wxString tags;

--- a/src/import_export/univcsvdialog.cpp
+++ b/src/import_export/univcsvdialog.cpp
@@ -97,7 +97,7 @@ mmUnivCSVDialog::mmUnivCSVDialog(
     m_account_id(account_id),
     m_file_path(file_path),
     decimal_(CurrencyModel::instance().get_base_data_n()->m_decimal_point),
-    depositType_(TrxType(TrxType::e_deposit).name())
+    depositType_(TrxType(TrxType::e_deposit).key())
 {
     CSVFieldName_[UNIV_CSV_ID].first                    = _n("ID");
     CSVFieldName_[UNIV_CSV_DATE].first                  = _n("Date");
@@ -343,7 +343,7 @@ void mmUnivCSVDialog::CreateControls()
 
     //Custom Fields
     FieldModel::DataA field_a = FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+        FieldCol::REFTYPE(TrxModel::s_ref_type.key_n())
     );
     if (!field_a.empty()) {
         std::sort(field_a.begin(), field_a.end(), FieldData::SorterByDESCRIPTION());
@@ -1851,7 +1851,7 @@ void mmUnivCSVDialog::OnExport(wxCommandEvent& WXUNUSED(event))
                             itemType = ITransactionsFile::TYPE_NUMBER;
                             break;
                         case UNIV_CSV_TYPE:
-                            entry = trx_d.m_type.name();
+                            entry = trx_d.m_type.key();
                             break;
                         case UNIV_CSV_ID:
                             entry = wxString::Format("%lld", trx_dx.m_id);
@@ -2238,7 +2238,7 @@ void mmUnivCSVDialog::update_preview()
                                 text << inQuotes(CurrencyModel::instance().toString(account_balance, currency), delimit);
                                 break;
                             case UNIV_CSV_TYPE:
-                                text << trx_d.m_type.name();
+                                text << trx_d.m_type.key();
                                 break;
                             default:
                                 // Custom Fields
@@ -2861,7 +2861,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             }
         ) == csvFieldOrder_.end()) {
             if ((amount > 0.0 && !m_reverce_sign) || (amount <= 0.0 && m_reverce_sign)) {
-                holder.Type = TrxType(TrxType::e_deposit).name();
+                holder.Type = TrxType(TrxType::e_deposit).key();
             }
         }
 
@@ -2970,7 +2970,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = TrxType(TrxType::e_withdrawal).name();
+        holder.Type = TrxType(TrxType::e_withdrawal).key();
         break;
 
     case UNIV_CSV_DEPOSIT:
@@ -2988,7 +2988,7 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
             break;
 
         holder.Amount = fabs(amount);
-        holder.Type = TrxType(TrxType::e_deposit).name();
+        holder.Type = TrxType(TrxType::e_deposit).key();
         break;
 
         // A number of type options are supported to make amount positive
@@ -2996,14 +2996,14 @@ void mmUnivCSVDialog::parseToken(int index, const wxString& orig_token, tran_hol
     case UNIV_CSV_TYPE:
         if (m_choiceAmountFieldSign->GetSelection() == DefindByType) {
             if (depositType_.CmpNoCase(token) == 0) {
-                holder.Type = TrxType(TrxType::e_deposit).name();
+                holder.Type = TrxType(TrxType::e_deposit).key();
                 break;
             }
         }
         else {
             for (const wxString entry : { "debit", "deposit", "+" }) {
                 if (entry.CmpNoCase(token) == 0) {
-                    holder.Type = TrxType(TrxType::e_deposit).name();
+                    holder.Type = TrxType(TrxType::e_deposit).key();
                     break;
                 }
             }
@@ -3226,7 +3226,7 @@ bool mmUnivCSVDialog::validateCustomFieldData(
 
     if (!value.IsEmpty()) {
         const FieldData* field_n = FieldModel::instance().get_id_data_n(fieldId);
-        wxString type_name = field_n->m_type_n.name_n();
+        wxString type_name = wxGetTranslation(field_n->m_type_n.name_n());
         switch (field_n->m_type_n.id_n()) {
         case FieldTypeN::e_integer:
             // Check if string can be read as an integer. Will fail if passed a double.

--- a/src/import_export/univcsvdialog.h
+++ b/src/import_export/univcsvdialog.h
@@ -145,7 +145,7 @@ private:
     struct tran_holder
     {
         wxDateTime Date;
-        wxString Type = TrxType(TrxType::e_withdrawal).name();
+        wxString Type = TrxType(TrxType::e_withdrawal).key();
         wxString Status = TrxStatus(TrxStatus::e_unreconciled).key();
         int64 ToAccountID = -1;
         double ToAmount = 0.0;

--- a/src/import_export/webapp.cpp
+++ b/src/import_export/webapp.cpp
@@ -687,13 +687,13 @@ wxString mmWebApp::downloadAttachment(
 ) {
     const wxString file_ext = wxFileName(attachment_w_name).GetExt().MakeLower();
     const wxString file_name =
-        TrxModel::s_ref_type.name_n() + "_" +
+        TrxModel::s_ref_type.key_n() + "_" +
         wxString::Format("%lld", trx_id) +
         "_Attach" + wxString::Format("%i", attachment_number) +
         "." + file_ext;
     const wxString file_path =
         mmex::getPathAttachment(mmAttachmentManage::InfotablePathSetting()) +
-        TrxModel::s_ref_type.name_n() + wxFileName::GetPathSeparator() +
+        TrxModel::s_ref_type.key_n() + wxFileName::GetPathSeparator() +
         file_name;
 
     CURLcode curlStatus = http_download_file(

--- a/src/manager/FieldManager.cpp
+++ b/src/manager/FieldManager.cpp
@@ -119,7 +119,7 @@ void FieldManager::fillControls()
         wxVector<wxVariant> data;
         if (debug_)
             data.push_back(wxVariant(wxString::Format("%lld", field_d.m_id)));
-        data.push_back(wxVariant(wxGetTranslation(field_d.m_ref_type.name_n())));
+        data.push_back(wxVariant(wxGetTranslation(field_d.m_ref_type.key_n())));
         data.push_back(wxVariant(field_d.m_description));
         data.push_back(wxVariant(wxGetTranslation(field_d.m_type_n.name_n())));
 

--- a/src/manager/TagManager.cpp
+++ b/src/manager/TagManager.cpp
@@ -43,26 +43,26 @@ wxBEGIN_EVENT_TABLE(TagManager, wxDialog)
     EVT_BUTTON(wxID_CANCEL,          TagManager::OnCancel)
 wxEND_EVENT_TABLE()
 
-TagManager::TagManager() : isSelection_(false)
+TagManager::TagManager() :
+    m_is_selection(false)
 {
 }
 
-TagManager::~TagManager()
+TagManager::TagManager(
+    wxWindow* parent_win,
+    bool is_selection,
+    const wxArrayString& selected_tag_a
+) :
+    m_is_selection(is_selection),
+    m_selected_tag_a(selected_tag_a)
 {
-    InfoModel::instance().saveSize("TAG_DIALOG_SIZE", GetSize());
-}
-
-TagManager::TagManager(wxWindow* parent, bool isSelection, const wxArrayString& selectedTags) : isSelection_(isSelection), selectedTags_(selectedTags)
-{
-    this->SetFont(parent->GetFont());
-    Create(parent);
-    if (isSelection_)
-    {
-        for (const auto& tag : selectedTags)
-        {
-            int index = tagListBox_->FindString(tag);
+    this->SetFont(parent_win->GetFont());
+    create(parent_win);
+    if (m_is_selection) {
+        for (const auto& tag : selected_tag_a) {
+            int index = getTagIndex(tag);
             if (index != wxNOT_FOUND)
-                dynamic_cast<wxCheckListBox*>(tagListBox_)->Check(index);
+                dynamic_cast<wxCheckListBox*>(w_tag_list)->Check(index);
         }
     }
 
@@ -70,16 +70,26 @@ TagManager::TagManager(wxWindow* parent, bool isSelection, const wxArrayString& 
     Fit();
 }
 
-bool TagManager::Create(wxWindow* parent, wxWindowID id
-    , const wxString& caption, const wxString& name
-    , const wxPoint& pos, const wxSize& size, long style)
+TagManager::~TagManager()
 {
+    InfoModel::instance().saveSize("TAG_DIALOG_SIZE", GetSize());
+}
+
+bool TagManager::create(
+    wxWindow* parent_win,
+    wxWindowID win_id,
+    const wxString& caption,
+    const wxString& name,
+    const wxPoint& pos,
+    const wxSize& size,
+    long style
+) {
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
-    wxDialog::Create(parent, id, caption, pos, size, style, name);
+    wxDialog::Create(parent_win, win_id, caption, pos, size, style, name);
 
     SetEvtHandlerEnabled(false);
 
-    CreateControls();
+    createControls();
     mmThemeAutoColour(this);
     SetEvtHandlerEnabled(true);
 
@@ -94,30 +104,41 @@ bool TagManager::Create(wxWindow* parent, wxWindowID id
     return true;
 }
 
-void TagManager::CreateControls()
+void TagManager::createControls()
 {
     wxBoxSizer* boxSizer = new wxBoxSizer(wxVERTICAL);
     this->SetSizer(boxSizer);
 
-    //--------------------------
-    for (const auto& tag_d : TagModel::instance().find_all(TagCol::COL_ID_TAGNAME))
-        tagList_.Add(tag_d.m_name);
+    for (const auto& tag_d : TagModel::instance().find_all(
+        TagCol::COL_ID_TAGNAME
+    ))
+        m_tag_a.Add(tag_d.m_name);
 
-    if (!isSelection_)
-        tagListBox_ = new wxListBox(this, wxID_VIEW_LIST, wxDefaultPosition, wxDefaultSize, tagList_, wxLB_EXTENDED | wxLB_SORT);
+    if (!m_is_selection)
+        w_tag_list = new wxListBox(this,
+            wxID_VIEW_LIST,
+            wxDefaultPosition, wxDefaultSize,
+            m_tag_a,
+            wxLB_EXTENDED | wxLB_SORT
+        );
     else
-        tagListBox_ = new wxCheckListBox(this, wxID_VIEW_LIST, wxDefaultPosition, wxDefaultSize, tagList_, wxLB_EXTENDED | wxLB_SORT);
+        w_tag_list = new wxCheckListBox(this,
+            wxID_VIEW_LIST,
+            wxDefaultPosition, wxDefaultSize,
+            m_tag_a,
+            wxLB_EXTENDED | wxLB_SORT
+        );
 
-    boxSizer->Add(tagListBox_, g_flagsExpand);
+    boxSizer->Add(w_tag_list, g_flagsExpand);
 
     wxPanel* searchPanel = new wxPanel(this, wxID_ANY);
     boxSizer->Add(searchPanel, wxSizerFlags(g_flagsExpand).Proportion(0));
     wxBoxSizer* search_sizer = new wxBoxSizer(wxHORIZONTAL);
     searchPanel->SetSizer(search_sizer);
 
-    searchCtrl_ = new wxSearchCtrl(searchPanel, wxID_FIND);
+    w_search_ctrl = new wxSearchCtrl(searchPanel, wxID_FIND);
     search_sizer->Add(new wxStaticText(searchPanel, wxID_STATIC, _t("Search")), g_flagsH);
-    search_sizer->Add(searchCtrl_, g_flagsExpand);
+    search_sizer->Add(w_search_ctrl, g_flagsExpand);
 
     wxPanel* buttonsPanel = new wxPanel(this, wxID_ANY);
     boxSizer->Add(buttonsPanel, wxSizerFlags(g_flagsV).Center());
@@ -127,67 +148,76 @@ void TagManager::CreateControls()
     wxStdDialogButtonSizer* editButtonSizer = new wxStdDialogButtonSizer;
     buttonsSizer->Add(editButtonSizer, wxSizerFlags(g_flagsV).Border(wxALL, 0).Center());
 
-    buttonAdd_ = new wxButton(buttonsPanel, wxID_ADD, _t("&Add "));
-    editButtonSizer->Add(buttonAdd_, g_flagsH);
-    mmToolTip(buttonAdd_, _t("Add a new tag"));
+    w_add_btn = new wxButton(buttonsPanel, wxID_ADD, _t("&Add "));
+    editButtonSizer->Add(w_add_btn, g_flagsH);
+    mmToolTip(w_add_btn, _t("Add a new tag"));
 
-    buttonEdit_ = new wxButton(buttonsPanel, wxID_EDIT, _t("&Edit "));
-    editButtonSizer->Add(buttonEdit_, g_flagsH);
-    buttonEdit_->Enable(false);
-    mmToolTip(buttonEdit_, _t("Edit the name of an existing tag"));
+    w_edit_btn = new wxButton(buttonsPanel, wxID_EDIT, _t("&Edit "));
+    editButtonSizer->Add(w_edit_btn, g_flagsH);
+    w_edit_btn->Enable(false);
+    mmToolTip(w_edit_btn, _t("Edit the name of an existing tag"));
 
-    buttonDelete_ = new wxButton(buttonsPanel, wxID_REMOVE, _t("&Delete "));
-    editButtonSizer->Add(buttonDelete_, g_flagsH);
-    buttonDelete_->Enable(false);
-    mmToolTip(buttonDelete_, _t("Delete an existing tag. The tag is unable to be used by existing transactions."));
+    w_delete_btn = new wxButton(buttonsPanel, wxID_REMOVE, _t("&Delete "));
+    editButtonSizer->Add(w_delete_btn, g_flagsH);
+    w_delete_btn->Enable(false);
+    mmToolTip(w_delete_btn, _t("Delete an existing tag. The tag is unable to be used by existing transactions."));
 
     //--------------------------
     wxStdDialogButtonSizer* dlgButtonSizer = new wxStdDialogButtonSizer();
     boxSizer->Add(dlgButtonSizer, wxSizerFlags(g_flagsV).Centre());
 
-    wxButton* itemButton24 = new wxButton(this, wxID_OK, (isSelection_ ? _t("Select") : _t("&OK ")));
+    wxButton* itemButton24 = new wxButton(this, wxID_OK,
+        (m_is_selection ? _t("Select") : _t("&OK "))
+    );
     dlgButtonSizer->Add(itemButton24, g_flagsH);
 
-    wxButton* itemButton25 = new wxButton(this, wxID_CANCEL, wxGetTranslation(isSelection_ ? g_CancelLabel : g_CloseLabel));
+    wxButton* itemButton25 = new wxButton(this, wxID_CANCEL,
+        wxGetTranslation(m_is_selection ? g_CancelLabel : g_CloseLabel)
+    );
     dlgButtonSizer->Add(itemButton25, g_flagsH);
+}
+
+int TagManager::getTagIndex(const wxString& tag)
+{
+    // FindString() without the second argument (bCase) fails, at least on macOS
+    // Temporary fix: set bCase to true (although this is not wanted)
+    // FIXME: implement a proper fix, or wait for a fix in wxWidgets
+    return w_tag_list->FindString(tag, true);
 }
 
 void TagManager::fillControls()
 {
     Freeze();
     wxArrayString filteredList;
-    for (const auto& tag : tagList_)
-        if (tag.Lower().Matches(mask_string_ + "*"))
+    for (const auto& tag : m_tag_a)
+        if (tag.Lower().Matches(m_mask_s + "*"))
             filteredList.Add(tag);
 
-    tagListBox_->Set(filteredList);
+    w_tag_list->Set(filteredList);
 
-    if (isSelection_)
-    {
+    if (m_is_selection) {
         // reselect previously selected items
-        for (const auto& tag : selectedTags_)
-        {
-            int index = tagListBox_->FindString(tag);
+        for (const auto& tag : m_selected_tag_a) {
+            int index = getTagIndex(tag);
             if (index != wxNOT_FOUND)
-                dynamic_cast<wxCheckListBox*>(tagListBox_)->Check(index);
+                dynamic_cast<wxCheckListBox*>(w_tag_list)->Check(index);
         }
     }
 
-    buttonEdit_->Disable();
-    buttonDelete_->Disable();
+    w_edit_btn->Disable();
+    w_delete_btn->Disable();
     Thaw();
 }
 
 bool TagManager::validateName(const wxString& name)
 {
-    if (name == "&" || name == "|")
-    {
+    if (name == "&" || name == "|") {
         wxString errMsg = _t("Invalid tag name");
         errMsg << "\n\n" << _t("Tag names may not be the '&' or '|' characters because these are reserved for filter operators");
         wxMessageBox(errMsg, _t("Tag Manager: Invalid Name"), wxOK | wxICON_ERROR);
         return false;
-    } else if (name.Find(' ') != wxNOT_FOUND)
-    {
+    }
+    else if (name.Find(' ') != wxNOT_FOUND) {
         wxString errMsg = _t("Name contains tag delimiter.");
         errMsg << "\n\n" << _t("Tag names may not contain the space (' ') character");
         wxMessageBox(errMsg, _t("Tag Manager: Invalid Name"), wxOK | wxICON_ERROR);
@@ -218,8 +248,10 @@ void TagManager::OnAdd(wxCommandEvent& WXUNUSED(event))
     if (text.IsEmpty())
         return;
 
-    const auto& tags = TagModel::instance().find(TagCol::TAGNAME(text));
-    if (!tags.empty()) {
+    const auto& tag_a = TagModel::instance().find(
+        TagCol::TAGNAME(text)
+    );
+    if (!tag_a.empty()) {
         wxMessageBox(
             _t("A tag with this name already exists"),
             _t("Tag Manager: Adding Error"),
@@ -232,8 +264,8 @@ void TagManager::OnAdd(wxCommandEvent& WXUNUSED(event))
     new_tag_d.m_name = text;
     TagModel::instance().add_data_n(new_tag_d);
 
-    refreshRequested_ = true;
-    tagList_.Add(text);
+    m_refresh_requested = true;
+    m_tag_a.Add(text);
     fillControls();
     setSelectedString(text);
 }
@@ -243,9 +275,10 @@ void TagManager::OnEdit(wxCommandEvent& WXUNUSED(event))
     wxArrayInt selections;
     wxString old_name;
     
-    tagListBox_->GetSelections(selections);
-    if (selections.IsEmpty()) return;
-    old_name = tagListBox_->GetString(selections[0]); 
+    w_tag_list->GetSelections(selections);
+    if (selections.IsEmpty())
+        return;
+    old_name = w_tag_list->GetString(selections[0]); 
 
     const wxString msg = wxString::Format(_t("Enter a new name for '%s'"), old_name);
     wxString text = wxGetTextFromUser(msg, _t("Edit Tag"), old_name);
@@ -268,14 +301,14 @@ void TagManager::OnEdit(wxCommandEvent& WXUNUSED(event))
     tag_d.m_name = text;
     TagModel::instance().save_data_n(tag_d);
 
-    tagList_.Remove(old_name);
-    tagList_.Add(text);
-    int index = selectedTags_.Index(old_name);
+    m_tag_a.Remove(old_name);
+    m_tag_a.Add(text);
+    int index = m_selected_tag_a.Index(old_name);
     if (index != wxNOT_FOUND) {
-        selectedTags_.RemoveAt(index);
-        selectedTags_.Add(text);
+        m_selected_tag_a.RemoveAt(index);
+        m_selected_tag_a.Add(text);
     }
-    refreshRequested_ = true;
+    m_refresh_requested = true;
     fillControls();
     setSelectedString(text);
 }
@@ -284,9 +317,9 @@ void TagManager::OnDelete(wxCommandEvent& WXUNUSED(event))
 {
     wxArrayInt selections;
     wxArrayString stringSelections;
-    tagListBox_->GetSelections(selections);
+    w_tag_list->GetSelections(selections);
     for (const auto& selection : selections)
-        stringSelections.Add(tagListBox_->GetString(selection));
+        stringSelections.Add(w_tag_list->GetString(selection));
 
     if (stringSelections.IsEmpty())
         return;
@@ -333,50 +366,53 @@ void TagManager::OnDelete(wxCommandEvent& WXUNUSED(event))
                     TrxModel::instance().purge_id(tp_n->m_trx_id);
                 }
             TagModel::instance().purge_id(tag_n->m_id);
-            tagList_.Remove(selection);
-            int index = selectedTags_.Index(selection);
+            m_tag_a.Remove(selection);
+            int index = m_selected_tag_a.Index(selection);
             if (index != wxNOT_FOUND)
-                selectedTags_.RemoveAt(index);
+                m_selected_tag_a.RemoveAt(index);
         }
     }
     TagModel::instance().db_release_savepoint();
     TagLinkModel::instance().db_release_savepoint();
     TrxModel::instance().db_release_savepoint();
     TrxSplitModel::instance().db_release_savepoint();
-    refreshRequested_ = true;
+    m_refresh_requested = true;
     fillControls();
-    int newIndex = std::min(selections[0], static_cast<int>(tagListBox_->GetCount()) - 1);
+    int newIndex = std::min(
+        selections[0],
+        static_cast<int>(w_tag_list->GetCount()) - 1
+    );
     if (newIndex >= 0)
         setSelectedItem(newIndex);
 }
 
 void TagManager::OnTextChanged(wxCommandEvent& event)
 {
-    mask_string_ = event.GetString();
-    if (!mask_string_.IsEmpty())
-        mask_string_ = mask_string_.Lower().Prepend("*");
+    m_mask_s = event.GetString();
+    if (!m_mask_s.IsEmpty())
+        m_mask_s = m_mask_s.Lower().Prepend("*");
     fillControls();
-    searchCtrl_->SetFocus();
-    searchCtrl_->SetInsertionPointEnd();
+    w_search_ctrl->SetFocus();
+    w_search_ctrl->SetInsertionPointEnd();
 }
 
 void TagManager::OnListSelChanged(wxCommandEvent& WXUNUSED(event))
 {
-    buttonEdit_->Enable(false);
-    buttonDelete_->Enable(false);
+    w_edit_btn->Enable(false);
+    w_delete_btn->Enable(false);
 
     wxArrayInt tag_i_a;
     wxArrayString tag_name_a;
 
-    tagListBox_->GetSelections(tag_i_a);
+    w_tag_list->GetSelections(tag_i_a);
     for (const auto& tag_i : tag_i_a)
-        tag_name_a.Add(tagListBox_->GetString(tag_i));
+        tag_name_a.Add(w_tag_list->GetString(tag_i));
 
     int count = tag_i_a.GetCount();
 
     // Can only edit one tag at a time
     if (count == 1) {
-        buttonEdit_->Enable();
+        w_edit_btn->Enable();
     }
     // Can delete multiple tags at once as long as all are unused
     if (count > 0) {
@@ -385,26 +421,25 @@ void TagManager::OnListSelChanged(wxCommandEvent& WXUNUSED(event))
             const TagData* tag_n = TagModel::instance().get_name_data_n(tag_name);
             is_used |= TagModel::instance().is_used(tag_n->m_id) == 1;
         }
-        buttonDelete_->Enable(!is_used);
+        w_delete_btn->Enable(!is_used);
     }    
 }
 
 void TagManager::OnCheckboxSelChanged(wxCommandEvent& event)
 {
-    if (dynamic_cast<wxCheckListBox*>(tagListBox_)->IsChecked(event.GetSelection()))
-        selectedTags_.Add(event.GetString());
-    else
-    {
-        int index = selectedTags_.Index(event.GetString());
+    if (dynamic_cast<wxCheckListBox*>(w_tag_list)->IsChecked(event.GetSelection()))
+        m_selected_tag_a.Add(event.GetString());
+    else {
+        int index = m_selected_tag_a.Index(event.GetString());
         if (index != wxNOT_FOUND)
-            selectedTags_.RemoveAt(index);
+            m_selected_tag_a.RemoveAt(index);
     }
 }
 
 void TagManager::setSelectedItem(int index)
 {
-    tagListBox_->EnsureVisible(index);
-    tagListBox_->SetSelection(index);
+    w_tag_list->EnsureVisible(index);
+    w_tag_list->SetSelection(index);
 
     wxCommandEvent evt;
     OnListSelChanged(evt);
@@ -412,8 +447,7 @@ void TagManager::setSelectedItem(int index)
 
 void TagManager::setSelectedString(const wxString& tagname)
 {
-    int index = tagListBox_->FindString(tagname);
-
+    int index = getTagIndex(tagname);
     if (index != wxNOT_FOUND)
         setSelectedItem(index);
 }

--- a/src/manager/TagManager.h
+++ b/src/manager/TagManager.h
@@ -32,49 +32,67 @@ class TagManager : public wxDialog
     wxDECLARE_DYNAMIC_CLASS(TagManager);
     wxDECLARE_EVENT_TABLE();
 
-public:
-    TagManager();
-    ~TagManager();
-    TagManager(wxWindow* parent, bool isSelection = false, const wxArrayString& selectedTags = wxArrayString());
-
-    bool getRefreshRequested() const;
-    wxArrayString getSelectedTags() const;
+// -- state
 
 private:
-    bool Create(wxWindow* parent, wxWindowID id = wxID_ANY,
+    bool m_is_selection;
+    wxArrayString m_selected_tag_a;
+    wxArrayString m_tag_a;
+    wxString m_mask_s = wxEmptyString;
+    bool m_refresh_requested = false;
+    //wxString searchText_;
+
+    wxSearchCtrl*  w_search_ctrl = nullptr;
+    wxListBox*     w_tag_list    = nullptr;
+    wxButton*      w_edit_btn    = nullptr;
+    wxButton*      w_add_btn     = nullptr;
+    wxButton*      w_delete_btn  = nullptr;
+
+public:
+    auto getSelectedTags() const -> wxArrayString { return m_selected_tag_a; }
+    bool getRefreshRequested() const { return m_refresh_requested; }
+
+// -- constructor
+
+public:
+    TagManager();
+    TagManager(
+        wxWindow* parent_win,
+        bool is_selection = false,
+        const wxArrayString& selected_tag_a = wxArrayString()
+    );
+    ~TagManager();
+
+private:
+    bool create(
+        wxWindow* parent_win,
+        wxWindowID win_id = wxID_ANY,
         const wxString& caption = _t("Tag Manager"),
         const wxString& name = "Organize Tags",
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
-        long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX | wxRESIZE_BORDER);
+        long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX | wxRESIZE_BORDER
+    );
+    void createControls();
 
-    void CreateControls();
+// -- methods
 
-    void OnAdd(wxCommandEvent& event);
-    void OnEdit(wxCommandEvent& event);
-    void OnDelete(wxCommandEvent& event);
-    void OnTextChanged(wxCommandEvent& event);
-    void OnListSelChanged(wxCommandEvent& event);
-    void OnCheckboxSelChanged(wxCommandEvent& event);
-    void OnOk(wxCommandEvent& event);
-    void OnCancel(wxCommandEvent& event);
-    void fillControls();
-    bool refreshRequested_ = false;
+private:
+    int  getTagIndex(const wxString& tag);
     bool validateName(const wxString& name);
+    void fillControls();
     void setSelectedItem(int index);
     void setSelectedString(const wxString& name);
 
-    wxSearchCtrl* searchCtrl_ = nullptr;
-    wxString searchText_;
-    wxListBoxBase* tagListBox_ = nullptr;
-    wxButton* buttonEdit_ = nullptr;
-    wxButton* buttonAdd_ = nullptr;
-    wxButton* buttonDelete_ = nullptr;
-    bool isSelection_;
-    wxArrayString tagList_;
-    wxArrayString selectedTags_;
-    wxString mask_string_ = wxEmptyString;
-};
+// -- event handlers
 
-inline bool TagManager::getRefreshRequested() const { return refreshRequested_; }
-inline wxArrayString TagManager::getSelectedTags() const { return selectedTags_; }
+private:
+    void OnAdd(                wxCommandEvent& event);
+    void OnEdit(               wxCommandEvent& event);
+    void OnDelete(             wxCommandEvent& event);
+    void OnTextChanged(        wxCommandEvent& event);
+    void OnListSelChanged(     wxCommandEvent& event);
+    void OnCheckboxSelChanged( wxCommandEvent& event);
+    void OnOk(                 wxCommandEvent& event);
+    void OnCancel(             wxCommandEvent& event);
+};

--- a/src/mmframe.cpp
+++ b/src/mmframe.cpp
@@ -651,7 +651,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
 
                     wxArrayInt64 tags;
                     for (const auto& gl_d : TagLinkModel::instance().find(
-                        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
+                        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.key_n()),
                         TagLinkCol::REFID(qp_d.m_id)
                     )) {
                         tags.push_back(gl_d.m_tag_id);
@@ -694,7 +694,7 @@ void mmGUIFrame::OnAutoRepeatTransactionsTimer(wxTimerEvent& /*event*/)
                 // Save base transaction tags
                 TagLinkModel::DataA new_gl_a;
                 for (const auto& gl_d : TagLinkModel::instance().find(
-                    TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
+                    TagLinkCol::REFTYPE(SchedModel::s_ref_type.key_n()),
                     TagLinkCol::REFID(sched_d.m_id)
                 )) {
                     TagLinkData new_gl_d = TagLinkData();

--- a/src/model/AccountModel.h
+++ b/src/model/AccountModel.h
@@ -41,7 +41,7 @@ public:
     static const RefTypeN s_ref_type;
 
     static AccountCol::STATUS STATUS(OP op, AccountStatus status) {
-        return AccountCol::STATUS(op, status.name());
+        return AccountCol::STATUS(op, status.key());
     }
 
     // TODO: move to AccountData

--- a/src/model/AssetModel.cpp
+++ b/src/model/AssetModel.cpp
@@ -96,7 +96,7 @@ const std::pair<double, double> AssetModel::get_data_value_date(
 
     TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find(
         TrxLinkCol::LINKRECORDID(asset_d.m_id),
-        TrxLinkCol::LINKTYPE(s_ref_type.name_n())
+        TrxLinkCol::LINKTYPE(s_ref_type.key_n())
     );
 
     TrxModel::DataA trx_a;

--- a/src/model/AssetModel.h
+++ b/src/model/AssetModel.h
@@ -35,7 +35,7 @@ public:
     static const RefTypeN s_ref_type;
 
     static AssetCol::ASSETTYPE ASSETTYPE(OP op, AssetType type) {
-        return AssetCol::ASSETTYPE(op, type.name());
+        return AssetCol::ASSETTYPE(op, type.key());
     }
     static AssetCol::STARTDATE STARTDATE(OP op, const mmDate& date);
 

--- a/src/model/AttachmentModel.cpp
+++ b/src/model/AttachmentModel.cpp
@@ -48,7 +48,7 @@ AttachmentModel& AttachmentModel::instance()
 int AttachmentModel::find_ref_c(RefTypeN ref_type, const int64 ref_id)
 {
     return AttachmentModel::instance().find(
-        AttachmentCol::REFTYPE(ref_type.name_n()),
+        AttachmentCol::REFTYPE(ref_type.key_n()),
         AttachmentCol::REFID(ref_id)
     ).size();
 }
@@ -60,8 +60,8 @@ const AttachmentModel::DataA AttachmentModel::find_ref_data_a(
 ) {
     DataA att_a;
     for (const Data& att_d : find_all(Col::COL_ID_DESCRIPTION)) {
-        if (att_d.m_ref_type_n.name_n().Lower().Matches(
-            ref_type.name_n().Lower().Append("*")
+        if (att_d.m_ref_type_n.key_n().Lower().Matches(
+            ref_type.key_n().Lower().Append("*")
         ) && att_d.m_ref_id == ref_id)
             att_a.push_back(att_d);
     }
@@ -90,7 +90,7 @@ std::map<int64, AttachmentModel::DataA> AttachmentModel::find_refType_mRefId(
 ) {
     std::map<int64, AttachmentModel::DataA> refId_dataA_m;
     for (const auto& att_d : find(
-        AttachmentCol::REFTYPE(ref_type.name_n())
+        AttachmentCol::REFTYPE(ref_type.key_n())
     )) {
         refId_dataA_m[att_d.m_ref_id].push_back(att_d);
     }

--- a/src/model/BudgetModel.h
+++ b/src/model/BudgetModel.h
@@ -33,7 +33,7 @@ class BudgetModel : public TableFactory<BudgetTable, BudgetData>
 
 public:
     static BudgetCol::PERIOD FREQUENCY(OP op, BudgetFreq freq) {
-        return BudgetCol::PERIOD(op, freq.name());
+        return BudgetCol::PERIOD(op, freq.key());
     }
 
 // -- constructor

--- a/src/model/CurrencyModel.h
+++ b/src/model/CurrencyModel.h
@@ -36,7 +36,7 @@ class CurrencyModel : public TableFactory<CurrencyTable, CurrencyData>
 
 public:
     static CurrencyCol::CURRENCY_TYPE CURRENCY_TYPE(OP op, CurrencyType currency_type) {
-        return CurrencyCol::CURRENCY_TYPE(op, currency_type.name());
+        return CurrencyCol::CURRENCY_TYPE(op, currency_type.key());
     }
 
 // -- constructor

--- a/src/model/FieldModel.cpp
+++ b/src/model/FieldModel.cpp
@@ -246,7 +246,7 @@ const FieldData* FieldModel::get_udfc_data_n(RefTypeN ref_type, const wxString& 
 {
     Document json_doc;
     for (const auto& field_d : find(
-        FieldCol::REFTYPE(ref_type.name_n())
+        FieldCol::REFTYPE(ref_type.key_n())
     )) {
         if (!json_doc.Parse(field_d.m_properties.utf8_str()).HasParseError() &&
             json_doc.HasMember("UDFC") &&
@@ -298,7 +298,7 @@ const wxArrayString FieldModel::get_data_udfc_a(const FieldData* field_n)
 {
     wxArrayString udfc_a = UDFC_FIELDS();
     for (const auto& field_d : FieldModel::instance().find(
-        FieldCol::REFTYPE(TrxModel::s_ref_type.name_n())
+        FieldCol::REFTYPE(TrxModel::s_ref_type.key_n())
     )) {
         const wxString udfc = FieldModel::getUDFC(field_d.m_properties);
         if (!udfc.empty() && udfc_a.Index(udfc) != wxNOT_FOUND) {

--- a/src/model/PrefModel.cpp
+++ b/src/model/PrefModel.cpp
@@ -820,6 +820,7 @@ int PrefModel::getHtmlScale() const noexcept
 
 int PrefModel::AccountImageId(const int64 account_id, const bool def, const bool ignoreClosure)
 {
+    // TODO: change type of acctStatus to AccountStatus
     wxString acctStatus = VIEW_ACCOUNTS_OPEN_STR;
     NavigatorTypes::TYPE_ID acctType = NavigatorTypes::TYPE_ID_CHECKING;
     int selectedImage = img::SAVINGS_ACC_NORMAL_PNG; //Default value
@@ -827,7 +828,7 @@ int PrefModel::AccountImageId(const int64 account_id, const bool def, const bool
     const AccountData* account_n = AccountModel::instance().get_id_data_n(account_id);
     if (account_n) {
         acctType = AccountModel::type_id(*account_n);
-        acctStatus = account_n->m_status.name();
+        acctStatus = account_n->m_status.key();
     }
 
     if (!def && !ignoreClosure && (acctStatus == "Closed"))
@@ -835,7 +836,10 @@ int PrefModel::AccountImageId(const int64 account_id, const bool def, const bool
 
     int max = acc_img::MAX_ACC_ICON - static_cast<int>(img::LAST_NAVTREE_PNG);
     int min = 1;
-    int custom_img_id = InfoModel::instance().getInt(wxString::Format("ACC_IMAGE_ID_%lld", account_id), 0);
+    int custom_img_id = InfoModel::instance().getInt(
+        wxString::Format("ACC_IMAGE_ID_%lld", account_id),
+        0
+    );
     if (custom_img_id > max) custom_img_id = custom_img_id - 20; //Bug #963 fix
     if (!def && (custom_img_id >= min && custom_img_id <= max))
         return custom_img_id + img::LAST_NAVTREE_PNG - 1;

--- a/src/model/SchedModel.cpp
+++ b/src/model/SchedModel.cpp
@@ -36,7 +36,7 @@ const RefTypeN SchedModel::s_ref_type = RefTypeN(RefTypeN::e_sched);
 
 SchedCol::TRANSCODE SchedModel::TYPE(OP op, TrxType sched_type)
 {
-    return SchedCol::TRANSCODE(op, sched_type.name());
+    return SchedCol::TRANSCODE(op, sched_type.key());
 }
 
 SchedCol::STATUS SchedModel::STATUS(OP op, TrxStatus sched_status)
@@ -100,7 +100,7 @@ const SchedSplitModel::DataA SchedModel::find_id_qp_a(int64 sched_id)
 const TagLinkModel::DataA SchedModel::find_id_gl_a(int64 sched_id)
 {
     return TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(SchedModel::s_ref_type.key_n()),
         TagLinkCol::REFID(sched_id)
     );
 }

--- a/src/model/SchedSplitModel.cpp
+++ b/src/model/SchedSplitModel.cpp
@@ -67,7 +67,7 @@ double SchedSplitModel::get_data_amount(const DataA& qp_a)
 const TagLinkModel::DataA SchedSplitModel::find_id_gl_a(int64 qp_id)
 {
     return TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(SchedSplitModel::s_ref_type.key_n()),
         TagLinkCol::REFID(qp_id)
     );
 }

--- a/src/model/TagLinkModel.cpp
+++ b/src/model/TagLinkModel.cpp
@@ -48,7 +48,7 @@ TagLinkModel& TagLinkModel::instance()
 void TagLinkModel::purge_ref(RefTypeN ref_type, int64 ref_id)
 {
     const auto& gl_a = instance().find(
-        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFTYPE(ref_type.key_n()),
         TagLinkCol::REFID(ref_id)
     );
     instance().db_savepoint();
@@ -61,7 +61,7 @@ const TagLinkData* TagLinkModel::get_key_data_n(int64 tag_id, RefTypeN ref_type,
 {
     const Data* gl_n = search_cache_n(
         TagLinkCol::TAGID(tag_id),
-        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFTYPE(ref_type.key_n()),
         TagLinkCol::REFID(ref_id)
     );
     if (gl_n)
@@ -69,7 +69,7 @@ const TagLinkData* TagLinkModel::get_key_data_n(int64 tag_id, RefTypeN ref_type,
 
     DataA gl_a = find(
         TagLinkCol::TAGID(tag_id),
-        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFTYPE(ref_type.key_n()),
         TagLinkCol::REFID(ref_id)
     );
     if (!gl_a.empty())
@@ -81,7 +81,7 @@ std::map<wxString, int64> TagLinkModel::find_ref_mTagName(RefTypeN ref_type, int
 {
     std::map<wxString, int64> tag_name_id_m;
     for (const auto& gl_d : find(
-        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFTYPE(ref_type.key_n()),
         TagLinkCol::REFID(ref_id)
     )) {
         const TagData* tag_n = TagModel::instance().get_id_data_n(gl_d.m_tag_id);
@@ -95,7 +95,7 @@ std::map<int64, TagLinkModel::DataA> TagLinkModel::find_refType_mRefId(
 ) {
     std::map<int64, DataA> refId_dataA_m;
     for (const auto& gl_d : instance().find(
-        TagLinkCol::REFTYPE(ref_type.name_n())
+        TagLinkCol::REFTYPE(ref_type.key_n())
     )) {
         refId_dataA_m[gl_d.m_ref_id].push_back(gl_d);
     }
@@ -109,7 +109,7 @@ int TagLinkModel::update(RefTypeN ref_type, int64 ref_id, const DataA& src_gl_a)
     std::map<int, int64> index_id_m;
 
     DataA old_gl_a = instance().find(
-        TagLinkCol::REFTYPE(ref_type.name_n()),
+        TagLinkCol::REFTYPE(ref_type.key_n()),
         TagLinkCol::REFID(ref_id)
     );
     if (old_gl_a.size() != src_gl_a.size())

--- a/src/model/TrxFilter.cpp
+++ b/src/model/TrxFilter.cpp
@@ -244,7 +244,7 @@ table {
         wxString AttachmentsLink = "";
         if (AttachmentModel::instance().find_ref_c(TrxModel::s_ref_type, trx_dx.m_id)) {
             AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
-                TrxModel::s_ref_type.name_n(), trx_dx.m_id,
+                TrxModel::s_ref_type.key_n(), trx_dx.m_id,
                 mmAttachmentManage::GetAttachmentNoteSign());
         }
 

--- a/src/model/TrxLinkModel.cpp
+++ b/src/model/TrxLinkModel.cpp
@@ -81,7 +81,7 @@ const TrxLinkData* TrxLinkModel::get_trx_data_n(int64 trx_id)
 TrxLinkModel::DataA TrxLinkModel::find_ref_data_a(RefTypeN ref_type, int64 ref_id)
 {
     return find(
-        TrxLinkCol::LINKTYPE(ref_type.name_n()),
+        TrxLinkCol::LINKTYPE(ref_type.key_n()),
         TrxLinkCol::LINKRECORDID(ref_id)
     );
 }

--- a/src/model/TrxModel.cpp
+++ b/src/model/TrxModel.cpp
@@ -53,7 +53,7 @@ TrxCol::TRANSDATE TrxModel::DATE(OP op, const mmDate& date)
 
 TrxCol::TRANSCODE TrxModel::TYPE(OP op, TrxType trx_type)
 {
-    return TrxCol::TRANSCODE(op, trx_type.name());
+    return TrxCol::TRANSCODE(op, trx_type.key());
 }
 
 TrxCol::STATUS TrxModel::STATUS(OP op, TrxStatus trx_status)
@@ -221,7 +221,7 @@ const TrxSplitModel::DataA TrxModel::find_id_tp_a(int64 trx_id)
 const TagLinkModel::DataA TrxModel::find_id_gl_a(int64 trx_id)
 {
     return TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.key_n()),
         TagLinkCol::REFID(trx_id)
     );
 }

--- a/src/model/TrxSplitModel.cpp
+++ b/src/model/TrxSplitModel.cpp
@@ -59,7 +59,7 @@ bool TrxSplitModel::purge_id(int64 tp_id)
 const TagLinkModel::DataA TrxSplitModel::find_id_gl_a(int64 tp_id)
 {
     return TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
         TagLinkCol::REFID(tp_id)
     );
 }

--- a/src/panel/AssetList.cpp
+++ b/src/panel/AssetList.cpp
@@ -131,8 +131,9 @@ void AssetList::onMouseRightClick(wxMouseEvent& event)
         );
         if (!asset_account)
             // ASSETTYPE <=> ACCOUNTNAME
+            // TODO: use translated name() instead of key()
             asset_account = AccountModel::instance().get_name_data_n(
-                w_panel->m_asset_a[m_selected_row].m_type.name()
+                w_panel->m_asset_a[m_selected_row].m_type.key()
             );
         menu.Enable(MENU_TREEPOPUP_GOTOACCOUNT, asset_account);
         menu.Enable(MENU_TREEPOPUP_VIEWTRANS, asset_account);

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -400,9 +400,9 @@ void AssetPanel::onMouseLeftDown (wxCommandEvent& event)
     wxMenu menu;
     menu.Append(++i, _t("All"));
 
-    for (int typeId = 0; typeId < AssetType::size; ++typeId) {
-        wxString type = AssetType(typeId).name();
-        menu.Append(++i, wxGetTranslation(type));
+    for (int type_id = 0; type_id < AssetType::size; ++type_id) {
+        wxString name = AssetType(type_id).name();
+        menu.Append(++i, wxGetTranslation(name));
     }
     PopupMenu(&menu);
 
@@ -472,9 +472,13 @@ void AssetPanel::addAssetTrans(const int selected_index)
     AssetData* asset = &m_asset_a[selected_index];
     AssetDialog asset_dialog(this, asset, true);
     const AccountData* account = AccountModel::instance().get_name_data_n(asset->m_name);
-    const AccountData* account2 = AccountModel::instance().get_name_data_n(asset->m_type.name());
+    // TODO: use translated name() instead of key()
+    const AccountData* account2 = AccountModel::instance().get_name_data_n(asset->m_type.key());
     if (account || account2) {
-        asset_dialog.SetTransactionAccountName(account ? asset->m_name : asset->m_type.name());
+        asset_dialog.SetTransactionAccountName(account
+            ? asset->m_name
+            : asset->m_type.key()
+        );
     }
     else {
         TrxLinkModel::DataA tl_a = TrxLinkModel::instance().find_ref_data_a(

--- a/src/panel/JournalList.cpp
+++ b/src/panel/JournalList.cpp
@@ -696,7 +696,7 @@ int64 JournalList::pasteTrx(const TrxData* trx_n)
     // Clone transaction tags
     TagLinkModel::DataA new_gl_a;
     for (const auto& tl_d : TagLinkModel::instance().find(
-        TagLinkCol::REFTYPE(TrxModel::s_ref_type.name_n()),
+        TagLinkCol::REFTYPE(TrxModel::s_ref_type.key_n()),
         TagLinkCol::REFID(trx_n->m_id)
     )) {
         TagLinkData new_gl_d;
@@ -714,7 +714,7 @@ int64 JournalList::pasteTrx(const TrxData* trx_n)
 
         // Clone split tags
         for (const auto& tl_d : TagLinkModel::instance().find(
-            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.name_n()),
+            TagLinkCol::REFTYPE(TrxSplitModel::s_ref_type.key_n()),
             TagLinkCol::REFID(tp_d.m_id)
         )) {
             TagLinkData new_gl_d;
@@ -1437,7 +1437,7 @@ void JournalList::onMouseRightClick(wxMouseEvent& event)
             }
             break;
         case LIST_ID_STATUS:
-            m_copy_text = menuItemText = m_journal_xa[row].m_status.name();
+            m_copy_text = menuItemText = m_journal_xa[row].m_status.key();
             m_filter = "{\n\"STATUS\": \"" + menuItemText + "\"\n}";
             break;
         case LIST_ID_CATEGORY:

--- a/src/pref/TrxPref.cpp
+++ b/src/pref/TrxPref.cpp
@@ -90,11 +90,12 @@ void TrxPref::Create()
         , wxDefaultPosition, wxDefaultSize, default_values);
     defaultCategoryNonTransferChoice->SetSelection(PrefModel::instance().getTransCategoryNone());
 
-    wxChoice* default_status = new wxChoice(transSettingsStaticBox
-        , ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS);
-    for (int i = 0; i < TrxStatus::size; ++i) {
-        wxString status = TrxStatus(i).name();
-        default_status->Append(wxGetTranslation(status), new wxStringClientData(status));
+    wxChoice* default_status = new wxChoice(transSettingsStaticBox,
+        ID_DIALOG_OPTIONS_DEFAULT_TRANSACTION_STATUS
+    );
+    for (int status_id = 0; status_id < TrxStatus::size; ++status_id) {
+        wxString name = TrxStatus(status_id).name();
+        default_status->Append(wxGetTranslation(name), new wxStringClientData(name));
     }
     default_status->SetSelection(PrefModel::instance().getTransStatusReconciled());
 

--- a/src/report/TrxReport.cpp
+++ b/src/report/TrxReport.cpp
@@ -375,7 +375,7 @@ table {
                     TrxModel::s_ref_type, trx_dx.m_id
                 )) {
                     AttachmentsLink = wxString::Format(R"(<a href = "attachment:%s|%lld" target="_blank">%s</a>)",
-                        TrxModel::s_ref_type.name_n(), trx_dx.m_id,
+                        TrxModel::s_ref_type.key_n(), trx_dx.m_id,
                         mmAttachmentManage::GetAttachmentNoteSign()
                     );
                 }

--- a/src/util/_simple.cpp
+++ b/src/util/_simple.cpp
@@ -1523,14 +1523,13 @@ void mmTagTextCtrl::OnDropDown(wxCommandEvent& )
 void mmTagTextCtrl::OnKeyPressed(wxKeyEvent& event)
 {
     int keyCode = event.GetKeyCode();
-    if (keyCode == WXK_RETURN || keyCode == WXK_NUMPAD_ENTER)
-    {
+    if (keyCode == WXK_RETURN || keyCode == WXK_NUMPAD_ENTER) {
         int ip = textCtrl_->GetInsertionPoint();
-        if (textCtrl_->GetText().IsEmpty() || ip == 0 || textCtrl_->GetTextRange(ip - 1, ip) == " ")
-        {
+        if (textCtrl_->GetText().IsEmpty() ||
+            ip == 0 || textCtrl_->GetTextRange(ip - 1, ip) == " "
+        ) {
             TagManager dlg(this, true, parseTags(textCtrl_->GetText()));
-            if (dlg.ShowModal() == wxID_OK)
-            {
+            if (dlg.ShowModal() == wxID_OK) {
                 wxString selection;
                 for (const auto& tag : dlg.getSelectedTags())
                     selection.Append(tag + " ");
@@ -1540,26 +1539,25 @@ void mmTagTextCtrl::OnKeyPressed(wxKeyEvent& event)
             if (dlg.getRefreshRequested())
                 init();
         }
-        else if (textCtrl_->AutoCompActive())
-        {
+        else if (textCtrl_->AutoCompActive()) {
             textCtrl_->AutoCompComplete();
         }
 
         ValidateTagText();
         return;
     }
-    else if (keyCode == WXK_TAB && !event.AltDown())
-    {
+    else if (keyCode == WXK_TAB && !event.AltDown()) {
         bool prev = event.ShiftDown();
         wxWindow* next_control = prev ? GetPrevSibling() : GetNextSibling();
         while (next_control && !next_control->IsFocusable())
-            next_control = prev ? next_control->GetPrevSibling() : next_control->GetNextSibling();
+            next_control = prev
+                ? next_control->GetPrevSibling()
+                : next_control->GetNextSibling();
         if (next_control)
             next_control->SetFocus();
         return;
     }
-    else if (keyCode == WXK_SPACE)
-    {
+    else if (keyCode == WXK_SPACE) {
         textCtrl_->AutoCompCancel();
         textCtrl_->InsertText(textCtrl_->GetInsertionPoint(), " ");
         ValidateTagText();
@@ -1573,7 +1571,9 @@ void mmTagTextCtrl::init()
     // Initialize the tag map and dropdown checkboxes
     tag_map_.clear();
     tagCheckListBox_->Clear();
-    for (const auto& tag_d : TagModel::instance().find_all(TagCol::COL_ID_TAGNAME)) {
+    for (const auto& tag_d : TagModel::instance().find_all(
+        TagCol::COL_ID_TAGNAME
+    )) {
         tag_map_[tag_d.m_name] = tag_d.m_id;
         tagCheckListBox_->Append(tag_d.m_name);
     }


### PR DESCRIPTION
Fix bug introduced in #8277.

The name of several choices In `data/_DataEnum` has been duplicated without translation, for use by model functions. Currently the following choices have different key (not translated) and name (translated):
* FieldTypeN
* RefTypeN

This PR replaces `name()` with `key()` in several model functions.

### Impact
The bug reported in #8283 is due to `RefTypeN` -> `e_sched`. There are more entries which create similar bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8286)
<!-- Reviewable:end -->
