### PR TITLE
fix(#8352): escape delimiter for regex parsing in CSV import

### DIFF
--- a/src/import_export/parsers.cpp
+++ b/src/import_export/parsers.cpp
@@ -52,7 +52,7 @@ bool FileCSV::Load(const wxString& fileName, unsigned int itemsInLine)
     // Parse rows
     wxString line;
     int row = 0;
-    wxRegEx splitLinePattern(delimiter_ + "[\x1a]?\"[^\"]*?$");
+    wxRegEx splitLinePattern("\\" + delimiter_ + "[\x1a]?\"[^\"]*?$");
     for (line = txtFile.GetFirstLine(); !txtFile.Eof(); line = txtFile.GetNextLine())
     {
         // remove double sets of quotes which parse as the double quote literal


### PR DESCRIPTION
Fixes #8352. Escape the chosen delimiter during file parsing in case the delimiter is a regex special character.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8372)
<!-- Reviewable:end -->
