### PR TITLE
Stock Panel updates

### DIFF
--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -511,21 +511,38 @@ int StockList::initVirtualListControl(int64 trx_id)
 {
     /* Clear all the records */
     DeleteAllItems();
-
-    // TODO
-    if (w_panel->m_account_id > -1 ) {
-        m_stock_a = StockModel::instance().find(
-            StockCol::HELDAT(w_panel->m_account_id),
-            StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0)
-        );
+    if (w_panel->m_name_filter_value.IsEmpty()) {
+        // TODO
+        if (w_panel->m_account_id > -1 ) {
+            m_stock_a = StockModel::instance().find(
+                StockCol::HELDAT(w_panel->m_account_id),
+                StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0)
+            );
+        }
+        else { // create summary
+            m_stock_a = StockModel::instance().find(
+                StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0)
+            );
+            if (!m_stock_a.empty())
+                createSummary();
+        }
     }
-    // create summary
     else {
-        m_stock_a = StockModel::instance().find(
-            StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0)
-        );
-        if (!m_stock_a.empty())
-            createSummary();
+        if (w_panel->m_account_id > -1 ) {
+            m_stock_a = StockModel::instance().find(
+                StockCol::HELDAT(w_panel->m_account_id),
+                StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0),
+                StockCol::STOCKNAME(OP_LK, w_panel->m_name_filter_value)
+            );
+        }
+        else { // create summary
+            m_stock_a = StockModel::instance().find(
+                StockCol::NUMSHARES(w_panel->getFilter() ? OP_GT : OP_GE, 0.0),
+                StockCol::STOCKNAME(OP_LK, w_panel->m_name_filter_value)
+            );
+            if (!m_stock_a.empty())
+                createSummary();
+        }
     }
 
     w_panel->updateHeader();

--- a/src/panel/StockList.cpp
+++ b/src/panel/StockList.cpp
@@ -125,6 +125,8 @@ StockList::StockList(
     if (!m_stock_a.empty()) {
         EnsureVisible(m_stock_a.size() - 1);
     }
+
+    this->Bind(wxEVT_SIZE, &StockList::onSize, this);
 }
 
 StockList::~StockList()
@@ -787,4 +789,42 @@ wxString StockList::getStockInfo(int selectedIndex, bool with_symbol) const
         );
     }
     return info_str;
+}
+
+void StockList::onSize(wxSizeEvent& event)
+{
+    struct colInfo {
+        int id;
+        int width;
+    };
+
+    // get total column width:
+    int twidth = 0;
+    int rwidth = 0;
+    std::vector<colInfo> resizable_ids;
+    for (int i = 0; i < GetColumnCount(); i++) {
+        int col_id = getColId_Nr(i);
+        if (!isHiddenColId(col_id)) {
+            int cw = GetColumnWidth(i);
+            twidth += cw;
+
+            switch (col_id) {
+                case LIST_ID_NAME:
+                case LIST_ID_NOTES:
+                    resizable_ids.push_back({i, cw});
+                    rwidth += cw;
+                    break;
+            }
+        }
+    }
+
+    // calculate and apply diff:
+    int diff = this->GetSize().GetWidth() - twidth;
+    if (abs(diff) > 5) {
+        int diffdelta = diff / resizable_ids.size();
+        for (colInfo col: resizable_ids) {
+            this->SetColumnWidth(col.id, col.width + diffdelta);
+        }
+    }
+    event.Skip();
 }

--- a/src/panel/StockList.h
+++ b/src/panel/StockList.h
@@ -113,4 +113,6 @@ private:
     void onMarkAllTransactions(wxCommandEvent& event);
     void onListKeyDown(wxListEvent& event);
     void onListItemSelected(wxListEvent& event);
