### PR TITLE
Translate "Cash Ledger"

### DIFF
--- a/src/app/mmFrame.cpp
+++ b/src/app/mmFrame.cpp
@@ -1085,7 +1085,7 @@ void mmFrame::DoRecreateNavTreeControl(bool home_page)
                     if (PrefModel::instance().getShowNavigatorCashLedger()) {
                         wxTreeItemId stockItem = m_nav_tree_ctrl->AppendItem(
                             accountItem,
-                            _n("Cash Ledger"),
+                            _t("Cash Ledger"),
                             accountImg, accountImg
                         );
                         m_nav_tree_ctrl->SetItemData(


### PR DESCRIPTION
The term "Cash Ledger" in the navigator was not translated. This fixes it.

Please do not forget to update the mmex.pot file and write information about the fixed bug in the prerelease [page](https://github.com/moneymanagerex/moneymanagerex/releases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8339)
<!-- Reviewable:end -->
