### PR TITLE
Fix Asset account view cannot be hidden in navigator configuration #8390

### DIFF
--- a/src/app/mmFrame.cpp
+++ b/src/app/mmFrame.cpp
@@ -2688,6 +2688,7 @@ void mmFrame::OnNew(wxCommandEvent& /*event*/)
     if (!fileName.EndsWith(".mmb"))
         fileName += ".mmb";
 
+    mmNavigatorList::instance().SetToDefault();
     SetDatabaseFile(fileName, true);
     SettingModel::instance().saveString("LASTFILENAME", fileName);
     loadGrmIconMapping();

--- a/src/dialog/NavigatorDialog.cpp
+++ b/src/dialog/NavigatorDialog.cpp
@@ -114,11 +114,17 @@ wxTreeListItem NavigatorDialog::appendAccountItem(wxTreeListItem parent, mmNavig
     m_treeList->SetItemText(item, 1, ainfo->navTyp > mmNavigatorItem::NAV_TYP_PANEL ? mmNavigatorList::GetTranslatedSelection(ainfo) : "");
     m_treeList->SetItemImage(item, ainfo->imageId);
     m_treeList->SetItemData(item, new NavData(ainfo));
-    if (ainfo->type == mmNavigatorItem::TYPE_ID_SHARES) {
-        m_treeList->CheckItem(item, PrefModel::instance().getHideShareAccounts() ? wxCHK_UNCHECKED : wxCHK_CHECKED);
-    }
-    else {
-        m_treeList->CheckItem(item, ainfo->navTyp != mmNavigatorItem::NAV_TYP_PANEL ? wxCHK_UNDETERMINED : (ainfo->active ? wxCHK_CHECKED : wxCHK_UNCHECKED));
+    switch (ainfo->type) {
+        case mmNavigatorItem::TYPE_ID_SHARES :
+            m_treeList->CheckItem(item, PrefModel::instance().getHideShareAccounts() ? wxCHK_UNCHECKED : wxCHK_CHECKED);
+            break;
+
+        case mmNavigatorItem::TYPE_ID_ASSET :
+            m_treeList->CheckItem(item, (ainfo->active ? wxCHK_CHECKED : wxCHK_UNCHECKED));
+            break;
+
+        default:
+            m_treeList->CheckItem(item, ainfo->navTyp != mmNavigatorItem::NAV_TYP_PANEL ? wxCHK_UNDETERMINED : (ainfo->active ? wxCHK_CHECKED : wxCHK_UNCHECKED));
     }
     return item;
 }
@@ -133,7 +139,7 @@ void NavigatorDialog::OnEdit(wxCommandEvent&)
         if (data->ref->navTyp > mmNavigatorItem::NAV_TYP_PANEL) {
             m_treeList->SetItemText(item, 1, data->ref->choice);
         }
-        else if (data->ref->navTyp == mmNavigatorItem::NAV_TYP_PANEL || data->ref->type == mmNavigatorItem::TYPE_ID_SHARES) {
+        else if (data->ref->navTyp == mmNavigatorItem::NAV_TYP_PANEL || data->ref->type == mmNavigatorItem::TYPE_ID_SHARES || data->ref->type == mmNavigatorItem::TYPE_ID_ASSET) {
             m_treeList->CheckItem(item, data->ref->active ? wxCHK_CHECKED : wxCHK_UNCHECKED);
         }
         m_treeList->SetItemImage(item, data->ref->imageId);
@@ -166,7 +172,7 @@ void NavigatorDialog::OnTreeItemChecked(wxTreeListEvent& event)
 {
     wxTreeListItem item = event.GetItem();
     NavData* data = static_cast<NavData*> (m_treeList->GetItemData(item));
-    if (data->ref->navTyp != mmNavigatorItem::NAV_TYP_PANEL && data->ref->type != mmNavigatorItem::TYPE_ID_SHARES) {
+    if (data->ref->navTyp != mmNavigatorItem::NAV_TYP_PANEL && data->ref->type != mmNavigatorItem::TYPE_ID_SHARES && data->ref->type != mmNavigatorItem::TYPE_ID_ASSET) {
         m_treeList->CheckItem(item, wxCHK_UNDETERMINED);
     }
 }
@@ -182,7 +188,7 @@ void NavigatorDialog::setDefault()
     mmNavigatorList::instance().SetToDefault();
     // FIXME: The application is not ready for dynamic account types.
     // Much of the code assumes well known and fixed account types.
-    // See also the commeent in mmNavigatorList::DeleteEntry
+    // See also the comment in mmNavigatorList::DeleteEntry
     AccountModel::instance().dangerous_reset_unknown_types();
 }
 
@@ -218,7 +224,7 @@ void NavigatorDialog::copyTreeItemData(wxTreeListItem src, wxTreeListItem dst) {
     data->ref->active = m_treeList->GetCheckedState(src) == wxCHK_CHECKED || data->ref->navTyp != mmNavigatorItem::NAV_TYP_PANEL;
     m_treeList->SetItemImage(dst, data->ref->imageId);
     m_treeList->SetItemData(dst, new NavData(data->ref));
-    if (data->ref->navTyp == mmNavigatorItem::NAV_TYP_PANEL || data->ref->type == mmNavigatorItem::TYPE_ID_SHARES) {
+    if (data->ref->navTyp == mmNavigatorItem::NAV_TYP_PANEL || data->ref->type == mmNavigatorItem::TYPE_ID_SHARES || data->ref->type == mmNavigatorItem::TYPE_ID_ASSET) {
         m_treeList->CheckItem(dst, data->ref->active ? wxCHK_CHECKED : wxCHK_UNCHECKED);
     }
     else {
@@ -235,7 +241,7 @@ void NavigatorDialog::updateItemsRecursive(wxTreeListItem item)
         mmNavigatorItem* ainfo = data->ref;
         if (ainfo) {
             data->ref->seq_no = idx++;
-            data->ref->active = m_treeList->GetCheckedState(child) == wxCHK_CHECKED || (data->ref->navTyp != mmNavigatorItem::NAV_TYP_PANEL && data->ref->type != mmNavigatorItem::TYPE_ID_SHARES);
+            data->ref->active = m_treeList->GetCheckedState(child) == wxCHK_CHECKED || (data->ref->navTyp != mmNavigatorItem::NAV_TYP_PANEL && data->ref->type != mmNavigatorItem::TYPE_ID_SHARES && data->ref->type != mmNavigatorItem::TYPE_ID_ASSET);
             updateItemsRecursive(child);
             child = m_treeList->GetNextSibling(child);
             // Special for Trash:
@@ -247,7 +253,7 @@ void NavigatorDialog::updateItemsRecursive(wxTreeListItem item)
                 }
             }
             // Special for Share Accounts:
-            if (data->ref->type == mmNavigatorItem::TYPE_ID_SHARES) {
+            else if (data->ref->type == mmNavigatorItem::TYPE_ID_SHARES) {
                 PrefModel::instance().saveHideShareAccounts(!data->ref->active);
                 mmFrame* mainFrame = wxDynamicCast(this->GetParent(), mmFrame);
                 if (mainFrame) {

--- a/src/panel/AssetList.cpp
+++ b/src/panel/AssetList.cpp
@@ -29,6 +29,7 @@
 #include "util/mmImage.h"
 #include "util/mmAttachment.h"
 #include "util/_simple.h"
+#include "util/mmNavigatorList.h"
 
 #include "model/_all.h"
 
@@ -187,6 +188,7 @@ void AssetList::onNewAsset(wxCommandEvent& /*event*/)
     AssetDialog dlg(this, static_cast<AssetData*>(nullptr));
     if (dlg.ShowModal() == wxID_OK) {
         doRefreshItems(dlg.asset_id());
+        mmNavigatorList::instance().setAssetAccountActive();
         w_panel->w_frame->RefreshNavigationTree();
     }
 }

--- a/src/panel/DashboardWidget.cpp
+++ b/src/panel/DashboardWidget.cpp
@@ -575,9 +575,11 @@ const wxString htmlWidgetGrandTotals::getHTMLText(double tBalance, double tRecon
     output += wxString::Format("<th>%s: <span class='money'>%s</span></th>"
                                         , ( PrefModel::instance().getShowReconciledInHomePage() ? _t("Reconciled") : _t("Accounts"))
                                         , CurrencyModel::instance().toCurrency(tReconciled));
-    output +=  wxString::Format("<th>%s: <span class='money'>%s</span></th>"
-                                        , _t("Assets")
-                                        , CurrencyModel::instance().toCurrency(tAssets));
+    if (mmNavigatorList::instance().isAssetAccountActive()) {
+        output +=  wxString::Format("<th>%s: <span class='money'>%s</span></th>"
+                                            , _t("Assets")
+                                            , CurrencyModel::instance().toCurrency(tAssets));
+    }
     output +=  wxString::Format("<th>%s: <span class='money'>%s</span></th>"
                                         , _t("Stock")
                                         , CurrencyModel::instance().toCurrency(tStocks));

--- a/src/report/BalanceReport.cpp
+++ b/src/report/BalanceReport.cpp
@@ -3,7 +3,7 @@
  Copyright (C) 2013 - 2022 Nikolay Akimov
  Copyright (C) 2017 James Higley
  Copyright (C) 2021 - 2022 Mark Whalley (mark@ipx.co.uk)
- Copyright (C) 2025 Klaus Wich
+ Copyright (C) 2025, 2026 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 
 #include "model/_all.h"
 #include "BalanceReport.h"
+#include "util/mmNavigatorList.h"
 
 BalanceReport::BalanceReport(BalanceReport::PERIOD_ID period_id) :
     ReportBase(wxString::Format(
@@ -186,7 +187,8 @@ wxString BalanceReport::getHTMLText()
         }
     }
 
-    const bool include_asset_series = view_accounts && !asset_a.empty();
+    const bool include_assets = mmNavigatorList::instance().isAssetAccountActive();
+    const bool include_asset_series = view_accounts && !asset_a.empty() && include_assets;
     if (include_asset_series)
         series_name_a.push_back(_t("Assets"));
 
@@ -284,13 +286,15 @@ wxString BalanceReport::getHTMLText()
             }
         }
         else {
-            type_idx = mmNavigatorList::instance().getAccountTypeIdx(mmNavigatorItem::TYPE_ID_ASSET);
-            if (type_idx > -1) {
-                for (const auto& asset_d : asset_a) {
-                    double rate = getCurrencyDateRate(asset_d.m_currency_id_n, end_date);
-                    balance_a[type_idx] += AssetModel::instance().get_data_value_date(
-                        asset_d, end_date
-                    ).second * rate;
+            if (include_assets) {
+                type_idx = mmNavigatorList::instance().getAccountTypeIdx(mmNavigatorItem::TYPE_ID_ASSET);
+                if (type_idx > -1) {
+                    for (const auto& asset_d : asset_a) {
+                        double rate = getCurrencyDateRate(asset_d.m_currency_id_n, end_date);
+                        balance_a[type_idx] += AssetModel::instance().get_data_value_date(
+                            asset_d, end_date
+                        ).second * rate;
+                    }
                 }
             }
         }

--- a/src/util/mmNavigatorList.cpp
+++ b/src/util/mmNavigatorList.cpp
@@ -494,3 +494,13 @@ int mmNavigatorList::GetDefaultImage(int navTyp)
 
     return navTyp < mmNavigatorItem::NAV_ENTRY_size ? defaultTyp[navTyp] : mmImage::img::SAVINGS_ACC_NORMAL_PNG;
 }
+
+bool mmNavigatorList::isAssetAccountActive()  // If used for other types, create general proc
+{
+    for (int i = 0; i < static_cast<int>(m_account_type_entries.size()); i++) {
+        if (m_account_type_entries[i]->type == mmNavigatorItem::TYPE_ID_ASSET) {
+            return m_account_type_entries[i]->active;
+        }
+    }
+    return false;
+}

--- a/src/util/mmNavigatorList.cpp
+++ b/src/util/mmNavigatorList.cpp
@@ -78,13 +78,6 @@ bool mmNavigatorList::DeleteEntry(mmNavigatorItem* info)
     bool result = false;
     for (int i = 0; i < static_cast<int>(m_navigator_entries.size()); i++) {
         if  (m_navigator_entries[i] == info) {
-            // change account type of all affected accounts to Banking
-            // FIXME: This is very dangerous; account types are significant
-            // in many parts of the application (e.g., reports).
-            // Changing the type of an account can break functionality.
-            // Not all account types are immediately convertible to Checking.
-            //
-            // No need to fix, all accounts addressed here are based on Checking account (KW)
             AccountModel::instance().dangerous_reset_type(info->dbaccid);
             m_navigator_entries.erase(m_navigator_entries.begin() + i);
             result = true;

--- a/src/util/mmNavigatorList.cpp
+++ b/src/util/mmNavigatorList.cpp
@@ -495,12 +495,26 @@ int mmNavigatorList::GetDefaultImage(int navTyp)
     return navTyp < mmNavigatorItem::NAV_ENTRY_size ? defaultTyp[navTyp] : mmImage::img::SAVINGS_ACC_NORMAL_PNG;
 }
 
-bool mmNavigatorList::isAssetAccountActive()  // If used for other types, create general proc
+mmNavigatorItem* mmNavigatorList::getAccountByNavType(int navTyp)
 {
     for (int i = 0; i < static_cast<int>(m_account_type_entries.size()); i++) {
-        if (m_account_type_entries[i]->type == mmNavigatorItem::TYPE_ID_ASSET) {
-            return m_account_type_entries[i]->active;
+        if (m_account_type_entries[i]->type == navTyp) {
+            return m_account_type_entries[i];
         }
     }
-    return false;
+    return NULL;
+}
+
+bool mmNavigatorList::isAssetAccountActive()
+{
+    mmNavigatorItem* item = getAccountByNavType(mmNavigatorItem::TYPE_ID_ASSET);
+    return item ? item->active : false;
+}
+
+void mmNavigatorList::setAssetAccountActive()
+{
+     mmNavigatorItem* item = getAccountByNavType(mmNavigatorItem::TYPE_ID_ASSET);
+     if (item) {
+        item->active = true;
+     }
 }

--- a/src/util/mmNavigatorList.h
+++ b/src/util/mmNavigatorList.h
@@ -124,6 +124,7 @@ public:
     wxString getAccountTypeName(int idx);
     bool isAccountTypeAsset(int idx);
     bool isAssetAccountActive();
+    void setAssetAccountActive();
     mmNavigatorItem* getAccountTypeItem(int idx);
     wxArrayString getAccountSelectionNames(wxString filter = "");
     wxString getAccountDbTypeFromChoice(const wxString& choiceName);
@@ -161,4 +162,5 @@ public:
 private:
     void sortEntriesBySeq();
     int getMaxId();
+    mmNavigatorItem* getAccountByNavType(int navTyp);
 };

--- a/src/util/mmNavigatorList.h
+++ b/src/util/mmNavigatorList.h
@@ -1,5 +1,5 @@
 /*******************************************************
- Copyright (C) 2025 Klaus Wich
+ Copyright (C) 2025, 2026 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -83,7 +83,7 @@ private:
     long unsigned int   m_lastIdx;
     mmNavigatorItem* m_previous;
 
-// -- costructor
+// -- constructor
 
 public:
     mmNavigatorList();
@@ -123,6 +123,7 @@ public:
     int getAccountTypeIdx(int account_type);
     wxString getAccountTypeName(int idx);
     bool isAccountTypeAsset(int idx);
+    bool isAssetAccountActive();
     mmNavigatorItem* getAccountTypeItem(int idx);
     wxArrayString getAccountSelectionNames(wxString filter = "");
     wxString getAccountDbTypeFromChoice(const wxString& choiceName);


### PR DESCRIPTION
This pull request fixes #8390 allowing to hide the asset account view in navigator configuration. If the view is hidden, also the asset value in the dashboard header widget and the assets in the balance report are hidden. Assets are made visible either in the navigator configuration or as soon as a new asset is created. 

An additional fix resets the navigator configuration to default values, when a new database is created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8392)
<!-- Reviewable:end -->
