### PR TITLE
Fix crash after account edit due to unsave mapping

### DIFF
--- a/src/app/mmFrame.cpp
+++ b/src/app/mmFrame.cpp
@@ -1485,24 +1485,20 @@ void mmFrame::OnReconcileAccount(wxCommandEvent& WXUNUSED(event))
 }
 
 //----------------------------------------------------------------------------
-void mmFrame::OnPopupEditAccount(wxCommandEvent& /*event*/)
+void mmFrame::OnPopupEditAccount(wxCommandEvent& WXUNUSED(event))
 {
     if (!selectedItemData_)
         return;
 
     int64 id = selectedItemData_->getId();
     AccountData* account = AccountModel::instance().unsafe_get_id_data_n(id);
-    if (!account)
-        return;
-
-    JournalPanel* cp = wxDynamicCast(panelCurrent_, JournalPanel);
-    AccountDialog dlg(account, this);
-    if (dlg.ShowModal() == wxID_OK)
-    {
-        RefreshNavigationTree();
-        cp->refreshList();
+    if (account) {
+        AccountDialog dlg(account, this);
+        if (dlg.ShowModal() == wxID_OK) {
+            RefreshNavigationTree();
+            refreshPanelData();
+        }
     }
-
 }
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Error occurs if a stock account or similar is edited. Looks like a regression.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8326)
<!-- Reviewable:end -->