+    void onSize(wxSizeEvent& event);
+
 };

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -89,6 +89,7 @@ bool StockPanel::create(
 
 StockPanel::~StockPanel()
 {
+    InfoModel::instance().saveBool("STOCKPANEL_SHOW_NON_ZERO", w_filter_choice->GetSelection() > 0);
 }
 
 void StockPanel::createControls()
@@ -108,7 +109,7 @@ void StockPanel::createControls()
     w_filter_choice->Append(_t("All"));
     w_filter_choice->Append(_t("Non-Zero Shares"));
     w_filter_choice->SetMinSize(wxSize(150, -1));
-    w_filter_choice->SetSelection(0);
+    w_filter_choice->SetSelection(InfoModel::instance().getBool("STOCKPANEL_SHOW_NON_ZERO", false) ? 1 : 0);
 
     w_filter_choice->Bind(wxEVT_CHOICE, [this](wxCommandEvent&)
     {

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -93,16 +93,13 @@ StockPanel::~StockPanel()
 
 void StockPanel::createControls()
 {
-    wxBoxSizer* itemBoxSizer9 = new wxBoxSizer(wxVERTICAL);
-    this->SetSizer(itemBoxSizer9);
+    wxBoxSizer* sizerVHeader = new wxBoxSizer(wxVERTICAL);
+    this->SetSizer(sizerVHeader);
 
     /* ---------------------- */
     wxPanel* headerPanel = new wxPanel(this, wxID_ANY
         , wxDefaultPosition , wxDefaultSize, wxNO_BORDER | wxTAB_TRAVERSAL);
-    itemBoxSizer9->Add(headerPanel, 0, wxALIGN_LEFT);
-
-    wxBoxSizer* itemBoxSizerVHeader = new wxBoxSizer(wxVERTICAL);
-    headerPanel->SetSizer(itemBoxSizerVHeader);
+    sizerVHeader->Add(headerPanel, 0, wxALIGN_LEFT);
 
     w_header_title = new wxStaticText(headerPanel, wxID_STATIC, "");
     w_header_title->SetFont(this->GetFont().Larger().Bold());
@@ -119,13 +116,37 @@ void StockPanel::createControls()
     });
 
     w_header_total = new wxStaticText(headerPanel, wxID_STATIC, "");
+    wxStaticText* sfilter = new wxStaticText(headerPanel, wxID_STATIC, "Name:", wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
+    w_nameFilter = new wxTextCtrl(headerPanel, wxID_INDEX, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    w_nameFilter->Bind(wxEVT_TEXT, &StockPanel::onFilterTextChanged, this);
+    w_filter_cancel = new wxBitmapButton(headerPanel, wxID_ANY, mmBitmapBundle(png::CLEAR, mmBitmapButtonSize));
+    w_filter_cancel->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &StockPanel::onFilterCancel, this);
+    mmToolTip(w_filter_cancel, _t("Reset filter"));
+
+    wxBoxSizer* itemBoxSizerVHeader1 = new wxBoxSizer(wxVERTICAL);
+    itemBoxSizerVHeader1->Add(w_header_title, 1, wxALL, 1);
+    itemBoxSizerVHeader1->AddSpacer(5);
+    itemBoxSizerVHeader1->Add(w_header_total, 1, wxALL, 1);
 
     wxBoxSizer* itemBoxSizerHHeader = new wxBoxSizer(wxHORIZONTAL);
-    itemBoxSizerHHeader->Add(w_header_title, 1, wxALIGN_CENTER_VERTICAL | wxALL, 1);
+    itemBoxSizerHHeader->AddSpacer(15);
+    itemBoxSizerHHeader->Add(itemBoxSizerVHeader1, 1, wxEXPAND, 1);
 
-    itemBoxSizerVHeader->Add(itemBoxSizerHHeader, 1, wxEXPAND, 1);
-    itemBoxSizerVHeader->Add(w_filter_choice, g_flagsBorder1V);
-    itemBoxSizerVHeader->Add(w_header_total, 1, wxALL, 1);
+    wxBoxSizer* itemBoxSizerHHeader2 = new wxBoxSizer(wxHORIZONTAL);
+    itemBoxSizerHHeader2->AddSpacer(15);
+    itemBoxSizerHHeader2->Add(w_filter_choice, 0, wxALIGN_CENTER_VERTICAL, 1);
+    itemBoxSizerHHeader2->AddSpacer(30);
+    itemBoxSizerHHeader2->Add(sfilter, 0, wxALIGN_CENTER_VERTICAL, 1);
+    itemBoxSizerHHeader2->AddSpacer(10);
+    itemBoxSizerHHeader2->Add(w_nameFilter, 0, wxALIGN_CENTER_VERTICAL, 1);
+    itemBoxSizerHHeader2->Add(w_filter_cancel, 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 2);
+
+    wxBoxSizer* itemBoxSizerVHeader = new wxBoxSizer(wxVERTICAL);
+    headerPanel->SetSizer(itemBoxSizerVHeader);
+    itemBoxSizerVHeader->Add(itemBoxSizerHHeader, 1, wxALL, 1);
+    itemBoxSizerVHeader->AddSpacer(5);
+    itemBoxSizerVHeader->Add(itemBoxSizerHHeader2, 1, wxEXPAND, 1);
+
 
     /* ---------------------- */
     mmSplitterWindow* itemSplitterWindow10 = new mmSplitterWindow(
@@ -147,7 +168,7 @@ void StockPanel::createControls()
     itemSplitterWindow10->SplitHorizontally(w_list, BottomPanel);
     itemSplitterWindow10->SetMinimumPaneSize(100);
     itemSplitterWindow10->SetSashGravity(1.0);
-    itemBoxSizer9->Add(itemSplitterWindow10, g_flagsExpandBorder1);
+    sizerVHeader->Add(itemSplitterWindow10, g_flagsExpandBorder1);
 
     wxBoxSizer* BoxSizerVBottom = new wxBoxSizer(wxVERTICAL);
     BottomPanel->SetSizer(BoxSizerVBottom);
@@ -513,7 +534,27 @@ void StockPanel::onRefreshQuotes(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-// Trigger a quote download
+void StockPanel::onFilterTextChanged(wxCommandEvent& WXUNUSED(event))
+{
+    w_filter_cancel->Enable(!w_nameFilter->GetValue().IsEmpty());
+    m_name_filter_value = w_nameFilter->GetValue();
+    if (!m_name_filter_value.IsEmpty()) {
+        m_name_filter_value = m_name_filter_value + "%";
+    }
+    refreshList();
+}
+
+void StockPanel::onFilterCancel(wxCommandEvent& WXUNUSED(event))
+{
+    w_nameFilter->SetValue("");
+    m_name_filter_value = w_nameFilter->GetValue();
+    if (!m_name_filter_value.IsEmpty()) {
+        m_name_filter_value = m_name_filter_value + "%";
+    }
+    refreshList();
+}
+
+/*** Trigger a quote download ***/
 bool StockPanel::onlineQuoteRefresh(wxString& msg)
 {
     wxString base_currency_symbol;

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -536,7 +536,8 @@ void StockPanel::updateHeader()
     }
 
     w_header_win->SetLabelText(lbl);
-    w_header_win->SetForegroundColour(*mmImage::themeMetaColour(marketValue > InvestedVal || InvestedVal == 0 ? mmImage::COLOR_TEXTCONTROL_FONT : mmImage::COLOR_REPORT_DEBIT));
+    const wxString c = mmImage::themeMetaString(marketValue > InvestedVal || InvestedVal == 0 ? mmImage::COLOR_TEXTCONTROL_FONT : mmImage::COLOR_REPORT_DEBIT);
+    w_header_win->SetForegroundColour(wxColor(c));
     this->Layout();
 }
 

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -117,17 +117,27 @@ void StockPanel::createControls()
     });
 
     w_header_total = new wxStaticText(headerPanel, wxID_STATIC, "");
+    w_header_info = new wxStaticText(headerPanel, wxID_STATIC, "");
+    w_header_win = new wxStaticText(headerPanel, wxID_STATIC, "");
+    wxBoxSizer* itemBoxSizerHHeader1 = new wxBoxSizer(wxHORIZONTAL);
+    //itemBoxSizerHHeader1->AddSpacer(15);
+    itemBoxSizerHHeader1->Add(w_header_total, 0, wxALIGN_BOTTOM, 1);
+    itemBoxSizerHHeader1->AddSpacer(20);
+    itemBoxSizerHHeader1->Add(w_header_info, 0, wxALIGN_BOTTOM, 1);
+    itemBoxSizerHHeader1->AddSpacer(20);
+    itemBoxSizerHHeader1->Add(w_header_win, 0, wxALIGN_BOTTOM, 1);
+
     wxStaticText* sfilter = new wxStaticText(headerPanel, wxID_STATIC, "Name:", wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
     w_nameFilter = new wxTextCtrl(headerPanel, wxID_INDEX, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     w_nameFilter->Bind(wxEVT_TEXT, &StockPanel::onFilterTextChanged, this);
-    w_filter_cancel = new wxBitmapButton(headerPanel, wxID_ANY, mmBitmapBundle(png::CLEAR, mmBitmapButtonSize));
+    w_filter_cancel = new wxBitmapButton(headerPanel, wxID_ANY, mmImage::bitmapBundle(mmImage::png::CLEAR, mmImage::bitmapButtonSize));
     w_filter_cancel->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &StockPanel::onFilterCancel, this);
     mmToolTip(w_filter_cancel, _t("Reset filter"));
 
     wxBoxSizer* itemBoxSizerVHeader1 = new wxBoxSizer(wxVERTICAL);
     itemBoxSizerVHeader1->Add(w_header_title, 1, wxALL, 1);
     itemBoxSizerVHeader1->AddSpacer(5);
-    itemBoxSizerVHeader1->Add(w_header_total, 1, wxALL, 1);
+    itemBoxSizerVHeader1->Add(itemBoxSizerHHeader1, 1, wxEXPAND, 1);
 
     wxBoxSizer* itemBoxSizerHHeader = new wxBoxSizer(wxHORIZONTAL);
     itemBoxSizerHHeader->AddSpacer(15);
@@ -503,15 +513,30 @@ void StockPanel::updateHeader()
     double diffPercents = InvestedVal != 0.0
         ? (marketValue > InvestedVal ? marketValue / InvestedVal*100.0 - 100.0 : -(marketValue / InvestedVal*100.0 - 100.0))
         : 0.0;
-    lbl = wxString::Format("%s     %s     %s     %s     %s (%s %%)"
-        , wxString::Format(_t("Total: %s"), CurrencyModel::instance().toCurrency(marketValue + cashBalance, m_currency_n))
-        , wxString::Format(_t("Cash Balance: %s"), CurrencyModel::instance().toCurrency(cashBalance, m_currency_n))
-        , wxString::Format(_t("Market Value: %s"), CurrencyModel::instance().toCurrency(marketValue, m_currency_n))
-        , wxString::Format(_t("Invested: %s"), CurrencyModel::instance().toCurrency(InvestedVal, m_currency_n))
-        , wxString::Format(marketValue > InvestedVal ? _t("Gain: %s") : _t("Loss: %s"), diffStr)
-        , CurrencyModel::instance().toString(diffPercents, m_currency_n, 2));
 
-    w_header_total->SetLabelText(lbl);
+    w_header_total->SetLabelText(cashBalance != 0 ? wxString::Format(_t("Total: %s"), CurrencyModel::instance().toCurrency(marketValue + cashBalance, m_currency_n))
+                                                 : wxString::Format(_t("Market Value: %s"), CurrencyModel::instance().toCurrency(marketValue, m_currency_n))
+    );
+
+    if (cashBalance != 0) {
+        lbl << wxString::Format(_t("Cash Balance: %s"), CurrencyModel::instance().toCurrency(cashBalance, m_currency_n))
+            << "    "
+            << wxString::Format(_t("Market Value: %s"), CurrencyModel::instance().toCurrency(marketValue, m_currency_n))
+            << "    ";
+    }
+    lbl << wxString::Format(_t("Invested: %s"), CurrencyModel::instance().toCurrency(InvestedVal, m_currency_n));
+    w_header_info->SetLabelText(lbl);
+
+    if (InvestedVal > 0) {
+        lbl =  wxString::Format(marketValue > InvestedVal ? _t("Gain: %s") : _t("Loss: %s"), diffStr)
+            << " (" << CurrencyModel::instance().toString(diffPercents, m_currency_n, 2) << "%)";
+    }
+    else {
+        lbl = "";
+    }
+
+    w_header_win->SetLabelText(lbl);
+    w_header_win->SetForegroundColour(*mmImage::themeMetaColour(marketValue > InvestedVal || InvestedVal == 0 ? mmImage::COLOR_TEXTCONTROL_FONT : mmImage::COLOR_REPORT_DEBIT));
     this->Layout();
 }
 

--- a/src/panel/StockPanel.h
+++ b/src/panel/StockPanel.h
@@ -47,6 +47,8 @@ private:
     StockList*      w_list           = nullptr;
     wxStaticText*   w_header_title   = nullptr;
     wxStaticText*   w_header_total   = nullptr;
+    wxStaticText*   w_header_info    = nullptr;
+    wxStaticText*   w_header_win     = nullptr;
     wxStaticText*   w_details        = nullptr;
     wxStaticText*   w_details_short  = nullptr;
     wxChoice*       w_filter_choice  = nullptr;

--- a/src/panel/StockPanel.h
+++ b/src/panel/StockPanel.h
@@ -41,6 +41,7 @@ private:
     wxString m_last_update;
     wxDateTime m_last_refresh;
     bool m_refresh_status;
+    wxString m_name_filter_value = "";
 
     mmFrame*        w_frame;
     StockList*      w_list           = nullptr;
@@ -51,6 +52,8 @@ private:
     wxChoice*       w_filter_choice  = nullptr;
     wxBitmapButton* w_attachment_btn = nullptr;
     wxBitmapButton* w_refresh_btn    = nullptr;
+    wxTextCtrl*     w_nameFilter     = nullptr;
+    wxBitmapButton* w_filter_cancel  = nullptr;
 
 public:
     StockPanel(
@@ -92,7 +95,6 @@ private:
     void copySelectedRowsToClipboard(wxListCtrl* listCtrl);
     int  getFilter();
     void updateHeader();
-
     void call_dialog(int selectedIndex);
     auto totalShares() -> const wxString;
 
@@ -107,4 +109,6 @@ private:
     void onEditStocks(wxCommandEvent& event) { w_list->onEditStocks(event); }
     void onOpenAttachment(wxCommandEvent& event) { w_list->onOpenAttachment(event); }
     void onRefreshQuotes(wxCommandEvent& event);
+    void onFilterTextChanged(wxCommandEvent& event);
+    void onFilterCancel(wxCommandEvent& event);
 };

--- a/src/table/_TableClause.cpp
+++ b/src/table/_TableClause.cpp
@@ -71,6 +71,7 @@ TableClause TableClause::where_op(const wxString& col, OP op)
         case OP_LE:  expr = col + " <= ?"; mult = 1; break;
         case OP_EQN: expr = "IFNULL(" + col + ", ?)" +  " = ?"; mult = 2; break;
         case OP_NEN: expr = "IFNULL(" + col + ", ?)" + " != ?"; mult = 2; break;
+        case OP_LK:  expr = col + " LIKE ?"; mult = 1; break;
     }
     return TableClause(CLAUSE_ID_WHERE, expr, mult);
 }
