### PR TITLE
Fix: Correct display of disabled buttons under Linux/GTK

### DIFF
--- a/src/util/_util.cpp
+++ b/src/util/_util.cpp
@@ -2,7 +2,7 @@
  Copyright (C) 2006 Madhan Kanagavel
  Copyright (C) 2013-2022 Nikolay Akimov
  Copyright (C) 2021-2024 Mark Whalley (mark@ipx.co.uk)
- Copyright (C) 2025 Klaus Wich
+ Copyright (C) 2025-2026 Klaus Wich
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -89,6 +89,7 @@ bool isDark(wxColour c)
 void mmThemeAutoColour([[maybe_unused]] wxWindow* object, [[maybe_unused]] bool recursive)
 {
 #ifndef __WXOSX__
+#ifndef __WXGTK__
     bool darkMode = mmPlatform::isDarkMode();
     size_t type = typeid(*object).hash_code();
     wxString bg, fg;
@@ -149,6 +150,7 @@ void mmThemeAutoColour([[maybe_unused]] wxWindow* object, [[maybe_unused]] bool 
             mmThemeAutoColour(child, recursive);
 
     enableMSWDarkMode(object, darkMode);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Under Linux/GTK the mmthemeAutoColour function interferes with the display of disabled buttons and controls, so that they can't be distinguished from active ones.  Disabling the function like for MACOS corrects the behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8403)
<!-- Reviewable:end -->
