### PR TITLE
Enhancements for backup/file handling and GRM

### DIFF
--- a/docs/en_US/index.html
+++ b/docs/en_US/index.html
@@ -692,37 +692,18 @@
         MMEX never modifies or overwrites existing backup files.
     </p>
 
-    <aside class="sticky notes">
-        MMEX cannot open <code>.bak</code> files directly.
-        To restore one, rename it to <code>dbname.mmb</code>.
-    </aside>
 
     <h4>How to Restore a Backup Safely</h4>
 
+
+    <aside class="sticky notes">
+        MMEX will not store the backup file name in the list of recently used file names.
+    </aside>
+
     <ol>
-        <li>Close MMEX.</li>
-        <li>Locate the folder containing the database and its backups.</li>
-
-        <li>
-            Rename the main database (<code>dbname.mmb</code>) to something like:<br>
-            <code>Last_dbname.mmb</code>
-            to avoid filename conflicts.
-        </li>
-
-        <li>
-            Make a copy of the backup you want to restore (right-click → copy → paste).
-        </li>
-
-        <li>
-            Rename the copied backup from:<br>
-            <code>dbname_start_YYYY-MM-DD.bak</code> or <code>dbname_update_YYYY-MM-DD.bak</code><br>
-            to:<br>
-            <code>dbname.mmb</code>
-        </li>
-
-        <li>
-            Open the renamed file using <kbd>File → Open Database…</kbd>.
-        </li>
+        <li>Open the backup file with <kbd>File → Open Database…</kbd> selecting either "MMEX Database Backup" file type or
+            if the file is encrypted "Encrypted MMEX Database Backup"</li>
+        <li>Store the file with <kbd>File → Save Database…</kbd> under the original / new name. </li>
     </ol>
 
     <aside class="sticky tips">

--- a/po/mmex.pot
+++ b/po/mmex.pot
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Choose database file to create"
 msgstr ""
 
-#: app/mmFrame.cpp:2657 app/mmFrame.cpp:2681 app/mmFrame.cpp:2727
+#: app/mmFrame.cpp:2657 app/mmFrame.cpp:2690 app/mmFrame.cpp:2727
 #: app/mmFrame.cpp:2912
 msgid "MMEX Database"
 msgstr ""
@@ -938,8 +938,16 @@ msgstr ""
 msgid "Choose database file to open"
 msgstr ""
 
-#: app/mmFrame.cpp:2681 app/mmFrame.cpp:2707 app/mmFrame.cpp:2912
+#: app/mmFrame.cpp:2690 app/mmFrame.cpp:2707 app/mmFrame.cpp:2912
 msgid "Encrypted MMEX Database"
+msgstr ""
+
+#: app/mmFrame.cpp:2691
+msgid "MMEX Database Backup"
+msgstr ""
+
+#: app/mmFrame.cpp:2692
+msgid "Encrypted MMEX Database Backup"
 msgstr ""
 
 #: app/mmFrame.cpp:2705