@@ -175,6 +176,8 @@ TableClause TableClause::merge(const std::vector<const TableClause*>& clause_na)
             // keep the last
             text = clause.m_text;
             is_empty = false;
+            break;
+        default:
             break;
         }
     }

--- a/src/table/_TableClause.h
+++ b/src/table/_TableClause.h
@@ -50,6 +50,7 @@ enum OP {
     OP_LE,     // Less or Equal
     OP_EQN,    // EQual to Null or argument
     OP_NEN,    // Not (Equal to Null or argument)
+    OP_LK      // Like
 };
 
 // deprecated

--- a/src/table/_TableFactory.h
+++ b/src/table/_TableFactory.h
@@ -206,7 +206,7 @@ auto TableFactory<T, D>::search_cache_n(const Args& ... args) -> const Data*
 //   find_where(true, AssetCol::ASSETID(2), AssetCol::ASSETTYPE("Jewellery"))
 //   produces the SQLite WHERE clause (ASSETID = 2 AND ASSETTYPE = "Jewellery").
 // Return an empty array if no records are found.
-// 
+//
 // TODO: do not store all results in a vactor; return an iterator instead.
 template<typename T, typename D>
 template<typename... Args>
@@ -250,6 +250,7 @@ void TableFactory<T, D>::write_condition(wxString& out, bool /*op_and*/, const A
         case OP_LE:  out += " " + col + " <= ?"; break;
         case OP_EQN: out += " IFNULL(" + col + ", ?)" +  " = ?"; break;
         case OP_NEN: out += " IFNULL(" + col + ", ?)" + " != ?"; break;
+        case OP_LK:  out += " " + col + " LIKE ? "; break;
     }
 }
 
