### PR TITLE
Fix regression and adapted journal panel

### DIFF
--- a/src/dialog/StockDialog.cpp
+++ b/src/dialog/StockDialog.cpp
@@ -351,9 +351,11 @@ void StockDialog::updateControls()
         ));
     }
     else {
-        w_value_label->SetLabelText(wxString::Format(wxT("%.2f"),
-            m_stock_n->m_current_price * m_stock_n->m_num_shares
-        ));
+        if (m_stock_n) {
+            w_value_label->SetLabelText(wxString::Format(wxT("%.2f"),
+                m_stock_n->m_current_price * m_stock_n->m_num_shares
+            ));
+        }
     }
 
     // Disable history buttons on new stocks
@@ -363,9 +365,9 @@ void StockDialog::updateControls()
     static_cast<wxBitmapButton*>(FindWindow(wxID_DELETE))->Enable(!is_new);
     static_cast<wxBitmapButton*>(FindWindow(wxID_ADD))->Enable(!is_new);
 
-    bool initial_shares = (TrxLinkModel::instance().find_stock_id_c(
+    bool initial_shares = m_stock_n ? (TrxLinkModel::instance().find_stock_id_c(
         m_stock_n->m_id
-    ) == 0);
+    ) == 0) : false;
     w_num_text->Enable(is_new || initial_shares);
     w_purchase_date_picker->Enable(is_new || initial_shares);
     w_purchase_price_text->Enable(is_new || initial_shares);

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -220,7 +220,6 @@ bool JournalPanel::create(
 void JournalPanel::createControls()
 {
     wxBoxSizer* sizerV = new wxBoxSizer(wxVERTICAL);
-    //this->SetSizer(sizerV);
 
     /* ---------------------- */
 
@@ -296,10 +295,8 @@ void JournalPanel::createControls()
     w_header_sortOrder = new wxStaticText(this, wxID_STATIC, "");
     sizerHCtrl->Add(w_header_sortOrder, g_flagsH);
 
+    sizerHCtrl->AddStretchSpacer(1);
     if (isAccount()) {
-        sizerHCtrl->AddStretchSpacer(1);
-        sizerHCtrl->AddSpacer(100);
-
         wxBitmapButton* btn = new wxBitmapButton(this, wxID_ANY,
             mmImage::bitmapBundle(mmImage::png::TRXNUM, mmImage::bitmapButtonSize)
         );
@@ -308,7 +305,7 @@ void JournalPanel::createControls()
         sizerHCtrl->Add(btn, 0, wxALIGN_CENTER_VERTICAL, 5);
     }
 
-    sizerV->Add(sizerHCtrl, 0, wxEXPAND | wxALL, 10);
+    sizerV->Add(sizerHCtrl, 0, wxEXPAND | wxALL, 15);
 
     w_range_btn->Connect(wxEVT_RIGHT_DOWN,
         wxMouseEventHandler(JournalPanel::onButtonRightDown),

--- a/src/table/_TableFactory.h
+++ b/src/table/_TableFactory.h
@@ -104,7 +104,7 @@ public:
     // Records fully owned by id are ignored (they can be deleted together with id).
     // If ignore_deleted is true, deleted transactions are also also ignored.
     // The complete list of table dependencies can be found in _dependencies.txt
-    virtual auto find_id_isUsed(int64 id, bool ignore_deleted = false) -> bool {
+    virtual auto find_id_isUsed([[maybe_unused]] int64 id, [[maybe_unused]] bool ignore_deleted = false) -> bool {
         return false;
     }
 


### PR DESCRIPTION
This pull request removes warnings and fixes an segmentation fault during adding of a new stock introduced with pull-request #8232. 
The third commit reduces the minimum gap of the reconcile button in the journal button, so that the panel is more responsive to size changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8333)
<!-- Reviewable:end -->
