### PR TITLE
Reconcile dialog - update sums after edit

### DIFF
--- a/src/dialog/ReconcileDialog.cpp
+++ b/src/dialog/ReconcileDialog.cpp
@@ -555,6 +555,7 @@ void ReconcileDialog::processRightClick(wxListCtrl* list, long item)
     else {
         newTransaction();
     }
+    UpdateAll();
 }
 
 void ReconcileDialog::OnListKeyDown(wxKeyEvent& event)
@@ -738,6 +739,7 @@ void ReconcileDialog::OnEdit(wxCommandEvent& WXUNUSED(event))
     if (list) {
         long item = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
         editTransaction(list, item);
+        UpdateAll();
     }
 }
 


### PR DESCRIPTION
A small fix to update the summary values in the reconcile dialog also after editing a transaction or adding a new one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8359)
<!-- Reviewable:end -->
