### PR TITLE
fix(#7685): restore UTF-8 report settings

### DIFF
--- a/src/report/_ReportBase.cpp
+++ b/src/report/_ReportBase.cpp
@@ -247,7 +247,7 @@ void ReportBase::saveReportSettings()
 void ReportBase::restoreReportSettings()
 {
     Document j_doc;
-    if (j_doc.Parse(m_settings.c_str()).HasParseError())
+    if (j_doc.Parse(m_settings.utf8_str()).HasParseError())
         return;
 
     if (j_doc.HasMember("REPORTPERIOD") && j_doc["REPORTPERIOD"].IsInt()) {


### PR DESCRIPTION
Parses saved report settings as UTF-8 so names containing emoji or other non-ASCII characters restore correctly. The regression harness and report target build pass. No localization strings change, so mmex.pot is unaffected. Fixes #7685.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8443)
<!-- Reviewable:end -->