@@ -275,6 +276,7 @@ void TableFactory<T, D>::bind_at(wxSQLite3Statement& stmt, int& index, const Arg
         case OP_LT:
         case OP_GE:
         case OP_LE:
+        case OP_LK:
             stmt.Bind(++index, arg1.m_value);
             break;
         case OP_EQN:

--- a/src/util/mmImage.cpp
+++ b/src/util/mmImage.cpp
@@ -200,7 +200,7 @@ const std::map<int, std::tuple<wxString, wxString, bool>> mmImage::metaDataTrans
     md[COLOR_HTMLPANEL_FORE]   = std::make_tuple("/colors/htmlPanel/foreColor",  "",       false);
     md[COLOR_REPORT_ALTROW]    = std::make_tuple("/colors/reports/altRow",      "#F5F5F5", false);
     md[COLOR_REPORT_CREDIT]    = std::make_tuple("/colors/reports/credit",      "#50B381", false);
-    md[COLOR_REPORT_DEBIT]     = std::make_tuple("/colors/reports/debit",       "#F75E51", false);
+    md[COLOR_REPORT_DEBIT]     = std::make_tuple("/colors/reports/debit",       "#f12121", false);
     md[COLOR_REPORT_DELTA]     = std::make_tuple("/colors/reports/delta",       "#008FFB", false);
     md[COLOR_REPORT_PERF]      = std::make_tuple("/colors/reports/perf",        "#FF6307", false);
     md[COLOR_REPORT_FORECOLOR] = std::make_tuple("/colors/reports/foreColor",   "#373D3F", false);
@@ -223,7 +223,7 @@ const std::map<int, std::tuple<wxString, wxString, bool>> mmImage::metaDataTrans
     md[COLOR_GRM_SPECIAL]      = std::make_tuple("/colors/grm/special",          "#e70870ff", false);
     md[COLOR_TEXTCONTROL]      = std::make_tuple("/colors/textControl",         wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX).GetAsString(wxC2S_HTML_SYNTAX), false);
     md[COLOR_TEXTCONTROL_FONT] = std::make_tuple("/colors/textControlFont",     wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT).GetAsString(wxC2S_HTML_SYNTAX), false);
-    
+
     return md;
 };
 


### PR DESCRIPTION
This pull request contains these updates:
- Added a name filter to the panel to select one or more stocks by name
- Colors a loss in red 
- Stores the Selection value for "All" or "Non-Zero values" in the settings
- Automatic adjustment of the column sizes when the window is resized. 

<img width="555" height="150" alt="StockPanelChanges" src="https://github.com/user-attachments/assets/afef00ff-7dd0-44b8-bae1-8e342732b375" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8302)
<!-- Reviewable:end -->
