### PR TITLE
ref(#8287): add apostrophe in currency group separators

### DIFF
--- a/src/manager/CurrencyManager.cpp
+++ b/src/manager/CurrencyManager.cpp
@@ -40,11 +40,11 @@
 wxIMPLEMENT_DYNAMIC_CLASS(CurrencyManager, wxDialog);
 
 wxBEGIN_EVENT_TABLE(CurrencyManager, wxDialog)
-    EVT_BUTTON(wxID_OK,                 CurrencyManager::OnOk)
-    EVT_BUTTON(wxID_CANCEL,             CurrencyManager::OnCancel)
-    EVT_TEXT(ID_DIALOG_CURRENCY,        CurrencyManager::OnDataChanged)
-    EVT_CHOICE(ID_DIALOG_CURRENCY,      CurrencyManager::OnDataChanged)
-    EVT_RADIOBUTTON(ID_DIALOG_CURRENCY, CurrencyManager::OnDataChanged)
+    EVT_BUTTON(wxID_OK,                 CurrencyManager::onOk)
+    EVT_BUTTON(wxID_CANCEL,             CurrencyManager::onCancel)
+    EVT_TEXT(ID_DIALOG_CURRENCY,        CurrencyManager::onDataChanged)
+    EVT_CHOICE(ID_DIALOG_CURRENCY,      CurrencyManager::onDataChanged)
+    EVT_RADIOBUTTON(ID_DIALOG_CURRENCY, CurrencyManager::onDataChanged)
 wxEND_EVENT_TABLE()
 
 static const int SCALE = 9;
@@ -57,7 +57,10 @@ CurrencyManager::~CurrencyManager()
 {
 }
 
-CurrencyManager::CurrencyManager(wxWindow* parent, const CurrencyData* currency) :
+CurrencyManager::CurrencyManager(
+    wxWindow* parent,
+    const CurrencyData* currency
+) :
     m_scale(SCALE)
 {
     if (currency) {
@@ -89,22 +92,27 @@ CurrencyManager::CurrencyManager(wxWindow* parent, const CurrencyData* currency)
 
 
     this->SetFont(parent->GetFont());
-    Create(parent);
+    create(parent);
     SetMinSize(wxSize(300, 420));
     Fit();
     mmThemeAutoColour(this);
 }
 
-bool CurrencyManager::Create(wxWindow* parent, wxWindowID id
-    , const wxString& caption, const wxString& name
-    , const wxPoint& pos, const wxSize& size, long style)
-{
+bool CurrencyManager::create(
+    wxWindow* parent,
+    wxWindowID id,
+    const wxString& caption,
+    const wxString& name,
+    const wxPoint& pos,
+    const wxSize& size,
+    long style
+) {
     SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
     wxDialog::Create(parent, id, caption, pos, size, style, name);
 
     SetEvtHandlerEnabled(false);
 
-    CreateControls();
+    createControls();
 
     if (!m_currency_n) {
         mmSingleChoiceDialog select_currency_name(this,
@@ -131,6 +139,134 @@ bool CurrencyManager::Create(wxWindow* parent, wxWindowID id
     Fit();
     Centre();
     return true;
+}
+
+void CurrencyManager::createControls()
+{
+    wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
+    this->SetSizer(itemBoxSizer2);
+
+    wxFlexGridSizer* itemFlexGridSizer3 = new wxFlexGridSizer(0, 2, 0, 0);
+    itemFlexGridSizer3->AddGrowableCol(1, 1);
+    itemBoxSizer2->Add(itemFlexGridSizer3, g_flagsExpand);
+
+    //--------------------------
+    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Currency Name")), g_flagsH);
+    w_name = new wxTextCtrl(this, ID_DIALOG_CURRENCY);
+    w_name->SetMinSize(wxSize(220, -1));
+    itemFlexGridSizer3->Add(w_name, g_flagsExpand);
+
+    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Currency Code")), g_flagsH);
+    w_code = new wxTextCtrl(this, ID_DIALOG_CURRENCY);
+    w_code->SetMaxLength(12);
+    itemFlexGridSizer3->Add(w_code, g_flagsExpand);
+
+    itemFlexGridSizer3->Add(
+        new wxStaticText(this, wxID_STATIC, _t("Currency Symbol")),
+        g_flagsH
+    );
+    w_symbol = new wxTextCtrl(this, ID_DIALOG_CURRENCY, "");
+    itemFlexGridSizer3->Add(w_symbol, g_flagsExpand);
+
+    itemFlexGridSizer3->Add(
+        new wxStaticText(this, wxID_STATIC, _t("Symbol Location")),
+        g_flagsH
+    );
+    w_prefix = new wxRadioButton(this, ID_DIALOG_CURRENCY,
+        _t("Prefix"),
+        wxDefaultPosition, wxDefaultSize,
+        wxRB_GROUP
+    );
+    w_suffix = new wxRadioButton(this, ID_DIALOG_CURRENCY,
+        _t("Suffix"),
+        wxDefaultPosition, wxDefaultSize
+    );
+    wxBoxSizer* radSizer = new wxBoxSizer(wxHORIZONTAL);
+    radSizer->Add(w_prefix);
+    radSizer->Add(w_suffix);
+    itemFlexGridSizer3->Add(radSizer, g_flagsExpand);
+
+    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC,
+        _t("Decimal Char:")),
+        g_flagsH
+    );
+    w_decimalSep = new wxChoice(this, ID_DIALOG_CURRENCY);
+    itemFlexGridSizer3->Add(w_decimalSep, g_flagsExpand);
+    w_decimalSep->Append(_t("Dot"), new wxStringClientData("."));
+    w_decimalSep->Append(_t("Comma"), new wxStringClientData(","));
+
+    itemFlexGridSizer3->Add(
+        new wxStaticText(this, wxID_STATIC, _t("Grouping Char")),
+        g_flagsH
+    );
+    w_groupSep = new wxChoice(this, ID_DIALOG_CURRENCY);
+    itemFlexGridSizer3->Add(w_groupSep, g_flagsExpand);
+    w_groupSep->Append(_t("None"),                new wxStringClientData(""));    
+    w_groupSep->Append(_t("Dot")        + " (.)", new wxStringClientData("."));
+    w_groupSep->Append(_t("Comma")      + " (,)", new wxStringClientData(","));
+    w_groupSep->Append(_t("Apostrophe") + " (')", new wxStringClientData("'"));
+    w_groupSep->Append(_t("Space")      + " ( )", new wxStringClientData(" "));
+
+    wxIntegerValidator<int> valInt(&m_scale, wxNUM_VAL_THOUSANDS_SEPARATOR);
+    valInt.SetMin(0); // Only allow positive numbers
+    valInt.SetMax(SCALE);
+    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Scale")), g_flagsH);
+    w_scale = new wxTextCtrl(this, ID_DIALOG_CURRENCY,
+        "",
+        wxDefaultPosition, wxDefaultSize,
+        wxALIGN_RIGHT,
+        valInt
+    );
+    itemFlexGridSizer3->Add(w_scale, g_flagsExpand);
+
+    itemFlexGridSizer3->Add(
+        new wxStaticText(this, wxID_STATIC, _t("Conversion to Base Rate")),
+        g_flagsH
+    );
+    w_baseConvRate = new mmTextCtrl(this, ID_DIALOG_CURRENCY_RATE,
+        "",
+        wxDefaultPosition, wxDefaultSize,
+        wxALIGN_RIGHT | wxTE_PROCESS_ENTER,
+        mmCalcValidator()
+    );
+    w_baseConvRate->Connect(
+        ID_DIALOG_CURRENCY_RATE, wxEVT_COMMAND_TEXT_ENTER,
+        wxCommandEventHandler(CurrencyManager::onTextEntered),
+        nullptr, this
+    );
+    w_baseConvRate->SetAltPrecision(SCALE);
+    wxString ConvRateTooltip = wxEmptyString;
+    if (PrefModel::instance().getUseCurrencyHistory())
+        ConvRateTooltip = _t("Conversion rate will be used in case no currency history has been found for the currency");
+    else
+        ConvRateTooltip = _t("Fixed conversion rate");
+    mmToolTip(w_baseConvRate, ConvRateTooltip);
+    itemFlexGridSizer3->Add(w_baseConvRate, g_flagsExpand);
+
+    //--------------------------
+    wxStaticBox* itemStaticBox_01 = new wxStaticBox(this, wxID_STATIC,
+        _t("Currency Format Sample:")
+    );
+    wxStaticBoxSizer* itemStaticBoxSizer_01 = new wxStaticBoxSizer(itemStaticBox_01,
+        wxHORIZONTAL
+    );
+    itemBoxSizer2->Add(itemStaticBoxSizer_01, wxSizerFlags(g_flagsExpand).Proportion(0));
+
+    w_sampleText = new wxStaticText(this, wxID_STATIC, "");
+    itemStaticBoxSizer_01->Add(w_sampleText, g_flagsExpand);
+    w_sampleText->SetMinSize(wxSize(220, -1));
+
+    //--------------------------
+    wxBoxSizer* itemBoxSizer22 = new wxBoxSizer(wxHORIZONTAL);
+    itemBoxSizer2->Add(itemBoxSizer22, wxSizerFlags(g_flagsV).Centre());
+
+    wxButton* itemButton24 = new wxButton(this, wxID_OK, _t("&OK "));
+    itemBoxSizer22->Add(itemButton24, g_flagsH);
+    mmToolTip(itemButton24, _t("Save any changes made"));
+
+    wxButton* itemButton25 = new wxButton(this, wxID_CANCEL, wxGetTranslation(g_CloseLabel));
+    itemBoxSizer22->Add(itemButton25, g_flagsH);
+    mmToolTip(itemButton25, _t("Any changes will be lost without update"));
 }
 
 void CurrencyManager::fillControls()
@@ -176,97 +312,7 @@ void CurrencyManager::fillControls()
     w_baseConvRate->Enable(!baseCurrency);
 }
 
-void CurrencyManager::CreateControls()
-{
-    wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
-    this->SetSizer(itemBoxSizer2);
-
-    wxFlexGridSizer* itemFlexGridSizer3 = new wxFlexGridSizer(0, 2, 0, 0);
-    itemFlexGridSizer3->AddGrowableCol(1, 1);
-    itemBoxSizer2->Add(itemFlexGridSizer3, g_flagsExpand);
-
-    //--------------------------
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Currency Name")), g_flagsH);
-    w_name = new wxTextCtrl(this, ID_DIALOG_CURRENCY);
-    w_name->SetMinSize(wxSize(220, -1));
-    itemFlexGridSizer3->Add(w_name, g_flagsExpand);
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Currency Code")), g_flagsH);
-    w_code = new wxTextCtrl(this, ID_DIALOG_CURRENCY);
-    w_code->SetMaxLength(12);
-    itemFlexGridSizer3->Add(w_code, g_flagsExpand);
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Currency Symbol")), g_flagsH);
-    w_symbol = new wxTextCtrl(this, ID_DIALOG_CURRENCY, "");
-    itemFlexGridSizer3->Add(w_symbol, g_flagsExpand);
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Symbol Location")), g_flagsH);
-    w_prefix = new wxRadioButton(this, ID_DIALOG_CURRENCY, _t("Prefix"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
-    w_suffix = new wxRadioButton(this, ID_DIALOG_CURRENCY, _t("Suffix"), wxDefaultPosition, wxDefaultSize);
-    wxBoxSizer* radSizer = new wxBoxSizer(wxHORIZONTAL);
-    radSizer->Add(w_prefix);
-    radSizer->Add(w_suffix);
-    itemFlexGridSizer3->Add(radSizer, g_flagsExpand);
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Decimal Char:")), g_flagsH);
-    w_decimalSep = new wxChoice(this, ID_DIALOG_CURRENCY);
-    itemFlexGridSizer3->Add(w_decimalSep, g_flagsExpand);
-    w_decimalSep->Append(_t("Dot"), new wxStringClientData("."));
-    w_decimalSep->Append(_t("Comma"), new wxStringClientData(","));
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Grouping Char")), g_flagsH);
-    w_groupSep = new wxChoice(this, ID_DIALOG_CURRENCY);
-    itemFlexGridSizer3->Add(w_groupSep, g_flagsExpand);
-    w_groupSep->Append(_t("None"), new wxStringClientData(""));    
-    w_groupSep->Append(_t("Dot"), new wxStringClientData("."));
-    w_groupSep->Append(_t("Comma"), new wxStringClientData(","));
-    w_groupSep->Append(_t("Space"), new wxStringClientData(" "));
-
-    wxIntegerValidator<int> valInt(&m_scale, wxNUM_VAL_THOUSANDS_SEPARATOR);
-    valInt.SetMin(0); // Only allow positive numbers
-    valInt.SetMax(SCALE);
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Scale")), g_flagsH);
-    w_scale = new wxTextCtrl(this, ID_DIALOG_CURRENCY, "", wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT, valInt);
-    itemFlexGridSizer3->Add(w_scale, g_flagsExpand);
-
-    itemFlexGridSizer3->Add(new wxStaticText(this, wxID_STATIC, _t("Conversion to Base Rate")), g_flagsH);
-    w_baseConvRate = new mmTextCtrl(this, ID_DIALOG_CURRENCY_RATE, ""
-        , wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT | wxTE_PROCESS_ENTER
-        , mmCalcValidator());
-    w_baseConvRate->Connect(ID_DIALOG_CURRENCY_RATE, wxEVT_COMMAND_TEXT_ENTER
-        , wxCommandEventHandler(CurrencyManager::OnTextEntered), nullptr, this);
-    w_baseConvRate->SetAltPrecision(SCALE);
-    wxString ConvRateTooltip = wxEmptyString;
-    if (PrefModel::instance().getUseCurrencyHistory())
-        ConvRateTooltip = _t("Conversion rate will be used in case no currency history has been found for the currency");
-    else
-        ConvRateTooltip = _t("Fixed conversion rate");
-    mmToolTip(w_baseConvRate, ConvRateTooltip);
-    itemFlexGridSizer3->Add(w_baseConvRate, g_flagsExpand);
-
-    //--------------------------
-    wxStaticBox* itemStaticBox_01 = new wxStaticBox(this, wxID_STATIC, _t("Currency Format Sample:"));
-    wxStaticBoxSizer* itemStaticBoxSizer_01 = new wxStaticBoxSizer(itemStaticBox_01, wxHORIZONTAL);
-    itemBoxSizer2->Add(itemStaticBoxSizer_01, wxSizerFlags(g_flagsExpand).Proportion(0));
-
-    w_sampleText = new wxStaticText(this, wxID_STATIC, "");
-    itemStaticBoxSizer_01->Add(w_sampleText, g_flagsExpand);
-    w_sampleText->SetMinSize(wxSize(220, -1));
-
-    //--------------------------
-    wxBoxSizer* itemBoxSizer22 = new wxBoxSizer(wxHORIZONTAL);
-    itemBoxSizer2->Add(itemBoxSizer22, wxSizerFlags(g_flagsV).Centre());
-
-    wxButton* itemButton24 = new wxButton(this, wxID_OK, _t("&OK "));
-    itemBoxSizer22->Add(itemButton24, g_flagsH);
-    mmToolTip(itemButton24, _t("Save any changes made"));
-
-    wxButton* itemButton25 = new wxButton(this, wxID_CANCEL, wxGetTranslation(g_CloseLabel));
-    itemBoxSizer22->Add(itemButton25, g_flagsH);
-    mmToolTip(itemButton25, _t("Any changes will be lost without update"));
-}
-
-void CurrencyManager::OnOk(wxCommandEvent& WXUNUSED(event))
+void CurrencyManager::onOk(wxCommandEvent& WXUNUSED(event))
 {
     const wxString name = w_name->GetValue().Trim();
     if (name.empty())
@@ -282,44 +328,58 @@ void CurrencyManager::OnOk(wxCommandEvent& WXUNUSED(event))
     if (!currency_code.empty() && m_currency_n->m_id == -1)
         return mmErrorDialogs::InvalidSymbol(w_code, true);
 
-    if (m_currency_n->m_scale > 1)
-        if (m_currency_n->m_group_separator == m_currency_n->m_decimal_point) {
-            return mmErrorDialogs::ToolTip4Object(w_groupSep, _t("Invalid Entry")
-                        , _t("Grouping character is unable to be the same as the decimal character"));
-        }
+    if (m_currency_n->m_scale > 1 &&
+        m_currency_n->m_group_separator == m_currency_n->m_decimal_point
+    ) {
+        return mmErrorDialogs::ToolTip4Object(
+            w_groupSep,
+            _t("Invalid Entry"),
+            _t("Grouping character is unable to be the same as the decimal character")
+        );
+    }
 
     if (w_baseConvRate->Calculate(SCALE))
         w_baseConvRate->GetDouble(m_currency_n->m_base_conv_rate);
     if (!w_baseConvRate->checkValue(m_currency_n->m_base_conv_rate))
-        return mmErrorDialogs::ToolTip4Object(w_baseConvRate, _t("Invalid Entry"), _t("Conversion to Base Rate"));;
+        return mmErrorDialogs::ToolTip4Object(
+            w_baseConvRate,
+            _t("Invalid Entry"),
+            _t("Conversion to Base Rate")
+        );
 
     CurrencyModel::instance().unsafe_save_data_n(m_currency_n);
     EndModal(wxID_OK);
 }
 
-void CurrencyManager::OnCancel(wxCommandEvent& /*event*/)
+void CurrencyManager::onCancel(wxCommandEvent& /*event*/)
 {
     EndModal(wxID_CANCEL);
 }
 
-void CurrencyManager::OnDataChanged(wxCommandEvent& WXUNUSED(event))
+void CurrencyManager::onDataChanged(wxCommandEvent& WXUNUSED(event))
 {
-    const wxString decimal = static_cast<wxStringClientData *>(w_decimalSep->GetClientObject(w_decimalSep->GetSelection()))->GetData();
-    const wxString grouping = static_cast<wxStringClientData *>(w_groupSep->GetClientObject(w_groupSep->GetSelection()))->GetData();
+    const wxString decimal = static_cast<wxStringClientData *>(
+        w_decimalSep->GetClientObject(w_decimalSep->GetSelection())
+    )->GetData();
+    const wxString grouping = static_cast<wxStringClientData *>(
+        w_groupSep->GetClientObject(w_groupSep->GetSelection())
+    )->GetData();
     int scale = wxAtoi(w_scale->GetValue());
 
     if ((scale > 0) && (grouping == decimal))
-        mmErrorDialogs::ToolTip4Object(w_groupSep, _t("Invalid Entry")
-                , _t("Grouping character is unable to be the same as the decimal character"));
+        mmErrorDialogs::ToolTip4Object(
+            w_groupSep,
+            _t("Invalid Entry"),
+            _t("Grouping character is unable to be the same as the decimal character")
+        );
 
     w_decimalSep->Enable(!m_locale_used && scale > 0); 
 
-    if (w_prefix->GetValue())
-    {
+    if (w_prefix->GetValue()) {
         m_currency_n->m_prefix_symbol = w_symbol->GetValue();
         m_currency_n->m_suffix_symbol = "";
-    } else
-    {
+    }
+    else {
         m_currency_n->m_prefix_symbol = "";
         m_currency_n->m_suffix_symbol = w_symbol->GetValue();  
     } 
@@ -341,7 +401,7 @@ void CurrencyManager::OnDataChanged(wxCommandEvent& WXUNUSED(event))
     w_sampleText->SetLabelText(dispAmount);
 }
 
-void CurrencyManager::OnTextEntered(wxCommandEvent& WXUNUSED(event))
+void CurrencyManager::onTextEntered(wxCommandEvent& WXUNUSED(event))
 {
     if (w_baseConvRate->Calculate(SCALE))
         w_baseConvRate->GetDouble(m_currency_n->m_base_conv_rate);

--- a/src/manager/CurrencyManager.h
+++ b/src/manager/CurrencyManager.h
@@ -35,6 +35,8 @@ class CurrencyManager : public wxDialog
     wxDECLARE_DYNAMIC_CLASS(CurrencyManager);
     wxDECLARE_EVENT_TABLE();
 
+// -- state
+
 private:
     CurrencyData* m_currency_n = nullptr;
     CurrencyData m_currency_d;
@@ -53,28 +55,34 @@ private:
     wxStaticText*  w_sampleText   = nullptr;
 
 public:
+    int64 getCurrencyID() { return m_currency_n->m_id; };
+
+// -- constructor
+
+public:
     CurrencyManager();
     CurrencyManager(wxWindow* parent, const CurrencyData* currency);
     ~CurrencyManager();
 
-    int64 getCurrencyID() { return m_currency_n->m_id; };
-
 private:
-    bool Create(
-        wxWindow* parent, wxWindowID id = wxID_ANY,
+    bool create(
+        wxWindow* parent,
+        wxWindowID id = wxID_ANY,
         const wxString& caption = _t("Currency Manager"),
         const wxString& name = "Currency Manager",
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = wxCAPTION | wxSYSTEM_MENU | wxCLOSE_BOX | wxRESIZE_BORDER
     );
-
-    void CreateControls();
+    void createControls();
     void fillControls();
 
-    void OnOk(wxCommandEvent& event);
-    void OnCancel(wxCommandEvent& event);
-    void OnDataChanged(wxCommandEvent& event);
-    void OnTextEntered(wxCommandEvent& event);
+// -- event handlers
+
+private:
+    void onOk(wxCommandEvent& event);
+    void onCancel(wxCommandEvent& event);
+    void onDataChanged(wxCommandEvent& event);
+    void onTextEntered(wxCommandEvent& event);
 };
 


### PR DESCRIPTION
Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8288)
<!-- Reviewable:end -->