--- a/src/app/mmFrame.cpp
+++ b/src/app/mmFrame.cpp
@@ -2678,7 +2678,8 @@ void mmFrame::OnOpen(wxCommandEvent& /*event*/)
     autoRepeatTransactionsTimer_.Stop();
     wxString fileName = wxFileSelector(
         _t("Choose database file to open"),
-        wxEmptyString, wxEmptyString, wxEmptyString,
+        SettingModel::instance().getString("LAST_FILE_OPEN_PATH", wxEmptyString),
+        wxEmptyString, wxEmptyString,
         _t("MMEX Database") + " (*.mmb)|*.mmb|" + _t("Encrypted MMEX Database") + " (*.emb)|*.emb",
         wxFD_FILE_MUST_EXIST | wxFD_OPEN,
         this
@@ -2687,6 +2688,7 @@ void mmFrame::OnOpen(wxCommandEvent& /*event*/)
     if (!fileName.empty()) {
         SetDatabaseFile(fileName);
         saveSettings();
+        SettingModel::instance().saveString("LAST_FILE_OPEN_PATH", wxFileName(fileName).GetPath());
         if (m_db) {
             autocleanDeletedTransactions();
             if (!StockModel::instance().find_all().empty() &&
@@ -2908,7 +2910,7 @@ void mmFrame::OnSaveAs(wxCommandEvent& /*event*/)
 
     wxFileDialog dlg(this,
         _t("Save database file as"),
-        wxEmptyString,
+        SettingModel::instance().getString("LAST_FILE_OPEN_PATH", wxEmptyString),
         wxEmptyString,
         _t("MMEX Database")+" (*.mmb)|*.mmb|"+_t("Encrypted MMEX Database")+" (*.emb)|*.emb",
         wxFD_SAVE | wxFD_OVERWRITE_PROMPT

--- a/src/app/mmFrame.cpp
+++ b/src/app/mmFrame.cpp
@@ -742,7 +742,9 @@ void mmFrame::saveSettings()
     SettingModel::instance().db_savepoint();
     if (!m_filename.IsEmpty()) {
         wxFileName fname(m_filename);
-        SettingModel::instance().saveString("LASTFILENAME", fname.GetFullPath());
+        if (fname.GetExt().Upper() != "BAK") {
+            SettingModel::instance().saveString("LASTFILENAME", fname.GetFullPath());
+        }
     }
     /* Aui Settings */
     SettingModel::instance().saveString("AUIPERSPECTIVE", m_mgr.SavePerspective());
@@ -2415,7 +2417,9 @@ bool mmFrame::createDataStore(const wxString& fileName, const wxString& pwd, boo
     wxFileName checkExt(fileName);
     wxString password;
     bool passwordCheckPassed = true;
-    if (checkExt.GetExt().Lower() == "emb" && wxFileName::FileExists(fileName)) {
+    if ((checkExt.GetExt().Lower() == "emb" ||
+        (checkExt.GetExt().Lower() == "bak" && (checkExt.GetName().Lower().Contains(".emb_update_") || checkExt.GetName().Lower().Contains(".emb_start_"))))
+        && wxFileName::FileExists(fileName)) {
         wxString password_message = wxString::Format(
             _t("Please enter password for Database\n\n%s"),
             fileName
@@ -2612,7 +2616,10 @@ bool mmFrame::openFile(const wxString& fileName, bool openingNew, const wxString
 {
     menuBar_->FindItem(MENU_CHANGE_ENCRYPT_PASSWORD)->Enable(false);
     if (createDataStore(fileName, password, openingNew)) {
-        m_recentFiles->AddFileToHistory(fileName);
+        wxFileName fname(fileName);
+        if (fname.GetExt().Upper() != "BAK") {
+            m_recentFiles->AddFileToHistory(fileName);
+        }
         menuEnableItems(true);
         menuPrintingEnable(false);
 
@@ -2673,14 +2680,16 @@ void mmFrame::OnNew(wxCommandEvent& /*event*/)
 }
 //----------------------------------------------------------------------------
 
-void mmFrame::OnOpen(wxCommandEvent& /*event*/)
+void mmFrame::OnOpen(wxCommandEvent& WXUNUSED(event))
 {
     autoRepeatTransactionsTimer_.Stop();
     wxString fileName = wxFileSelector(
         _t("Choose database file to open"),
         SettingModel::instance().getString("LAST_FILE_OPEN_PATH", wxEmptyString),
         wxEmptyString, wxEmptyString,
-        _t("MMEX Database") + " (*.mmb)|*.mmb|" + _t("Encrypted MMEX Database") + " (*.emb)|*.emb",
+        _t("MMEX Database") + " (*.mmb)|*.mmb|" + _t("Encrypted MMEX Database") + " (*.emb)|*.emb|"
+        + _t("MMEX Database Backup") + " (*.mmb_update_*.bak;*.mmb_start_*.bak)|*.mmb_update_*.bak;*.mmb_start_*.bak|"
+        + _t("Encrypted MMEX Database Backup") + " (*.emb_update_*.bak;*.emb_start_*.bak)|*.emb_update_*.bak;*.emb_start_*.bak",
         wxFD_FILE_MUST_EXIST | wxFD_OPEN,
         this
     );

--- a/src/manager/GeneralReportManager.cpp
+++ b/src/manager/GeneralReportManager.cpp
@@ -333,7 +333,7 @@ bool GeneralReportManager::Create(wxWindow* parent
     CreateControls();
     fillControls();
     GetSizer()->Fit(this);
-    GetSizer()->SetSizeHints(this);
+    //GetSizer()->SetSizeHints(this);
     SetIcon(mmPath::getProgramIcon());
 
     m_images = NavTreeIconImages::instance().getList(PrefModel::instance().getToolbarIconSize());


### PR DESCRIPTION
This pull request contains these changes:
- Remove setting the fixed min size for GRM,  which prevents the GRM window from shrinking after saving the current size
- Remember the last path used in the file open dialog for file open and save, instead of using the default path.
- Extend the file open dialog with a file selection for backup files, to open backup files directly, without having to rename them first. This simplifies the restore to two steps:
      1.) Open the Backup file with File -> Open Database
      2.) Save the file under a new/existing name with File -> Save Database as
(see also discussion in #7928, issue 2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8328)
<!-- Reviewable:end -->
