### PR TITLE
Fix new account type always defaulting to Checking

### DIFF
--- a/src/util/mmNavigatorList.cpp
+++ b/src/util/mmNavigatorList.cpp
@@ -349,7 +349,7 @@ int mmNavigatorList::getAccountTypeIdx(int account_type)
 wxString mmNavigatorList::getAccountDbTypeFromChoice(const wxString& choiceName)
 {
     for (mmNavigatorItem* entry : m_navigator_entries) {
-        if (entry->choice == choiceName) {
+        if (entry->choice == choiceName || GetTranslatedSelection(entry) == choiceName) {
             return entry->dbaccid;
         }
     }
@@ -441,7 +441,7 @@ int mmNavigatorList::getTypeIdFromDBName(const wxString& dbname, int default_id)
 int mmNavigatorList::getTypeIdFromChoice(const wxString& choice, int default_id)
 {
     for (mmNavigatorItem* entry : m_navigator_entries) {
-        if (entry->choice == choice) {
+        if (entry->choice == choice || GetTranslatedSelection(entry) == choice) {
             return entry->type;
         }
     }


### PR DESCRIPTION
This PR fixes an issue where selecting an account type in the Add Account wizard was ignored, and the account was always created as Checking.
The wizard stores and passes translated account type labels, but type resolution compared only untranslated strings. When lookup failed, it fell back to the default type (Checking).

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8335)
<!-- Reviewable:end -->
