### PR TITLE
Fix: display configured names in panel haeders and navigator edit dialog

### DIFF
--- a/src/dialog/NavigatorEditDialog.cpp
+++ b/src/dialog/NavigatorEditDialog.cpp
@@ -39,7 +39,7 @@ NavigatorEditDialog::NavigatorEditDialog(wxWindow* parent, const mmNavigatorItem
     SetIcon(mmPath::getProgramIcon());
 
     if (info) {
-        m_nameTextCtrl->SetValue(info->name);
+        m_nameTextCtrl->SetValue(wxGetTranslation(info->name));
         switch(info->navTyp) {
             case mmNavigatorItem::NAV_TYP_PANEL:
                 m_activeCheckBox->SetValue(info->active);
@@ -57,7 +57,7 @@ NavigatorEditDialog::NavigatorEditDialog(wxWindow* parent, const mmNavigatorItem
             default:
                 m_aktivLabel->Show(false);
                 m_activeCheckBox->Show(false);
-                m_choiceTextCtrl->SetValue(info->choice);
+                m_choiceTextCtrl->SetValue(wxGetTranslation(info->choice));
         }
         m_cbIcon->SetSelection(info->imageId);
     }

--- a/src/panel/AssetPanel.cpp
+++ b/src/panel/AssetPanel.cpp
@@ -105,7 +105,8 @@ void AssetPanel::createControls()
     wxBoxSizer* itemBoxSizerVHeader = new wxBoxSizer(wxVERTICAL);
     headerPanel->SetSizer(itemBoxSizerVHeader);
 
-    wxStaticText* itemStaticText9 = new wxStaticText(headerPanel, wxID_STATIC, _t("Assets"));
+    wxStaticText* itemStaticText9 = new wxStaticText(headerPanel, wxID_STATIC,
+        wxGetTranslation(mmNavigatorList::instance().getAccountSectionName(mmNavigatorItem::TYPE_ID_ASSET)));
     itemStaticText9->SetFont(this->GetFont().Larger().Bold());
     itemBoxSizerVHeader->Add(itemStaticText9, g_flagsBorder1V);
 

--- a/src/panel/JournalPanel.cpp
+++ b/src/panel/JournalPanel.cpp
@@ -138,25 +138,28 @@ void JournalPanel::mmPlayTransactionSound()
 
 wxString JournalPanel::getPanelTitle() const
 {
-    if (isAllTrans())
-        return _t("All Transactions");
-    else if (isDeletedTrans())
-        return _t("Deleted Transactions");
-    else if (isGroup()) {
-        if (m_account_group_id == -3)
-            return _t("Favorites");
-        else {
-            int account_Type = -(static_cast<int>(m_account_group_id.GetValue()) + 4);
-            if (account_Type >= mmNavigatorItem::TYPE_ID_size) {
-                account_Type += mmNavigatorItem::NAV_IDXDIFF;
-            }
-            return mmNavigatorList::instance().getAccountSectionName(account_Type);
-        }
-    }
-    else if (m_account_n)
+    if (m_account_n)
         return wxString::Format(_t("Account View: %s"), m_account_n->m_name);
-    else
-        return "";
+    else {
+        int account_Type = -1;
+        if (isAllTrans()) {
+            account_Type =  mmNavigatorItem::NAV_ENTRY_ALL_TRANSACTIONS;
+        }
+        else if (isDeletedTrans()) {
+            account_Type =  mmNavigatorItem::NAV_ENTRY_DELETED_TRANSACTIONS;
+        }
+        else if (isGroup()) {
+            if (m_account_group_id == -3)
+                account_Type =  mmNavigatorItem::NAV_ENTRY_FAVORITES;
+            else {
+                account_Type = -(static_cast<int>(m_account_group_id.GetValue()) + 4);
+                if (account_Type >= mmNavigatorItem::TYPE_ID_size) {
+                    account_Type += mmNavigatorItem::NAV_IDXDIFF;
+                }
+            }
+        }
+        return account_Type != -1 ? wxGetTranslation(mmNavigatorList::instance().getAccountSectionName(account_Type)) : "";
+    }
 }
 
 // -- constructor

--- a/src/panel/SchedPanel.cpp
+++ b/src/panel/SchedPanel.cpp
@@ -106,7 +106,7 @@ void SchedPanel::createControls()
     headerPanel->SetSizer(itemBoxSizerVHeader);
 
     wxStaticText* itemStaticText9 = new wxStaticText(headerPanel, wxID_ANY,
-        _t("Scheduled Transactions")
+        wxGetTranslation(mmNavigatorList::instance().getAccountSectionName(mmNavigatorItem::NAV_ENTRY_SCHEDULED_TRANSACTIONS))
     );
     itemStaticText9->SetFont(this->GetFont().Larger().Bold());
     itemBoxSizerVHeader->Add(itemStaticText9, g_flagsBorder1V);
@@ -137,7 +137,7 @@ void SchedPanel::createControls()
     images.push_back(mmImage::bitmapBundle(mmImage::png::DOWNARROW));
 
     w_list = new SchedList(this, itemSplitterWindowBillsDeposit);
-    
+
     w_list->SetSmallImages(images);
 
     wxPanel* bdPanel = new wxPanel(itemSplitterWindowBillsDeposit, wxID_ANY,

--- a/src/panel/StockPanel.cpp
+++ b/src/panel/StockPanel.cpp
@@ -507,7 +507,7 @@ void StockPanel::updateHeader()
         }
     }
     else {
-        w_header_title->SetLabelText(wxString::Format(_t("Stock Portfolios Overview")));
+        w_header_title->SetLabelText(wxGetTranslation(mmNavigatorList::instance().getAccountSectionName(mmNavigatorItem::TYPE_ID_INVESTMENT)));
         if (w_list) {
             w_list->getInvestmentBalance(InvestedVal, marketValue);
         }


### PR DESCRIPTION
This corrects a mismatch that in in the panel the (translated) default names are used, even if new names got configured in the navigator display, which is confusing. Also the navigator edit dialog used the US English default names and not the country specific no custom names are set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8400)
<!-- Reviewable:end -->
